### PR TITLE
Override handle to load references based on C# attributes

### DIFF
--- a/src/QsCompiler/CompilationManager/AssemblyLoader.cs
+++ b/src/QsCompiler/CompilationManager/AssemblyLoader.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Quantum.QsCompiler
         /// Throws a FileNotFoundException if no file with the given name exists. 
         /// Throws the corresponding exceptions if the information cannot be extracted.
         /// </summary>
-        public static bool LoadReferencedAssembly(Uri asm, out References.Headers headers)
+        public static bool LoadReferencedAssembly(Uri asm, out References.Headers headers, bool ignoreDllResources = false)
         {
             if (asm == null) throw new ArgumentNullException(nameof(asm));
             if (!CompilationUnitManager.TryGetFileId(asm, out var id) || !File.Exists(asm.LocalPath))
@@ -42,11 +42,11 @@ namespace Microsoft.Quantum.QsCompiler
 
             using var stream = File.OpenRead(asm.LocalPath);
             using var assemblyFile = new PEReader(stream);
-            if (!FromResource(assemblyFile, out var syntaxTree)) 
+            if (ignoreDllResources || !FromResource(assemblyFile, out var syntaxTree)) 
             {
                 var attributes = LoadHeaderAttributes(assemblyFile);
                 headers = new References.Headers(id, attributes);
-                return !attributes.Any(); // just means we have no references
+                return ignoreDllResources || !attributes.Any(); // just means we have no references
             }
             headers = new References.Headers(id, syntaxTree?.Namespaces ?? ImmutableArray<QsNamespace>.Empty);
             return true;

--- a/src/QsCompiler/CompilationManager/CompilationUnit.cs
+++ b/src/QsCompiler/CompilationManager/CompilationUnit.cs
@@ -7,7 +7,6 @@ using System.Collections.Immutable;
 using System.Collections.ObjectModel;
 using System.Linq;
 using System.Threading;
-using Microsoft.Quantum.QsCompiler;
 using Microsoft.Quantum.QsCompiler.DataTypes;
 using Microsoft.Quantum.QsCompiler.Diagnostics;
 using Microsoft.Quantum.QsCompiler.SymbolManagement;

--- a/src/QsCompiler/Compiler/CompilationLoader.cs
+++ b/src/QsCompiler/Compiler/CompilationLoader.cs
@@ -110,6 +110,24 @@ namespace Microsoft.Quantum.QsCompiler
             /// </summary>
             internal bool SerializeSyntaxTree =>
                 BuildOutputFolder != null || DllOutputPath != null;
+
+            /// <summary>
+            /// If the ProjectName does not have an ending "proj", appends a .qsproj ending to the project name. 
+            /// Returns null if the project name is null. 
+            /// </summary>
+            internal string ProjectNameWithExtension =>
+                this.ProjectName == null ? null :
+                this.ProjectName.EndsWith("proj") ? this.ProjectName : 
+                $"{this.ProjectName}.qsproj";
+
+            /// <summary>
+            /// If the ProjectName does have an extension ending with "proj", returns the project name without that extension. 
+            /// Returns null if the project name is null. 
+            /// </summary>
+            internal string ProjectNameWithoutExtension =>
+                this.ProjectName == null ? null :
+                Path.GetExtension(this.ProjectName).EndsWith("proj") ? Path.GetFileNameWithoutExtension(this.ProjectName) :
+                this.ProjectName;
         }
 
         /// <summary>
@@ -566,7 +584,7 @@ namespace Microsoft.Quantum.QsCompiler
             void onException(Exception ex) => this.LogAndUpdate(ref this.CompilationStatus.ReferenceLoading, ex);
             void onDiagnostic(Diagnostic d) => this.LogAndUpdateLoadDiagnostics(ref this.CompilationStatus.ReferenceLoading, d);
             var headers = ProjectManager.LoadReferencedAssemblies(refs ?? Enumerable.Empty<string>(), onDiagnostic, onException);
-            var projId = this.Config.ProjectName == null ? null : Path.ChangeExtension(Path.GetFullPath(this.Config.ProjectName), "qsproj");
+            var projId = this.Config.ProjectName == null ? null : Path.ChangeExtension(Path.GetFullPath(this.Config.ProjectNameWithExtension), "qsproj");
             var references = new References(headers, (code, args) => onDiagnostic(Errors.LoadError(code, args, projId)));
             this.PrintResolvedAssemblies(references.Declarations.Keys);
             return references;
