### PR TITLE
Reverting change to public method

### DIFF
--- a/src/QsCompiler/DataStructures/SymbolResolution.fs
+++ b/src/QsCompiler/DataStructures/SymbolResolution.fs
@@ -81,8 +81,7 @@ module SymbolResolution =
     let private TypeParameterResolutionWarnings (argumentType : ResolvedType) (returnType : ResolvedType, range) typeParams = 
         // FIXME: this verification needs to be done for each specialization individually once type specializations are fully supported
         let typeParamsResolvedByArg = 
-            let getTypeParams (t : ResolvedType) = 
-                match t.Resolution with 
+            let getTypeParams = function
                 | QsTypeKind.TypeParameter (tp : QsTypeParameter) -> [tp.TypeName].AsEnumerable() 
                 | _ -> Enumerable.Empty()
             argumentType.ExtractAll getTypeParams |> Seq.toList

--- a/src/QsCompiler/DataStructures/SyntaxExtensions.fs
+++ b/src/QsCompiler/DataStructures/SyntaxExtensions.fs
@@ -132,7 +132,7 @@ type ResolvedType with
     /// Returns an enumerable of all extracted return values. 
     member this.ExtractAll (extract : _ -> IEnumerable<_>) : IEnumerable<_> = 
         let inner (t : ResolvedType) = t.Resolution
-        ResolvedType.ExtractAll (inner, extract) this
+        ResolvedType.ExtractAll (inner, (inner >> extract)) this
 
 
 type QsType with 


### PR DESCRIPTION
I did a minor change to one of the extension methods not realizing it was public. Changing that such that the public signature stays the same. 