### PR TITLE
Fixing doc gen call

### DIFF
--- a/src/QsCompiler/Compiler/CompilationLoader.cs
+++ b/src/QsCompiler/Compiler/CompilationLoader.cs
@@ -229,7 +229,7 @@ namespace Microsoft.Quantum.QsCompiler
                 this.CompilationStatus.Documentation = 0;
                 var docsFolder = Path.GetFullPath(String.IsNullOrWhiteSpace(this.Config.DocumentationOutputFolder) ? "." : this.Config.DocumentationOutputFolder);
                 void onDocException(Exception ex) => this.LogAndUpdate(ref this.CompilationStatus.Documentation, ex);
-                var docsGenerated = this.VerifiedCompilation != null && DocBuilder.Run(docsFolder, this.VerifiedCompilation.SyntaxTree.Values, onException: onDocException);
+                var docsGenerated = this.VerifiedCompilation != null && DocBuilder.Run(docsFolder, this.VerifiedCompilation.SyntaxTree.Values, this.VerifiedCompilation.SourceFiles, onException: onDocException);
                 if (!docsGenerated) this.LogAndUpdate(ref this.CompilationStatus.Documentation, ErrorCode.DocGenerationFailed, Enumerable.Empty<string>());
             }
 

--- a/src/QsCompiler/Compiler/CompilationLoader.cs
+++ b/src/QsCompiler/Compiler/CompilationLoader.cs
@@ -229,8 +229,7 @@ namespace Microsoft.Quantum.QsCompiler
                 this.CompilationStatus.Documentation = 0;
                 var docsFolder = Path.GetFullPath(String.IsNullOrWhiteSpace(this.Config.DocumentationOutputFolder) ? "." : this.Config.DocumentationOutputFolder);
                 void onDocException(Exception ex) => this.LogAndUpdate(ref this.CompilationStatus.Documentation, ex);
-                var (tree, sources) = (this.VerifiedCompilation?.SyntaxTree?.Values, this.VerifiedCompilation?.SyntaxTree?.Keys);
-                var docsGenerated = this.VerifiedCompilation != null && DocBuilder.Run(docsFolder, tree, sources, onException: onDocException);
+                var docsGenerated = this.VerifiedCompilation != null && DocBuilder.Run(docsFolder, this.VerifiedCompilation.SyntaxTree.Values, onException: onDocException);
                 if (!docsGenerated) this.LogAndUpdate(ref this.CompilationStatus.Documentation, ErrorCode.DocGenerationFailed, Enumerable.Empty<string>());
             }
 

--- a/src/QsCompiler/Tests.Compiler/CommandLineTests.fs
+++ b/src/QsCompiler/Tests.Compiler/CommandLineTests.fs
@@ -46,8 +46,8 @@ let ``valid snippet`` () =
 [<Fact>]
 let ``invalid snippet`` () =
     [|
-        @"-s" 
-        @"let a = " 
+        "-s" 
+        "let a = " 
     |]
     |> testSnippet ReturnCode.COMPILATION_ERRORS
 
@@ -55,16 +55,16 @@ let ``invalid snippet`` () =
 [<Fact>]
 let ``one valid file`` () =
     [|
-        @"-i"
+        "-i"
         ("TestFiles","test-00.qs") |> Path.Combine
-        @"-v"
+        "-v"
     |]
     |> testInput ReturnCode.SUCCESS
     
 [<Fact>]
 let ``multiple valid file`` () =
     [|
-        @"--input" 
+        "--input" 
         ("TestFiles","test-00.qs") |> Path.Combine
         ("TestFiles","test-01.qs") |> Path.Combine
     |]
@@ -74,7 +74,7 @@ let ``multiple valid file`` () =
 [<Fact>]
 let ``one invalid file`` () =
     [|
-        @"-i" 
+        "-i" 
         ("TestFiles","test-02.qs") |> Path.Combine
     |]
     |> testInput ReturnCode.COMPILATION_ERRORS
@@ -83,7 +83,7 @@ let ``one invalid file`` () =
 [<Fact>]
 let ``mixed files`` () =
     [|
-        @"-i" 
+        "-i" 
         ("TestFiles","test-01.qs") |> Path.Combine
         ("TestFiles","test-02.qs") |> Path.Combine
     |]
