### PR TITLE
Top level node representing a Q# compilation

### DIFF
--- a/src/QsCompiler/CommandLineTool/Commands/Diagnose.cs
+++ b/src/QsCompiler/CommandLineTool/Commands/Diagnose.cs
@@ -225,8 +225,8 @@ namespace Microsoft.Quantum.QsCompiler.CommandLineCompiler
             if (logger.Verbosity < DiagnosticSeverity.Information) logger.Verbosity = DiagnosticSeverity.Information;
             if (options.PrintTextRepresentation) PrintFileContentInMemory(loaded.VerifiedCompilation, logger);
             if (options.PrintTokenization) PrintContentTokenization(loaded.VerifiedCompilation, logger);
-            if (options.PrintSyntaxTree) PrintSyntaxTree(loaded.GeneratedSyntaxTree, loaded.VerifiedCompilation, logger);
-            if (options.PrintCompiledCode) PrintGeneratedQs(loaded.GeneratedSyntaxTree, loaded.VerifiedCompilation, logger);
+            if (options.PrintSyntaxTree) PrintSyntaxTree(loaded.CompilationOutput?.Namespaces, loaded.VerifiedCompilation, logger);
+            if (options.PrintCompiledCode) PrintGeneratedQs(loaded.CompilationOutput?.Namespaces, loaded.VerifiedCompilation, logger);
             return ReturnCode.Status(loaded);
         }
     }

--- a/src/QsCompiler/CompilationManager/AssemblyLoader.cs
+++ b/src/QsCompiler/CompilationManager/AssemblyLoader.cs
@@ -58,17 +58,17 @@ namespace Microsoft.Quantum.QsCompiler
         // tools for loading the compiled syntax tree from the dll resource (later setup for shipping Q# libraries)
 
         /// <summary>
-        /// Given a stream containing the binary representation of compiled Q# code, returns the corresponding syntax tree.
+        /// Given a stream containing the binary representation of compiled Q# code, returns the corresponding Q# compilation.
         /// Throws an ArgumentNullException if the given stream is null.
         /// May throw an exception if the given binary file has been compiled with a different compiler version.
         /// </summary>
-        public static IEnumerable<QsNamespace> LoadSyntaxTree(Stream stream)
+        public static QsCompilation LoadSyntaxTree(Stream stream)
         {
             if (stream == null) throw new ArgumentNullException(nameof(stream));
             using (var reader = new BsonDataReader(stream))
             {
-                reader.ReadRootValueAsArray = true;
-                return Json.Serializer.Deserialize<IEnumerable<QsNamespace>>(reader);
+                reader.ReadRootValueAsArray = false;
+                return Json.Serializer.Deserialize<QsCompilation>(reader);
             }
         }
 
@@ -85,8 +85,8 @@ namespace Microsoft.Quantum.QsCompiler
                 );
 
         /// <summary>
-        /// Given a reader for the byte stream of a dotnet dll, loads any Q# syntax tree included as a resource.
-        /// Returns true as well as the loaded tree if the given dll includes a suitable resource, 
+        /// Given a reader for the byte stream of a dotnet dll, loads any Q# compilation included as a resource.
+        /// Returns true as well as the syntax tree of the loaded compilation if the given dll includes a suitable resource, 
         /// and returns false as well as an empty sequence otherwise. 
         /// Throws an ArgumentNullException if any of the given readers is null.
         /// May throw an exception if the given binary file has been compiled with a different compiler version.
@@ -115,7 +115,7 @@ namespace Microsoft.Quantum.QsCompiler
             // the first four bytes of the resource denote how long the resource is, and are followed by the actual resource data
             var resourceLength = BitConverter.ToInt32(image.GetContent(absResourceOffset, sizeof(Int32)).ToArray(), 0);
             var resourceData = image.GetContent(absResourceOffset + sizeof(Int32), resourceLength).ToArray();
