### PR TITLE
Pack qsc as standalone tool.

### DIFF
--- a/build/pack.ps1
+++ b/build/pack.ps1
@@ -30,6 +30,7 @@ function Pack-One() {
 }
 
 Pack-One '../src/QsCompiler/Compiler/QsCompiler.csproj' '-IncludeReferencedProjects'
+Pack-One '../src/QsCompiler/CommandLineTool/QsCommandLineTool.csproj' '-IncludeReferencedProjects'
 
 ##
 # VS Code Extension

--- a/src/QsCompiler/CommandLineTool/QsCommandLineTool.csproj
+++ b/src/QsCompiler/CommandLineTool/QsCommandLineTool.csproj
@@ -8,6 +8,22 @@
     <OutputType>Exe</OutputType>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <Authors>Microsoft</Authors>
+    <Description>Microsoft's Q# compiler tool.</Description>
+    <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
+    <PackageReleaseNotes>See: https://docs.microsoft.com/en-us/quantum/relnotes/</PackageReleaseNotes>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageProjectUrl>https://github.com/Microsoft/qsharpc-compiler</PackageProjectUrl>
+    <PackageIconUrl>https://secure.gravatar.com/avatar/bd1f02955b2853ba0a3b1cdc2434e8ec.png</PackageIconUrl>
+    <PackageTags>Quantum Q# Qsharp</PackageTags>
+    <PackAsTool>true</PackAsTool>
+    <ToolCommandName>qsc</ToolCommandName>
+    <PackageId>Microsoft.Quantum.Compiler.Tool</PackageId>
+    <ContentTargetFolders>\</ContentTargetFolders>
+    <ApplicationIcon />
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.2.1" />
   </ItemGroup>

--- a/src/QsCompiler/CommandLineTool/QsCommandLineTool.csproj
+++ b/src/QsCompiler/CommandLineTool/QsCommandLineTool.csproj
@@ -35,4 +35,10 @@
   <ItemGroup>
     <Compile Include="..\Common\DelaySign.cs" Link="Properties\DelaySign.cs" />
   </ItemGroup>
+
+  <ItemGroup>
+    <Content Include="..\..\..\NOTICE.txt" Link="NOTICE.txt">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
This PR modifies the command-line interface for the Q# → serialized AST compiler to be its own .NET Tool, so that it can either be installed as a [`<DotNetCliToolReference />`](https://docs.microsoft.com/en-us/dotnet/core/tools/extensibility) or as a global tool.