### PR TITLE
Add code action for updating deprecated operation characteristics syntax

### DIFF
--- a/src/QsCompiler/CompilationManager/DiagnosticTools.cs
+++ b/src/QsCompiler/CompilationManager/DiagnosticTools.cs
@@ -194,7 +194,16 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         internal static Func<Diagnostic, bool> ErrorType(params ErrorCode[] types)
         {
             var codes = types.Select(err => err.Code());
-            return m => m.Severity == DiagnosticSeverity.Error && codes.Contains(m.Code);
+            return m => m.IsError() && codes.Contains(m.Code);
+        }
+
+        /// <summary>
+        /// Returns a function that returns true if the WarningType of the given Diagnostic is one of the given types.
+        /// </summary>
+        internal static Func<Diagnostic, bool> WarningType(params WarningCode[] types)
+        {
+            var codes = types.Select(warn => warn.Code());
+            return m => m.IsWarning() && codes.Contains(m.Code);
         }
 
         /// <summary>

--- a/src/QsCompiler/CompilationManager/DiagnosticTools.cs
+++ b/src/QsCompiler/CompilationManager/DiagnosticTools.cs
@@ -71,6 +71,21 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         }
 
         /// <summary>
+        /// Returns true if this range overlaps the given range.
+        /// </summary>
+        internal static bool Overlaps(this Range range1, Range range2)
+        {
+            Range first, second;
+            if (range1.Start.Line < range2.Start.Line && range1.Start.Character < range2.Start.Character)
+                (first, second) = (range1, range2);
+            else
+                (first, second) = (range2, range1);
+            return
+                first.End.Line > second.Start.Line ||
+                first.End.Line == second.Start.Line && first.End.Character > second.Start.Character;
+        }
+
+        /// <summary>
         /// Given the location information for a declared symbol,
         /// as well as the position of the declaration within which the symbol is declared, 
         /// returns the zero-based line and character index indicating the position of the symbol in the file.

--- a/src/QsCompiler/CompilationManager/DiagnosticTools.cs
+++ b/src/QsCompiler/CompilationManager/DiagnosticTools.cs
@@ -76,7 +76,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         internal static bool Overlaps(this Range range1, Range range2)
         {
             Range first, second;
-            if (range1.Start.Line < range2.Start.Line && range1.Start.Character < range2.Start.Character)
+            if (range1.Start.Line <= range2.Start.Line && range1.Start.Character <= range2.Start.Character)
                 (first, second) = (range1, range2);
             else
                 (first, second) = (range2, range1);

--- a/src/QsCompiler/CompilationManager/EditorSupport.cs
+++ b/src/QsCompiler/CompilationManager/EditorSupport.cs
@@ -377,7 +377,9 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
             {
                 var fragment = file.TryGetFragmentAt(diagnostic.Range.Start);
                 QsTuple<Tuple<QsSymbol, QsType>> argument;
-                if (fragment.Kind is QsFragmentKind.OperationDeclaration operation)
+                if (fragment.Kind is QsFragmentKind.FunctionDeclaration function)
+                    argument = function.Item2.Argument;
+                else if (fragment.Kind is QsFragmentKind.OperationDeclaration operation)
                     argument = operation.Item2.Argument;
                 else if (fragment.Kind is QsFragmentKind.TypeDefinition type)
                     argument = type.Item2;

--- a/src/QsCompiler/DataStructures/SymbolResolution.fs
+++ b/src/QsCompiler/DataStructures/SymbolResolution.fs
@@ -57,12 +57,12 @@ type SpecializationBundleProperties = internal {
             (fun group -> group.ToImmutableDictionary(getKind)))
 
 
-module private SymbolResolution = 
+module SymbolResolution = 
 
     // routines for resolving types and signatures
 
     /// helper function for ResolveType and ResolveCallableSignature
-    let rec private ResolveCharacteristics (ex : Characteristics) = // needs to preserve set parameters
+    let rec ResolveCharacteristics (ex : Characteristics) = // needs to preserve set parameters
         match ex.Characteristics with
         | EmptySet -> ResolvedCharacteristics.Empty
         | SimpleSet s -> SimpleSet s |> ResolvedCharacteristics.New 

--- a/src/QsCompiler/DataStructures/SyntaxExtensions.fs
+++ b/src/QsCompiler/DataStructures/SyntaxExtensions.fs
@@ -345,3 +345,21 @@ let GlobalCallableResolutions (syntaxTree : IEnumerable<QsNamespace>) =
         | _ -> None))
     callables.ToImmutableDictionary(fst, snd)
     
+/// Returns all of the operation characteristics found in the given type.
+[<Extension>]
+let rec GetCharacteristicsInType (qsType : QsType) =
+    match qsType.Type with
+    | ArrayType arrayType -> GetCharacteristicsInType arrayType
+    | TupleType types -> types.SelectMany GetCharacteristicsInType
+    | SyntaxTokens.Operation ((input, output), characteristics) ->
+        (GetCharacteristicsInType input).Concat(GetCharacteristicsInType output).Append(characteristics)
+    | SyntaxTokens.Function (input, output) ->
+        (GetCharacteristicsInType input).Concat(GetCharacteristicsInType output)
+    | _ -> Seq.empty
+
+/// Returns all of the operation characteristics found in the given argument tuple.
+[<Extension>]
+let rec GetCharacteristicsInArgumentTuple (tuple : QsTuple<QsSymbol * QsType>) =
+    match tuple with
+    | QsTupleItem (_, qsType) -> GetCharacteristicsInType qsType
+    | QsTuple items -> items.SelectMany GetCharacteristicsInArgumentTuple


### PR DESCRIPTION
This PR adds a code action for turning the deprecated operation characteristics syntax (`: Adjoint, Controlled`) into the new one (`is Adj + Ctl`). It works in function, operation, and newtype declarations. (I think those are all the places a characteristics type can appear?)

Other changes:
* Added a method for checking if one range overlaps another (I couldn't find an existing one for this, but I might've missed it).
* Made `SymbolResolution.ResolveCharacteristics` public so the characteristics in the code fragment can be resolved (needed for `ExpressionTypeToQs.onCharacteristicsExpression`).