### PR TITLE
Compile time errors for overflowing int and double literals

### DIFF
--- a/src/QsCompiler/DataStructures/Diagnostics.fs
+++ b/src/QsCompiler/DataStructures/Diagnostics.fs
@@ -108,6 +108,8 @@ type ErrorCode =
     | InvalidValueArray = 3301
     | InvalidValueTuple = 3302
     | UpdateOfArrayItemExpr = 3303
+    | IntOverflow = 3304
+    | DoubleOverflow = 3305
 
     | NotWithinGlobalScope = 4001
     | NotWithinNamespace = 4002
@@ -415,6 +417,8 @@ type DiagnosticItem =
             | ErrorCode.InvalidValueArray                       -> "Syntax error in value array. Expecting a comma separated list of expressions."
             | ErrorCode.InvalidValueTuple                       -> "Syntax error in value tuple. Expecting a comma separated list of tuple items."
             | ErrorCode.UpdateOfArrayItemExpr                   -> "Array items are immutable. To set an item \"idx\" of an array \"arr\" to a value \"expr\", use and reassign a copy-and-update expression instead: \"set arr w/= idx <- expr;\"."
+            | ErrorCode.IntOverflow                             -> "Int literal is outside of the range of valid values."
+            | ErrorCode.DoubleOverflow                          -> "Double literal is outside of the range of valid values."
 
             | ErrorCode.NotWithinGlobalScope                    -> "Namespace declarations can only occur on a global scope."
             | ErrorCode.NotWithinNamespace                      -> "Declarations and open-directives can only occur within a namespace."

--- a/src/QsCompiler/Tests.Compiler/SyntaxTests.fs
+++ b/src/QsCompiler/Tests.Compiler/SyntaxTests.fs
@@ -141,49 +141,59 @@ let ``Symbol name tests`` () =
 
 [<Fact>]
 let ``Expression literal tests`` () =
