### PR TITLE
Use Enum for Status Instead of Int

### DIFF
--- a/src/QsCompiler/Compiler/CompilationLoader.cs
+++ b/src/QsCompiler/Compiler/CompilationLoader.cs
@@ -362,13 +362,9 @@ namespace Microsoft.Quantum.QsCompiler
             {
                 var serialized = this.Config.SerializeSyntaxTree && this.SerializeSyntaxTree(ms);
                 if (serialized && this.Config.BuildOutputFolder != null)
-                {
-                    this.PathToCompiledBinary = this.GenerateBinary(ms);
-                }
+                { this.PathToCompiledBinary = this.GenerateBinary(ms); }
                 if (serialized && this.Config.DllOutputPath != null)
-                {
-                    this.DllOutputPath = this.GenerateDll(ms);
-                }
+                { this.DllOutputPath = this.GenerateDll(ms); }
             }
 
             // executing the specified generation steps 


### PR DESCRIPTION
In the compilation loader, use the Status enum rather that integers throughout the file for better code clarity and reduce the need to use a conversion method.