### PR TITLE
Sccarda/loop range simplify code action

### DIFF
--- a/src/QsCompiler/CompilationManager/DataStructures.cs
+++ b/src/QsCompiler/CompilationManager/DataStructures.cs
@@ -220,6 +220,30 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder.DataStructures
                 this.Index = index;
             }
 
+            internal TokenIndex(FileContentManager file, Position position)
+            {
+                this.File = file ?? throw new ArgumentNullException(nameof(file));
+                if (position.Line < 0 || position.Line >= file.NrTokenizedLines()) throw new ArgumentOutOfRangeException(nameof(position));
+
+                this.Line = position.Line;
+
+                int index = -1;
+                var line = file.GetTokenizedLine(position.Line);
+                for (int i = 0; i < line.Count(); i++)
+                {
+                    CodeFragment frag = line[i];
+                    // if the given position is within the fragment
+                    if (frag.GetRange().Start.Character <= position.Character &&
+                        frag.GetRange().End.Character >= position.Character)
+                    {
+                        index = i;
+                        break;
+                    }
+                }
+                if (index < 0) throw new ArgumentOutOfRangeException(nameof(position));
+                this.Index = index;
+            }
+
             internal TokenIndex(TokenIndex tIndex)
                 : this(tIndex.File, tIndex.Line, tIndex.Index) { }
 

--- a/src/QsCompiler/CompilationManager/EditorSupport.cs
+++ b/src/QsCompiler/CompilationManager/EditorSupport.cs
@@ -362,6 +362,12 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
             Position afterArgsStart = null;
             Position afterArgsEnd = null;
 
+            Position ConvertFragPosToGlobalPos(QsPositionInfo posToConvert) => new Position
+            (
+                fragStart.Line + posToConvert.Line - 1,
+                (posToConvert.Line == 1 ? fragStart.Character : 0) + posToConvert.Column - 1
+            );
+
             var forLoopIntroExpression = (QsFragmentKind.ForLoopIntro)frag.Kind;
 
             if (!forLoopIntroExpression.Item2.Range.IsNull)
@@ -369,8 +375,8 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
                 var rangeStart = ((QsFragmentKind.ForLoopIntro)frag.Kind).Item2.Range.Item.Item1;
                 var rangeEnd = ((QsFragmentKind.ForLoopIntro)frag.Kind).Item2.Range.Item.Item2;
 
-                beforeArgsStart = new Position(fragStart.Line + rangeStart.Line - 1, fragStart.Character + rangeStart.Column - 1);
-                afterArgsEnd = new Position(fragStart.Line + rangeEnd.Line - 1, fragStart.Character + rangeEnd.Column - 1);
+                beforeArgsStart = ConvertFragPosToGlobalPos(rangeStart);
+                afterArgsEnd = ConvertFragPosToGlobalPos(rangeEnd);
             }
 
             if (forLoopIntroExpression.Item2.Expression is QsExpressionKind<QsExpression, QsSymbol, QsType>.RangeLiteral rangeExpression)
@@ -397,8 +403,8 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
                                 var argRangeStart = callLikeExression.Item2.Range.Item.Item1;
                                 var argRangeEnd = callLikeExression.Item2.Range.Item.Item2;
 
-                                beforeArgsEnd = new Position(fragStart.Line + argRangeStart.Line - 1, fragStart.Character + argRangeStart.Column - 1);
-                                afterArgsStart = new Position(fragStart.Line + argRangeEnd.Line - 1, fragStart.Character + argRangeEnd.Column - 1);
+                                beforeArgsEnd = ConvertFragPosToGlobalPos(argRangeStart);
+                                afterArgsStart = ConvertFragPosToGlobalPos(argRangeEnd);
                             }
                         }
                     }


### PR DESCRIPTION
This adds a code action that replaces range expressions in for loops with a call to IndexRange, if equivalent. It will also add the appropriate open directive if IndexRange is not known in the current namespace.
Based off of this Issue: https://github.com/microsoft/qsharp-compiler/issues/80