### PR TITLE
Disable code completion in Visual Studio 16.2 or older; use a workaround in 16.3

### DIFF
--- a/src/QsCompiler/LanguageServer/LanguageServer.cs
+++ b/src/QsCompiler/LanguageServer/LanguageServer.cs
@@ -158,7 +158,11 @@ namespace Microsoft.Quantum.QsLanguageServer
             var capabilities = new ServerCapabilities
             {
                 TextDocumentSync = new TextDocumentSyncOptions(),
-                CompletionProvider = new CompletionOptions(),
+                // Disable completion in Visual Studio until a bug where completion is not dismissed after typing
+                // whitespace is fixed.
+                CompletionProvider = "VisualStudio".Equals(this.ClientName, StringComparison.InvariantCultureIgnoreCase)
+                    ? null
+                    : new CompletionOptions(),
                 SignatureHelpProvider = new SignatureHelpOptions(),
                 ExecuteCommandProvider = new ExecuteCommandOptions(),
             };
@@ -175,8 +179,11 @@ namespace Microsoft.Quantum.QsLanguageServer
             capabilities.DocumentHighlightProvider = true;
             capabilities.SignatureHelpProvider.TriggerCharacters = new[] { "(", "," };
             capabilities.ExecuteCommandProvider.Commands = new[] { CommandIds.ApplyEdit }; // do not declare internal capabilities 
-            capabilities.CompletionProvider.ResolveProvider = true;
-            capabilities.CompletionProvider.TriggerCharacters = new[] { "." };
+            if (capabilities.CompletionProvider != null)
+            {
+                capabilities.CompletionProvider.ResolveProvider = true;
+                capabilities.CompletionProvider.TriggerCharacters = new[] { "." };
+            }
 
             this.WaitForInit = null;
             return new InitializeResult { Capabilities = capabilities };

--- a/src/VisualStudioExtension/QsharpVSIX/QsLanguageClient.cs
+++ b/src/VisualStudioExtension/QsharpVSIX/QsLanguageClient.cs
@@ -1,6 +1,11 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using Microsoft.VisualStudio.LanguageServer.Client;
+using Microsoft.VisualStudio.Threading;
+using Microsoft.VisualStudio.Utilities;
+using Newtonsoft.Json.Linq;
+using StreamJsonRpc;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel.Composition;
@@ -9,20 +14,17 @@ using System.IO;
 using System.IO.Pipes;
 using System.Reflection;
 using System.Security.Principal;
+using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.VisualStudio.LanguageServer.Client;
-using Microsoft.VisualStudio.Threading;
-using Microsoft.VisualStudio.Utilities;
-using Newtonsoft.Json.Linq;
-using StreamJsonRpc;
+using static System.Diagnostics.FileVersionInfo;
 
 
 namespace Microsoft.Quantum.QsLanguageExtensionVS
 {
     [ContentType("Q#")]
     [Export(typeof(ILanguageClient))]
-    public class QsLanguageClient : VisualStudio.Shell.AsyncPackage, ILanguageClient, ILanguageClientCustomMessage 
+    public class QsLanguageClient : VisualStudio.Shell.AsyncPackage, ILanguageClient, ILanguageClientCustomMessage
     {
         public QsLanguageClient() : base() =>
             CustomMessageTarget = new CustomServerNotifications();
@@ -33,7 +35,7 @@ namespace Microsoft.Quantum.QsLanguageExtensionVS
         public object CustomMessageTarget { get; }
 
         /// called third, before initializing the server
-        public Task AttachForCustomMessageAsync(JsonRpc rpc) => 
+        public Task AttachForCustomMessageAsync(JsonRpc rpc) =>
             Task.CompletedTask; // we don't need to send custom messages
 
         // properties required by ILanguageClient
@@ -41,7 +43,11 @@ namespace Microsoft.Quantum.QsLanguageExtensionVS
         public string Name => "Q# Language Extension"; // name as displayed to the user
         public IEnumerable<string> ConfigurationSections => null; // null is fine if the client does not provide settings
         public IEnumerable<string> FilesToWatch => null; // we use our own watcher rather than the one of the LSP Client
-        public object InitializationOptions => "VisualStudio";
+        public object InitializationOptions => JObject.FromObject(new
+        {
+            name = "VisualStudio",
+            version = GetVisualStudioVersion()
+        });
 
         // events required by ILanguageClient
 
@@ -133,6 +139,25 @@ namespace Microsoft.Quantum.QsLanguageExtensionVS
                 catch (Exception ex)
                 { Debug.Assert(false, $"error sending telemetry: \n{ex}"); }
             }
+        }
+
+        private static string GetVisualStudioVersion()
+        {
+            FileVersionInfo versionInfo;
+            try
+            {
+                versionInfo = GetVersionInfo(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "msenv.dll"));
+            }
+            catch (FileNotFoundException)
+            {
+                return null;
+            }
+
+            // Extract the version number from the string in the format "D16.2", "D16.3", etc.
+            var version = Regex.Match(versionInfo.FileVersion, @"D([\d\.]+)");
+            if (version.Success)
+                return version.Groups[1].Value;
+            return null;
         }
     }
 }


### PR DESCRIPTION
Due to a bug in Visual Studio 16.2, code completions in Q# aren't dismissed after typing whitespace, and accepting a completion after typing multiple symbols separated by whitespace replaces the whole line instead of just the last symbol. For now, we are disabling completion in the Visual Studio extension until the bug is resolved. (Code completion in the Visual Studio Code extension isn't affected.)

Part of issue #44.