-            syntaxTree = LoadSyntaxTree(new MemoryStream(resourceData));
+            syntaxTree = LoadSyntaxTree(new MemoryStream(resourceData)).Namespaces;
             return true;
         }
 

--- a/src/QsCompiler/CompilationManager/CompilationUnitManager.cs
+++ b/src/QsCompiler/CompilationManager/CompilationUnitManager.cs
@@ -663,7 +663,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// before constructing the syntax tree by calling FlushAndExecute.
         /// </summary>
         public IEnumerable<QsNamespace> GetSyntaxTree() =>
-            this.FlushAndExecute(() => this.CompilationUnit.Build().AsEnumerable());
+            this.FlushAndExecute(() => this.CompilationUnit.Build().Namespaces.AsEnumerable());
 
         /// <summary>
         /// Returns a Compilation object containing all information about the current state of the compilation. 
@@ -698,10 +698,13 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
             /// </summary>
             public readonly ImmutableDictionary<NonNullable<string>, ImmutableArray<ImmutableArray<CodeFragment>>> Tokenization;
             /// <summary>
-            /// Contains a dictionary that maps the ID of a file included in the compilation 
-            /// to the syntax tree built based on its content. 
+            /// Contains a dictionary that maps the name of a namespace to the compiled Q# namespace.
             /// </summary>
             public readonly ImmutableDictionary<NonNullable<string>, QsNamespace> SyntaxTree;
+            /// <summary>
+            /// Contains the built Q# compilation.
+            /// </summary>
+            public readonly QsCompilation BuiltCompilation; 
 
             /// <summary>
             /// Contains a dictionary that maps the name of each namespace defined in the compilation to a look-up 
