### PR TITLE
Support arbitrary execution targets for unit tests

### DIFF
--- a/src/ProjectTemplates/Quantum.Test1/Tests.qs
+++ b/src/ProjectTemplates/Quantum.Test1/Tests.qs
@@ -5,7 +5,7 @@
     open Microsoft.Quantum.Intrinsic;
 
 
-    @TestOperation("QuantumSimulator")
+    @Test("QuantumSimulator")
     operation AllocateQubit () : Unit {
         using (q = Qubit()) {
             Assert([PauliZ], [q], Zero, "Newly allocated qubit must be in |0> state");

--- a/src/QsCompiler/Core/Dependencies.fs
+++ b/src/QsCompiler/Core/Dependencies.fs
@@ -43,7 +43,7 @@ type BuiltIn = {
 
     /// Returns true if the given attribute marks the corresponding declaration as unit test. 
     static member MarksTestOperation (att : QsDeclarationAttribute) = att.TypeId |> function 
-        | Value tId -> tId.Namespace.Value = BuiltIn.TestOperation.Namespace.Value && tId.Name.Value = BuiltIn.TestOperation.Name.Value
+        | Value tId -> tId.Namespace.Value = BuiltIn.Test.Namespace.Value && tId.Name.Value = BuiltIn.Test.Name.Value
         | Null -> false
 
 
@@ -79,8 +79,8 @@ type BuiltIn = {
         TypeParameters = ImmutableArray.Empty
     }
 
-    static member TestOperation = {
-        Name = "TestOperation" |> NonNullable<string>.New
+    static member Test = {
+        Name = "Test" |> NonNullable<string>.New
         Namespace = BuiltIn.DiagnosticsNamespace
         TypeParameters = ImmutableArray.Empty
     }

--- a/src/QsCompiler/Core/SymbolResolution.fs
+++ b/src/QsCompiler/Core/SymbolResolution.fs
@@ -128,6 +128,7 @@ module SymbolResolution =
         let validTargets = BuiltIn.ValidExecutionTargets.ToImmutableDictionary(fun t -> t.ToLowerInvariant())
         let targetName (target : string) = 
             if target = null then null
+            elif SyntaxGenerator.FullyQualifiedName.IsMatch target then target
             else target.ToLowerInvariant() |> validTargets.TryGetValue |> function
                 | true, valid -> valid
                 | false, _ -> null

--- a/src/QsCompiler/Core/SymbolTable.fs
+++ b/src/QsCompiler/Core/SymbolTable.fs
@@ -845,7 +845,7 @@ and NamespaceManager
                     | :? CallableSignature as signature when signature |> isUnitToUnit && not (signature.TypeParameters.Any()) -> 
                         let arg = att.Argument |> AttributeAnnotation.NonInterpolatedStringArgument (fun ex -> ex.Expression)
                         let validExecutionTargets = BuiltIn.ValidExecutionTargets |> Seq.map (fun x -> x.ToLowerInvariant())
-                        if arg <> null && validExecutionTargets |> Seq.contains (arg.ToLowerInvariant()) then
+                        if arg <> null && (validExecutionTargets |> Seq.contains (arg.ToLowerInvariant()) || SyntaxGenerator.FullyQualifiedName.IsMatch arg) then
                             attributeHash :: alreadyDefined, att :: resAttr 
                         else (att.Offset, att.Argument.Range |> orDefault |> QsCompilerDiagnostic.Error (ErrorCode.InvalidExecutionTargetForTest, [])) |> Seq.singleton |> returnInvalid 
                     | _ -> (att.Offset, tId.Range |> orDefault |> QsCompilerDiagnostic.Error (ErrorCode.InvalidTestAttributePlacement, [])) |> Seq.singleton |> returnInvalid

--- a/src/QsCompiler/Core/SymbolTable.fs
+++ b/src/QsCompiler/Core/SymbolTable.fs
@@ -831,7 +831,7 @@ and NamespaceManager
                     | _ -> (att.Offset, tId.Range |> orDefault |> QsCompilerDiagnostic.Error (ErrorCode.InvalidEntryPointPlacement, [])) |> Seq.singleton |> returnInvalid
                 
                 // the attribute marks a unit test
-                elif tId.Namespace.Value = BuiltIn.TestOperation.Namespace.Value && tId.Name.Value = BuiltIn.TestOperation.Name.Value then
+                elif tId.Namespace.Value = BuiltIn.Test.Namespace.Value && tId.Name.Value = BuiltIn.Test.Name.Value then
                     let isUnitToUnit (signature : CallableSignature) = 
                         let isUnitType = function 
                             | Tuple _ | Missing -> false

--- a/src/QsCompiler/Core/SyntaxGenerator.fs
+++ b/src/QsCompiler/Core/SyntaxGenerator.fs
@@ -5,6 +5,7 @@ namespace Microsoft.Quantum.QsCompiler
 
 open System
 open System.Collections.Immutable
+open System.Text.RegularExpressions
 open Microsoft.Quantum.QsCompiler.DataTypes
 open Microsoft.Quantum.QsCompiler.ReservedKeywords
 open Microsoft.Quantum.QsCompiler.SyntaxExtensions
@@ -50,6 +51,11 @@ type public StripPositionInfo(setDeclLocToDefault) =
 
 
 module SyntaxGenerator = 
+
+    /// Matches only if the string consists of a fully qualified name and nothing else. 
+    let internal FullyQualifiedName = 
+        new Regex(@"^[\p{L}_][\p{L}\p{Nd}_]*(\.[\p{L}_][\p{L}\p{Nd}_]*)+$")
+
 
     // literal expresssions
 

--- a/src/QsCompiler/Tests.Compiler/LocalVerificationTests.fs
+++ b/src/QsCompiler/Tests.Compiler/LocalVerificationTests.fs
@@ -216,6 +216,10 @@ type LocalVerificationTests (output:ITestOutputHelper) =
         this.Expect "ValidTestAttribute14"   []
         this.Expect "ValidTestAttribute15"   [Warning WarningCode.DuplicateAttribute]
         this.Expect "ValidTestAttribute16"   [Error ErrorCode.MissingType]
+        this.Expect "ValidTestAttribute17"   []
+        this.Expect "ValidTestAttribute18"   []
+        this.Expect "ValidTestAttribute19"   [Warning WarningCode.DuplicateAttribute]
+        this.Expect "ValidTestAttribute20"   []
                                              
         this.Expect "InvalidTestAttribute1"  [Error ErrorCode.InvalidTestAttributePlacement]
         this.Expect "InvalidTestAttribute2"  [Error ErrorCode.MisplacedDeclarationAttribute]
@@ -235,3 +239,9 @@ type LocalVerificationTests (output:ITestOutputHelper) =
         this.Expect "InvalidTestAttribute16" [Error ErrorCode.InvalidTestAttributePlacement; Error ErrorCode.UnknownType]
         this.Expect "InvalidTestAttribute17" [Error ErrorCode.InvalidExecutionTargetForTest; Error ErrorCode.AttributeArgumentTypeMismatch]
         this.Expect "InvalidTestAttribute18" [Error ErrorCode.InvalidExecutionTargetForTest; Error ErrorCode.MissingAttributeArgument]
+        this.Expect "InvalidTestAttribute19" [Error ErrorCode.InvalidExecutionTargetForTest]
+        this.Expect "InvalidTestAttribute20" [Error ErrorCode.InvalidExecutionTargetForTest]
+        this.Expect "InvalidTestAttribute21" [Error ErrorCode.InvalidExecutionTargetForTest]
+        this.Expect "InvalidTestAttribute22" [Error ErrorCode.InvalidExecutionTargetForTest]
+
+

--- a/src/QsCompiler/Tests.Compiler/TestCases/LinkingTests/Core.qs
+++ b/src/QsCompiler/Tests.Compiler/TestCases/LinkingTests/Core.qs
@@ -21,6 +21,7 @@ namespace Microsoft.Quantum.Core {
 
 namespace Microsoft.Quantum.Diagnostics {
 
+    // needs to be available for testing
     @ Attribute()
-    newtype TestOperation = String;
+    newtype Test = String;
 }

--- a/src/QsCompiler/Tests.Compiler/TestCases/LocalVerification.qs
+++ b/src/QsCompiler/Tests.Compiler/TestCases/LocalVerification.qs
@@ -878,127 +878,154 @@ namespace Microsoft.Quantum.Testing.LocalVerification {
 
     // unit tests
 
-    @ TestOperation("QuantumSimulator")
+    @ Test("QuantumSimulator")
     function ValidTestAttribute1 () : Unit {}
 
-    @ TestOperation("TraceSimulator")
+    @ Test("TraceSimulator")
     function ValidTestAttribute2 () : Unit {}
 
-    @ TestOperation("ToffoliSimulator")
+    @ Test("ToffoliSimulator")
     function ValidTestAttribute3 () : Unit {}
 
-    @ TestOperation("QuantumSimulator")
+    @ Test("QuantumSimulator")
     operation ValidTestAttribute4 () : Unit {}
 
-    @ TestOperation("TraceSimulator")
+    @ Test("TraceSimulator")
     operation ValidTestAttribute5 () : Unit {}
 
-    @ TestOperation("ToffoliSimulator")
+    @ Test("ToffoliSimulator")
     operation ValidTestAttribute6 () : Unit {}
 
-    @ TestOperation("QuantumSimulator")
+    @ Test("QuantumSimulator")
     operation ValidTestAttribute7 () : Unit 
     is Adj + Ctl{}
 
-    @ TestOperation("TraceSimulator")
+    @ Test("TraceSimulator")
     operation ValidTestAttribute8 () : Unit 
     is Adj {}
 
-    @ TestOperation("ToffoliSimulator")
+    @ Test("ToffoliSimulator")
     operation ValidTestAttribute9 () : Unit 
     is Ctl {}
 
-    @ TestOperation("QuantumSimulator")
+    @ Test("QuantumSimulator")
     function ValidTestAttribute10 () : ((Unit)) {}
 
-    @ TestOperation("TraceSimulator")
+    @ Test("TraceSimulator")
     function ValidTestAttribute11 (arg : Unit) : Unit { }
 
-    @ TestOperation("ToffoliSimulator")
+    @ Test("ToffoliSimulator")
     operation ValidTestAttribute12 (arg : (Unit)) : Unit { }
 
-    @ TestOperation("QuantumSimulator")
-    @ TestOperation("ToffoliSimulator")
-    @ TestOperation("TraceSimulator")
+    @ Test("QuantumSimulator")
+    @ Test("ToffoliSimulator")
+    @ Test("TraceSimulator")
     function ValidTestAttribute13 () : Unit { }
 
-    @ TestOperation("QuantumSimulator")
-    @ TestOperation("ToffoliSimulator")
-    @ TestOperation("TraceSimulator")
+    @ Test("QuantumSimulator")
+    @ Test("ToffoliSimulator")
+    @ Test("TraceSimulator")
     operation ValidTestAttribute14 () : Unit { }
 
-    @ TestOperation("QuantumSimulator")
-    @ TestOperation("QuantumSimulator")
+    @ Test("QuantumSimulator")
+    @ Test("QuantumSimulator")
     operation ValidTestAttribute15 () : Unit { }
 
-    @ TestOperation("QuantumSimulator")
+    @ Test("QuantumSimulator")
     operation ValidTestAttribute16 () : { }
 
+    @ Test("SomeNamespace.Target")
+    operation ValidTestAttribute17 () : Unit { }
 
-    @ TestOperation("QuantumSimulator")
+    @ Test("SomeNamespace.Target1")
+    @ Test("_Some3_Namespace_._My45.Target2")
+    function ValidTestAttribute18 () : Unit { }
+
+    @ Test("SomeNamespace.Target")
+    @ Test("SomeNamespace.Target")
+    function ValidTestAttribute19 () : Unit { }
+
+    @ Test("SomeNamespace.Target")
+    @ Test("QuantumSimulator")
+    operation ValidTestAttribute20 () : Unit { }
+
+
+    @ Test("QuantumSimulator")
     newtype InvalidTestAttribute1 = Unit;
 
     function InvalidTestAttribute2 () : Unit {
-        @ TestOperation("ToffoliSimulator")
+        @ Test("ToffoliSimulator")
         body (...) {}
     }
 
     operation InvalidTestAttribute3 () : Unit {
-        @ TestOperation("TraceSimulator")
+        @ Test("TraceSimulator")
         body (...) {}
     }
 
     operation InvalidTestAttribute4 () : Unit {
         body (...) { }
-        @ TestOperation("TraceSimulator")
+        @ Test("TraceSimulator")
         adjoint (...) { }
     }
 
-    @ TestOperation("TraceSimulator")
+    @ Test("TraceSimulator")
     function InvalidTestAttribute5<'T> () : Unit { }
 
-    @ TestOperation("QuantumSimulator")
+    @ Test("QuantumSimulator")
     operation InvalidTestAttribute6<'T> () : Unit { }
 
-    @ TestOperation("TraceSimulator")
+    @ Test("TraceSimulator")
     operation InvalidTestAttribute7 () : Int { 
         return 1;
     }
 
-    @ TestOperation("ToffoliSimulator")
+    @ Test("ToffoliSimulator")
     function InvalidTestAttribute8 () : String { 
         return "";
     }
 
-    @ TestOperation("QuantumSimulator")
+    @ Test("QuantumSimulator")
     function InvalidTestAttribute9 (a : Unit, b : Unit) : Unit { }
 
-    @ TestOperation("TraceSimulator")
+    @ Test("TraceSimulator")
     operation InvalidTestAttribute10 (a : Bool) : Unit { }
 
-    @ TestOperation("ToffoliSimulator")
+    @ Test("ToffoliSimulator")
     operation InvalidTestAttribute11 ((a : Double)) : Unit { }
 
-    @ TestOperation("")
+    @ Test("")
     operation InvalidTestAttribute12 () : Unit { }
 
-    @ TestOperation("  ")
+    @ Test("  ")
     function InvalidTestAttribute13 () : Unit { }
 
-    @ TestOperation("Target")
+    @ Test("Target")
     function InvalidTestAttribute14 () : Unit { }
 
-    @ TestOperation("Target")
-    @ TestOperation("ToffoliSimulator")
-    @ TestOperation("ToffoliSimulator")
+    @ Test("Target")
+    @ Test("ToffoliSimulator")
+    @ Test("ToffoliSimulator")
     operation InvalidTestAttribute15 () : Unit { }
 
-    @ TestOperation("QuantumSimulator")
+    @ Test("QuantumSimulator")
     operation InvalidTestAttribute16 () : NonExistent { }
 
-    @ TestOperation ()
+    @ Test ()
     operation InvalidTestAttribute17 () : Unit { }
 
-    @ TestOperation 
+    @ Test 
     operation InvalidTestAttribute18 () : Unit { }
+
+    @ Test("SomeNamespace.")
+    operation InvalidTestAttribute19 () : Unit { }
+
+    @ Test("NS.3Qubit")
+    operation InvalidTestAttribute20 () : Unit { }
+
+    @ Test("SomeNamespace .Target")
+    function InvalidTestAttribute21 () : Unit { }
+
+    @ Test("Some Namespace.Target")
+    function InvalidTestAttribute22 () : Unit { }
 }

--- a/src/VisualStudioExtension/QsharpTestTemplate/TestProjectTemplate.xml
+++ b/src/VisualStudioExtension/QsharpTestTemplate/TestProjectTemplate.xml
@@ -12,6 +12,6 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
-    <DotNetCliToolReference Include="dotnet-xunit" Version="2.4.1" />
+    <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
   </ItemGroup>
 </Project>

--- a/src/VisualStudioExtension/QsharpTestTemplate/Tests.qs
+++ b/src/VisualStudioExtension/QsharpTestTemplate/Tests.qs
@@ -5,7 +5,7 @@
     open Microsoft.Quantum.Intrinsic;
     
     
-    @TestOperation("QuantumSimulator")
+    @Test("QuantumSimulator")
     operation AllocateQubit () : Unit {
         using (q = Qubit()) {
             Assert([PauliZ], [q], Zero, "Newly allocated qubit must be in |0> state");


### PR DESCRIPTION
This PR adds support to specify arbitrary execution targets for unit tests via a fully qualified name. 
It also adapts the expected name of the attribute to be Test instead of TestOperation, and adapts the templates accordingly. 