### PR TITLE
Handling specialization redeclarations

### DIFF
--- a/src/QsCompiler/CompilationManager/CompilationUnit.cs
+++ b/src/QsCompiler/CompilationManager/CompilationUnit.cs
@@ -408,8 +408,11 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
                     var specializations = this.GlobalSymbols.DefinedSpecializations(header.QualifiedName).Select(defined =>
                     {
                         var specHeader = defined.Item2;
-                        var compiledSpecs = compiled.Specializations.Where(spec => spec.Kind == specHeader.Kind);
-                        QsCompilerError.Verify(compiledSpecs.Count() <= 1, "more than one specialization of the same kind exists"); // currently not supported
+                        var compiledSpecs = compiled.Specializations.Where(spec => 
+                            spec.Kind == specHeader.Kind &&
+                            spec.TypeArguments.Equals(specHeader.TypeArguments)
+                        ); 
+                        QsCompilerError.Verify(compiledSpecs.Count() <= 1, "more than one specialization of the same kind exists");
                         if (!compiledSpecs.Any()) return null; // may happen if a file has been modified during global type checking
 
                         var compiledSpec = compiledSpecs.Single();

--- a/src/QsCompiler/DataStructures/SymbolTable.fs
+++ b/src/QsCompiler/DataStructures/SymbolTable.fs
@@ -172,6 +172,7 @@ type private PartialNamespace private
 
     /// Deletes the *explicitly* defined specialization at the specified location for the callable with the given name.
     /// Does not delete specializations that have been inserted by the compiler, i.e. specializations whose location matches the callable declaration location.
+    /// Returns the number of removed specializations. 
     /// Throws the standard key does not exist exception if no specialization for the callable with that name exists.
     member internal this.RemoveCallableSpecialization (location : QsLocation) cName = 
         match CallableDeclarations.TryGetValue cName with 
@@ -547,6 +548,7 @@ and Namespace private
         this.TryAddCallableSpecialization kind (source, location) ((parentName, declLocation.Range), generator, doc) 
 
     /// Deletes the specialization(s) defined at the specified location and source file for the callable with the given name.
+    /// Returns the number of removed specializations.
     /// Throws an ArgumentException if the given source file is not listed as a source for (part of) the namespace.
     /// Throws the standard key does not exist exception if no callable with that name exists.
     member internal this.RemoveSpecialization (source, location) cName =

--- a/src/QsCompiler/LanguageServer/LanguageServer.cs
+++ b/src/QsCompiler/LanguageServer/LanguageServer.cs
@@ -172,7 +172,7 @@ namespace Microsoft.Quantum.QsLanguageServer
             capabilities.RenameProvider = true;
             capabilities.HoverProvider = true;
             capabilities.DocumentHighlightProvider = true;
-            capabilities.SignatureHelpProvider.TriggerCharacters = new[] { "," };
+            capabilities.SignatureHelpProvider.TriggerCharacters = new[] { "(", "," };
             capabilities.ExecuteCommandProvider.Commands = new[] { CommandIds.ApplyEdit }; // do not declare internal capabilities 
 
             this.WaitForInit = null;

--- a/src/QsCompiler/Tests.Compiler/GlobalVerificationTests.fs
+++ b/src/QsCompiler/Tests.Compiler/GlobalVerificationTests.fs
@@ -52,6 +52,37 @@ type GlobalVerificationTests (output:ITestOutputHelper) =
 
 
     [<Fact>]
+    member this.``Uniqueness of specializations`` () = 
+
+        this.Expect "ValidSetOfSpecializations1"  []
+        this.Expect "ValidSetOfSpecializations2"  []
+        this.Expect "ValidSetOfSpecializations3"  []
+        this.Expect "ValidSetOfSpecializations4"  []
+        this.Expect "ValidSetOfSpecializations5"  []
+        this.Expect "ValidSetOfSpecializations6"  []
+        this.Expect "ValidSetOfSpecializations7"  []
+        this.Expect "ValidSetOfSpecializations8"  []
+        this.Expect "ValidSetOfSpecializations9"  []
+        this.Expect "ValidSetOfSpecializations10" []
+        this.Expect "ValidSetOfSpecializations11" []
+        this.Expect "ValidSetOfSpecializations12" []
+        this.Expect "ValidSetOfSpecializations13" []
+
+        this.Expect "InvalidSetOfSpecializations1"  [Error ErrorCode.RedefinitionOfControlledAdjoint]
+        this.Expect "InvalidSetOfSpecializations2"  [Error ErrorCode.RedefinitionOfControlledAdjoint]
+        this.Expect "InvalidSetOfSpecializations3"  [Error ErrorCode.RedefinitionOfControlledAdjoint]
+        this.Expect "InvalidSetOfSpecializations4"  [Error ErrorCode.RedefinitionOfControlledAdjoint]
+        this.Expect "InvalidSetOfSpecializations5"  [Error ErrorCode.RedefinitionOfControlledAdjoint]
+        this.Expect "InvalidSetOfSpecializations6"  [Error ErrorCode.RedefinitionOfControlledAdjoint]
+        this.Expect "InvalidSetOfSpecializations7"  [Error ErrorCode.RedefinitionOfAdjoint]
+        this.Expect "InvalidSetOfSpecializations8"  [Error ErrorCode.RedefinitionOfAdjoint]
+        this.Expect "InvalidSetOfSpecializations9"  [Error ErrorCode.RedefinitionOfAdjoint]
+        this.Expect "InvalidSetOfSpecializations10" [Error ErrorCode.RedefinitionOfControlled]
+        this.Expect "InvalidSetOfSpecializations11" [Error ErrorCode.RedefinitionOfControlled]
+        this.Expect "InvalidSetOfSpecializations12" [Error ErrorCode.RedefinitionOfControlled]
+
+
+    [<Fact>]
     member this.``Circular dependencies in user defined types`` () = 
 
         this.Expect "TypeA1"       []

--- a/src/QsCompiler/Tests.Compiler/TestCases/GlobalVerification.qs
+++ b/src/QsCompiler/Tests.Compiler/TestCases/GlobalVerification.qs
@@ -122,6 +122,158 @@ namespace Microsoft.Quantum.Testing.GlobalVerification {
     }
 
 
+	// checking for duplicate specializations
+
+	operation ValidSetOfSpecializations1 () : Unit {
+		body (...) {}
+		adjoint auto; 
+		controlled auto;
+		adjoint controlled auto;
+	}
+
+	operation ValidSetOfSpecializations2 () : Unit {
+		body (...) {}
+		adjoint auto; 
+		controlled auto;
+		controlled adjoint auto;
+	}
+
+	operation ValidSetOfSpecializations3 () : Unit {
+		body (...) {}
+		controlled adjoint auto;
+	}
+
+	operation ValidSetOfSpecializations4 () : Unit {
+		body (...) {}
+		adjoint auto;
+	}
+
+	operation ValidSetOfSpecializations5 () : Unit {
+		body (...) {}
+		controlled auto;
+	}
+
+	operation ValidSetOfSpecializations6 () : Unit {
+		body (...) {}
+		adjoint (...) {} 
+		controlled (cs, ...) {} 
+		adjoint controlled (cs, ...) {} 
+	}
+
+	operation ValidSetOfSpecializations7 () : Unit {
+		body (...) {}
+		adjoint (...) {} 
+		controlled (cs, ...) {} 
+		controlled adjoint (cs, ...) {} 
+	}
+
+	operation ValidSetOfSpecializations8 () : Unit {
+		body (...) {}
+		controlled adjoint (cs, ...) {} 
+	}
+
+	operation ValidSetOfSpecializations9 () : Unit {
+		body (...) {}
+		adjoint (...) {} 
+	}
+
+	operation ValidSetOfSpecializations10 () : Unit {
+		body (...) {}
+		controlled (cs, ...) {} 
+	}
+
+	operation ValidSetOfSpecializations11 () : Unit
+	is Adj + Ctl {
+		body (...) {}
+		controlled adjoint (cs, ...) {} 
+	}
+
+	operation ValidSetOfSpecializations12 () : Unit
+	is Adj + Ctl {
+		body (...) {}
+		adjoint (...) {} 
+	}
+
+	operation ValidSetOfSpecializations13 () : Unit
+	is Adj + Ctl {
+		body (...) {}
+		controlled (cs, ...) {} 
+	}
+
+
+	operation InvalidSetOfSpecializations1 () : Unit {
+		body (...) {}
+		controlled adjoint auto;
+		controlled adjoint auto;
+	}
+
+	operation InvalidSetOfSpecializations2 () : Unit {
+		body (...) {}
+		controlled adjoint auto;
+		controlled adjoint (cs, ...) {}
+	}
+
+	operation InvalidSetOfSpecializations3 () : Unit {
+		body (...) {}
+		controlled adjoint (cs, ...) {}
+		controlled adjoint (cs, ...) {}
+	}
+
+	operation InvalidSetOfSpecializations4 () : Unit {
+		body (...) {}
+		controlled adjoint auto;
+		adjoint controlled auto;
+	}
+
+	operation InvalidSetOfSpecializations5 () : Unit {
+		body (...) {}
+		controlled adjoint (cs, ...) {}
+		adjoint controlled auto;
+	}
+
+	operation InvalidSetOfSpecializations6 () : Unit {
+		body (...) {}
+		controlled adjoint (cs, ...) {}
+		adjoint controlled (cs, ...) {}
+	}
+
+	operation InvalidSetOfSpecializations7 () : Unit {
+		body (...) {}
+		adjoint auto;
+		adjoint auto;
+	}
+
+	operation InvalidSetOfSpecializations8 () : Unit {
+		body (...) {}
+		adjoint auto;
+		adjoint (...) {}
+	}
+
+	operation InvalidSetOfSpecializations9 () : Unit {
+		body (...) {}
+		adjoint (...) {}
+		adjoint (...) {}
+	}
+
+	operation InvalidSetOfSpecializations10 () : Unit {
+		body (...) {}
+		controlled auto;
+		controlled auto;
+	}
+
+	operation InvalidSetOfSpecializations11 () : Unit {
+		body (...) {}
+		controlled (cs, ...) {}
+		controlled auto;
+	}
+
+	operation InvalidSetOfSpecializations12 () : Unit {
+		body (...) {}
+		controlled (cs, ...) {}
+		controlled (cs, ...) {}
+	}
+
+
     // all paths return a value or fail
 
     function AllPathsReturnValue1 () : Int {


### PR DESCRIPTION
This PR fixes the issue #50. 
Duplicate declarations will be deleted from the symbol table, and excluded from the built syntax tree. 
