### PR TITLE
Sccarda/generic resolution

### DIFF
--- a/src/QsCompiler/Compiler/CompilationLoader.cs
+++ b/src/QsCompiler/Compiler/CompilationLoader.cs
@@ -218,14 +218,14 @@ namespace Microsoft.Quantum.QsCompiler
 
             // executing the specified rewrite steps 
 
+            this.GeneratedSyntaxTree = Transformations.Monomorphization.ResolveGenericsSyntax.Apply(this.GeneratedSyntaxTree);
+
             if (this.Config.GenerateFunctorSupport)
             {
                 this.CompilationStatus.FunctorSupport = 0;
                 var functorSpecGenerated = this.GeneratedSyntaxTree != null && FunctorGeneration.GenerateFunctorSpecializations(this.GeneratedSyntaxTree, out this.GeneratedSyntaxTree);
                 if (!functorSpecGenerated) this.LogAndUpdate(ref this.CompilationStatus.FunctorSupport, ErrorCode.FunctorGenerationFailed, Enumerable.Empty<string>());
             }
-
-            this.GeneratedSyntaxTree = Transformations.Monomorphization.ResolveGenericsSyntax.Apply(this.GeneratedSyntaxTree);
 
             if (!this.Config.SkipSyntaxTreeTrimming)
             {

--- a/src/QsCompiler/Compiler/CompilationLoader.cs
+++ b/src/QsCompiler/Compiler/CompilationLoader.cs
@@ -225,7 +225,7 @@ namespace Microsoft.Quantum.QsCompiler
                 if (!functorSpecGenerated) this.LogAndUpdate(ref this.CompilationStatus.FunctorSupport, ErrorCode.FunctorGenerationFailed, Enumerable.Empty<string>());
             }
 
-            Transformations.Monomorphization.ResolveGenericsSyntax.Apply(this.GeneratedSyntaxTree);
+            this.GeneratedSyntaxTree = Transformations.Monomorphization.ResolveGenericsSyntax.Apply(this.GeneratedSyntaxTree);
 
             if (!this.Config.SkipSyntaxTreeTrimming)
             {

--- a/src/QsCompiler/Compiler/CompilationLoader.cs
+++ b/src/QsCompiler/Compiler/CompilationLoader.cs
@@ -225,6 +225,8 @@ namespace Microsoft.Quantum.QsCompiler
                 if (!functorSpecGenerated) this.LogAndUpdate(ref this.CompilationStatus.FunctorSupport, ErrorCode.FunctorGenerationFailed, Enumerable.Empty<string>());
             }
 
