### PR TITLE
Parsing for Q# Attributes

### DIFF
--- a/src/QsCompiler/DataStructures/Diagnostics.fs
+++ b/src/QsCompiler/DataStructures/Diagnostics.fs
@@ -66,6 +66,7 @@ type ErrorCode =
     | InvalidOperationCharacteristics = 3115
     | MissingOperationCharacteristics = 3116
     | ExpectingUpdateExpression = 3117
+    | InvalidAttribute = 3118
 
     | InvalidIdentifierDeclaration = 3201
     | MissingIdentifierDeclaration = 3202
@@ -103,6 +104,8 @@ type ErrorCode =
     | MissingUdtItemDeclaration = 3234
     | InvalidUdtItemNameDeclaration = 3235
     | MissingUdtItemNameDeclaration = 3236
+    | MissingClosingAttributeSign = 3237
+    | MissingAttributeArgs = 3238
 
     | EmptyValueArray = 3300 
     | InvalidValueArray = 3301
@@ -134,6 +137,7 @@ type ErrorCode =
     | InvertControlledGenerator = 4110
     | ControlledGenArgMismatch = 4111
     | ControlledAdjointGenArgMismatch = 4112
+    | MissingFollowingDeclaration = 4113
 
     | MissingExprInArray = 5001
     | MultipleTypesInArray = 5002
@@ -356,6 +360,7 @@ type DiagnosticItem =
             | ErrorCode.ExcessContinuation                      -> "Unexpected code fragment."
             | ErrorCode.NonCallExprAsStatement                  -> "An expression used as a statement must be a call expression."
                                                             
+            | ErrorCode.InvalidAttribute                        -> "Syntax error in attribute."
             | ErrorCode.InvalidExpression                       -> "Syntax error in expression."
             | ErrorCode.MissingExpression                       -> "Expecting expression."
             | ErrorCode.InvalidIdentifierName                   -> "Identifiers need to start with an ASCII letter or an underscore, and need to contain at least one non-underscore character."
@@ -441,7 +446,10 @@ type DiagnosticItem =
             | ErrorCode.InvertControlledGenerator               -> "Invalid generator for controlled specialization. Valid generators are \"distributed\" and \"auto\"."
             | ErrorCode.ControlledGenArgMismatch                -> "The argument to a user-defined controlled specialization must must be of the form \"(ctlQsName, ...)\"."
             | ErrorCode.ControlledAdjointGenArgMismatch         -> "The argument to a user-defined controlled-adjoint specialization must must be of the form \"(ctlQsName, ...)\"."
-                                                            
+            | ErrorCode.MissingFollowingDeclaration             -> "The attribute must be above another attribute, a type definition, an operator declaration, or a function declaration."
+            | ErrorCode.MissingClosingAttributeSign             -> "Missing closing sign for attribute, did you mean to type @ ?"
+            | ErrorCode.MissingAttributeArgs                    -> "Missing arguments for specified attribute."
+
             | ErrorCode.MissingExprInArray                      -> "Underscores cannot be used to denote missing array elements."
             | ErrorCode.MultipleTypesInArray                    -> "Array items must have a common base type."
             | ErrorCode.InvalidArrayItemIndex                   -> "Expecting an expression of type Int or Range. Got an expression of type {0}."

--- a/src/QsCompiler/DataStructures/SyntaxTokens.fs
+++ b/src/QsCompiler/DataStructures/SyntaxTokens.fs
@@ -212,6 +212,7 @@ type QsFragmentKind =
 | AdjointDeclaration            of QsSpecializationGenerator
 | ControlledDeclaration         of QsSpecializationGenerator
 | ControlledAdjointDeclaration  of QsSpecializationGenerator
+| AttributeDeclaration          of QsExpression * QsExpression
 | OperationDeclaration          of QsSymbol * CallableSignature
 | FunctionDeclaration           of QsSymbol * CallableSignature
 | TypeDefinition                of QsSymbol * QsTuple<QsSymbol * QsType>
@@ -223,7 +224,8 @@ with
     /// returns the error code for an invalid fragment of the given kind
     member this.ErrorCode = 
         match this with
