### PR TITLE
Show completions for named type items

### DIFF
--- a/src/QsCompiler/CompilationManager/EditorSupport/EditorCompletion.cs
+++ b/src/QsCompiler/CompilationManager/EditorSupport/EditorCompletion.cs
@@ -13,6 +13,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.Serialization;
+using static Microsoft.Quantum.QsCompiler.SyntaxGenerator;
 using static Microsoft.Quantum.QsCompiler.TextProcessing.CodeCompletion.FragmentParsing;
 
 namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
@@ -371,7 +372,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
                 throw new ArgumentNullException(nameof(compilation));
             return compilation.GlobalSymbols.DefinedTypes()
                 .Concat(compilation.GlobalSymbols.ImportedTypes())
-                .SelectMany(type => FlattenQsTuple(type.TypeItems))
+                .SelectMany(type => ExtractItems(type.TypeItems))
                 .Where(item => item.IsNamed)
                 .Select(item => new CompletionItem()
                 {
@@ -684,21 +685,5 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
                 IsIncomplete = isIncomplete,
                 Items = items?.ToArray()
             };
-
-        /// <summary>
-        /// Returns a flattened enumerable of all items in the <see cref="QsTuple{Item}"/>.
-        /// </summary>
-        private static IEnumerable<T> FlattenQsTuple<T>(QsTuple<T> tuple)
-        {
-            switch (tuple)
-            {
-                case QsTuple<T>.QsTupleItem item:
-                    return new[] { item.Item };
-                case QsTuple<T>.QsTuple items:
-                    return items.Item.SelectMany(FlattenQsTuple);
-                default:
-                    throw new ArgumentOutOfRangeException();
-            }
-        }
     }
 }

--- a/src/QsCompiler/CompilationManager/EditorSupport/EditorCompletion.cs
+++ b/src/QsCompiler/CompilationManager/EditorSupport/EditorCompletion.cs
@@ -61,8 +61,10 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         }
     }
 
-    // Provides code completion for the language server.
-    internal static partial class EditorSupport
+    /// <summary>
+    /// Provides code completion for the language server.
+    /// </summary>
+    internal static class EditorCompletion
     {
         /// <summary>
         /// Returns a list of suggested completion items for the given position.


### PR DESCRIPTION
This PR adds a simple kind of named item completion that shows all named items for every type whenever a named item is expected.

Depends on #161. Part of issue #44.