### PR TITLE
Show only completions for namespace declarations at the top-level scope of a file

### DIFF
--- a/src/QsCompiler/DataStructures/SymbolTable.fs
+++ b/src/QsCompiler/DataStructures/SymbolTable.fs
@@ -1201,3 +1201,6 @@ and NamespaceManager
             hash (callablesHash, typesHash), importsHash
         finally syncRoot.ExitReadLock() 
 
+    /// Returns true if the given namespace name exists in the symbol table.
+    member this.NamespaceExists nsName =
+        Namespaces.ContainsKey nsName

--- a/src/QsCompiler/Tests.Compiler/CompletionParsingTests.fs
+++ b/src/QsCompiler/Tests.Compiler/CompletionParsingTests.fs
@@ -105,7 +105,20 @@ let testElifElse scope previous =
     ]
 
 [<Fact>]
-let ``Inside namespace parser tests`` () =
+let ``Top-level parser tests`` () =
+    List.iter (matches TopLevel Null) [
+        ("", [Keyword "namespace"])
+        ("namespace ", [Namespace])
+        ("namespace Foo", [Namespace])
+        ("namespace Foo.", [Member ("Foo", Namespace)])
+        ("namespace Foo.Bar", [Member ("Foo", Namespace)])
+        ("namespace Foo.Bar.", [Member ("Foo.Bar", Namespace)])
+        ("namespace Foo.Bar.Baz", [Member ("Foo.Bar", Namespace)])
+        ("namespace Foo.Bar.Baz ", [])
+    ]
+
+[<Fact>]
+let ``Namespace top-level parser tests`` () =
     let keywords = [
         Keyword "function"
         Keyword "operation"


### PR DESCRIPTION
This adds a parser for top-level code fragments so only namespace declarations are shown as completions.

Depends on PR #139. Part of issue #44.