### PR TITLE
Add install template and new project commands to VS Code extension.

### DIFF
--- a/src/VSCodeExtension/package.json.v.template
+++ b/src/VSCodeExtension/package.json.v.template
@@ -28,7 +28,8 @@
         "onLanguage:qsharp",
         "onCommand:quantum.installTemplates",
         "onCommand:quantum.newProject",
-        "onCommand:quantum.openDocumentation"
+        "onCommand:quantum.openDocumentation",
+        "onCommand:quantum.installIQSharp"
     ],
     "main": "./out/extension",
     "contributes": {
@@ -37,15 +38,20 @@
                 "command": "quantum.installTemplates",
                 "title": "Q#: Install project templates"
             },
-            
+
             {
                 "command": "quantum.newProject",
                 "title": "Q#: Create new project..."
             },
-            
+
             {
                 "command": "quantum.openDocumentation",
                 "title": "Q#: Go to Quantum Development Kit documentation"
+            },
+
+            {
+                "command": "quantum.installIQSharp",
+                "title": "Q#: Install IQ#"
             }
         ],
         "languages": [

--- a/src/VSCodeExtension/package.json.v.template
+++ b/src/VSCodeExtension/package.json.v.template
@@ -105,12 +105,13 @@
         "test": "npm run compile && node ./node_modules/vscode/bin/test"
     },
     "dependencies": {
-        "vscode-languageclient": "5.1.0",
         "portfinder": "1.0.13",
-        "which": "1.3.1",
-        "vscode-extension-telemetry": "0.0.18",
+        "semver": "^6.0.0",
         "tmp": "0.0.33",
-        "semver": "^6.0.0"
+        "ts-optchain": "^0.1.7",
+        "vscode-extension-telemetry": "0.0.18",
+        "vscode-languageclient": "5.1.0",
+        "which": "1.3.1"
     },
     "devDependencies": {
         "vscode": "^1.1.34",
@@ -125,5 +126,6 @@
     },
     "aiKey": "AIF-d9b70cd4-b9f9-4d70-929b-a071c400b217",
     "requiredDotNetCoreSDK": "2.1.0",
-    "enableTelemetry" : #ENABLE_TELEMETRY#
+    "enableTelemetry" : #ENABLE_TELEMETRY#,
+    "nugetVersion": "#NUGET_VERSION#"
 }