+            Transformations.Monomorphization.ResolveGenericsSyntax.Apply(this.GeneratedSyntaxTree);
+
             if (!this.Config.SkipSyntaxTreeTrimming)
             {
                 this.CompilationStatus.TreeTrimming = 0;

--- a/src/QsCompiler/DataStructures/Diagnostics.fs
+++ b/src/QsCompiler/DataStructures/Diagnostics.fs
@@ -271,6 +271,7 @@ type ErrorCode =
     | DocGenerationFailed = 7105
     | GeneratingBinaryFailed = 7106
     | TargetExecutionFailed = 7107
+    | MonomorphizationFailed = 7108
 
 
 type WarningCode = 
@@ -599,6 +600,7 @@ type DiagnosticItem =
             | ErrorCode.DocGenerationFailed                     -> "Unable to generate documentation for the compiled code."
             | ErrorCode.GeneratingBinaryFailed                  -> "Unable to generate binary format for the compilation."
             | ErrorCode.TargetExecutionFailed                   -> "Processing of the compiled binary with the target {0} failed."
+            | ErrorCode.MonomorphizationFailed                  -> "Replacing type parametrizations with the concrete instantiations failed."
             | _                                                 -> "" 
         code |> ApplyArguments             
              

--- a/src/QsCompiler/Transformations/BasicTransformations.cs
+++ b/src/QsCompiler/Transformations/BasicTransformations.cs
@@ -13,6 +13,34 @@ namespace Microsoft.Quantum.QsCompiler.Transformations.BasicTransformations
 {
     // syntax tree transformations
 
+    public class ResolveGenerics :
+            SyntaxTreeTransformation<NoScopeTransformations>
+    {
+        public static QsNamespace Apply(QsNamespace ns)
+        {
+            if (ns == null) throw new ArgumentNullException(nameof(ns));
+            var filter = new ResolveGenerics();
+            return filter.Transform(ns);
+        }
+
+        //private readonly Dictionary<thing1, thing2> Callables;
+        private ResolveGenerics() : base(new NoScopeTransformations()) {}
+
+        public override QsSpecialization onSpecializationImplementation(QsSpecialization spec) // short cut to avoid further evaluation
+        {
+            this.onSourceFile(spec.SourceFile);
+            return spec;
+        }
+
+        public override QsNamespace Transform(QsNamespace ns)
+        {
+            // Get global callables
+            // this.Callables = GetCallables(ns);
+            var newNs = base.Transform(ns);
+            return newNs;
+        }
+    }
+
     public class GetSourceFiles :
         SyntaxTreeTransformation<NoScopeTransformations>
     {

--- a/src/QsCompiler/Transformations/BasicTransformations.cs
+++ b/src/QsCompiler/Transformations/BasicTransformations.cs
@@ -13,34 +13,6 @@ namespace Microsoft.Quantum.QsCompiler.Transformations.BasicTransformations
 {
     // syntax tree transformations
 
-    public class ResolveGenerics :
-            SyntaxTreeTransformation<NoScopeTransformations>
-    {
-        public static QsNamespace Apply(QsNamespace ns)
-        {
-            if (ns == null) throw new ArgumentNullException(nameof(ns));
-            var filter = new ResolveGenerics();
-            return filter.Transform(ns);
-        }
-
-        //private readonly Dictionary<thing1, thing2> Callables;
-        private ResolveGenerics() : base(new NoScopeTransformations()) {}
-
-        public override QsSpecialization onSpecializationImplementation(QsSpecialization spec) // short cut to avoid further evaluation
-        {
-            this.onSourceFile(spec.SourceFile);
-            return spec;
-        }
-
-        public override QsNamespace Transform(QsNamespace ns)
-        {
-            // Get global callables
-            // this.Callables = GetCallables(ns);
-            var newNs = base.Transform(ns);
-            return newNs;
-        }
-    }
-
     public class GetSourceFiles :
         SyntaxTreeTransformation<NoScopeTransformations>
     {

--- a/src/QsCompiler/Transformations/CodeTransformations.cs
+++ b/src/QsCompiler/Transformations/CodeTransformations.cs
@@ -55,7 +55,8 @@ namespace Microsoft.Quantum.QsCompiler.Transformations
             new InlineConjugationStatements().Transform(scope);
 
         /// <summary>
-        /// ...
+        /// Eliminates all type parameterized callables from the scope by replacing their definitions and references to concrete
+        /// versions of the callable.
         /// Throws an ArgumentNullException if the given syntaxTree is null.
         /// </summary>
         public static bool Monomorphisize(IEnumerable<QsNamespace> syntaxTree, out IEnumerable<QsNamespace> result, 

--- a/src/QsCompiler/Transformations/CodeTransformations.cs
+++ b/src/QsCompiler/Transformations/CodeTransformations.cs
@@ -1,9 +1,12 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
+using System.Collections.Generic;
 using Microsoft.Quantum.QsCompiler.SyntaxTree;
 using Microsoft.Quantum.QsCompiler.Transformations.Conjugations;
 using Microsoft.Quantum.QsCompiler.Transformations.FunctorGeneration;
+using Microsoft.Quantum.QsCompiler.Transformations.Monomorphization;
 using Microsoft.Quantum.QsCompiler.Transformations.SearchAndReplace;
 
 
@@ -18,6 +21,7 @@ namespace Microsoft.Quantum.QsCompiler.Transformations
         /// Given the body of an operation, auto-generates the (content of the) adjoint specialization, 
         /// under the assumption that operation calls may only ever occur within expression statements, 
         /// and while-loops cannot occur within operations. 
+        /// Throws an ArgumentNullException if the given scope is null.
         /// </summary>
         public static QsScope GenerateAdjoint(this QsScope scope)
         {
@@ -32,6 +36,7 @@ namespace Microsoft.Quantum.QsCompiler.Transformations
         /// <summary>
         /// Given the body of an operation, auto-generates the (content of the) controlled specialization 
         /// using the default name for control qubits.
+        /// Throws an ArgumentNullException if the given scope is null.
         /// </summary>
         public static QsScope GenerateControlled(this QsScope scope)
         {
@@ -44,9 +49,31 @@ namespace Microsoft.Quantum.QsCompiler.Transformations
         /// The generation of the adjoint for the outer block is subject to the same limitation as any adjoint auto-generation. 
         /// In particular, it is only guaranteed to be valid if operation calls only occur within expression statements, and 
         /// throws an InvalidOperationException if the outer block contains while-loops. 
+        /// Throws an ArgumentNullException if the given scope is null.
         /// </summary>
         public static QsScope InlineConjugations(this QsScope scope) =>
-            new InlineConjugationStatements().Transform(scope); 
+            new InlineConjugationStatements().Transform(scope);
+
+        /// <summary>
+        /// ...
+        /// Throws an ArgumentNullException if the given syntaxTree is null.
+        /// </summary>
+        public static bool Monomorphisize(IEnumerable<QsNamespace> syntaxTree, out IEnumerable<QsNamespace> result, 
+            Action<Exception> onException = null) 
+        {
+            if (syntaxTree == null) throw new ArgumentNullException(nameof(syntaxTree));
+            result = syntaxTree;
+            try
+            {
+                result = ResolveGenericsSyntax.Apply(syntaxTree);
+                return true;
+            }
+            catch (Exception ex)
+            {
+                onException?.Invoke(ex);
+                return false;
+            }
+        }
     }
 }
 

--- a/src/QsCompiler/Transformations/Monomorphization.cs
+++ b/src/QsCompiler/Transformations/Monomorphization.cs
@@ -2,41 +2,113 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using Microsoft.Quantum.QsCompiler.DataTypes;
+using Microsoft.Quantum.QsCompiler.SyntaxTokens;
 using Microsoft.Quantum.QsCompiler.SyntaxTree;
-
+using Microsoft.Quantum.QsCompiler.Transformations.Core;
 
 namespace Microsoft.Quantum.QsCompiler.Transformations.Monomorphization
 {
-    public class ResolveGenerics :
-            SyntaxTreeTransformation<NoScopeTransformations>
+    public class ResolveGenericsSyntax :
+        SyntaxTreeTransformation<ResolveGenericsScope>
     {
-        public static QsNamespace Apply(QsNamespace ns)
+        public static IEnumerable<QsNamespace> Apply(IEnumerable<QsNamespace> namespaces)
         {
-            if (ns == null) throw new ArgumentNullException(nameof(ns));
-            var filter = new ResolveGenerics();
-            return filter.Transform(ns);
+            if (namespaces == null || namespaces.Contains(null)) throw new ArgumentNullException(nameof(namespaces));
+            var filter = new ResolveGenericsSyntax(new ResolveGenericsScope());
+
+            // Get list of generics
+            var Callables = namespaces.GlobalCallableResolutions();
+            foreach (var callable in Callables)
+            {
+                if (callable.Value.Signature.TypeParameters.Any())
+                {
+                    filter.Generics.Add(callable.Value);
+                }
+            }
+
+            foreach (var ns in namespaces)
+            {
+                filter.Transform(ns);
+            }
+            return namespaces;
         }
 
-        //private readonly Dictionary<thing1, thing2> Callables;
-        private ResolveGenerics() : base(new NoScopeTransformations()) { }
-
-        public override QsSpecialization onSpecializationImplementation(QsSpecialization spec) // short cut to avoid further evaluation
+        public static IEnumerable<QsNamespace> Apply(params QsNamespace[] namespaces)
         {
-            this.onSourceFile(spec.SourceFile);
-            return spec;
+            return Apply(namespaces);
         }
 
-        public override QsNamespace Transform(QsNamespace ns)
+        List<QsCallable> Generics;
+
+        public ResolveGenericsSyntax(ResolveGenericsScope scope) : base(scope)
         {
-            // Get global callables
-            // this.Callables = GetCallables(ns);
-            var newNs = base.Transform(ns);
-            return newNs;
+            this.Generics = new List<QsCallable>();
         }
+
+        //public override QsNamespace Transform(QsNamespace ns)
+        //{
+        //    // Get global callables
+        //    
+        //    // this.Callables = GetCallables(ns);
+        //    var newNs = base.Transform(ns);
+        //    return newNs;
+        //}
     }
 
+    public class ResolveGenericsScope :
+            ScopeTransformation<ResolveGenericsExpression>
+    {
+        public ResolveGenericsScope() : base(new ResolveGenericsExpression()) { }
+
+        //public override QsStatementKind onExpressionStatement(TypedExpression te)
+        //{
+        //    return QsStatementKind.NewQsExpressionStatement(te);
+        //}
+    }
+
+    public class ResolveGenericsExpression :
+        ExpressionTransformation<ResolvedGenericsExpressionKind>
+    {
+        public ResolveGenericsExpression() : base(ex => new ResolvedGenericsExpressionKind(ex as ResolveGenericsExpression))
+        {
+            
+        }
+
+        //public override TypedExpression Transform(TypedExpression ex)
+        //{
+        //    if (ex.Expression is QsExpressionKind<TypedExpression, Identifier, ResolvedType>.Identifier temp)
+        //    {
+        //        temp.Item1.IsGlobalCallable
+        //        var kind = QsExpressionKind<TypedExpression, Identifier, ResolvedType>.NewIdentifier(
+        //            Identifier.NewGlobalCallable(
+        //                new QsQualifiedName(NonNullable<string>.New(""), NonNullable<string>.New(""))),
+        //            new QsNullable<ImmutableArray<ResolvedType>>());
+        //        ex = new TypedExpression(kind, ex.TypeParameterResolutions, ex.ResolvedType, ex.InferredInformation, ex.Range);
+        //    }
+        //    return ex;
+        //}
+    }
+
+    public class ResolvedGenericsExpressionKind :
+        ExpressionKindTransformation<ResolveGenericsExpression>
+    {
+        public ResolvedGenericsExpressionKind(ResolveGenericsExpression expr) : base(expr)
+        {
+            
+        }
+
+        public override QsExpressionKind<TypedExpression, Identifier, ResolvedType> onIdentifier(Identifier sym, QsNullable<ImmutableArray<ResolvedType>> tArgs)
+        {
+            if (sym is Identifier.GlobalCallable temp)
+            {
+                sym = Identifier.NewGlobalCallable(new QsQualifiedName(temp.Item.Namespace, NonNullable<string>.New("REWRITE_" + temp.Item.Name.Value)));
+            }
+            return base.onIdentifier(sym, tArgs);
+        }
+    }
 }

--- a/src/QsCompiler/Transformations/Monomorphization.cs
+++ b/src/QsCompiler/Transformations/Monomorphization.cs
@@ -11,10 +11,11 @@ using Microsoft.Quantum.QsCompiler.SyntaxTokens;
 using Microsoft.Quantum.QsCompiler.SyntaxTree;
 using Microsoft.Quantum.QsCompiler.Transformations.Core;
 
+
 namespace Microsoft.Quantum.QsCompiler.Transformations.Monomorphization
 {
     public class ResolveGenericsSyntax :
-        SyntaxTreeTransformation<ResolveGenericsScope>
+        SyntaxTreeTransformation<ScopeTransformation<ResolveGenericsExpression>>
     {
         public static IEnumerable<QsNamespace> Apply(IEnumerable<QsNamespace> namespaces)
         {
@@ -31,28 +32,22 @@ namespace Microsoft.Quantum.QsCompiler.Transformations.Monomorphization
                 }
             }
 
-            var filter = new ResolveGenericsSyntax(new ResolveGenericsScope());
+            var filter = new ResolveGenericsSyntax(new ScopeTransformation<ResolveGenericsExpression>(new ResolveGenericsExpression()));
             return namespaces.Select(ns => filter.Transform(ns));
         }
 
         public static IEnumerable<QsNamespace> Apply(params QsNamespace[] namespaces)
         {
-            return Apply(namespaces);
+            return Apply((IEnumerable<QsNamespace>)namespaces);
         }
 
-        public ResolveGenericsSyntax(ResolveGenericsScope scope) : base(scope) { }
-    }
-
-    public class ResolveGenericsScope :
-            ScopeTransformation<ResolveGenericsExpression>
-    {
-        public ResolveGenericsScope() : base(new ResolveGenericsExpression()) { }
+        public ResolveGenericsSyntax(ScopeTransformation<ResolveGenericsExpression> scope) : base(scope) { }
     }
 
     public class ResolveGenericsExpression :
-        ExpressionTransformation<ResolvedGenericsExpressionKind>
+        ExpressionTransformation<ExpressionKindTransformation<ResolveGenericsExpression>>
     {
-        public ResolveGenericsExpression() : base(ex => new ResolvedGenericsExpressionKind(ex as ResolveGenericsExpression)) { }
+        public ResolveGenericsExpression() : base(ex => new ExpressionKindTransformation<ResolveGenericsExpression>(ex as ResolveGenericsExpression)) { }
 
         public override TypedExpression Transform(TypedExpression ex)
         {
@@ -100,11 +95,5 @@ namespace Microsoft.Quantum.QsCompiler.Transformations.Monomorphization
                 .Select(kvp => kvp.Key.TypeName.Value + "_" + kvp.Value.Resolution.ToString() + "_")
                 );
         }
-    }
-
-    public class ResolvedGenericsExpressionKind :
-        ExpressionKindTransformation<ResolveGenericsExpression>
-    {
-        public ResolvedGenericsExpressionKind(ResolveGenericsExpression expr) : base(expr) { }
     }
 }

--- a/src/QsCompiler/Transformations/Monomorphization.cs
+++ b/src/QsCompiler/Transformations/Monomorphization.cs
@@ -11,7 +11,6 @@ using Microsoft.Quantum.QsCompiler.SyntaxTokens;
 using Microsoft.Quantum.QsCompiler.SyntaxTree;
 using Microsoft.Quantum.QsCompiler.Transformations.Core;
 
-
 namespace Microsoft.Quantum.QsCompiler.Transformations.Monomorphization
 {
     public class ResolveGenericsSyntax :
@@ -51,6 +50,7 @@ namespace Microsoft.Quantum.QsCompiler.Transformations.Monomorphization
 
         public override TypedExpression Transform(TypedExpression ex)
         {
+            // TODO: This should be recursive and use a more robust data structure to handle the type information for generics
             ImmutableDictionary<QsTypeParameter, ResolvedType> types = ex.TypeParameterResolutions;
 
             if (types.Any() && ex.Expression is QsExpressionKind<TypedExpression, Identifier, ResolvedType>.CallLikeExpression call)

--- a/src/QsCompiler/Transformations/Monomorphization.cs
+++ b/src/QsCompiler/Transformations/Monomorphization.cs
@@ -19,18 +19,23 @@ namespace Microsoft.Quantum.QsCompiler.Transformations.Monomorphization
         public static IEnumerable<QsNamespace> Apply(IEnumerable<QsNamespace> namespaces)
         {
             if (namespaces == null || namespaces.Contains(null)) throw new ArgumentNullException(nameof(namespaces));
-            var filter = new ResolveGenericsSyntax(new ResolveGenericsScope());
 
             // Get list of generics
+            List<QsQualifiedName> generics = new List<QsQualifiedName>();
             var Callables = namespaces.GlobalCallableResolutions();
             foreach (var callable in Callables)
             {
                 if (callable.Value.Signature.TypeParameters.Any())
                 {
-                    filter.Generics.Add(callable.Value);
+                    generics.Add(callable.Key);
                 }
             }
 
+            // Function for determining if callable is a generic
+            Func<QsQualifiedName, bool> isGeneric = callable =>
+                generics.Any(generic => generic.Name.Value == callable.Name.Value && generic.Namespace.Value == callable.Namespace.Value);
+
+            var filter = new ResolveGenericsSyntax(new ResolveGenericsScope(isGeneric));
             return namespaces.Select(ns => filter.Transform(ns));
         }
 
@@ -39,27 +44,13 @@ namespace Microsoft.Quantum.QsCompiler.Transformations.Monomorphization
             return Apply(namespaces);
         }
 
-        List<QsCallable> Generics;
-
-        public ResolveGenericsSyntax(ResolveGenericsScope scope) : base(scope)
-        {
-            this.Generics = new List<QsCallable>();
-        }
-
-        //public override QsNamespace Transform(QsNamespace ns)
-        //{
-        //    // Get global callables
-        //    
-        //    // this.Callables = GetCallables(ns);
-        //    var newNs = base.Transform(ns);
-        //    return newNs;
-        //}
+        public ResolveGenericsSyntax(ResolveGenericsScope scope) : base(scope) { }
     }
 
     public class ResolveGenericsScope :
             ScopeTransformation<ResolveGenericsExpression>
     {
-        public ResolveGenericsScope() : base(new ResolveGenericsExpression()) { }
+        public ResolveGenericsScope(Func<QsQualifiedName, bool> isGeneric) : base(new ResolveGenericsExpression(isGeneric)) { }
 
         //public override QsStatementKind onExpressionStatement(TypedExpression te)
         //{
@@ -70,37 +61,23 @@ namespace Microsoft.Quantum.QsCompiler.Transformations.Monomorphization
     public class ResolveGenericsExpression :
         ExpressionTransformation<ResolvedGenericsExpressionKind>
     {
-        public ResolveGenericsExpression() : base(ex => new ResolvedGenericsExpressionKind(ex as ResolveGenericsExpression))
-        {
-            
-        }
-
-        //public override TypedExpression Transform(TypedExpression ex)
-        //{
-        //    if (ex.Expression is QsExpressionKind<TypedExpression, Identifier, ResolvedType>.Identifier temp)
-        //    {
-        //        temp.Item1.IsGlobalCallable
-        //        var kind = QsExpressionKind<TypedExpression, Identifier, ResolvedType>.NewIdentifier(
-        //            Identifier.NewGlobalCallable(
-        //                new QsQualifiedName(NonNullable<string>.New(""), NonNullable<string>.New(""))),
-        //            new QsNullable<ImmutableArray<ResolvedType>>());
-        //        ex = new TypedExpression(kind, ex.TypeParameterResolutions, ex.ResolvedType, ex.InferredInformation, ex.Range);
-        //    }
-        //    return ex;
-        //}
+        public ResolveGenericsExpression(Func<QsQualifiedName, bool> isGeneric) :
+            base(ex => new ResolvedGenericsExpressionKind(ex as ResolveGenericsExpression, isGeneric)) { }
     }
 
     public class ResolvedGenericsExpressionKind :
         ExpressionKindTransformation<ResolveGenericsExpression>
     {
-        public ResolvedGenericsExpressionKind(ResolveGenericsExpression expr) : base(expr)
+        public ResolvedGenericsExpressionKind(ResolveGenericsExpression expr, Func<QsQualifiedName, bool> isGeneric) : base(expr)
         {
-            
+            this.isGeneric = isGeneric;
         }
+
+        private Func<QsQualifiedName, bool> isGeneric;
 
         public override QsExpressionKind<TypedExpression, Identifier, ResolvedType> onIdentifier(Identifier sym, QsNullable<ImmutableArray<ResolvedType>> tArgs)
         {
-            if (sym is Identifier.GlobalCallable temp)
+            if (sym is Identifier.GlobalCallable temp && this.isGeneric(temp.Item))
             {
                 sym = Identifier.NewGlobalCallable(new QsQualifiedName(temp.Item.Namespace, NonNullable<string>.New("REWRITE_" + temp.Item.Name.Value)));
             }

--- a/src/QsCompiler/Transformations/Monomorphization.cs
+++ b/src/QsCompiler/Transformations/Monomorphization.cs
@@ -31,11 +31,7 @@ namespace Microsoft.Quantum.QsCompiler.Transformations.Monomorphization
                 }
             }
 
-            foreach (var ns in namespaces)
-            {
-                filter.Transform(ns);
-            }
-            return namespaces;
+            return namespaces.Select(ns => filter.Transform(ns));
         }
 
         public static IEnumerable<QsNamespace> Apply(params QsNamespace[] namespaces)

--- a/src/QsCompiler/Transformations/Monomorphization.cs
+++ b/src/QsCompiler/Transformations/Monomorphization.cs
@@ -1,0 +1,42 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.Quantum.QsCompiler.DataTypes;
+using Microsoft.Quantum.QsCompiler.SyntaxTree;
+
+
+namespace Microsoft.Quantum.QsCompiler.Transformations.Monomorphization
+{
+    public class ResolveGenerics :
+            SyntaxTreeTransformation<NoScopeTransformations>
+    {
+        public static QsNamespace Apply(QsNamespace ns)
+        {
+            if (ns == null) throw new ArgumentNullException(nameof(ns));
+            var filter = new ResolveGenerics();
+            return filter.Transform(ns);
+        }
+
+        //private readonly Dictionary<thing1, thing2> Callables;
+        private ResolveGenerics() : base(new NoScopeTransformations()) { }
+
+        public override QsSpecialization onSpecializationImplementation(QsSpecialization spec) // short cut to avoid further evaluation
+        {
+            this.onSourceFile(spec.SourceFile);
+            return spec;
+        }
+
+        public override QsNamespace Transform(QsNamespace ns)
+        {
+            // Get global callables
+            // this.Callables = GetCallables(ns);
+            var newNs = base.Transform(ns);
+            return newNs;
+        }
+    }
+
+}


### PR DESCRIPTION
Rewriting calls to global generics to have type-specific identifiers. Robust naming collision handling is not yet addressed.