-        | ExpressionStatement          _ -> ErrorCode.InvalidExpressionStatement             
+        | ExpressionStatement          _ -> ErrorCode.InvalidExpressionStatement    
+        | AttributeDeclaration         _ -> ErrorCode.InvalidAttribute
         | ReturnStatement              _ -> ErrorCode.InvalidReturnStatement             
         | FailStatement                _ -> ErrorCode.InvalidFailStatement               
         | ImmutableBinding             _ -> ErrorCode.InvalidImmutableBinding                 
@@ -252,6 +254,7 @@ with
     /// returns the error code for an invalid fragment ending on the given kind
     member this.InvalidEnding = 
         match this with
+        | AttributeDeclaration           _ -> ErrorCode.UnexpectedFragmentDelimiter
         | ExpressionStatement            _ 
         | ReturnStatement                _ 
         | FailStatement                  _ 

--- a/src/QsCompiler/SyntaxProcessor/SyntaxExtensions.fs
+++ b/src/QsCompiler/SyntaxProcessor/SyntaxExtensions.fs
@@ -147,7 +147,8 @@ type SymbolInformation = {
 [<Extension>]
 let public SymbolInformation fragmentKind = 
     let chooseValues = QsNullable<_>.Choose id >> Seq.toArray
-    fragmentKind |> function
+    fragmentKind |> function          
+    | QsFragmentKind.AttributeDeclaration              _ -> [||],                      ([||], [||], [||]) 
     | QsFragmentKind.ExpressionStatement              ex -> [||],                      ([ex]     , [])          |> collectWith SymbolsFromExpr
     | QsFragmentKind.ReturnStatement                  ex -> [||],                      ([ex]     , [])          |> collectWith SymbolsFromExpr
     | QsFragmentKind.FailStatement                    ex -> [||],                      ([ex]     , [])          |> collectWith SymbolsFromExpr

--- a/src/QsCompiler/TextProcessor/QsExpressionParsing.fs
+++ b/src/QsCompiler/TextProcessor/QsExpressionParsing.fs
@@ -354,6 +354,13 @@ let internal callLikeExpr =
     attempt ((itemAccessExpr <|> identifier <|> tupledItem expr) .>>. argumentTuple) // identifier needs to come *after* arrayItemExpr
     |>> fun (callable, arg) -> applyBinary CallLikeExpression () callable arg
 
+/// Parses a Q# attribute identifier (separated from arguments to better handle errors)
+let internal attributeId =
+    attempt identifier
+
+/// Parses Q# attribute arguments
+let internal attributeArgs =
+    attempt argumentTuple
 
 // processing terms of operator precedence parsers
 

--- a/src/QsCompiler/TextProcessor/QsFragmentParsing.fs
+++ b/src/QsCompiler/TextProcessor/QsFragmentParsing.fs
@@ -238,6 +238,9 @@ and private namespaceDeclaration =
     let invalid = NamespaceDeclaration invalidSymbol
     buildFragment namespaceDeclHeader.parse (expectedNamespaceName eof) invalid NamespaceDeclaration
 
+/// Uses buildAttribute to parse a Q# AttributeDeclaration as a QsFragment.
+and private attributeDeclaration = 
+    buildAttribute attributeId attributeArgs AttributeDeclaration
 
 // operation and function parsing
 
@@ -442,7 +445,8 @@ let private expressionStatement =
 let internal codeFragment =
     let validFragment = 
         choice (getFragments() |> List.map snd)
-        <|> expressionStatement // the expressionStatement needs to be last
+        <|> attributeDeclaration
+        <|> expressionStatement// the expressionStatement needs to be last
     let invalidFragment = 
         let valid = fun _ -> InvalidFragment
         buildFragment (preturn ()) (fail "invalid syntax") InvalidFragment valid


### PR DESCRIPTION
Adds support for parsing the syntax of attributes. Includes some specific error handling for if the ending tag is missing on an attribute or the arguments are missing for an attribute, as well as context verification so that the attribute is only above an operation, function, or type definition.

Making this a draft pull request until a feature branch exists for attributes.

Targets #81 


