### PR TITLE
Fixing typo that causes stackoverflow exception

### DIFF
--- a/src/QsCompiler/Core/TreeTransformation.fs
+++ b/src/QsCompiler/Core/TreeTransformation.fs
@@ -120,8 +120,8 @@ type SyntaxTreeTransformation() =
         | Provided (argTuple, body) -> this.onProvidedImplementation (argTuple, body) |> Provided
 
 
-    abstract member onSpecialization : QsSpecialization -> QsSpecialization
-    default this.onSpecialization (spec : QsSpecialization) = 
+    abstract member onSpecializationImplementation : QsSpecialization -> QsSpecialization
+    default this.onSpecializationImplementation (spec : QsSpecialization) = 
         let source = this.onSourceFile spec.SourceFile
         let loc = this.onLocation spec.Location
         let doc = this.onDocumentation spec.Documentation
@@ -132,16 +132,16 @@ type SyntaxTreeTransformation() =
         QsSpecialization.New spec.Kind (source, loc) (spec.Parent, typeArgs, signature, impl, doc, comments)
 
     abstract member onBodySpecialization : QsSpecialization -> QsSpecialization
-    default this.onBodySpecialization spec = this.onSpecialization spec
+    default this.onBodySpecialization spec = this.onSpecializationImplementation spec
     
     abstract member onAdjointSpecialization : QsSpecialization -> QsSpecialization
-    default this.onAdjointSpecialization spec = this.onSpecialization spec
+    default this.onAdjointSpecialization spec = this.onSpecializationImplementation spec
 
     abstract member onControlledSpecialization : QsSpecialization -> QsSpecialization
-    default this.onControlledSpecialization spec = this.onSpecialization spec
+    default this.onControlledSpecialization spec = this.onSpecializationImplementation spec
 
     abstract member onControlledAdjointSpecialization : QsSpecialization -> QsSpecialization
-    default this.onControlledAdjointSpecialization spec = this.onSpecialization spec
+    default this.onControlledAdjointSpecialization spec = this.onSpecializationImplementation spec
 
     member this.dispatchSpecialization (spec : QsSpecialization) = 
         let spec = this.beforeSpecialization spec
@@ -162,8 +162,8 @@ type SyntaxTreeTransformation() =
         let typeItems = this.onTypeItems t.TypeItems
         QsCustomType.New (source, loc) (t.FullName, typeItems, underlyingType, doc, comments)
 
-    abstract member onCallable : QsCallable -> QsCallable
-    default this.onCallable (c : QsCallable) = 
+    abstract member onCallableImplementation : QsCallable -> QsCallable
+    default this.onCallableImplementation (c : QsCallable) = 
         let source = this.onSourceFile c.SourceFile
         let loc = this.onLocation c.Location
         let doc = this.onDocumentation c.Documentation
@@ -174,13 +174,13 @@ type SyntaxTreeTransformation() =
         QsCallable.New c.Kind (source, loc) (c.FullName, argTuple, signature, specializations, doc, comments)
 
     abstract member onOperation : QsCallable -> QsCallable
-    default this.onOperation c = this.onCallable c
+    default this.onOperation c = this.onCallableImplementation c
 
     abstract member onFunction : QsCallable -> QsCallable
-    default this.onFunction c = this.onCallable c
+    default this.onFunction c = this.onCallableImplementation c
 
     abstract member onTypeConstructor : QsCallable -> QsCallable
-    default this.onTypeConstructor c = this.onCallable c
+    default this.onTypeConstructor c = this.onCallableImplementation c
 
 
     member this.dispatchCallable (c : QsCallable) = 

--- a/src/QsCompiler/Transformations/BasicTransformations.cs
+++ b/src/QsCompiler/Transformations/BasicTransformations.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Quantum.QsCompiler.Transformations.BasicTransformations
             base(new NoScopeTransformations()) =>
             this.SourceFiles = new HashSet<NonNullable<string>>();
 
-        public override QsSpecialization onSpecialization(QsSpecialization spec) // short cut to avoid further evaluation
+        public override QsSpecialization onSpecializationImplementation(QsSpecialization spec) // short cut to avoid further evaluation
         {
             this.onSourceFile(spec.SourceFile);
             return spec;
@@ -88,7 +88,7 @@ namespace Microsoft.Quantum.QsCompiler.Transformations.BasicTransformations
 
         // TODO: these transformations needs to be adapted once we support external specializations
         public override QsCustomType onType(QsCustomType t) => AddTypeIfInSource(t);
-        public override QsCallable onCallable(QsCallable c) => AddCallableIfInSource(c);
+        public override QsCallable onCallableImplementation(QsCallable c) => AddCallableIfInSource(c);
 
         public override QsNamespace Transform(QsNamespace ns)
         {

--- a/src/QsCompiler/Transformations/SearchAndReplace.cs
+++ b/src/QsCompiler/Transformations/SearchAndReplace.cs
@@ -102,8 +102,8 @@ namespace Microsoft.Quantum.QsCompiler.Transformations.SearchAndReplace
         public override QsCallable onOperation(QsCallable c) =>
             this.IsRelevant(c.SourceFile) ? base.onOperation(c) : c;
 
-        public override QsSpecialization onSpecialization(QsSpecialization spec) =>
-            this.IsRelevant(spec.SourceFile) ? base.onSpecialization(spec) : spec;
+        public override QsSpecialization onSpecializationImplementation(QsSpecialization spec) =>
+            this.IsRelevant(spec.SourceFile) ? base.onSpecializationImplementation(spec) : spec;
 
         public override QsLocation onLocation(QsLocation l)
         {


### PR DESCRIPTION
Introduced a rather bad typo in the SearchAndReplace transformation that causes the server to crash due to a stackoverflow… 