### PR TITLE
Fixing build issue

### DIFF
--- a/build/init.yml
+++ b/build/init.yml
@@ -21,3 +21,9 @@ steps:
     command: custom
     verbose: false
     customCommand: 'install -g vsce'
+
+- task: UseDotNet@2
+  displayName: 'Use .NET Core 2.2.105'
+  inputs:
+    packageType: sdk
+    version: '2.2.105'

--- a/build/wrap-up.yml
+++ b/build/wrap-up.yml
@@ -10,12 +10,6 @@ steps:
     testResultsFiles: '$(System.DefaultWorkingDirectory)/**/*.trx'
     testRunTitle: 'Q# compiler tests'
 
-- task: PublishSymbols@1
-  displayName: 'Publish symbols'
-  continueOnError: true
-  inputs:
-    SearchPattern: '**\bin\**\*.pdb'
-
 - task: CopyFiles@2
   displayName: 'Copy extensions to: $(VSIX.Outdir)'
   condition: succeededOrFailed()


### PR DESCRIPTION
There is a bug in certain versions of .NET Core that will cause the build to hang on the language server project. Hence I'll force it to use not one of these versions. 