+    let minInt = System.Int64.MinValue // -9223372036854775808L
+    let maxInt = System.Int64.MaxValue // 9223372036854775807L
+    let minDouble = System.Double.MinValue // -1.7976931348623157E+308
+    let maxDouble = System.Double.MaxValue // 1.7976931348623157E+308
+    Assert.Equal(minInt, -(-minInt))
+
     let noExprs = ([| |] : QsExpression[]).ToImmutableArray()
     [
-        ("()",                  true,    toExpr UnitValue,                                                      []); 
-        ("1",                   true,    toInt 1,                                                               []); 
-        ("+1",                  true,    toInt 1,                                                               []); 
-        ("-1",                  true,    toExpr (NEG (toInt 1)),                                                []); 
-        ("0x1",                 true,    toInt 1,                                                               []); 
-        ("+0x1",                true,    toInt 1,                                                               []); 
-        ("1L",                  true,    toBigInt "1",                                                          []); 
-        ("+1L",                 true,    toBigInt "1",                                                          []); 
-        ("-1L",                 true,    toExpr (NEG (toBigInt "1")),                                           []); 
-        ("10000000000000000L",  true,    toBigInt "10000000000000000",                                          []); 
-        ("0xfL",                true,    toBigInt "15",                                                         []); 
-        ("0xffL",               true,    toBigInt "255",                                                        []); 
-        ("1l",                  true,    toBigInt "1",                                                          []); 
-        ("+1l",                 true,    toBigInt "1",                                                          []); 
-        ("-1l",                 true,    toExpr (NEG (toBigInt "1")),                                           []); 
-        ("10000000000000000l",  true,    toBigInt "10000000000000000",                                          []); 
-        ("0xfl",                true,    toBigInt "15",                                                         []); 
-        ("+0xfl",               true,    toBigInt "15",                                                         []); 
-        ("0xffl",               true,    toBigInt "255",                                                        []); 
-        ("+0xffl",              true,    toBigInt "255",                                                        []); 
-        ("0b1",                 true,    toInt 1,                                                               []); 
-        ("0b100",               true,    toInt 4,                                                               []); 
-        ("+0b100",              true,    toInt 4,                                                               []); 
-        ("-0b100",              true,    toExpr (NEG (toInt 4)),                                                []);
-        (".1",                  true,    toExpr (DoubleLiteral 0.1),                                            []); 
-        ("1.0",                 true,    toExpr (DoubleLiteral 1.0),                                            []); 
-        ("1.",                  true,    toExpr (DoubleLiteral 1.0),                                            []); 
-        ("+1.0",                true,    toExpr (DoubleLiteral 1.0),                                            []); 
-        ("-1.0",                true,    toExpr (NEG (toExpr (DoubleLiteral 1.0))),                             []); 
-        ("-1.0e2",              true,    toExpr (NEG (toExpr (DoubleLiteral 100.0))),                           []);
-        ("-1.0e-2",             true,    toExpr (NEG (toExpr (DoubleLiteral 0.01))),                            []);
-        ("\"\"",                true,    toExpr (StringLiteral (NonNullable<string>.New "", noExprs)),          []);
-        ("\"hello\"",           true,    toExpr (StringLiteral (NonNullable<string>.New "hello", noExprs)),     []);
-        ("One",                 true,    toExpr (ResultLiteral One),                                            []);
-        ("Zero",                true,    toExpr (ResultLiteral Zero),                                           []);
-        ("PauliI",              true,    toExpr (PauliLiteral PauliI),                                          []);
-        ("PauliX",              true,    toExpr (PauliLiteral PauliX),                                          []);
-        ("PauliY",              true,    toExpr (PauliLiteral PauliY),                                          []);
-        ("PauliZ",              true,    toExpr (PauliLiteral PauliZ),                                          []);
-        ("true",                true,    toExpr (BoolLiteral true),                                             []);
-        ("false",               true,    toExpr (BoolLiteral false),                                            []);
+        ("()",                    true,    toExpr UnitValue,                                                      []); 
+        ("1",                     true,    toInt 1,                                                               []); 
+        ("+1",                    true,    toInt 1,                                                               []); 
+        ("-1",                    true,    toExpr (NEG (toInt 1)),                                                []); 
+        (minInt.ToString(),       true,    toExpr (NEG (NEG (IntLiteral minInt |> toExpr) |> toExpr)),            []); 
+        (maxInt.ToString(),       true,    toExpr (IntLiteral maxInt),                                            []); 
+        (minDouble.ToString("R"), true,    toExpr (NEG (DoubleLiteral -minDouble |> toExpr)),                     []); 
+        (maxDouble.ToString("R"), true,    toExpr (DoubleLiteral maxDouble),                                      []); 
+        ("0x1",                   true,    toInt 1,                                                               []); 
+        ("+0x1",                  true,    toInt 1,                                                               []); 
+        ("1L",                    true,    toBigInt "1",                                                          []); 
+        ("+1L",                   true,    toBigInt "1",                                                          []); 
+        ("-1L",                   true,    toExpr (NEG (toBigInt "1")),                                           []); 
+        ("10000000000000000L",    true,    toBigInt "10000000000000000",                                          []); 
+        ("0xfL",                  true,    toBigInt "15",                                                         []); 
+        ("0xffL",                 true,    toBigInt "255",                                                        []); 
+        ("1l",                    true,    toBigInt "1",                                                          []); 
+        ("+1l",                   true,    toBigInt "1",                                                          []); 
+        ("-1l",                   true,    toExpr (NEG (toBigInt "1")),                                           []); 
+        ("10000000000000000l",    true,    toBigInt "10000000000000000",                                          []); 
+        ("0xfl",                  true,    toBigInt "15",                                                         []); 
+        ("+0xfl",                 true,    toBigInt "15",                                                         []); 
+        ("0xffl",                 true,    toBigInt "255",                                                        []); 
+        ("+0xffl",                true,    toBigInt "255",                                                        []); 
+        ("0b1",                   true,    toInt 1,                                                               []); 
+        ("0b100",                 true,    toInt 4,                                                               []); 
+        ("+0b100",                true,    toInt 4,                                                               []); 
+        ("-0b100",                true,    toExpr (NEG (toInt 4)),                                                []);
+        (".1",                    true,    toExpr (DoubleLiteral 0.1),                                            []); 
+        ("1.0",                   true,    toExpr (DoubleLiteral 1.0),                                            []); 
+        ("1.",                    true,    toExpr (DoubleLiteral 1.0),                                            []); 
+        ("+1.0",                  true,    toExpr (DoubleLiteral 1.0),                                            []); 
+        ("-1.0",                  true,    toExpr (NEG (toExpr (DoubleLiteral 1.0))),                             []); 
+        ("-1.0e2",                true,    toExpr (NEG (toExpr (DoubleLiteral 100.0))),                           []);
+        ("-1.0e-2",               true,    toExpr (NEG (toExpr (DoubleLiteral 0.01))),                            []);
+        ("\"\"",                  true,    toExpr (StringLiteral (NonNullable<string>.New "", noExprs)),          []);
+        ("\"hello\"",             true,    toExpr (StringLiteral (NonNullable<string>.New "hello", noExprs)),     []);
+        ("One",                   true,    toExpr (ResultLiteral One),                                            []);
+        ("Zero",                  true,    toExpr (ResultLiteral Zero),                                           []);
+        ("PauliI",                true,    toExpr (PauliLiteral PauliI),                                          []);
+        ("PauliX",                true,    toExpr (PauliLiteral PauliX),                                          []);
+        ("PauliY",                true,    toExpr (PauliLiteral PauliY),                                          []);
+        ("PauliZ",                true,    toExpr (PauliLiteral PauliZ),                                          []);
+        ("true",                  true,    toExpr (BoolLiteral true),                                             []);
+        ("false",                 true,    toExpr (BoolLiteral false),                                            []);
     ]
     |> List.iter testExpr
 