@@ -799,6 +802,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
             {
                 try
                 {
+                    this.BuiltCompilation = manager.CompilationUnit.Build();
                     this.SourceFiles = manager.FileContentManagers.Keys.ToImmutableHashSet();
                     this.References = manager.CompilationUnit.Externals.Declarations.Keys.ToImmutableHashSet();
 
@@ -808,7 +812,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
                     this.Tokenization = this.SourceFiles
                         .Select(file => (file, manager.FileContentManagers[file].GetTokenizedLines().Select(line => line.Select(frag => frag.Copy()).ToImmutableArray()).ToImmutableArray()))
                         .ToImmutableDictionary(tuple => tuple.Item1, tuple => tuple.Item2);
-                    this.SyntaxTree = manager.CompilationUnit.Build().ToImmutableDictionary(ns => ns.Name);
+                    this.SyntaxTree = this.BuiltCompilation.Namespaces.ToImmutableDictionary(ns => ns.Name);
 
                     this.OpenDirectivesForEachFile = this.SyntaxTree.Keys.ToImmutableDictionary(
                         nsName => nsName, 

--- a/src/QsCompiler/Compiler/CompilationLoader.cs
+++ b/src/QsCompiler/Compiler/CompilationLoader.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.IO;
@@ -14,11 +13,8 @@ using Microsoft.Quantum.QsCompiler.Documentation;
 using Microsoft.Quantum.QsCompiler.ReservedKeywords;
 using Microsoft.Quantum.QsCompiler.Serialization;
 using Microsoft.Quantum.QsCompiler.SyntaxTree;
-using Microsoft.Quantum.QsCompiler.Transformations;
 using Microsoft.Quantum.QsCompiler.Transformations.BasicTransformations;
-using Microsoft.Quantum.QsCompiler.Transformations.Conjugations;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
-using Newtonsoft.Json;
 using Newtonsoft.Json.Bson;
 using MetadataReference = Microsoft.CodeAnalysis.MetadataReference;
 
@@ -227,9 +223,9 @@ namespace Microsoft.Quantum.QsCompiler
         /// </summary>
         public readonly CompilationUnitManager.Compilation VerifiedCompilation;
         /// <summary>
-        /// Contains the syntax tree after executing all configured rewrite steps.
+        /// Contains the built compilation including the syntax tree after executing all configured rewrite steps.
         /// </summary>
-        public readonly IEnumerable<QsNamespace> GeneratedSyntaxTree;
+        public readonly QsCompilation CompilationOutput;
         /// <summary>
         /// Contains the absolute path where the binary representation of the generated syntax tree has been written to disk.
         /// </summary>
@@ -264,7 +260,7 @@ namespace Microsoft.Quantum.QsCompiler
             compilationManager.UpdateReferencesAsync(references);
             compilationManager.AddOrUpdateSourceFilesAsync(files);
             this.VerifiedCompilation = compilationManager.Build();
-            this.GeneratedSyntaxTree = this.VerifiedCompilation?.SyntaxTree.Values;
+            this.CompilationOutput = this.VerifiedCompilation?.BuiltCompilation;
 
             foreach (var diag in this.VerifiedCompilation.SourceFiles?.SelectMany(this.VerifiedCompilation.Diagnostics) ?? Enumerable.Empty<Diagnostic>())
             { this.LogAndUpdate(ref this.CompilationStatus.Validation, diag); }
@@ -274,23 +270,24 @@ namespace Microsoft.Quantum.QsCompiler
             if (this.Config.GenerateFunctorSupport)
             {
                 this.CompilationStatus.FunctorSupport = 0;
-                var functorSpecGenerated = this.GeneratedSyntaxTree != null && FunctorGeneration.GenerateFunctorSpecializations(this.GeneratedSyntaxTree, out this.GeneratedSyntaxTree);
-                if (!functorSpecGenerated) this.LogAndUpdate(ref this.CompilationStatus.FunctorSupport, ErrorCode.FunctorGenerationFailed, Enumerable.Empty<string>());
+                void onException(Exception ex) => this.LogAndUpdate(ref this.CompilationStatus.FunctorSupport, ex);
+                var generated = this.CompilationOutput != null && CodeGeneration.GenerateFunctorSpecializations(this.CompilationOutput, out this.CompilationOutput, onException);
+                if (!generated) this.LogAndUpdate(ref this.CompilationStatus.FunctorSupport, ErrorCode.FunctorGenerationFailed, Enumerable.Empty<string>());
             }
 
             if (!this.Config.SkipSyntaxTreeTrimming)
             {
                 this.CompilationStatus.TreeTrimming = 0;
-                var rewrite = new InlineConjugations(onException: ex => this.LogAndUpdate(ref this.CompilationStatus.TreeTrimming, ex));
-                this.GeneratedSyntaxTree = this.GeneratedSyntaxTree?.Select(ns => rewrite.Transform(ns))?.ToImmutableArray();
-                if (this.GeneratedSyntaxTree == null || !rewrite.Success) this.LogAndUpdate(ref this.CompilationStatus.TreeTrimming, ErrorCode.TreeTrimmingFailed, Enumerable.Empty<string>());
+                void onException(Exception ex) => this.LogAndUpdate(ref this.CompilationStatus.TreeTrimming, ex);
+                var trimmed = this.CompilationOutput != null && CodeTransformations.InlineConjugations(this.CompilationOutput, out this.CompilationOutput, onException);
+                if (!trimmed) this.LogAndUpdate(ref this.CompilationStatus.TreeTrimming, ErrorCode.TreeTrimmingFailed, Enumerable.Empty<string>());
             }
 
             if (this.Config.AttemptFullPreEvaluation)
             {
                 this.CompilationStatus.PreEvaluation = 0;
                 void onException(Exception ex) => this.LogAndUpdate(ref this.CompilationStatus.PreEvaluation, ex);
-                var evaluated = this.GeneratedSyntaxTree != null && CodeTransformations.PreEvaluateAll(this.GeneratedSyntaxTree, out this.GeneratedSyntaxTree, onException);
+                var evaluated = this.CompilationOutput != null && CodeTransformations.PreEvaluateAll(this.CompilationOutput, out this.CompilationOutput, onException);
                 if (!evaluated) this.LogAndUpdate(ref this.CompilationStatus.PreEvaluation, ErrorCode.PreEvaluationFailed, Enumerable.Empty<string>()); 
             }
 
@@ -487,7 +484,7 @@ namespace Microsoft.Quantum.QsCompiler
         }
 
         /// <summary>
-        /// Writes a binary representation of the generated syntax tree to the given memory stream. 
+        /// Writes a binary representation of the built Q# compilation output to the given memory stream. 
         /// Logs suitable diagnostics in the process and modifies the compilation status accordingly.
         /// Does *not* close the given memory stream, and
         /// returns true if the serialization has been successfully generated. 
@@ -496,29 +493,32 @@ namespace Microsoft.Quantum.QsCompiler
         private bool SerializeSyntaxTree(MemoryStream ms)
         {
             if (ms == null) throw new ArgumentNullException(nameof(ms));
+            bool ErrorAndReturn ()
+            { 
+                this.LogAndUpdate(ref this.CompilationStatus.Serialization, ErrorCode.SerializationFailed, Enumerable.Empty<string>());
+                return false;
+            }
             this.CompilationStatus.Serialization = 0;
+            if (this.CompilationOutput == null) ErrorAndReturn();
 
             // FIXME: this needs to be revised
             var invalidReferences = this.LoadDiagnostics
                 .Filter(DiagnosticTools.WarningType(WarningCode.UnrecognizedContentInReference))
                 .Select(d => d.Source).ToImmutableHashSet();
-            var validSources = this.GeneratedSyntaxTree == null
+            var validSources = this.CompilationOutput.Namespaces == null
                 ? new NonNullable<string>[0]
-                : GetSourceFiles.Apply(this.GeneratedSyntaxTree).Where(s => !invalidReferences.Contains(s.Value)).ToArray();
+                : GetSourceFiles.Apply(this.CompilationOutput.Namespaces).Where(s => !invalidReferences.Contains(s.Value)).ToArray();
 
-            var serialized = this.GeneratedSyntaxTree != null;
-            using (var writer = new BsonDataWriter(ms) { CloseOutput = false })
+            using var writer = new BsonDataWriter(ms) { CloseOutput = false };
+            var valid = this.CompilationOutput.Namespaces.Select(ns => FilterBySourceFile.Apply(ns, validSources));
+            var compilation = new QsCompilation(valid.ToImmutableArray(), this.CompilationOutput.EntryPoints);
+            try { Json.Serializer.Serialize(writer, compilation); }
+            catch (Exception ex)
             {
-                var validTree = this.GeneratedSyntaxTree?.Select(ns => FilterBySourceFile.Apply(ns, validSources));
-                try { Json.Serializer.Serialize(writer, validTree ?? Enumerable.Empty<QsNamespace>()); }
-                catch (Exception ex)
-                {
-                    this.LogAndUpdate(ref this.CompilationStatus.Serialization, ex);
-                    serialized = false;
-                }
+                this.LogAndUpdate(ref this.CompilationStatus.Serialization, ex);
+                ErrorAndReturn();
             }
-            if (!serialized) this.LogAndUpdate(ref this.CompilationStatus.Serialization, ErrorCode.SerializationFailed, Enumerable.Empty<string>());
-            return serialized;
+            return true;
         }
 
         /// <summary>
@@ -575,7 +575,7 @@ namespace Microsoft.Quantum.QsCompiler
             outputPath = Path.ChangeExtension(outputPath, "dll");
 
             // FIXME: this needs to be revised
-            var usedReferences = GetSourceFiles.Apply(this.GeneratedSyntaxTree);
+            var usedReferences = GetSourceFiles.Apply(this.CompilationOutput.Namespaces);
             var invalidReferences = this.LoadDiagnostics
                 .Filter(DiagnosticTools.WarningType(WarningCode.UnrecognizedContentInReference))
                 .Select(d => d.Source).ToImmutableHashSet();
@@ -622,20 +622,20 @@ namespace Microsoft.Quantum.QsCompiler
         }
 
         /// <summary>
-        /// Given the path to a Q# binary file, reads the content of that file and returns the corresponding syntax tree. 
+        /// Given the path to a Q# binary file, reads the content of that file and returns the corresponding syntax tree as out parameter. 
         /// Throws the corresponding exception if the given path does not correspond to a suitable binary file.
         /// May throw an exception if the given binary file has been compiled with a different compiler version.
         /// </summary>
-        public static IEnumerable<QsNamespace> ReadBinary(string file) =>
-            ReadBinary(new MemoryStream(File.ReadAllBytes(Path.GetFullPath(file))));
+        public static void ReadBinary(string file, out IEnumerable<QsNamespace> syntaxTree) =>
+            ReadBinary(new MemoryStream(File.ReadAllBytes(Path.GetFullPath(file))), out syntaxTree);
 
         /// <summary>
-        /// Given a stream with the content of a Q# binary file, returns the corresponding syntax tree.
+        /// Given a stream with the content of a Q# binary file, returns the corresponding syntax tree as out parameter.
         /// Throws an ArgumentNullException if the given stream is null.
         /// May throw an exception if the given binary file has been compiled with a different compiler version.
         /// </summary>
-        public static IEnumerable<QsNamespace> ReadBinary(Stream stream) =>
-            AssemblyLoader.LoadSyntaxTree(stream);
+        public static void ReadBinary(Stream stream, out IEnumerable<QsNamespace> syntaxTree)
+        { syntaxTree = AssemblyLoader.LoadSyntaxTree(stream).Namespaces; }
 
         /// <summary>
         /// Given a file id assigned by the Q# compiler, computes the corresponding path in the specified output folder. 

--- a/src/QsCompiler/Core/ConstructorExtensions.fs
+++ b/src/QsCompiler/Core/ConstructorExtensions.fs
@@ -243,3 +243,9 @@ type QsNamespace with
         Documentation = documentation
     }
 