--- a/src/VSCodeExtension/package.json.v.template
+++ b/src/VSCodeExtension/package.json.v.template
@@ -27,7 +27,8 @@
     "activationEvents": [
         "onLanguage:qsharp",
         "onCommand:quantum.installTemplates",
-        "onCommand:quantum.newProject"
+        "onCommand:quantum.newProject",
+        "onCommand:quantum.openDocumentation"
     ],
     "main": "./out/extension",
     "contributes": {
@@ -39,7 +40,12 @@
             
             {
                 "command": "quantum.newProject",
-                "title": "Q#: Create new project"
+                "title": "Q#: Create new project..."
+            },
+            
+            {
+                "command": "quantum.openDocumentation",
+                "title": "Q#: Go to Quantum Development Kit documentation"
             }
         ],
         "languages": [

--- a/src/VSCodeExtension/package.json.v.template
+++ b/src/VSCodeExtension/package.json.v.template
@@ -25,10 +25,23 @@
     ],
     "qna": "https://github.com/microsoft/qsharp-compiler",
     "activationEvents": [
-        "onLanguage:qsharp"
+        "onLanguage:qsharp",
+        "onCommand:quantum.installTemplates",
+        "onCommand:quantum.newProject"
     ],
     "main": "./out/extension",
     "contributes": {
+        "commands": [
+            {
+                "command": "quantum.installTemplates",
+                "title": "Q#: Install project templates"
+            },
+            
+            {
+                "command": "quantum.newProject",
+                "title": "Q#: Create new project"
+            }
+        ],
         "languages": [
             {
                 "id": "qsharp",

--- a/src/VSCodeExtension/src/commands.ts
+++ b/src/VSCodeExtension/src/commands.ts
@@ -1,0 +1,133 @@
+'use strict';
+import * as vscode from 'vscode';
+import * as cp from 'child_process';
+
+import { DotnetInfo } from './dotnet';
+import { IPackageInfo } from './packageInfo';
+import { sendTelemetryEvent, EventNames } from './telemetry';
+
+export function registerCommand(context: vscode.ExtensionContext, name: string, action: () => void) {
+    context.subscriptions.push(
+        vscode.commands.registerCommand(
+            name,
+            () => {
+                sendTelemetryEvent(
+                    EventNames.commandExecuted,
+                    {
+                        commandName: name
+                    },
+                    {}
+                )
+                action();
+            }
+        )
+    )
+}
+
+export function createNewProject(dotNetSdk: DotnetInfo) {    
+    const projectTypes: {[key: string]: string} = {
+        "Standalone console application": "console",
+        "Quantum library": "classlib",
+        "Unit testing project": "xunit"
+    };
+    let errorMessage = "";
+    vscode.window.showQuickPick(
+        Object.keys(projectTypes)
+    ).then(
+        projectTypeSelection => {
+            if (projectTypeSelection === undefined) {
+                throw undefined;
+            }
+            let projectType = projectTypes[projectTypeSelection];
+            
+            vscode.window.showSaveDialog({
+                saveLabel: "Create Project"
+            }).then(
+                (uri) => {
+                    if (uri !== undefined) {
+                        if (uri.scheme !== "file") {
+                            vscode.window.showErrorMessage(
+                                "New projects must be saved to the filesystem."
+                            );
+                            throw new Error("URI scheme was not file.");
+                        }
+                        else {
+                            return uri;
+                        }
+                    } else {
+                        throw undefined;
+                    }
+                }
+            )
+            .then(uri => {
+                let proc = cp.spawn(
+                    dotNetSdk.path,
+                    ["new", projectType, "-lang", "Q#", "-o", uri.fsPath]
+                );
+                proc.stderr.on('data', data => {
+                    errorMessage = errorMessage + data;
+                });
+                proc.on(
+                    'exit', (code, signal) => {
+                        if (code === 0) {
+                            const openItem = "Open new project...";
+                            vscode.window.showInformationMessage(
+                                `Successfully created new project at ${uri.fsPath}.`,
+                                openItem
+                            ).then(
+                                (item) => {
+                                    if (item === openItem) {
+                                        vscode.commands.executeCommand(
+                                            "vscode.openFolder",
+                                            uri
+                                        ).then(
+                                            (value) => {},
+                                            (value) => {
+                                                vscode.window.showErrorMessage("Could not open new project");
+                                            }
+                                        );
+                                    }
+                                }
+                            );
+                        } else {
+                            vscode.window.showErrorMessage(
+                                `.NET Core SDK exited with code ${code} when creating a new project:\n${errorMessage}`
+                            );
+                        }
+                    }
+                );
+            });
+        }
+    );
+}
+
+export function installTemplates(dotNetSdk: DotnetInfo, packageInfo ?: IPackageInfo) {
+    let packageVersion = 
+        packageInfo === undefined
+        ? ""
+        : `::${packageInfo.version}`;
+    let errorMessage = "";
+    let proc = cp.spawn(
+        dotNetSdk.path,
+        ["new", "--install", `Microsoft.Quantum.ProjectTemplates${packageVersion}`]
+    );
+    proc.stderr.on(
+        'data', data => {
+            errorMessage = errorMessage + data;
+        }
+    );
+    proc.on(
+        'exit',
+        (code, signal) => {
+            if (code === 0) {
+                vscode.window.showInformationMessage(
+                    "Project templates installed successfully."
+                );
+            } else {
+                vscode.window.showErrorMessage(
+                    `.NET Core SDK exited with code ${code} when installing project templates:\n${errorMessage}`
+                );
+            }
+        }
+    );
+}

--- a/src/VSCodeExtension/src/commands.ts
+++ b/src/VSCodeExtension/src/commands.ts
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 'use strict';
 import * as vscode from 'vscode';
 import * as cp from 'child_process';

--- a/src/VSCodeExtension/src/commands.ts
+++ b/src/VSCodeExtension/src/commands.ts
@@ -59,7 +59,7 @@ function createNewProjectAtUri(dotNetSdk: DotnetInfo, projectType: string, uri: 
                 // Check if the problem was that the project templates are missing.
                 // If so, we can give a more helpful error message and offer the
                 // user to install templates.
-                if (errorMessage.includes("'Q#' is not a valid value for -lang")) {
+                if (errorMessage.includes("Q#") && errorMessage.includes("-lang")) {
                     const installTemplatesItem = "Install project templates and retry";
                     vscode.window.showErrorMessage(
                         "Project creation failed, as the Q# project templates not installed.",

--- a/src/VSCodeExtension/src/commands.ts
+++ b/src/VSCodeExtension/src/commands.ts
@@ -62,7 +62,7 @@ function createNewProjectAtUri(dotNetSdk: DotnetInfo, projectType: string, uri: 
                 if (errorMessage.includes("Q#") && errorMessage.includes("-lang")) {
                     const installTemplatesItem = "Install project templates and retry";
                     vscode.window.showErrorMessage(
-                        "Project creation failed, as the Q# project templates not installed.",
+                        "Project creation failed. The Q# project templates may not be installed.",
                         installTemplatesItem
                     )
                     .then(

--- a/src/VSCodeExtension/src/commands.ts
+++ b/src/VSCodeExtension/src/commands.ts
@@ -9,6 +9,7 @@ import { DotnetInfo, findIQSharpVersion } from './dotnet';
 import { IPackageInfo } from './packageInfo';
 import * as semver from 'semver';
 import { promisify } from 'util';
+import { oc } from 'ts-optchain';
 
 export function registerCommand(context: vscode.ExtensionContext, name: string, action: () => void) {
     context.subscriptions.push(
@@ -98,11 +99,11 @@ export function createNewProject(dotNetSdk: DotnetInfo) {
     );
 }
 
-export function installTemplates(dotNetSdk: DotnetInfo, packageInfo ?: IPackageInfo) {
+export function installTemplates(dotNetSdk: DotnetInfo, packageInfo?: IPackageInfo) {
     let packageVersion =
-        packageInfo === undefined
-        ? ""
-        : `::${packageInfo.version}`;
+        oc(packageInfo).nugetVersion
+        ? `::${oc(packageInfo).nugetVersion}`
+        : "";
     let errorMessage = "";
     let proc = cp.spawn(
         dotNetSdk.path,

--- a/src/VSCodeExtension/src/commands.ts
+++ b/src/VSCodeExtension/src/commands.ts
@@ -4,20 +4,12 @@ import * as cp from 'child_process';
 
 import { DotnetInfo } from './dotnet';
 import { IPackageInfo } from './packageInfo';
-import { sendTelemetryEvent, EventNames } from './telemetry';
 
 export function registerCommand(context: vscode.ExtensionContext, name: string, action: () => void) {
     context.subscriptions.push(
         vscode.commands.registerCommand(
             name,
             () => {
-                sendTelemetryEvent(
-                    EventNames.commandExecuted,
-                    {
-                        commandName: name
-                    },
-                    {}
-                )
                 action();
             }
         )

--- a/src/VSCodeExtension/src/commands.ts
+++ b/src/VSCodeExtension/src/commands.ts
@@ -131,3 +131,9 @@ export function installTemplates(dotNetSdk: DotnetInfo, packageInfo ?: IPackageI
         }
     );
 }
+
+export function openDocumentationHome() {
+    return vscode.env.openExternal(
+        vscode.Uri.parse("https://docs.microsoft.com/quantum/")
+    );
+}

--- a/src/VSCodeExtension/src/extension.ts
+++ b/src/VSCodeExtension/src/extension.ts
@@ -245,6 +245,7 @@ export function activate(context: vscode.ExtensionContext) {
                                     );
 
                                 }
+                                // TODO: show quick pick between console, library, and tests.
                                 cp.spawn(
                                     dotNetSdk.path,
                                     ["new", "console", "-lang", "Q#", "-o", uri.fsPath]

--- a/src/VSCodeExtension/src/extension.ts
+++ b/src/VSCodeExtension/src/extension.ts
@@ -19,7 +19,7 @@ import { ChildProcess } from 'child_process';
 import { startTelemetry, EventNames, sendTelemetryEvent, reporter, ErrorSeverities, forwardServerTelemetry } from './telemetry';
 import { DotnetInfo, requireDotNetSdk } from './dotnet';
 import { getPackageInfo } from './packageInfo';
-import { installTemplates, createNewProject, registerCommand } from './commands';
+import { installTemplates, createNewProject, registerCommand, openDocumentationHome } from './commands';
 
 const extensionStartedAt = Date.now();
 
@@ -208,6 +208,12 @@ export function activate(context: vscode.ExtensionContext) {
                 dotNetSdk => installTemplates(dotNetSdk, packageInfo)
             );
         }
+    );
+
+    registerCommand(
+        context,
+        "quantum.openDocumentation",
+        openDocumentationHome
     );
 
     let rootFolder = findRootFolder();

--- a/src/VSCodeExtension/src/extension.ts
+++ b/src/VSCodeExtension/src/extension.ts
@@ -19,7 +19,7 @@ import { ChildProcess } from 'child_process';
 import { startTelemetry, EventNames, sendTelemetryEvent, reporter, ErrorSeverities, forwardServerTelemetry } from './telemetry';
 import { DotnetInfo, requireDotNetSdk } from './dotnet';
 import { getPackageInfo } from './packageInfo';
-import { installTemplates, createNewProject, registerCommand, openDocumentationHome } from './commands';
+import { installTemplates, createNewProject, registerCommand, openDocumentationHome, installOrUpdateIQSharp } from './commands';
 
 const extensionStartedAt = Date.now();
 
@@ -214,6 +214,19 @@ export function activate(context: vscode.ExtensionContext) {
         context,
         "quantum.openDocumentation",
         openDocumentationHome
+    );
+
+    registerCommand(
+        context,
+        "quantum.installIQSharp",
+        () => {
+            requireDotNetSdk(dotNetSdkVersion).then(
+                dotNetSdk => installOrUpdateIQSharp(
+                    dotNetSdk
+                    // TODO: pass a required version here.
+                )
+            );
+        }
     );
 
     let rootFolder = findRootFolder();

--- a/src/VSCodeExtension/src/extension.ts
+++ b/src/VSCodeExtension/src/extension.ts
@@ -222,8 +222,8 @@ export async function activate(context: vscode.ExtensionContext) {
         () => {
             requireDotNetSdk(dotNetSdkVersion).then(
                 dotNetSdk => installOrUpdateIQSharp(
-                    dotNetSdk
-                    // TODO: pass a required version here.
+                    dotNetSdk,
+                    packageInfo ? packageInfo.nugetVersion : undefined
                 )
             );
         }

--- a/src/VSCodeExtension/src/packageInfo.ts
+++ b/src/VSCodeExtension/src/packageInfo.ts
@@ -15,6 +15,7 @@ export interface IPackageInfo {
     aiKey: string;
     requiredDotNetCoreSDK: string;
     enableTelemetry: string;
+    nugetVersion?: string;
 }
 
 export function getPackageInfo(context: vscode.ExtensionContext): IPackageInfo | undefined {
@@ -25,7 +26,8 @@ export function getPackageInfo(context: vscode.ExtensionContext): IPackageInfo |
             version: extensionPackage.version,
             aiKey: extensionPackage.aiKey,
             requiredDotNetCoreSDK: extensionPackage.requiredDotNetCoreSDK,
-            enableTelemetry: extensionPackage.enableTelemetry
+            enableTelemetry: extensionPackage.enableTelemetry,
+            nugetVersion: extensionPackage.nugetVersion
         };
     }
     return;

--- a/src/VSCodeExtension/src/telemetry.ts
+++ b/src/VSCodeExtension/src/telemetry.ts
@@ -29,6 +29,7 @@ export namespace EventNames {
     export const lspReady = "lsp-ready";
     export const lspStopped = "lsp-stopped";
     export const error = "error";
+    export const commandExecuted = "command-executed";
 }
 
 // @ts-ignore

--- a/src/VSCodeExtension/src/telemetry.ts
+++ b/src/VSCodeExtension/src/telemetry.ts
@@ -29,7 +29,6 @@ export namespace EventNames {
     export const lspReady = "lsp-ready";
     export const lspStopped = "lsp-stopped";
     export const error = "error";
-    export const commandExecuted = "command-executed";
 }
 
 // @ts-ignore


### PR DESCRIPTION
This PR adds two new commands to the VS Code extension:

![image](https://user-images.githubusercontent.com/31516/61767096-ed097e00-ad97-11e9-9c63-8f01f655bff4.png)

Still TODO:
- [x] Prompt user what kind of Q# project they want to make.