--- a/src/QsCompiler/Tests.Compiler/TestUtils.fs
+++ b/src/QsCompiler/Tests.Compiler/TestUtils.fs
@@ -155,12 +155,12 @@ let rec matchExpression e1 e2 =
     | UnitValue
     | IntLiteral _
     | BigIntLiteral _
-    | DoubleLiteral _
     | BoolLiteral _
     | ResultLiteral _
     | PauliLiteral _
     | MissingExpr
     | InvalidExpr                   -> ex1 = ex2
+    | DoubleLiteral d1              -> match ex2 with | DoubleLiteral d2 -> d1 = d2 || (Double.IsNaN d1 && Double.IsNaN d2)                                                   | _ -> false
     | Identifier (i1,t1)            -> match ex2 with | Identifier (i2,t2) -> i1.Symbol = i2.Symbol && matchTypeArray t1 t2                                                   | _ -> false
     | StringLiteral (s1, a1)        -> match ex2 with | StringLiteral (s2, a2) -> (s1 = s2) && (matchAll a1 a2)                                                               | _ -> false
     | ValueTuple a1                 -> match ex2 with | ValueTuple a2 -> matchAll a1 a2                                                                                       | _ -> false

--- a/src/VisualStudioExtension/QsharpAppTemplate/AppProjectTemplate.xml
+++ b/src/VisualStudioExtension/QsharpAppTemplate/AppProjectTemplate.xml
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
 

--- a/src/VisualStudioExtension/QsharpVSIX/QsharpVSIX.csproj
+++ b/src/VisualStudioExtension/QsharpVSIX/QsharpVSIX.csproj
@@ -117,6 +117,9 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.VisualStudio.SDK" Version="15.9.3" ExcludeAssets="runtime" />
+    <PackageReference Include="Microsoft.VisualStudio.Telemetry">
+      <Version>16.3.2</Version>
+    </PackageReference>
     <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="16.0.2268" />
     <PackageReference Include="System.ComponentModel.Composition">
       <Version>4.5.0</Version>

--- a/src/VisualStudioExtension/QsharpVSIX/source.extension.vsixmanifest.v.template
+++ b/src/VisualStudioExtension/QsharpVSIX/source.extension.vsixmanifest.v.template
@@ -20,13 +20,13 @@
         <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />
     </Dependencies>
     <Assets>
-        <Asset Type="Microsoft.VisualStudio.ProjectTemplate" d:Source="Project" d:ProjectName="QsharpAppTemplate" d:TargetPath="|QsharpAppTemplate;TemplateProjectOutputGroup|" Path="ProjectTemplates" d:VsixSubPath="ProjectTemplates" />
-        <Asset Type="Microsoft.VisualStudio.ProjectTemplate" d:Source="Project" d:ProjectName="QsharpTestTemplate" d:TargetPath="|QsharpTestTemplate;TemplateProjectOutputGroup|" Path="ProjectTemplates" d:VsixSubPath="ProjectTemplates" />
-        <Asset Type="Microsoft.VisualStudio.ProjectTemplate" d:Source="Project" d:ProjectName="QsharpLibTemplate" d:TargetPath="|QsharpLibTemplate;TemplateProjectOutputGroup|" Path="ProjectTemplates" d:VsixSubPath="ProjectTemplates" />
-        <Asset Type="Microsoft.VisualStudio.ItemTemplate" d:Source="Project" d:TargetPath="|QsharpFileTemplate;TemplateProjectOutputGroup|" Path="ItemTemplates" d:VsixSubPath="ItemTemplates" />
         <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="File" Path="syntax.pkgdef" />
         <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%|" />
         <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
+        <Asset Type="Microsoft.VisualStudio.ProjectTemplate" d:Source="Project" d:ProjectName="QsharpAppTemplate" d:TargetPath="|QsharpAppTemplate;TemplateProjectOutputGroup|" Path="ProjectTemplates" d:VsixSubPath="ProjectTemplates" />
+        <Asset Type="Microsoft.VisualStudio.ProjectTemplate" d:Source="Project" d:ProjectName="QsharpLibTemplate" d:TargetPath="|QsharpLibTemplate;TemplateProjectOutputGroup|" Path="ProjectTemplates" d:VsixSubPath="ProjectTemplates" />
+        <Asset Type="Microsoft.VisualStudio.ProjectTemplate" d:Source="Project" d:ProjectName="QsharpTestTemplate" d:TargetPath="|QsharpTestTemplate;TemplateProjectOutputGroup|" Path="ProjectTemplates" d:VsixSubPath="ProjectTemplates" />
+        <Asset Type="Microsoft.VisualStudio.ItemTemplate" d:Source="Project" d:ProjectName="QsharpFileTemplate" d:TargetPath="|QsharpFileTemplate;TemplateProjectOutputGroup|" Path="ItemTemplates" d:VsixSubPath="ItemTemplates" />
     </Assets>
     <Prerequisites>
         <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[16.0.28315.86,17.0)" DisplayName="Visual Studio core editor" />


### PR DESCRIPTION
This PR adds a proper Q# diagnostic for everything that would result in a compile time error in C#. 
It also fixes issue #86. 