### PR TITLE
Fixing the perf issues for reading declaration headers

### DIFF
--- a/src/QsCompiler/CompilationManager/AssemblyLoader.cs
+++ b/src/QsCompiler/CompilationManager/AssemblyLoader.cs
@@ -68,8 +68,7 @@ namespace Microsoft.Quantum.QsCompiler
             using (var reader = new BsonDataReader(stream))
             {
                 reader.ReadRootValueAsArray = true;
-                var serializer = Json.Serializer(Json.Converters(false));
-                return serializer.Deserialize<IEnumerable<QsNamespace>>(reader);
+                return Json.Serializer.Deserialize<IEnumerable<QsNamespace>>(reader);
             }
         }
 

--- a/src/QsCompiler/Compiler/CompilationLoader.cs
+++ b/src/QsCompiler/Compiler/CompilationLoader.cs
@@ -509,9 +509,8 @@ namespace Microsoft.Quantum.QsCompiler
             var serialized = this.GeneratedSyntaxTree != null;
             using (var writer = new BsonDataWriter(ms) { CloseOutput = false })
             {
-                var serializer = Json.Serializer(Json.Converters(false));
                 var validTree = this.GeneratedSyntaxTree?.Select(ns => FilterBySourceFile.Apply(ns, validSources));
-                try { serializer.Serialize(writer, validTree ?? Enumerable.Empty<QsNamespace>()); }
+                try { Json.Serializer.Serialize(writer, validTree ?? Enumerable.Empty<QsNamespace>()); }
                 catch (Exception ex)
                 {
                     this.LogAndUpdate(ref this.CompilationStatus.Serialization, ex);

--- a/src/QsCompiler/Core/DeclarationHeaders.fs
+++ b/src/QsCompiler/Core/DeclarationHeaders.fs
@@ -17,19 +17,16 @@ open Newtonsoft.Json
 /// to be removed in future releases
 module private DeclarationHeader = 
 
-    let Serializer = Json.Converters false |> Json.Serializer
-    let PermissiveSerializer = Json.Converters true |> Json.Serializer
-
     let FromJson<'T> json = 
         let deserialize (serializer : JsonSerializer) =             
             let reader = new JsonTextReader(new StringReader(json));
             serializer.Deserialize<'T>(reader)
-        try true, Serializer |> deserialize
-        with _ -> false, PermissiveSerializer |> deserialize
+        try true, Json.Serializer |> deserialize
+        with _ -> false, Json.PermissiveSerializer |> deserialize
 
     let ToJson obj = 
         let builder = new StringBuilder()
-        (Json.Converters false |> Json.Serializer).Serialize(new StringWriter(builder), obj)
+        Json.Serializer.Serialize(new StringWriter(builder), obj)
         builder.ToString()
 
 

--- a/src/QsCompiler/Core/DeclarationHeaders.fs
+++ b/src/QsCompiler/Core/DeclarationHeaders.fs
@@ -15,16 +15,19 @@ open Newtonsoft.Json
 
 
 /// to be removed in future releases
-type private DeclarationHeader = 
+module private DeclarationHeader = 
 
-    static member internal FromJson<'T> json = 
-        let deserialize converters =             
+    let Serializer = Json.Converters false |> Json.Serializer
+    let PermissiveSerializer = Json.Converters true |> Json.Serializer
+
+    let FromJson<'T> json = 
+        let deserialize (serializer : JsonSerializer) =             
             let reader = new JsonTextReader(new StringReader(json));
-            (converters |> Json.Serializer).Deserialize<'T>(reader)
-        try true, Json.Converters false |> deserialize
-        with _ -> false, Json.Converters true |> deserialize
+            serializer.Deserialize<'T>(reader)
+        try true, Serializer |> deserialize
+        with _ -> false, PermissiveSerializer |> deserialize
 
-    static member internal ToJson obj = 
+    let ToJson obj = 
         let builder = new StringBuilder()
         (Json.Converters false |> Json.Serializer).Serialize(new StringWriter(builder), obj)
         builder.ToString()

--- a/src/QsCompiler/DataStructures/Serialization.fs
+++ b/src/QsCompiler/DataStructures/Serialization.fs
@@ -102,8 +102,9 @@ type DictionaryAsArrayResolver () =
         else base.CreateContract(objectType);
 
 
-type Json =
-    static member Converters ignoreSerializationException = 
+module Json =
+    
+    let Converters ignoreSerializationException = 
         [|
             new NonNullableConverter<string>()                                  :> JsonConverter
             new ResolvedTypeConverter(ignoreSerializationException)             :> JsonConverter
@@ -113,10 +114,15 @@ type Json =
             new QsNamespaceConverter()                                          :> JsonConverter
         |]
 
-    static member Serializer converters = 
+    let Serializer = 
         let settings = new JsonSerializerSettings() 
-        settings.Converters <- converters
+        settings.Converters <- Converters false
         settings.ContractResolver <- new DictionaryAsArrayResolver()
         JsonSerializer.CreateDefault(settings)
 
+    let PermissiveSerializer = 
+        let settings = new JsonSerializerSettings() 
+        settings.Converters <- Converters true
+        settings.ContractResolver <- new DictionaryAsArrayResolver()
+        JsonSerializer.CreateDefault(settings)
 


### PR DESCRIPTION
It seems like constructing the Json serializer takes a fair amount of time due to the array contract. 
Hence making sure it is only constructed once...