@@ -93,13 +93,13 @@ let ``mixed files`` () =
 [<Fact>]
 let ``missing file`` () =
     [|
-        @"-i"
+        "-i"
         ("TestFiles","foo-00.qs") |> Path.Combine
     |]
     |> testInput ReturnCode.UNRESOLVED_FILES
     
     [|
-        @"-i"
+        "-i"
         ("TestFiles","test-01.qs") |> Path.Combine
         ("TestFiles","foo-00.qs") |> Path.Combine
     |]
@@ -109,9 +109,9 @@ let ``missing file`` () =
 [<Fact>]
 let ``invalid argument`` () =
     [|
-        @"-i"
+        "-i"
         ("TestFiles","test-00.qs") |> Path.Combine
-        @"--foo"
+        "--foo"
     |]
     |> testInput ReturnCode.INVALID_ARGUMENTS
         
@@ -120,7 +120,7 @@ let ``invalid argument`` () =
 let ``missing verb`` () =
     let args = 
         [|
-            @"-i"
+            "-i"
             ("TestFiles","test-00.qs") |> Path.Combine
         |]        
     let result = Program.Main args
@@ -131,8 +131,8 @@ let ``missing verb`` () =
 let ``invalid verb`` () =
     let args = 
         [|
-            @"foo"
-            @"-i"
+            "foo"
+            "-i"
             ("TestFiles","test-00.qs") |> Path.Combine
         |]
     let result = Program.Main args
@@ -143,7 +143,7 @@ let ``invalid verb`` () =
 let ``diagnose outputs`` () =
     let args = 
         [|
-            @"-i"
+            "-i"
             ("TestFiles","test-00.qs") |> Path.Combine
             "--tree"
             "--tokenization"
@@ -152,6 +152,32 @@ let ``diagnose outputs`` () =
         |]        
     let result = Program.Main args
     Assert.Equal(ReturnCode.INVALID_ARGUMENTS, result)
+
+
+[<Fact>]
+let ``generate docs`` () =
+    let docsFolder = ("TestFiles", "docs.Out") |> Path.Combine
+    for file in Directory.GetFiles docsFolder do
+        File.Delete file
+
+    let toc = Path.Combine (docsFolder, "toc.yml") 
+    let nsDoc = Path.Combine (docsFolder, "Compiler.Tests.yml")
+    let opDoc = Path.Combine (docsFolder, "compiler.tests.test01.yml")
+    let existsAndNotEmpty fileName = fileName |> File.Exists && not (File.ReadAllText fileName |> String.IsNullOrWhiteSpace)
+    let args = 
+        [|
+            "build"
+            "--input" 
+            ("TestFiles","test-01.qs") |> Path.Combine
+            "--doc"
+            docsFolder
+        |]
+
+    let result = Program.Main args
+    Assert.Equal(ReturnCode.SUCCESS, result) 
+    Assert.True (existsAndNotEmpty toc)
+    Assert.True (existsAndNotEmpty nsDoc)
+    Assert.True (existsAndNotEmpty opDoc)
 
     
 [<Fact>]

--- a/src/QsCompiler/Tests.Compiler/CommandLineTests.fs
+++ b/src/QsCompiler/Tests.Compiler/CommandLineTests.fs
@@ -157,8 +157,9 @@ let ``diagnose outputs`` () =
 [<Fact>]
 let ``generate docs`` () =
     let docsFolder = ("TestFiles", "docs.Out") |> Path.Combine
-    for file in Directory.GetFiles docsFolder do
-        File.Delete file
+    if (Directory.Exists docsFolder) then
+        for file in Directory.GetFiles docsFolder do
+            File.Delete file
 
     let toc = Path.Combine (docsFolder, "toc.yml") 
     let nsDoc = Path.Combine (docsFolder, "Compiler.Tests.yml")

--- a/src/QsCompiler/Tests.Compiler/TestFiles/test-01.qs
+++ b/src/QsCompiler/Tests.Compiler/TestFiles/test-01.qs
@@ -3,5 +3,7 @@
 
 namespace Compiler.Tests
 {
-	operation test01() : () { body intrinsic; }
+	/// # Summary
+	/// Test operation. 
+	operation Test01() : Unit { body intrinsic; }
 }


### PR DESCRIPTION
Doc gen is looking at all files in the doc gen folder upon generation of the namespace documentation. Hence, running docs generation without cleaning the doc gen folder prior to execution causes a failure. 
Let's have a chat on if/how we want to address that. 