@@ -617,7 +635,7 @@ namespace Microsoft.Quantum.QsCompiler
             if (serialization == null) throw new ArgumentNullException(nameof(serialization));
             this.CompilationStatus.BinaryFormat = 0;
 
-            var projId = NonNullable<string>.New(Path.GetFullPath(this.Config.ProjectName ?? Path.GetRandomFileName()));
+            var projId = NonNullable<string>.New(Path.GetFullPath(this.Config.ProjectNameWithExtension ?? Path.GetRandomFileName()));
             var outFolder = Path.GetFullPath(String.IsNullOrWhiteSpace(this.Config.BuildOutputFolder) ? "." : this.Config.BuildOutputFolder);
             var target = GeneratedFile(projId, outFolder, ".bson", "");
 
@@ -651,7 +669,7 @@ namespace Microsoft.Quantum.QsCompiler
             if (serialization == null) throw new ArgumentNullException(nameof(serialization));
             this.CompilationStatus.DllGeneration = 0;
 
-            var fallbackFileName = (this.PathToCompiledBinary ?? this.Config.ProjectName) ?? Path.GetRandomFileName();
+            var fallbackFileName = (this.PathToCompiledBinary ?? this.Config.ProjectNameWithExtension) ?? Path.GetRandomFileName();
             var outputPath = Path.GetFullPath(String.IsNullOrWhiteSpace(this.Config.DllOutputPath) ? fallbackFileName : this.Config.DllOutputPath);
             outputPath = Path.ChangeExtension(outputPath, "dll");
 
@@ -689,7 +707,7 @@ namespace Microsoft.Quantum.QsCompiler
                 }
 
                 var compilation = CodeAnalysis.CSharp.CSharpCompilation.Create(
-                    this.Config.ProjectName ?? Path.GetFileNameWithoutExtension(outputPath),
+                    this.Config.ProjectNameWithoutExtension ?? Path.GetFileNameWithoutExtension(outputPath),
                     syntaxTrees: new[] { csharpTree },
                     references: references.Select(r => r.Item2).Append(MetadataReference.CreateFromFile(typeof(object).Assembly.Location)), // if System.Object can't be found a warning is generated
                     options: new CodeAnalysis.CSharp.CSharpCompilationOptions(outputKind: CodeAnalysis.OutputKind.DynamicallyLinkedLibrary)

--- a/src/QsCompiler/Compiler/ExternalRewriteSteps.cs
+++ b/src/QsCompiler/Compiler/ExternalRewriteSteps.cs
@@ -209,7 +209,7 @@ namespace Microsoft.Quantum.QsCompiler
 
                     var defaultOutput = assemblyConstants.TryGetValue(AssemblyConstants.OutputPath, out var path) ? path : null; 
                     assemblyConstants[AssemblyConstants.OutputPath] = outputFolder ?? defaultOutput ?? config.BuildOutputFolder;
-                    assemblyConstants[AssemblyConstants.AssemblyName] = config.ProjectName;
+                    assemblyConstants[AssemblyConstants.AssemblyName] = config.ProjectNameWithoutExtension;
                 }
 
                 loadedSteps.Sort((fst, snd) => snd.Priority - fst.Priority);

--- a/src/QsCompiler/Tests.Compiler/SerializationTests.fs
+++ b/src/QsCompiler/Tests.Compiler/SerializationTests.fs
@@ -246,7 +246,8 @@ module SerializationTests =
     let ``attribute reader`` () =
         let dllUri = new Uri(Assembly.GetExecutingAssembly().Location)
         let gotId, dllId = CompilationUnitManager.TryGetFileId dllUri
-        let loadedFromResource, attrs = AssemblyLoader.LoadReferencedAssembly dllUri
+        let mutable attrs = null
+        let loadedFromResource = AssemblyLoader.LoadReferencedAssembly (dllUri, &attrs, false)
         Assert.True(gotId && not loadedFromResource, "loading should indicate failure when headers are loaded based on attributes rather than resources");
 
         let callables = attrs.Callables |> Seq.map (fun c -> c.ToJson()) |> Seq.toList


### PR DESCRIPTION
I don't like this, but it seems like we need it for now. 