### PR TITLE
Various minor bug fixes for code completion

### DIFF
--- a/src/QsCompiler/CompilationManager/EditorSupport/EditorCompletion.cs
+++ b/src/QsCompiler/CompilationManager/EditorSupport/EditorCompletion.cs
@@ -309,7 +309,9 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// <summary>
         /// Returns completions for all callables visible given the current namespace and the list of open namespaces.
         /// </summary>
-        /// <exception cref="ArgumentNullException">Thrown when any argument is null.</exception>
+        /// <exception cref="ArgumentNullException">
+        /// Thrown when any argument except <paramref name="currentNamespace"/> is null.
+        /// </exception>
         private static IEnumerable<CompletionItem> GetCallableCompletions(
             FileContentManager file,
             CompilationUnit compilation,
@@ -320,8 +322,6 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
                 throw new ArgumentNullException(nameof(file));
             if (compilation == null)
                 throw new ArgumentNullException(nameof(compilation));
-            if (currentNamespace == null)
-                throw new ArgumentNullException(nameof(currentNamespace));
             if (openNamespaces == null)
                 throw new ArgumentNullException(nameof(openNamespaces));
             return
@@ -344,7 +344,9 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// <summary>
         /// Returns completions for all types visible given the current namespace and the list of open namespaces.
         /// </summary>
-        /// <exception cref="ArgumentNullException">Thrown when any argument is null.</exception>
+        /// <exception cref="ArgumentNullException">
+        /// Thrown when any argument except <paramref name="currentNamespace"/> is null.
+        /// </exception>
         private static IEnumerable<CompletionItem> GetTypeCompletions(
             FileContentManager file,
             CompilationUnit compilation,
@@ -355,8 +357,6 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
                 throw new ArgumentNullException(nameof(file));
             if (compilation == null)
                 throw new ArgumentNullException(nameof(compilation));
-            if (currentNamespace == null)
-                throw new ArgumentNullException(nameof(currentNamespace));
             if (openNamespaces == null)
                 throw new ArgumentNullException(nameof(openNamespaces));
             return

--- a/src/QsCompiler/CompilationManager/EditorSupport/EditorCompletion.cs
+++ b/src/QsCompiler/CompilationManager/EditorSupport/EditorCompletion.cs
@@ -324,6 +324,9 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
                 throw new ArgumentNullException(nameof(compilation));
             if (openNamespaces == null)
                 throw new ArgumentNullException(nameof(openNamespaces));
+
+            if (!compilation.GlobalSymbols.ContainsResolutions)
+                return Array.Empty<CompletionItem>();
             return
                 compilation.GlobalSymbols.DefinedCallables()
                 .Concat(compilation.GlobalSymbols.ImportedCallables())
@@ -359,6 +362,9 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
                 throw new ArgumentNullException(nameof(compilation));
             if (openNamespaces == null)
                 throw new ArgumentNullException(nameof(openNamespaces));
+
+            if (!compilation.GlobalSymbols.ContainsResolutions)
+                return Array.Empty<CompletionItem>();
             return
                 compilation.GlobalSymbols.DefinedTypes()
                 .Concat(compilation.GlobalSymbols.ImportedTypes())
@@ -383,6 +389,9 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         {
             if (compilation == null)
                 throw new ArgumentNullException(nameof(compilation));
+
+            if (!compilation.GlobalSymbols.ContainsResolutions)
+                return Array.Empty<CompletionItem>();
             return compilation.GlobalSymbols.DefinedTypes()
                 .Concat(compilation.GlobalSymbols.ImportedTypes())
                 .SelectMany(type => ExtractItems(type.TypeItems))

--- a/src/QsCompiler/Tests.Compiler/CompletionParsingTests.fs
+++ b/src/QsCompiler/Tests.Compiler/CompletionParsingTests.fs
@@ -488,7 +488,6 @@ let ``Function statement parser tests`` () =
 [<Fact>]
 let ``Operation statement parser tests`` () =
     let functorGen = [
-        Keyword "intrinsic"
         Keyword "auto"
         Keyword "self"
         Keyword "invert"
@@ -588,7 +587,7 @@ let ``Operation statement parser tests`` () =
     List.iter (matches OperationTopLevel Null) [
         ("", operationTopLevelStatement)
         ("body ", functorGen)
-        ("body intrinsic ", [])
+        ("body auto ", [])
         ("body (", [Declaration])
         ("body (.", [])
         ("body (..", [])

--- a/src/QsCompiler/TextProcessor/CodeCompletion/FragmentParsing.fs
+++ b/src/QsCompiler/TextProcessor/CodeCompletion/FragmentParsing.fs
@@ -163,7 +163,6 @@ let private specializationDeclaration =
     let argumentTuple = tuple (expectedId Declaration (term symbol) <|> operator omittedSymbols.id "")
     let generator = 
         pcollect [
-            expectedKeyword intrinsicFunctorGenDirective
             expectedKeyword autoFunctorGenDirective
             expectedKeyword selfFunctorGenDirective
             expectedKeyword invertFunctorGenDirective


### PR DESCRIPTION
* Allow the current namespace to be null in `GetCallableCompletions` and `GetTypeCompletions`. This fixes an exception thrown when getting completions outside a namespace or just after the language server has started (not sure what was causing this - maybe the file contents haven't been loaded yet).
* Check that types have been resolved before accessing the global symbol table to avoid another exception.
* Remove `intrinsic` from the list of specialization generator completions.

Part of issue #44.