### PR TITLE
Trim the syntax tree by default

### DIFF
--- a/src/QsCompiler/CommandLineTool/Commands/Build.cs
+++ b/src/QsCompiler/CommandLineTool/Commands/Build.cs
@@ -94,7 +94,7 @@ namespace Microsoft.Quantum.QsCompiler.CommandLineCompiler
             {
                 ProjectFile = options.ProjectName == null ? null : new Uri(Path.GetFullPath(options.ProjectName)),
                 GenerateFunctorSupport = true,
-                TrimSyntaxTree = true,
+                SkipSyntaxTreeTrimming = false,
                 DocumentationOutputFolder = options.DocFolder,
                 BuildOutputFolder = options.OutputFolder ?? (specifiesTargets ? "." : null),
                 Targets = options.Targets.ToImmutableDictionary(id => id, DefineTarget)

--- a/src/QsCompiler/CommandLineTool/Commands/Diagnose.cs
+++ b/src/QsCompiler/CommandLineTool/Commands/Diagnose.cs
@@ -213,7 +213,7 @@ namespace Microsoft.Quantum.QsCompiler.CommandLineCompiler
             if (options == null) throw new ArgumentNullException(nameof(options));
             if (logger == null) throw new ArgumentNullException(nameof(logger));
 
-            var loadOptions = new CompilationLoader.Configuration { GenerateFunctorSupport = true, TrimSyntaxTree = options.TrimSyntaxTree }; 
+            var loadOptions = new CompilationLoader.Configuration { GenerateFunctorSupport = true, SkipSyntaxTreeTrimming = !options.TrimSyntaxTree }; 
             var loaded = new CompilationLoader(options.LoadSourcesOrSnippet(logger), options.References, loadOptions, logger);
             if (loaded.VerifiedCompilation == null) return ReturnCode.Status(loaded);
 

--- a/src/QsCompiler/Compiler/CompilationLoader.cs
+++ b/src/QsCompiler/Compiler/CompilationLoader.cs
@@ -55,10 +55,10 @@ namespace Microsoft.Quantum.QsCompiler
             /// </summary>
             public bool GenerateFunctorSupport;
             /// <summary>
-            /// If set to true, the syntax tree rewrite step that eliminated selective abstractions is executed during compilation. 
+            /// Unless this is set to true, the syntax tree rewrite step that eliminates selective abstractions is executed during compilation. 
             /// In particular, all conjugations are inlined. 
             /// </summary>
-            public bool TrimSyntaxTree;
+            public bool SkipSyntaxTreeTrimming;
             /// <summary>
             /// If the output folder is not null, 
             /// documentation is generated in the specified folder based on doc comments in the source code. 
@@ -98,7 +98,7 @@ namespace Microsoft.Quantum.QsCompiler
                 this.ReferenceLoading <= 0 &&
                 WasSuccessful(true, this.Validation) &&
                 WasSuccessful(options.GenerateFunctorSupport, this.FunctorSupport) &&
-                WasSuccessful(options.TrimSyntaxTree, this.TreeTrimming) &&
+                WasSuccessful(!options.SkipSyntaxTreeTrimming, this.TreeTrimming) &&
                 WasSuccessful(options.DocumentationOutputFolder != null, this.Documentation) &&
                 WasSuccessful(options.BuildOutputFolder != null, this.BinaryFormat) &&
                 !this.BuildTargets.Values.Any(status => !WasSuccessful(true, status))
@@ -225,7 +225,7 @@ namespace Microsoft.Quantum.QsCompiler
                 if (!functorSpecGenerated) this.LogAndUpdate(ref this.CompilationStatus.FunctorSupport, ErrorCode.FunctorGenerationFailed, Enumerable.Empty<string>());
             }
 
-            if (this.Config.TrimSyntaxTree)
+            if (!this.Config.SkipSyntaxTreeTrimming)
             {
                 this.CompilationStatus.TreeTrimming = 0;
                 var rewrite = new InlineConjugations(onException: ex => this.LogAndUpdate(ref this.CompilationStatus.TreeTrimming, ex));


### PR DESCRIPTION
Changing the default of this configuration from false to true. 