### PR TITLE
Disallowing Returning From Apply-Blocks

### DIFF
--- a/src/QsCompiler/DataStructures/Diagnostics.fs
+++ b/src/QsCompiler/DataStructures/Diagnostics.fs
@@ -133,14 +133,15 @@ type ErrorCode =
     | MissingPrecedingRepeat = 4103
     | MissingPrecedingWithin = 4104
     | MissingContinuationApply = 4105
-    | DistributedAdjointGenerator = 4106
-    | InvalidBodyGenerator = 4107
-    | BodyGenArgMismatch = 4108
-    | AdjointGenArgMismatch = 4109
-    | SelfControlledGenerator = 4110
-    | InvertControlledGenerator = 4111
-    | ControlledGenArgMismatch = 4112
-    | ControlledAdjointGenArgMismatch = 4113
+    | ReturnFromWithinApplyBlock = 4106 // temporary restriction
+    | DistributedAdjointGenerator = 4107
+    | InvalidBodyGenerator = 4108
+    | BodyGenArgMismatch = 4109
+    | AdjointGenArgMismatch = 4110
+    | SelfControlledGenerator = 4111
+    | InvertControlledGenerator = 4112
+    | ControlledGenArgMismatch = 4113
+    | ControlledAdjointGenArgMismatch = 4114
 
     | MissingExprInArray = 5001
     | MultipleTypesInArray = 5002
@@ -440,7 +441,7 @@ type DiagnosticItem =
             | ErrorCode.AdjointDeclInFunction                   -> "Adjoint specializations can only be defined for operations."
             | ErrorCode.ControlledDeclInFunction                -> "Controlled specializations can only be defined for operations."
             | ErrorCode.ControlledAdjointDeclInFunction         -> "Controlled-adjoint specializations can only be defined for operations."
-            | ErrorCode.InvalidReturnWithinAllocationScope      -> "Return statements may only occur at the end of a using- or borrowing-block."
+            | ErrorCode.InvalidReturnWithinAllocationScope      -> "Return-statements may only occur at the end of a using- or borrowing-block."
             | ErrorCode.WhileLoopInOperation                    -> "While-loops cannot be used in operations. Avoid conditional loops in operations if possible, and use a repeat-until-success pattern otherwise."
             | ErrorCode.ConjugationWithinFunction               -> "Conjugations may only occur within operations, since they cannot add to the expressiveness within functions."
                                                             
@@ -449,6 +450,7 @@ type DiagnosticItem =
             | ErrorCode.MissingPrecedingRepeat                  -> "An until-clause must be preceded by a repeat-block."
             | ErrorCode.MissingPrecedingWithin                  -> "An apply-block must be preceded by the within-block."
             | ErrorCode.MissingContinuationApply                -> "A within-block must be followed by an apply-block."
+            | ErrorCode.ReturnFromWithinApplyBlock              -> "Return-statements may not occur in an apply-block." 
             | ErrorCode.DistributedAdjointGenerator             -> "Invalid generator for adjoint specialization. Valid generators are \"invert\", \"self\" and \"auto\"."
             | ErrorCode.InvalidBodyGenerator                    -> "Invalid generator for body specialization. A body specialization must be user defined (\"body (...)\"), or specified as intrinsic (\"body intrinsic\")."
             | ErrorCode.BodyGenArgMismatch                      -> "The argument to a user-defined body specialization must be of the form \"(...)\"."

--- a/src/QsCompiler/SyntaxProcessor/ContextVerification.fs
+++ b/src/QsCompiler/SyntaxProcessor/ContextVerification.fs
@@ -118,6 +118,9 @@ let private verifyStatement (context : SyntaxTokenContext) =
     let checkForNotValidInOperation = function
         | WhileLoopIntro _         -> false, [| (ErrorCode.WhileLoopInOperation |> Error, context.Range) |]
         | _                        -> true, [||]
+    let checkForNotValidInApply = function
+        | ReturnStatement _         -> false, [| (ErrorCode.ReturnFromWithinApplyBlock |> Error, context.Range) |]
+        | _                        -> true, [||]
 
     let NullOr = ApplyOrDefaultTo (false, [||]) context.Self // empty fragments can be excluded from the compilation 
     let notWithinSpecialization = false, [| (ErrorCode.NotWithinSpecialization |> Error, context.Range) |]
@@ -125,6 +128,7 @@ let private verifyStatement (context : SyntaxTokenContext) =
         | [] -> notWithinSpecialization
         | parent :: tail -> parent |> function 
             // (potentially) valid parents for statements
+            | Value (ApplyBlockIntro _) -> NullOr checkForNotValidInApply 
             | Value (FunctionDeclaration _) -> NullOr checkForNotValidInFunction
             | Value (OperationDeclaration _) -> NullOr checkForNotValidInOperation
             | Value (BodyDeclaration _)

--- a/src/QsCompiler/Tests.Compiler/AutoGenerationTests.fs
+++ b/src/QsCompiler/Tests.Compiler/AutoGenerationTests.fs
@@ -196,7 +196,7 @@ type FunctorAutoGenTests (output:ITestOutputHelper) =
         this.Expect "ValidInversion2"        []
         this.Expect "ValidInversion3"        []
         this.Expect "ValidInversion4"        []
-        this.Expect "ValidInversion5"        []
+        this.Expect "ValidInversion5"        [Error ErrorCode.ReturnFromWithinApplyBlock]
         this.Expect "ValidInversion6"        []
         this.Expect "ValidInversion7"        []
         this.Expect "ValidInversion8"        []

