### PR TITLE
Hide completions for "private" (underscore-prefixed) global symbols

### DIFF
--- a/src/QsCompiler/CompilationManager/EditorSupport/EditorCompletion.cs
+++ b/src/QsCompiler/CompilationManager/EditorSupport/EditorCompletion.cs
@@ -61,8 +61,10 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         }
     }
 
-    // Provides code completion for the language server.
-    internal static partial class EditorSupport
+    /// <summary>
+    /// Provides code completion for the language server.
+    /// </summary>
+    internal static class EditorCompletion
     {
         /// <summary>
         /// Returns a list of suggested completion items for the given position.


### PR DESCRIPTION
An underscore prefix is sometimes used to indicate private operations/types (e.g., in the `Microsoft.Quantum.Arithmetic` namespace). This PR hides those symbols from code completion unless they belong to the same namespace that code completion is activated from.

Depends on PR #161. Part of issue #44.