### PR TITLE
Add completion for callables, types and keywords

### DIFF
--- a/src/QsCompiler/CompilationManager/EditorSupport.cs
+++ b/src/QsCompiler/CompilationManager/EditorSupport.cs
@@ -688,11 +688,11 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
             if (file == null || compilation == null || position == null)
                 return Array.Empty<CompletionItem>();
 
-            var visibleNamespaces = GetVisibleNamespaces(file, compilation, position);
+            var openedNamespaces = GetOpenedNamespaces(file, compilation, position);
             return
                 compilation.GlobalSymbols.DefinedCallables()
                 .Concat(compilation.GlobalSymbols.ImportedCallables())
-                .Where(callable => visibleNamespaces.Contains(callable.QualifiedName.Namespace.Value))
+                .Where(callable => openedNamespaces.Contains(callable.QualifiedName.Namespace.Value))
                 .Select(callable => new CompletionItem()
                 {
                     Label = callable.QualifiedName.Name.Value,
@@ -713,11 +713,11 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
             if (file == null || compilation == null || position == null)
                 return Array.Empty<CompletionItem>();
 
-            var visibleNamespaces = GetVisibleNamespaces(file, compilation, position);
+            var openedNamespaces = GetOpenedNamespaces(file, compilation, position);
             return 
                 compilation.GlobalSymbols.DefinedTypes()
                 .Concat(compilation.GlobalSymbols.ImportedTypes())
-                .Where(type => visibleNamespaces.Contains(type.QualifiedName.Namespace.Value))
+                .Where(type => openedNamespaces.Contains(type.QualifiedName.Namespace.Value))
                 .Select(type => new CompletionItem()
                 {
                     Label = type.QualifiedName.Name.Value,
@@ -768,12 +768,12 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         }
 
         /// <summary>
-        /// Returns all of the namespaces that are visible at the given position in the file. This includes the current
-        /// namespace and all opened namespaces.
+        /// Returns the names of all namespaces that have been opened at the given position in the file, including the
+        /// current namespace.
         /// <para/>
         /// Returns an empty or incomplete list of namespaces if any parameter is null or the position is invalid.
         /// </summary>
-        private static IEnumerable<string> GetVisibleNamespaces(
+        private static IEnumerable<string> GetOpenedNamespaces(
             FileContentManager file, CompilationUnit compilation, Position position)
         {
             string @namespace = file.TryGetNamespaceAt(position);


### PR DESCRIPTION
I decided to show completions for all keywords instead of just type keywords since it was easier for now. :) And it looks like completions for C# in Visual Studio show the same icon for all keywords, including type keywords, so there is no need to separate the different kinds of keywords yet. When completion becomes more context-aware I will probably have to start grouping the keywords into different kinds.

With this PR, I think every possible identifier except namespaces should show up as a completion now.