--- a/src/QsCompiler/Tests.Compiler/GlobalVerificationTests.fs
+++ b/src/QsCompiler/Tests.Compiler/GlobalVerificationTests.fs
@@ -132,7 +132,7 @@ type GlobalVerificationTests (output:ITestOutputHelper) =
         this.Expect "AllPathsReturnValue11"    []
         this.Expect "AllPathsReturnValue12"    []
         this.Expect "AllPathsReturnValue13"    [Error ErrorCode.ReturnStatementWithinAutoInversion]
-        this.Expect "AllPathsReturnValue14"    []
+        this.Expect "AllPathsReturnValue14"    [Error ErrorCode.ReturnFromWithinApplyBlock; Error ErrorCode.MissingReturnOrFailStatement] // these are both due to temporary restrictions
 
         this.Expect "AllPathsFail1"     []
         this.Expect "AllPathsFail2"     []
@@ -196,7 +196,7 @@ type GlobalVerificationTests (output:ITestOutputHelper) =
         this.Expect "InvalidReturnFromWithinUsing4"      [Error ErrorCode.InvalidReturnWithinAllocationScope; Warning WarningCode.UnreachableCode]
         this.Expect "InvalidReturnFromWithinUsing5"      [Error ErrorCode.InvalidReturnWithinAllocationScope]
         this.Expect "InvalidReturnFromWithinUsing6"      [Error ErrorCode.ReturnStatementWithinAutoInversion; Error ErrorCode.InvalidReturnWithinAllocationScope]
-        this.Expect "InvalidReturnFromWithinUsing7"      [Error ErrorCode.InvalidReturnWithinAllocationScope]
+        this.Expect "InvalidReturnFromWithinUsing7"      [Error ErrorCode.ReturnFromWithinApplyBlock]
         this.Expect "InvalidReturnFromWithinUsing8"      [Error ErrorCode.InvalidReturnWithinAllocationScope; Warning WarningCode.UnreachableCode]
         this.Expect "InvalidReturnFromWithinUsing9"      [Error ErrorCode.InvalidReturnWithinAllocationScope]
         this.Expect "InvalidReturnFromWithinUsing10"     [Error ErrorCode.InvalidReturnWithinAllocationScope; Error ErrorCode.InvalidReturnWithinAllocationScope]
@@ -222,7 +222,7 @@ type GlobalVerificationTests (output:ITestOutputHelper) =
         this.Expect "InvalidReturnFromWithinBorrowing6"  [Error ErrorCode.InvalidReturnWithinAllocationScope; Warning WarningCode.UnreachableCode; Warning WarningCode.UnreachableCode]
         this.Expect "InvalidReturnFromWithinBorrowing7"  [Error ErrorCode.InvalidReturnWithinAllocationScope; Warning WarningCode.UnreachableCode]
         this.Expect "InvalidReturnFromWithinBorrowing8"  [Error ErrorCode.ReturnStatementWithinAutoInversion; Error ErrorCode.InvalidReturnWithinAllocationScope]
-        this.Expect "InvalidReturnFromWithinBorrowing9"  [Error ErrorCode.InvalidReturnWithinAllocationScope]
+        this.Expect "InvalidReturnFromWithinBorrowing9"  [Error ErrorCode.ReturnFromWithinApplyBlock]
         this.Expect "InvalidReturnFromWithinBorrowing10" [Error ErrorCode.InvalidReturnWithinAllocationScope; Warning WarningCode.UnreachableCode]
         this.Expect "InvalidReturnFromWithinBorrowing11" [Error ErrorCode.InvalidReturnWithinAllocationScope]
         this.Expect "InvalidReturnFromWithinBorrowing12" [Error ErrorCode.InvalidReturnWithinAllocationScope]
@@ -262,9 +262,9 @@ type GlobalVerificationTests (output:ITestOutputHelper) =
         this.Expect "InvalidReturnPlacement13"           [Error ErrorCode.InvalidReturnWithinAllocationScope]
         this.Expect "InvalidReturnPlacement14"           [Error ErrorCode.InvalidReturnWithinAllocationScope]
         this.Expect "InvalidReturnPlacement15"           [Error ErrorCode.InvalidReturnWithinAllocationScope]
-        this.Expect "InvalidReturnPlacement16"           [Error ErrorCode.InvalidReturnWithinAllocationScope]
+        this.Expect "InvalidReturnPlacement16"           [Error ErrorCode.ReturnFromWithinApplyBlock]
         this.Expect "InvalidReturnPlacement17"           [Error ErrorCode.ReturnStatementWithinAutoInversion; Error ErrorCode.InvalidReturnWithinAllocationScope]
-        this.Expect "InvalidReturnPlacement18"           [Error ErrorCode.InvalidReturnWithinAllocationScope]
+        this.Expect "InvalidReturnPlacement18"           [Error ErrorCode.ReturnFromWithinApplyBlock]
         this.Expect "InvalidReturnPlacement19"           [Error ErrorCode.ReturnStatementWithinAutoInversion; Error ErrorCode.InvalidReturnWithinAllocationScope]
         this.Expect "InvalidReturnPlacement20"           [Error ErrorCode.ReturnStatementWithinAutoInversion; Error ErrorCode.InvalidReturnWithinAllocationScope; Warning WarningCode.UnreachableCode]
 


### PR DESCRIPTION
Giving an error for return statements inside apply-blocks until we have the necessary infrastructure in place to treat conjugations as try-finally pattern without requiring additional runtime support. 