### PR TITLE
Insert doc comments before declaration attributes

### DIFF
--- a/src/QsCompiler/CompilationManager/EditorSupport/SymbolInformation.cs
+++ b/src/QsCompiler/CompilationManager/EditorSupport/SymbolInformation.cs
@@ -165,8 +165,9 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
             IImmutableSet<NonNullable<string>> limitToSourceFiles = null)
         {
             (referenceLocations, declarationLocation) = (null, null);
-            var symbolInfo = file?.TryGetQsSymbolInfo(position, true, out var _); // includes the end position 
-            if (symbolInfo == null || compilation == null) return false;
+            if (file == null || compilation == null) return false;
+            var symbolInfo = file.TryGetQsSymbolInfo(position, true, out var fragment); // includes the end position 
+            if (symbolInfo == null || fragment?.Kind is QsFragmentKind.NamespaceDeclaration) return false;
 
             var sym = symbolInfo.UsedTypes.Any()
                 && symbolInfo.UsedTypes.Single().Type is QsTypeKind<QsType, QsSymbol, QsSymbol, Characteristics>.UserDefinedType udt ? udt.Item


### PR DESCRIPTION
A minor thing I came across when working: The code action for adding doc comments did not get updated when we added support for attributes, such that the doc comments were inserted immediately before the declaration instead of before all attributes attached to the declaration. 