+type QsCompilation with 
+    static member New (namespaces, entryPoints) = {
+        Namespaces = namespaces
+        EntryPoints = entryPoints
+    }
+

--- a/src/QsCompiler/DataStructures/SyntaxTree.fs
+++ b/src/QsCompiler/DataStructures/SyntaxTree.fs
@@ -738,6 +738,16 @@ type QsNamespace = {
 }
 
 
+/// Describes a compiled Q# library or executable.
+type QsCompilation = {
+    /// contains all compiled namespaces 
+    Namespaces : ImmutableArray<QsNamespace>
+    /// Contains the names of all entry points of the compilation.
+    /// In the case of a library the array is empty.
+    EntryPoints : ImmutableArray<QsQualifiedName>
+}
+
+
 
 
 

--- a/src/QsCompiler/TestTargets/Simulation/Target/Program.cs
+++ b/src/QsCompiler/TestTargets/Simulation/Target/Program.cs
@@ -1,15 +1,28 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.IO;
 using System.Linq;
 using CommandLine;
 using Microsoft.Quantum.QsCompiler.CommandLineCompiler;
 using Microsoft.Quantum.QsCompiler.CsharpGeneration;
+using Microsoft.Quantum.QsCompiler.Serialization;
+using Microsoft.Quantum.QsCompiler.SyntaxTree;
 using Microsoft.Quantum.QsCompiler.Transformations.BasicTransformations;
