### PR TITLE
Bug fix: Expression Kind Transformations Disabled on Monomorphization

### DIFF
--- a/src/QsCompiler/Transformations/Monomorphization.cs
+++ b/src/QsCompiler/Transformations/Monomorphization.cs
@@ -207,7 +207,7 @@ namespace Microsoft.Quantum.QsCompiler.Transformations.Monomorphization
         public ReplaceTypeParamImplementationsSyntax(ImmutableConcretion typeParams) : base(
             new ScopeTransformation<ExpressionTransformation<Core.ExpressionKindTransformation, ReplaceTypeParamImplementationsExpressionType>>(
                 new ExpressionTransformation<Core.ExpressionKindTransformation, ReplaceTypeParamImplementationsExpressionType>(
-                    null,
+                    ex => new ExpressionKindTransformation<ExpressionTransformation<Core.ExpressionKindTransformation, ReplaceTypeParamImplementationsExpressionType>>(ex as ExpressionTransformation<Core.ExpressionKindTransformation, ReplaceTypeParamImplementationsExpressionType>),
                     ex => new ReplaceTypeParamImplementationsExpressionType(typeParams, ex as ExpressionTransformation<Core.ExpressionKindTransformation, ReplaceTypeParamImplementationsExpressionType>)
                     ))) { }
 


### PR DESCRIPTION
Bug fix: null lambda was causing expression kind transformations to be disabled.