### PR TITLE
Check that namespace exists before resolving documentation

### DIFF
--- a/src/QsCompiler/CompilationManager/EditorSupport/EditorCompletion.cs
+++ b/src/QsCompiler/CompilationManager/EditorSupport/EditorCompletion.cs
@@ -487,7 +487,9 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
                 throw new ArgumentNullException(nameof(compilation));
             if (data == null)
                 throw new ArgumentNullException(nameof(data));
-            if (data.QualifiedName == null || data.SourceFile == null)
+            if (data.QualifiedName == null
+                    || data.SourceFile == null
+                    || !compilation.GlobalSymbols.NamespaceExists(data.QualifiedName.Namespace))
                 return null;
 
             switch (kind)

--- a/src/QsCompiler/LanguageServer/EditorState.cs
+++ b/src/QsCompiler/LanguageServer/EditorState.cs
@@ -369,10 +369,11 @@ namespace Microsoft.Quantum.QsLanguageServer
             : null;
 
         /// <summary>
-        /// Resolves additional information for the given completion item.
+        /// Resolves additional information for the given completion item. Returns the original completion item if no
+        /// additional information is available.
         /// <para/>
         /// Returns null if any parameter is null or the file given in the original completion request is invalid or
-        /// ignored, or if the completion to resolve is outdated. 
+        /// ignored.
         /// </summary>
         internal CompletionItem ResolveCompletion(CompletionItem item, CompletionItemData data, MarkupKind format) =>
             item != null && ValidFileUri(data?.TextDocument?.Uri) && !IgnoreFile(data.TextDocument.Uri)

--- a/src/QsCompiler/LanguageServer/EditorState.cs
+++ b/src/QsCompiler/LanguageServer/EditorState.cs
@@ -370,7 +370,7 @@ namespace Microsoft.Quantum.QsLanguageServer
 
         /// <summary>
         /// Resolves additional information for the given completion item. Returns the original completion item if no
-        /// additional information is available.
+        /// additional information is available, or if the completion item is no longer valid or accurate.
         /// <para/>
         /// Returns null if any parameter is null or the file given in the original completion request is invalid or
         /// ignored.


### PR DESCRIPTION
This fixes an exception that was thrown if a completion resolve request was received with a qualified name that doesn't exist. The behavior now is to return the completion item unchanged if its qualified name is invalid.

Part of issue #44.