### PR TITLE
Suppress spurious installation prompt, fix chmod +x issue on macOS and Linux

### DIFF
--- a/src/VSCodeExtension/src/dotnet.ts
+++ b/src/VSCodeExtension/src/dotnet.ts
@@ -34,7 +34,7 @@ function promptToInstallDotNetCoreSDK(msg : string) {
  * Returns the path to the .NET Core SDK, or prompts the user to install
  * if the SDK is not found.
  */
-export function findDotNetSdk() : Promise<DotnetInfo> {
+export function findDotNetSdk(promptIfMissing : boolean = true) : Promise<DotnetInfo> {
     return new Promise((resolve, reject) => {
 
         if (dotnet === undefined) {
@@ -50,7 +50,9 @@ export function findDotNetSdk() : Promise<DotnetInfo> {
                     }
                 );
             } catch (ex) {
-                promptToInstallDotNetCoreSDK("The .NET Core SDK was not found on your PATH.");
+                if (promptIfMissing) {
+                    promptToInstallDotNetCoreSDK("The .NET Core SDK was not found on your PATH.");
+                }
                 reject(ex);
             }
         } else {

--- a/src/VSCodeExtension/src/extension.ts
+++ b/src/VSCodeExtension/src/extension.ts
@@ -41,7 +41,7 @@ export async function activate(context: vscode.ExtensionContext) {
     // Get any .NET Core SDK version number to report in telemetry.
     var dotNetSdk : DotnetInfo | undefined;
     try {
-        dotNetSdk = await findDotNetSdk();
+        dotNetSdk = await findDotNetSdk(false);
     } catch {
         dotNetSdk = undefined;
     }


### PR DESCRIPTION
This PR removes a prompt to install .NET Core SDK (only needed for using Q# commands like new project creation, so the prompt shouldn't show on launch more generally), and fixes a permissions error for macOS and Linux.