### PR TITLE
Build VS Code dependencies from either pwsh or powershell.

### DIFF
--- a/src/VSCodeExtension/Build-Dependencies.ps1
+++ b/src/VSCodeExtension/Build-Dependencies.ps1
@@ -59,9 +59,9 @@ if (
 if (Get-Item -Path $binDir -ErrorAction SilentlyContinue) {
     Remove-Item -Recurse -Force $binDir
 }
-mkdir -Path $binDir | Out-Null
-Copy-Item -Recurse -Path (Join-Path $PublishRoot "*") -Destination $binDir -Verbose
+New-Item -Type Directory -Force -Path $binDir | Out-Null
+Copy-Item -Force -Recurse -Path (Join-Path $PublishRoot "*") -Destination $binDir -Verbose
 
 # Copy the third party notice
 Write-Host "$(Join-Path $RepoRoot "NOTICE.txt")"
-Copy-Item -Path (Join-Path $RepoRoot "NOTICE.txt") -Destination $PSScriptRoot -Verbose
+Copy-Item -Force -Path (Join-Path $RepoRoot "NOTICE.txt") -Destination $PSScriptRoot -Verbose

--- a/src/VSCodeExtension/builddeps.js
+++ b/src/VSCodeExtension/builddeps.js
@@ -1,0 +1,28 @@
+#!/usr/bin/env node
+// This file is needed to detect whether PowerShell is provided
+// as `powershell` (Windows PowerShell, version 5.1 and earlier),
+// or as `pwsh` (PowerShell Core, version 6, or PowerShell, version
+// 7 and later).
+// That detection is a little more complicated than can be done with
+// the intersection of /bin/sh and cmd.exe that is supported by the
+// scripts key of the package.json spec, so we resolve that with a small
+// node file instead.
+// Note that this file does not use TypeScript, as the tsc command is not
+// yet available at this point.
+
+// IMPORTS ///////////////////////////////////////////////////////////////////
+
+const which = require('which');
+const { spawn } = require('child_process');
+
+// MAIN //////////////////////////////////////////////////////////////////////
+
+let powershell = which.sync('pwsh', {nothrow: true});
+if (powershell == null) {
+    powershell = which.sync('powershell');
+}
+console.log("Using PowerShell executable", powershell);
+
+spawn(powershell, ["-NoProfile", "-File", "Build-Dependencies.ps1"], {
+    stdio: ['inherit', 'inherit', 'inherit']
+})

--- a/src/VSCodeExtension/package.json.v.template
+++ b/src/VSCodeExtension/package.json.v.template
@@ -73,7 +73,7 @@
     },
     "scripts": {
         "vscode:prepublish": "npm install && npm run compile && npm run builddeps",
-        "builddeps": "powershell -NoProfile ./Build-Dependencies.ps1",
+        "builddeps": "builddeps",
         "compile": "tsc -p ./",
         "watch": "tsc -watch -p ./",
         "postinstall": "node ./node_modules/vscode/bin/install",

--- a/src/VSCodeExtension/package.json.v.template
+++ b/src/VSCodeExtension/package.json.v.template
@@ -73,7 +73,7 @@
     },
     "scripts": {
         "vscode:prepublish": "npm install && npm run compile && npm run builddeps",
-        "builddeps": "builddeps",
+        "builddeps": "node builddeps.js",
         "compile": "tsc -p ./",
         "watch": "tsc -watch -p ./",
         "postinstall": "node ./node_modules/vscode/bin/install",


### PR DESCRIPTION
This PR should fix #58 by using a small node.js script (since that is already required for VS Code extension development) to detect whether PowerShell Core or Windows PowerShell is being used.