### PR TITLE
Removing required framework version from VS templates

### DIFF
--- a/src/VisualStudioExtension/QsharpAppTemplate/QsharpAppTemplate.vstemplate
+++ b/src/VisualStudioExtension/QsharpAppTemplate/QsharpAppTemplate.vstemplate
@@ -5,7 +5,6 @@
     <Description>A project for creating and running an application that invokes quantum operations.</Description>
     <Icon>mobius_strip_icon.png</Icon>
     <ProjectType>CSharp</ProjectType>
-    <RequiredFrameworkVersion>2.0</RequiredFrameworkVersion>
     <SortOrder>1000</SortOrder>
     <TemplateID>Microsoft.Common.Console.QSharp</TemplateID>
     <CreateNewFolder>true</CreateNewFolder>

--- a/src/VisualStudioExtension/QsharpLibTemplate/QsharpLibTemplate.vstemplate
+++ b/src/VisualStudioExtension/QsharpLibTemplate/QsharpLibTemplate.vstemplate
@@ -5,7 +5,6 @@
     <Description>A project for creating a library with quantum operations.</Description>
     <Icon>mobius_strip_icon.png</Icon>
     <ProjectType>CSharp</ProjectType>
-    <RequiredFrameworkVersion>2.0</RequiredFrameworkVersion>
     <SortOrder>1000</SortOrder>
     <TemplateID>Microsoft.Common.Classlib.QSharp</TemplateID>
     <CreateNewFolder>true</CreateNewFolder>

--- a/src/VisualStudioExtension/QsharpTestTemplate/QsharpTestTemplate.vstemplate
+++ b/src/VisualStudioExtension/QsharpTestTemplate/QsharpTestTemplate.vstemplate
@@ -5,7 +5,6 @@
     <Description>A project for testing quantum operations.</Description>
     <Icon>mobius_strip_icon.png</Icon>
     <ProjectType>CSharp</ProjectType>
-    <RequiredFrameworkVersion>2.0</RequiredFrameworkVersion>
     <SortOrder>1000</SortOrder>
     <TemplateID>Microsoft.Test.xUnit.QSharp</TemplateID>
     <CreateNewFolder>true</CreateNewFolder>


### PR DESCRIPTION
When creating a project, the user is forced to pick a framework version if that property is specified. The picked version is irrelevant since all projects are .NET Core projects anyway, and the version is picked by the template. Removing that to avoid confusion. 