### PR TITLE
Minor restructuring of transformations

### DIFF
--- a/build/ci.yml
+++ b/build/ci.yml
@@ -4,7 +4,7 @@ trigger:
 
 variables:
   Build.Major: 0
-  Build.Minor: 0
+  Build.Minor: 9
   Assembly.Version: $(Build.BuildNumber)
   Assembly.Constants: ''
   Drops.Dir: $(Build.ArtifactStagingDirectory)/drops

--- a/src/QsCompiler/CompilationManager/CompilationUnit.cs
+++ b/src/QsCompiler/CompilationManager/CompilationUnit.cs
@@ -618,7 +618,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         internal LocalDeclarations TryGetLocalDeclarations(FileContentManager file, Position pos, out QsQualifiedName parentCallable)
         {
             var implementation = this.TryGetSpecializationAt(file, pos, out parentCallable, out var callablePos, out var specPos);
-            var declarations = implementation?.LocalDeclarationsAt(pos.Subtract(specPos)).Item1;
+            var declarations = implementation?.LocalDeclarationsAt(pos.Subtract(specPos));
             return this.PositionedDeclarations(parentCallable, callablePos, specPos, declarations); 
         }
     }

--- a/src/QsCompiler/CompilationManager/EditorSupport/SymbolInformation.cs
+++ b/src/QsCompiler/CompilationManager/EditorSupport/SymbolInformation.cs
@@ -175,7 +175,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
             if (sym == null) return false;
 
             var implementation = compilation.TryGetSpecializationAt(file, position, out var parentName, out var callablePos, out var specPos);
-            var declarations = implementation?.LocalDeclarationsAt(position.Subtract(specPos)).Item1;
+            var declarations = implementation?.LocalDeclarationsAt(position.Subtract(specPos));
             var locals = compilation.PositionedDeclarations(parentName, callablePos, specPos, declarations);
             var definition = locals.LocalVariable(sym);
 
@@ -219,7 +219,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
             else // the given position corresponds to a variable declared as part of a specialization declaration or implementation
             {
                 var defStart = DiagnosticTools.GetAbsolutePosition(defOffset, defRange.Item1);
-                var statements = implementation.LocalDeclarationsAt(defStart.Subtract(specPos)).Item2;
+                var statements = implementation.StatementsAfterDeclaration(defStart.Subtract(specPos));
                 var scope = new QsScope(statements.ToImmutableArray(), locals);
                 var rootOffset = DiagnosticTools.AsTuple(specPos); 
                 referenceLocations = IdentifierLocation.Find(definition.Item.Item1, scope, file.FileName, rootOffset).Distinct().Select(AsLocation);

--- a/src/QsCompiler/Core/ExpressionTransformation.fs
+++ b/src/QsCompiler/Core/ExpressionTransformation.fs
@@ -250,8 +250,8 @@ and ExpressionTypeTransformation(?enable) =
 
     abstract member onCallableInformation : CallableInformation -> CallableInformation
     default this.onCallableInformation opInfo = 
-        let inferred = opInfo.InferredInformation
         let characteristics = this.onCharacteristicsExpression opInfo.Characteristics
+        let inferred = opInfo.InferredInformation
         CallableInformation.New (characteristics, inferred)
 
     abstract member onUserDefinedType : UserDefinedType -> ExpressionType
@@ -362,8 +362,8 @@ and ExpressionTransformation(?enableKindTransformations) =
     abstract member Transform : TypedExpression -> TypedExpression
     default this.Transform (ex : TypedExpression) =
         let range                = this.onRangeInformation ex.Range
-        let kind                 = this.Kind.Transform ex.Expression
         let typeParamResolutions = ex.TypeParameterResolutions
+        let kind                 = this.Kind.Transform ex.Expression
         let exType               = this.Type.Transform ex.ResolvedType
         let inferredInfo         = this.onExpressionInformation ex.InferredInformation
         TypedExpression.New (kind, typeParamResolutions, exType, inferredInfo, range)

--- a/src/QsCompiler/Core/StatementTransformation.fs
+++ b/src/QsCompiler/Core/StatementTransformation.fs
@@ -50,14 +50,14 @@ type StatementKindTransformation(?enable) =
 
     abstract member onVariableDeclaration : QsBinding<TypedExpression> -> QsStatementKind
     default this.onVariableDeclaration stm = 
-        let lhs = this.onSymbolTuple stm.Lhs
         let rhs = this.ExpressionTransformation stm.Rhs
+        let lhs = this.onSymbolTuple stm.Lhs
         QsBinding<TypedExpression>.New stm.Kind (lhs, rhs) |> QsVariableDeclaration
 
     abstract member onValueUpdate : QsValueUpdate -> QsStatementKind
     default this.onValueUpdate stm = 
-        let lhs = this.ExpressionTransformation stm.Lhs
         let rhs = this.ExpressionTransformation stm.Rhs
+        let lhs = this.ExpressionTransformation stm.Lhs
         QsValueUpdate.New (lhs, rhs) |> QsValueUpdate
 
     member private this.onPositionedBlock (intro : TypedExpression option, block : QsPositionedBlock) = 
@@ -77,8 +77,8 @@ type StatementKindTransformation(?enable) =
 
     abstract member onForStatement : QsForStatement -> QsStatementKind
     default this.onForStatement stm = 
-        let loopVar = fst stm.LoopItem |> this.onSymbolTuple
         let iterVals = this.ExpressionTransformation stm.IterationValues
+        let loopVar = fst stm.LoopItem |> this.onSymbolTuple
         let loopVarType = this.TypeTransformation (snd stm.LoopItem)
         let body = this.ScopeTransformation stm.Body
         QsForStatement.New ((loopVar, loopVarType), iterVals, body) |> QsForStatement
@@ -103,8 +103,8 @@ type StatementKindTransformation(?enable) =
 
     member private this.onQubitScope (stm : QsQubitScope) = 
         let kind = stm.Kind
-        let lhs = this.onSymbolTuple stm.Binding.Lhs
         let rhs = this.onQubitInitializer stm.Binding.Rhs
+        let lhs = this.onSymbolTuple stm.Binding.Lhs
         let body = this.ScopeTransformation stm.Body
         QsQubitScope.New kind ((lhs, rhs), body) |> QsQubitScope
 

--- a/src/QsCompiler/DataStructures/SyntaxTree.fs
+++ b/src/QsCompiler/DataStructures/SyntaxTree.fs
@@ -412,6 +412,7 @@ type LocalDeclarations = { // keeping things here as arrays for resource reasons
     Variables : ImmutableArray<LocalVariableDeclaration<NonNullable<string>>>
 }
     with 
+    member this.IsEmpty = this.Variables.Length = 0
     static member Empty = {Variables = ImmutableArray.Empty}
 
 


### PR DESCRIPTION
This PR switches the order of expression and declaration evaluations for default transformations such that now the rhs is evaluated before the lhs. It also slightly adapts the routine for getting local declarations at a certain position to make the resolution more precise (and in particular not include variables that are defined only after the statement at the specified position). 