+using Newtonsoft.Json.Bson;
 
 
 namespace Microsoft.Quantum.QsCompiler.Testing.Simulation
 {
+    /// TODO BE REMOVED!
+    public class QsCompilation
+    {
+        public ImmutableArray<QsNamespace> Namespaces;
+        ImmutableArray<QsQualifiedName> EntryPoints;
+    }
+
     /// <summary>
     /// This executable server as example program for defining an executable 
     /// that can be given as target to the Q# command line compiler (via -t path/To/Simulation.dll). 
@@ -18,9 +31,21 @@ namespace Microsoft.Quantum.QsCompiler.Testing.Simulation
     /// </summary>
     public static class Program
     {
+        /// TODO BE REMOVED!
+        private static IEnumerable<QsNamespace> ReadBinary(string file)
+        {
+
+            using var stream = new MemoryStream(File.ReadAllBytes(Path.GetFullPath(file)));
+            using var reader = new BsonDataReader(stream);
+            reader.ReadRootValueAsArray = false;
+            return Json.Serializer.Deserialize<QsCompilation>(reader).Namespaces;
+        }
+
+
         private static void GenerateFromBinary(string outputFolder, string pathToBinary)
         {
-            var syntaxTree = CompilationLoader.ReadBinary(pathToBinary).ToArray();
+            /// TODO: TO BE REPLACED BY CompilationLoader.ReadBinary
+            var syntaxTree = ReadBinary(pathToBinary).ToArray();
             var allSources = GetSourceFiles.Apply(syntaxTree); // also generate the code for referenced libraries
             foreach (var source in allSources)
             {

--- a/src/QsCompiler/TestTargets/Simulation/Target/Simulation.csproj
+++ b/src/QsCompiler/TestTargets/Simulation/Target/Simulation.csproj
@@ -23,7 +23,8 @@
 
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.6.0" />
-    <PackageReference Include="Microsoft.Quantum.CsharpGeneration" Version="0.8.1907.1701" />
+    <PackageReference Include="Microsoft.Quantum.CsharpGeneration" Version="0.10.1910.2301-alpha" />
+    <PackageReference Include="Newtonsoft.Json.Bson" Version="1.0.2" />
   </ItemGroup>
 
 </Project>

--- a/src/QsCompiler/Tests.Compiler/SetupVerificationTests.fs
+++ b/src/QsCompiler/Tests.Compiler/SetupVerificationTests.fs
@@ -20,8 +20,9 @@ open Xunit.Abstractions
 type CompilerTests (compilation : CompilationUnitManager.Compilation, output:ITestOutputHelper) = 
 
     let syntaxTree = 
-        match compilation.SyntaxTree.Values |> FunctorGeneration.GenerateFunctorSpecializations with 
-        | _, tree -> tree // the functor generation is expected to fail for certain cases
+        let mutable compilation = compilation.BuiltCompilation
+        CodeGeneration.GenerateFunctorSpecializations (compilation, &compilation) |> ignore // the functor generation is expected to fail for certain cases
+        compilation.Namespaces
 
     let callables = syntaxTree |> GlobalCallableResolutions
     let types = syntaxTree |> GlobalTypeResolutions

--- a/src/QsCompiler/Tests.Compiler/TransformationTests.fs
+++ b/src/QsCompiler/Tests.Compiler/TransformationTests.fs
@@ -73,9 +73,9 @@ let private buildSyntaxTree code =
     let compilationUnit = new CompilationUnitManager(fun ex -> failwith ex.Message) 
     let file = CompilationUnitManager.InitializeFileManager(fileId, code)
     compilationUnit.AddOrUpdateSourceFileAsync file |> ignore  // spawns a task that modifies the current compilation
-    let mutable syntaxTree = compilationUnit.GetSyntaxTree()   // will wait for any current tasks to finish
-    FunctorGeneration.GenerateFunctorSpecializations(syntaxTree, &syntaxTree) |> ignore
-    syntaxTree
+    let mutable syntaxTree = compilationUnit.Build().BuiltCompilation // will wait for any current tasks to finish
+    CodeGeneration.GenerateFunctorSpecializations(syntaxTree, &syntaxTree) |> ignore
+    syntaxTree.Namespaces
 
 
 //////////////////////////////// tests //////////////////////////////////

--- a/src/QsCompiler/Transformations/CodeTransformations.cs
+++ b/src/QsCompiler/Transformations/CodeTransformations.cs
@@ -2,7 +2,8 @@
 // Licensed under the MIT License.
 
 using System;
-using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
 using Microsoft.Quantum.QsCompiler.Optimizations;
 using Microsoft.Quantum.QsCompiler.SyntaxTree;
 using Microsoft.Quantum.QsCompiler.Transformations.Conjugations;
@@ -10,7 +11,7 @@ using Microsoft.Quantum.QsCompiler.Transformations.FunctorGeneration;
 using Microsoft.Quantum.QsCompiler.Transformations.SearchAndReplace;
 
 
-namespace Microsoft.Quantum.QsCompiler.Transformations
+namespace Microsoft.Quantum.QsCompiler
 {
     /// <summary>
     /// Static base class to accumulate the handles to individual syntax tree rewrite steps. 
@@ -43,25 +44,37 @@ namespace Microsoft.Quantum.QsCompiler.Transformations
         }
 
         /// <summary>
-        /// Eliminates all conjugations from the given scope by replacing them with the corresponding implementations (i.e. inlining them). 
+        /// Eliminates all conjugations from the given compilation by replacing them with the corresponding implementations (i.e. inlining them). 
         /// The generation of the adjoint for the outer block is subject to the same limitation as any adjoint auto-generation. 
         /// In particular, it is only guaranteed to be valid if operation calls only occur within expression statements, and 
         /// throws an InvalidOperationException if the outer block contains while-loops. 
+        /// Any thrown exception is logged using the given onException action and are silently ignored if onException is not specified or null. 
+        /// Returns true if the transformation succeeded without throwing an exception, and false otherwise. 
+        /// Throws an ArgumentNullException (that is not logged or ignored) if the given compilation is null. 
         /// </summary>
-        public static QsScope InlineConjugations(this QsScope scope) =>
-            new InlineConjugationStatements().Transform(scope);
+        public static bool InlineConjugations(this QsCompilation compilation, out QsCompilation inlined, Action<Exception> onException = null)
+        {
+            if (compilation == null) throw new ArgumentNullException(nameof(compilation));
+            var inline = new InlineConjugations(onException); 
+            var namespaces = compilation.Namespaces.Select(inline.Transform).ToImmutableArray();
+            inlined = new QsCompilation(namespaces, compilation.EntryPoints);
+            return inline.Success;
+        }
 
         /// <summary>
-        /// 
+        /// Pre-evaluates as much of the classical computations as possible in the given compilation. 
+        /// Any thrown exception is logged using the given onException action and are silently ignored if onException is not specified or null. 
+        /// Returns true if the transformation succeeded without throwing an exception, and false otherwise. 
+        /// Throws an ArgumentNullException (that is not logged or ignored) if the given compilation is null. 
         /// </summary>
-        public static bool PreEvaluateAll(IEnumerable<QsNamespace> syntaxTree, 
-            out IEnumerable<QsNamespace> evaluated, Action<Exception> onException = null)
+        public static bool PreEvaluateAll(this QsCompilation compilation, out QsCompilation evaluated, Action<Exception> onException = null)
         {
-            try { evaluated = PreEvalution.All(syntaxTree); }
+            if (compilation == null) throw new ArgumentNullException(nameof(compilation));
+            try { evaluated = PreEvalution.All(compilation); }
             catch (Exception ex)
             {
                 onException?.Invoke(ex);
-                evaluated = syntaxTree;
+                evaluated = compilation;
                 return false;
             }
             return true;


### PR DESCRIPTION
We will want this handle going forward, so hence it would be good to actually make that change before we ship the compiled Q# for the first time...