### PR TITLE
Fix incorrect indentation in Visual Studio when pressing enter before closing bracket

### DIFF
--- a/src/VisualStudioExtension/QsharpVSIX/QsSmartIndent.cs
+++ b/src/VisualStudioExtension/QsharpVSIX/QsSmartIndent.cs
@@ -128,8 +128,9 @@ namespace Microsoft.Quantum.QsLanguageExtensionVS
         private static bool IsIndentation(char c) => c == ' ' || c == '\t';
 
         /// <summary>
-        /// Returns the last non-empty line before the given line. If all of the lines before the given line are empty,
-        /// returns the first line of the snapshot instead.
+        /// Returns the last non-empty line before the given line. A non-empty line is any line that contains at least
+        /// one non-whitespace character. If all of the lines before the given line are empty, returns the first line of
+        /// the snapshot instead. 
         /// <para/>
         /// Returns null if the given line is the first line in the snapshot.
         /// </summary>
@@ -138,9 +139,10 @@ namespace Microsoft.Quantum.QsLanguageExtensionVS
             int lineNumber = line.LineNumber - 1;
             if (lineNumber < 0)
                 return null;
-            while (lineNumber > 0 && line.Snapshot.GetLineFromLineNumber(lineNumber).Length == 0)
+            ITextSnapshot snapshot = line.Snapshot;
+            while (lineNumber > 0 && string.IsNullOrWhiteSpace(snapshot.GetLineFromLineNumber(lineNumber).GetText()))
                 lineNumber--;
-            return line.Snapshot.GetLineFromLineNumber(lineNumber);
+            return snapshot.GetLineFromLineNumber(lineNumber);
         }
     }
 }


### PR DESCRIPTION
This bug happens in the following case, where `.` indicates a space and `|` indicates the cursor position:

```
namespace Foo {
....operation Bar () : Unit {
....|}
}
```

Pressing enter where the cursor is would incorrectly decrease the indentation of the operation's closing brace to match the namespace's closing brace. This is because just after pressing enter (and before `GetDesiredIndentation` has been called), the text is:

```
namespace Foo {
....operation Bar () : Unit {
....
|}
}
```

Relative to the last line before the cursor, which has 1 level of indentation, 0 levels of indentation is "correct" for the closing brace, but it's not what you would expect to happen. To fix this, use the last non-empty, non-whitespace line to determine indentation. Since that is the operation declaration line (level 1), which starts a block (1 + 1 = level 2), and the current line ends a block (2 - 1 = level 1), it will have the expected indentation level.