### PR TITLE
Fix Unit Test - Apply If One Else Zero

### DIFF
--- a/src/QsCompiler/Tests.Compiler/ClasicalControlTests.fs
+++ b/src/QsCompiler/Tests.Compiler/ClasicalControlTests.fs
@@ -223,8 +223,8 @@ type ClassicalControlTests () =
         Assert.True(DoesCallSupportFunctors expectedFunctors call, sprintf "Callable %O did not support the expected functors" call.FullName)
 
     [<Fact>]
-    [<Trait("Category","Classical Control")>]
-    member this.``Classical Control Basic Hoist`` () =
+    [<Trait("Category","Content Hoisting")>]
+    member this.``Basic Hoist`` () =
         let result = CompileClassicalControlTest 1
 
         let generated = GetCallablesWithSuffix result Signatures.ClassicalControlNs "_Foo"
@@ -238,35 +238,35 @@ type ClassicalControlTests () =
         |> AssertSpecializationHasContent generated
 
     [<Fact>]
-    [<Trait("Category","Classical Control")>]
-    member this.``Classical Control Hoist Loops`` () =
+    [<Trait("Category","Content Hoisting")>]
+    member this.``Hoist Loops`` () =
         CompileClassicalControlTest 2 |> ignore
 
     [<Fact>]
-    [<Trait("Category","Classical Control")>]
-    member this.``Classical Control Don't Hoist Single Call`` () =
+    [<Trait("Category","Content Hoisting")>]
+    member this.``Don't Hoist Single Call`` () =
         // Single calls should not be hoisted into their own operation
         CompileClassicalControlTest 3 |> ignore
 
-    [<Fact>]
-    [<Trait("Category","Classical Control")>]
-    member this.``Classical Control Hoist Single Non-Call`` () =
+    [<Fact(Skip="Failure Tracked")>]
+    [<Trait("Category","Content Hoisting")>]
+    member this.``Hoist Single Non-Call`` () =
         // Single expressions that are not calls should be hoisted into their own operation
         CompileClassicalControlTest 4 |> ignore
 
     [<Fact>]
-    [<Trait("Category","Classical Control")>]
-    member this.``Classical Control Don't Hoist Return Statments`` () =
+    [<Trait("Category","Content Hoisting")>]
+    member this.``Don't Hoist Return Statments`` () =
         CompileClassicalControlTest 5 |> ignore
 
-    [<Fact>]
-    [<Trait("Category","Classical Control")>]
-    member this.``Classical Control All-Or-None Hoisting`` () =
+    [<Fact(Skip="Failure Tracked")>]
+    [<Trait("Category","Content Hoisting")>]
+    member this.``All-Or-None Hoisting`` () =
         CompileClassicalControlTest 6 |> ignore
 
     [<Fact>]
-    [<Trait("Category","Classical Control")>]
-    member this.``Classical Control ApplyIfZero And ApplyIfOne`` () =
+    [<Trait("Category","Apply If Calls")>]
+    member this.``ApplyIfZero And ApplyIfOne`` () =
         let result = CompileClassicalControlTest 7
 
         let originalOp = GetCallableWithName result Signatures.ClassicalControlNs "Foo" |> GetBodyFromCallable
@@ -279,23 +279,23 @@ type ClassicalControlTests () =
         |> AssertSpecializationHasContent originalOp
 
     [<Fact>]
-    [<Trait("Category","Classical Control")>]
-    member this.``Classical Control Apply If Zero Else One`` () =
+    [<Trait("Category","Apply If Calls")>]
+    member this.``Apply If Zero Else One`` () =
         let (args, ifOp, elseOp) = CompileClassicalControlTest 8 |> ApplyIfElseTest
         IsApplyIfElseArgsMatch args "r" ifOp elseOp
         |> (fun (x,_,_,_,_) -> Assert.True(x, "ApplyIfElse did not have the correct arguments"))
 
-    [<Fact>]
-    [<Trait("Category","Classical Control")>]
-    member this.``Classical Control Apply If One Else Zero`` () =
+    [<Fact(Skip="Failure Tracked")>]
+    [<Trait("Category","Apply If Calls")>]
+    member this.``Apply If One Else Zero`` () =
         let (args, ifOp, elseOp) = CompileClassicalControlTest 9 |> ApplyIfElseTest
         // The operation arguments should be swapped from the previous test
         IsApplyIfElseArgsMatch args "r" elseOp ifOp
         |> (fun (x,_,_,_,_) -> Assert.True(x, "ApplyIfElse did not have the correct arguments"))
 
     [<Fact>]
-    [<Trait("Category","Classical Control")>]
-    member this.``Classical Control If Elif`` () =
+    [<Trait("Category","If Structure Reshape")>]
+    member this.``If Elif`` () =
         let result = CompileClassicalControlTest 10
 
         let generated = GetCallablesWithSuffix result Signatures.ClassicalControlNs "_Foo"
@@ -336,8 +336,8 @@ type ClassicalControlTests () =
         |> (fun (x,_,_,_,_) -> Assert.True(x, errorMsg))
 
     [<Fact>]
-    [<Trait("Category","Classical Control")>]
-    member this.``Classical Control And Condition`` () =
+    [<Trait("Category","If Structure Reshape")>]
+    member this.``And Condition`` () =
         let (args, ifOp, elseOp) = CompileClassicalControlTest 11 |> ApplyIfElseTest
 
         let errorMsg = "ApplyIfElse did not have the correct arguments"
@@ -347,8 +347,8 @@ type ClassicalControlTests () =
         |> (fun (x,_,_,_,_) -> Assert.True(x, errorMsg))
 
     [<Fact>]
-    [<Trait("Category","Classical Control")>]
-    member this.``Classical Control Or Condition`` () =
+    [<Trait("Category","If Structure Reshape")>]
+    member this.``Or Condition`` () =
         let (args, ifOp, elseOp) = CompileClassicalControlTest 12 |> ApplyIfElseTest
 
         let errorMsg = "ApplyIfElse did not have the correct arguments"
@@ -357,24 +357,24 @@ type ClassicalControlTests () =
         IsApplyIfElseArgsMatch subArgs "r" ifOp elseOp
         |> (fun (x,_,_,_,_) -> Assert.True(x, errorMsg))
 
-    [<Fact>]
-    [<Trait("Category","Classical Control")>]
-    member this.``Classical Control Don't Hoist Functions`` () =
+    [<Fact(Skip="Failure Tracked")>]
+    [<Trait("Category","Content Hoisting")>]
+    member this.``Don't Hoist Functions`` () =
         CompileClassicalControlTest 13 |> ignore
 
     [<Fact>]
-    [<Trait("Category","Classical Control")>]
-    member this.``Classical Control Hoist Self-Contained Mutable`` () =
+    [<Trait("Category","Content Hoisting")>]
+    member this.``Hoist Self-Contained Mutable`` () =
         CompileClassicalControlTest 14 |> ignore
 
     [<Fact>]
-    [<Trait("Category","Classical Control")>]
-    member this.``Classical Control Don't Hoist General Mutable`` () =
+    [<Trait("Category","Content Hoisting")>]
+    member this.``Don't Hoist General Mutable`` () =
         CompileClassicalControlTest 15 |> ignore
 
     [<Fact>]
-    [<Trait("Category","Classical Control")>]
-    member this.``Classical Control Generics Support`` () =
+    [<Trait("Category","Generics Support")>]
+    member this.``Generics Support`` () =
         let result = CompileClassicalControlTest 16
 
         let callables = result.Namespaces
@@ -414,8 +414,8 @@ type ClassicalControlTests () =
         AssertTypeArgsMatch originalTypeParams <| typeArgs.Replace("'", "").Replace(" ", "").Split(",")
 
     [<Fact>]
-    [<Trait("Category","Classical Control")>]
-    member this.``Classical Control Adjoint Support`` () =
+    [<Trait("Category","Functor Support")>]
+    member this.``Adjoint Support`` () =
         let result = CompileClassicalControlTest 17
 
         let callables = result.Namespaces
@@ -476,8 +476,8 @@ type ClassicalControlTests () =
         AssertCallSupportsFunctors [] adjGen
 
     [<Fact>]
-    [<Trait("Category","Classical Control")>]
-    member this.``Classical Control Controlled Support`` () =
+    [<Trait("Category","Functor Support")>]
+    member this.``Controlled Support`` () =
         let result = CompileClassicalControlTest 18
 
         let callables = result.Namespaces
@@ -527,8 +527,8 @@ type ClassicalControlTests () =
         AssertCallSupportsFunctors [] ctlGen
 
     [<Fact>]
-    [<Trait("Category","Classical Control")>]
-    member this.``Classical Control Controlled Adjoint Support - Provided`` () =
+    [<Trait("Category","Functor Support")>]
+    member this.``Controlled Adjoint Support - Provided`` () =
         let result = CompileClassicalControlTest 19
 
         let callables = result.Namespaces
@@ -739,8 +739,8 @@ type ClassicalControlTests () =
         allCheck ()
 
     [<Fact>]
-    [<Trait("Category","Classical Control")>]
-    member this.``Classical Control Controlled Adjoint Support - Distribute`` ()=
+    [<Trait("Category","Functor Support")>]
+    member this.``Controlled Adjoint Support - Distribute`` ()=
         let result = CompileClassicalControlTest 20
 
         let callables = result.Namespaces
@@ -912,8 +912,8 @@ type ClassicalControlTests () =
         allCheck ()
 
     [<Fact>]
-    [<Trait("Category","Classical Control")>]
-    member this.``Classical Control Controlled Adjoint Support - Invert`` ()=
+    [<Trait("Category","Functor Support")>]
+    member this.``Controlled Adjoint Support - Invert`` ()=
         let result = CompileClassicalControlTest 21
 
         let callables = result.Namespaces
@@ -1085,8 +1085,8 @@ type ClassicalControlTests () =
         allCheck ()
 
     [<Fact>]
-    [<Trait("Category","Classical Control")>]
-    member this.``Classical Control Controlled Adjoint Support - Self`` ()=
+    [<Trait("Category","Functor Support")>]
+    member this.``Controlled Adjoint Support - Self`` ()=
         let result = CompileClassicalControlTest 22
 
         let callables = result.Namespaces

--- a/src/QsCompiler/Tests.Compiler/ClasicalControlTests.fs
+++ b/src/QsCompiler/Tests.Compiler/ClasicalControlTests.fs
@@ -1,0 +1,1166 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace Microsoft.Quantum.QsCompiler.Testing
+
+open System
+open System.IO
+open Microsoft.Quantum.QsCompiler
+open Microsoft.Quantum.QsCompiler.CompilationBuilder
+open Microsoft.Quantum.QsCompiler.DataTypes
+open Microsoft.Quantum.QsCompiler.SyntaxTree
+open Microsoft.Quantum.QsCompiler.Transformations.ClassicallyControlledTransformation
+open Xunit
+open Microsoft.Quantum.QsCompiler.Transformations.QsCodeOutput
+open System.Text.RegularExpressions
+open Microsoft.Quantum.QsCompiler.SyntaxTokens
+
+
+type ClassicalControlTests () =
+
+    let compilationManager = new CompilationUnitManager(new Action<Exception> (fun ex -> failwith ex.Message))
+
+    let getTempFile () = new Uri(Path.GetFullPath(Path.GetRandomFileName()))
+    let getManager uri content = CompilationUnitManager.InitializeFileManager(uri, content, compilationManager.PublishDiagnostics, compilationManager.LogException)
+
+    do  let addOrUpdateSourceFile filePath = getManager (new Uri(filePath)) (File.ReadAllText filePath) |> compilationManager.AddOrUpdateSourceFileAsync |> ignore
+        Path.Combine ("TestCases", "LinkingTests", "Core.qs") |> Path.GetFullPath |> addOrUpdateSourceFile
+
+    let ReadAndChunkSourceFile fileName =
+        let sourceInput = Path.Combine ("TestCases", "LinkingTests", fileName) |> File.ReadAllText
+        sourceInput.Split ([|"==="|], StringSplitOptions.RemoveEmptyEntries)
+
+    let BuildContent content =
+
+        let fileId = getTempFile()
+        let file = getManager fileId content
+
+        compilationManager.AddOrUpdateSourceFileAsync(file) |> ignore
+        let compilationDataStructures = compilationManager.Build()
+        compilationManager.TryRemoveSourceFileAsync(fileId, false) |> ignore
+
+        compilationDataStructures.Diagnostics() |> Seq.exists (fun d -> d.IsError()) |> Assert.False
+        Assert.NotNull compilationDataStructures.BuiltCompilation
+
+        compilationDataStructures
+
+    let CompileClassicalControlTest testNumber =
+        let srcChunks = ReadAndChunkSourceFile "ClassicalControl.qs"
+        srcChunks.Length >= testNumber + 1 |> Assert.True
+        let shared = srcChunks.[0]
+        let compilationDataStructures = BuildContent <| shared + srcChunks.[testNumber]
+        let processedCompilation = ClassicallyControlledTransformation.Apply compilationDataStructures.BuiltCompilation
+        Assert.NotNull processedCompilation
+        Signatures.SignatureCheck [Signatures.ClassicalControlNs] Signatures.ClassicalControlSignatures.[testNumber-1] processedCompilation
+        processedCompilation
+
+    let GetBodyFromCallable call = call.Specializations |> Seq.find (fun x -> x.Kind = QsSpecializationKind.QsBody)
+    let GetAdjFromCallable call = call.Specializations |> Seq.find (fun x -> x.Kind = QsSpecializationKind.QsAdjoint)
+    let GetCtlFromCallable call = call.Specializations |> Seq.find (fun x -> x.Kind = QsSpecializationKind.QsControlled)
+    let GetCtlAdjFromCallable call = call.Specializations |> Seq.find (fun x -> x.Kind = QsSpecializationKind.QsControlledAdjoint)
+
+    let GetLinesFromSpecialization specialization =
+        let writer = new SyntaxTreeToQs()
+
+        specialization
+        |> fun x -> match x.Implementation with | Provided (_, body) -> Some body | _ -> None
+        |> Option.get
+        |> writer.Scope.Transform
+        |> ignore
+
+        (writer.Scope :?> ScopeToQs).Output.Split("\r\n")
+
+    let CheckIfLineIsCall ``namespace`` name input =
+        let call = sprintf @"(%s\.)?%s" <| Regex.Escape ``namespace`` <| Regex.Escape name
+        let typeArgs = @"(<\s*([^<]*[^<\s])\s*>)?" // Does not support nested type args
+        let args = @"\(\s*(.*[^\s])?\s*\)"
+        let regex = sprintf @"^%s\s*%s\s*%s;$" call typeArgs args
+
+        let regexMatch = Regex.Match(input, regex)
+        if regexMatch.Success then
+            (true, regexMatch.Groups.[3].Value, regexMatch.Groups.[4].Value)
+        else
+            (false, "", "")
+
+    let MakeApplicationRegex (opName : QsQualifiedName) =
+        let call = sprintf @"(%s\.)?%s" <| Regex.Escape opName.Namespace.Value <| Regex.Escape opName.Name.Value
+        let typeArgs = @"(<\s*([^<]*[^<\s])\s*>)?"  // Does not support nested type args
+        let args = @"\(\s*(.*[^\s])?\s*\)"
+
+        sprintf @"\(%s\s*%s,\s*%s\)" <| call <| typeArgs <| args
+
+    let IsApplyIfArgMatch input resultVar (opName : QsQualifiedName) =
+        let regexMatch = Regex.Match(input, sprintf @"^%s,\s*%s$" <| Regex.Escape resultVar <| MakeApplicationRegex opName)
+
+        if regexMatch.Success then
+            (true, regexMatch.Groups.[3].Value, regexMatch.Groups.[4].Value)
+        else
+            (false, "", "")
+
+
+    let IsApplyIfElseArgsMatch input resultVar (opName1 : QsQualifiedName) (opName2 : QsQualifiedName) =
+        let ApplyIfElseRegex = sprintf @"^%s,\s*%s,\s*%s$"
+                                <| Regex.Escape resultVar
+                                <| MakeApplicationRegex opName1
+                                <| MakeApplicationRegex opName2
+
+        let regexMatch = Regex.Match(input, ApplyIfElseRegex)
+        if regexMatch.Success then
+            (true, regexMatch.Groups.[3].Value, regexMatch.Groups.[4].Value, regexMatch.Groups.[7].Value, regexMatch.Groups.[8].Value)
+        else
+            (false, "", "", "", "")
+
+    let CheckIfSpecializationHasContent specialization (content : seq<int * string * string>) =
+        let lines = GetLinesFromSpecialization specialization
+        Seq.forall (fun (i, ns, name) -> CheckIfLineIsCall ns name lines.[i] |> (fun (x,_,_) -> x)) content
+
+    let AssertSpecializationHasContent specialization content =
+        Assert.True(CheckIfSpecializationHasContent specialization content, sprintf "Callable %O(%A) did not have expected content" specialization.Parent specialization.Kind)
+
+    let IdentifyGeneratedByContent generatedCalls contents =
+        let mutable calls = generatedCalls |> Seq.map (fun x -> x, x |> (GetBodyFromCallable >> GetLinesFromSpecialization))
+        let hasContent call (content : seq<int * string * string>) =
+            let (_, lines : string[]) = call
+            Seq.forall (fun (i, ns, name) -> CheckIfLineIsCall ns name lines.[i] |> (fun (x,_,_) -> x)) content
+
+        Assert.True(Seq.length calls = Seq.length contents) // This should be true if this method is call correctly
+
+        let mutable rtrn = Seq.empty
+
+        let removeAt i lst =
+            Seq.append
+            <| Seq.take i lst
+            <| Seq.skip (i+1) lst
+
+        for content in contents do
+            calls
+            |> Seq.tryFindIndex (fun callSig -> hasContent callSig content)
+            |> (fun x ->
+                    Assert.True (x <> None, sprintf "Did not find expected generated content")
+                    rtrn <- Seq.append rtrn [Seq.item x.Value calls]
+                    calls <- removeAt x.Value calls
+               )
+        rtrn |> Seq.map (fun (x,y) -> x)
+
+    let GetCallablesWithSuffix compilation ns (suffix : string) =
+        compilation.Namespaces
+        |> Seq.filter (fun x -> x.Name.Value = ns)
+        |> GlobalCallableResolutions
+        |> Seq.filter (fun x -> x.Key.Name.Value.EndsWith suffix)
+        |> Seq.map (fun x -> x.Value)
+
+    let GetCallableWithName compilation ns name =
+        compilation.Namespaces
+        |> Seq.filter (fun x -> x.Name.Value = ns)
+        |> GlobalCallableResolutions
+        |> Seq.find (fun x -> x.Key.Name.Value = name)
+        |> (fun x -> x.Value)
+
+    let ApplyIfElseTest compilation =
+        let generated = GetCallablesWithSuffix compilation Signatures.ClassicalControlNs "_Foo"
+
+        Assert.True(2 = Seq.length generated) // Should already be asserted by the signature check
+
+        let ifContent =
+            [
+                (0, "SubOps", "SubOp1");
+                (1, "SubOps", "SubOp2");
+            ]
+        let elseContent =
+            [
+                (0, "SubOps", "SubOp2");
+                (1, "SubOps", "SubOp3");
+            ]
+
+        let orderedGens = IdentifyGeneratedByContent generated [ifContent; elseContent]
+        let ifOp, elseOp = (Seq.item 0 orderedGens), (Seq.item 1 orderedGens)
+
+        let original = GetCallableWithName compilation Signatures.ClassicalControlNs "Foo" |> GetBodyFromCallable
+        let lines = original |> GetLinesFromSpecialization
+
+        Assert.True(2 = Seq.length lines, sprintf "Callable %O(%A) did not have the expected number of statements" original.Parent original.Kind)
+
+        let (success, _, args) = CheckIfLineIsCall BuiltIn.ApplyIfElseR.Namespace.Value BuiltIn.ApplyIfElseR.Name.Value lines.[1]
+        Assert.True(success, sprintf "Callable %O(%A) did not have expected content" original.Parent original.Kind)
+
+        args, ifOp.FullName, elseOp.FullName
+
+    let DoesCallSupportFunctors expectedFunctors call =
+        let hasAdjoint = expectedFunctors |> Seq.contains QsFunctor.Adjoint
+        let hasControlled = expectedFunctors |> Seq.contains QsFunctor.Controlled
+
+        (*Checks the Characteristics match*)
+        let charMatch = lazy match call.Signature.Information.Characteristics.SupportedFunctors with
+                             | Value x -> x.SetEquals(expectedFunctors)
+                             | Null -> 0 = Seq.length expectedFunctors
+
+        (*Checks that the target specializations are present*)
+        let adjMatch = lazy if hasAdjoint then
+                                call.Specializations
+                                |> Seq.tryFind (fun x -> x.Kind = QsSpecializationKind.QsAdjoint)
+                                |> function
+                                   | None -> false
+                                   | Some x -> match x.Implementation with
+                                               | SpecializationImplementation.Generated gen -> gen = QsGeneratorDirective.Invert || gen = QsGeneratorDirective.SelfInverse
+                                               | SpecializationImplementation.Provided _ -> true
+                                               | _ -> false
+                            else true
+
+        let ctlMatch = lazy if hasControlled then
+                                call.Specializations
+                                |> Seq.tryFind (fun x -> x.Kind = QsSpecializationKind.QsControlled)
+                                |> function
+                                   | None -> false
+                                   | Some x -> match x.Implementation with
+                                               | SpecializationImplementation.Generated gen -> gen = QsGeneratorDirective.Distribute
+                                               | SpecializationImplementation.Provided _ -> true
+                                               | _ -> false
+                            else true
+
+        charMatch.Value && adjMatch.Value && ctlMatch.Value
+
+    let AssertCallSupportsFunctors expectedFunctors call =
+        Assert.True(DoesCallSupportFunctors expectedFunctors call, sprintf "Callable %O did not support the expected functors" call.FullName)
+
+    [<Fact>]
+    [<Trait("Category","Classical Control")>]
+    member this.``Classical Control Basic Hoist`` () =
+        let result = CompileClassicalControlTest 1
+
+        let generated = GetCallablesWithSuffix result Signatures.ClassicalControlNs "_Foo"
+                        |> (fun x -> Assert.True(1 = Seq.length x); Seq.item 0 x |> GetBodyFromCallable)
+
+        [
+            (0, "SubOps", "SubOp1");
+            (1, "SubOps", "SubOp2");
+            (2, "SubOps", "SubOp3");
+        ]
+        |> AssertSpecializationHasContent generated
+
+    [<Fact>]
+    [<Trait("Category","Classical Control")>]
+    member this.``Classical Control Hoist Loops`` () =
+        CompileClassicalControlTest 2 |> ignore
+
+    [<Fact>]
+    [<Trait("Category","Classical Control")>]
+    member this.``Classical Control Don't Hoist Single Call`` () =
+        // Single calls should not be hoisted into their own operation
+        CompileClassicalControlTest 3 |> ignore
+
+    [<Fact>]
+    [<Trait("Category","Classical Control")>]
+    member this.``Classical Control Hoist Single Non-Call`` () =
+        // Single expressions that are not calls should be hoisted into their own operation
+        CompileClassicalControlTest 4 |> ignore
+
+    [<Fact>]
+    [<Trait("Category","Classical Control")>]
+    member this.``Classical Control Don't Hoist Return Statments`` () =
+        CompileClassicalControlTest 5 |> ignore
+
+    [<Fact>]
+    [<Trait("Category","Classical Control")>]
+    member this.``Classical Control All-Or-None Hoisting`` () =
+        CompileClassicalControlTest 6 |> ignore
+
+    [<Fact>]
+    [<Trait("Category","Classical Control")>]
+    member this.``Classical Control ApplyIfZero And ApplyIfOne`` () =
+        let result = CompileClassicalControlTest 7
+
+        let originalOp = GetCallableWithName result Signatures.ClassicalControlNs "Foo" |> GetBodyFromCallable
+
+        [
+            (1, BuiltIn.ApplyIfZero);
+            (3, BuiltIn.ApplyIfOne);
+        ]
+        |> Seq.map (fun (i, builtin) -> (i, builtin.Namespace.Value, builtin.Name.Value))
+        |> AssertSpecializationHasContent originalOp
+
+    [<Fact>]
+    [<Trait("Category","Classical Control")>]
+    member this.``Classical Control Apply If Zero Else One`` () =
+        let (args, ifOp, elseOp) = CompileClassicalControlTest 8 |> ApplyIfElseTest
+        IsApplyIfElseArgsMatch args "r" ifOp elseOp
+        |> (fun (x,_,_,_,_) -> Assert.True(x, "ApplyIfElse did not have the correct arguments"))
+
+    [<Fact>]
+    [<Trait("Category","Classical Control")>]
+    member this.``Classical Control Apply If One Else Zero`` () =
+        let (args, ifOp, elseOp) = CompileClassicalControlTest 9 |> ApplyIfElseTest
+        // The operation arguments should be swapped from the previous test
+        IsApplyIfElseArgsMatch args "r" elseOp ifOp
+        |> (fun (x,_,_,_,_) -> Assert.True(x, "ApplyIfElse did not have the correct arguments"))
+
+    [<Fact>]
+    [<Trait("Category","Classical Control")>]
+    member this.``Classical Control If Elif`` () =
+        let result = CompileClassicalControlTest 10
+
+        let generated = GetCallablesWithSuffix result Signatures.ClassicalControlNs "_Foo"
+
+        Assert.True(3 = Seq.length generated) // Should already be asserted by the signature check
+
+        let ifContent =
+            [
+                (0, "SubOps", "SubOp1");
+                (1, "SubOps", "SubOp2");
+            ]
+        let elifContent =
+            [
+                (0, "SubOps", "SubOp3");
+                (1, "SubOps", "SubOp1");
+            ]
+        let elseContent =
+            [
+                (0, "SubOps", "SubOp2");
+                (1, "SubOps", "SubOp3");
+            ]
+
+        let orderedGens = IdentifyGeneratedByContent generated [ifContent; elifContent; elseContent]
+        let ifOp, elifOp, elseOp = (Seq.item 0 orderedGens), (Seq.item 1 orderedGens), (Seq.item 2 orderedGens)
+
+        let original = GetCallableWithName result Signatures.ClassicalControlNs "Foo" |> GetBodyFromCallable
+        let lines = original |> GetLinesFromSpecialization
+
+        Assert.True(2 = Seq.length lines, sprintf "Callable %O(%A) did not have the expected number of statements" original.Parent original.Kind)
+
+        let (success, _, args) = CheckIfLineIsCall BuiltIn.ApplyIfElseR.Namespace.Value BuiltIn.ApplyIfElseR.Name.Value lines.[1]
+        Assert.True(success, sprintf "Callable %O(%A) did not have expected content" original.Parent original.Kind)
+
+        let errorMsg = "ApplyIfElse did not have the correct arguments"
+        let (success, _, _, _, subArgs) = IsApplyIfElseArgsMatch args "r" ifOp.FullName { Namespace = BuiltIn.ApplyIfElseR.Namespace; Name = BuiltIn.ApplyIfElseR.Name }
+        Assert.True(success, errorMsg)
+        IsApplyIfElseArgsMatch subArgs "r" elifOp.FullName elseOp.FullName
+        |> (fun (x,_,_,_,_) -> Assert.True(x, errorMsg))
+
+    [<Fact>]
+    [<Trait("Category","Classical Control")>]
+    member this.``Classical Control And Condition`` () =
+        let (args, ifOp, elseOp) = CompileClassicalControlTest 11 |> ApplyIfElseTest
+
+        let errorMsg = "ApplyIfElse did not have the correct arguments"
+        let (success, _, subArgs, _, _) = IsApplyIfElseArgsMatch args "r" { Namespace = BuiltIn.ApplyIfElseR.Namespace; Name = BuiltIn.ApplyIfElseR.Name } elseOp
+        Assert.True(success, errorMsg)
+        IsApplyIfElseArgsMatch subArgs "r" ifOp elseOp
+        |> (fun (x,_,_,_,_) -> Assert.True(x, errorMsg))
+
+    [<Fact>]
+    [<Trait("Category","Classical Control")>]
+    member this.``Classical Control Or Condition`` () =
+        let (args, ifOp, elseOp) = CompileClassicalControlTest 12 |> ApplyIfElseTest
+
+        let errorMsg = "ApplyIfElse did not have the correct arguments"
+        let (success, _, _, _, subArgs) = IsApplyIfElseArgsMatch args "r" ifOp { Namespace = BuiltIn.ApplyIfElseR.Namespace; Name = BuiltIn.ApplyIfElseR.Name }
+        Assert.True(success, errorMsg)
+        IsApplyIfElseArgsMatch subArgs "r" ifOp elseOp
+        |> (fun (x,_,_,_,_) -> Assert.True(x, errorMsg))
+
+    [<Fact>]
+    [<Trait("Category","Classical Control")>]
+    member this.``Classical Control Don't Hoist Functions`` () =
+        CompileClassicalControlTest 13 |> ignore
+
+    [<Fact>]
+    [<Trait("Category","Classical Control")>]
+    member this.``Classical Control Hoist Self-Contained Mutable`` () =
+        CompileClassicalControlTest 14 |> ignore
+
+    [<Fact>]
+    [<Trait("Category","Classical Control")>]
+    member this.``Classical Control Don't Hoist General Mutable`` () =
+        CompileClassicalControlTest 15 |> ignore
+
+    [<Fact>]
+    [<Trait("Category","Classical Control")>]
+    member this.``Classical Control Generics Support`` () =
+        let result = CompileClassicalControlTest 16
+
+        let callables = result.Namespaces
+                        |> Seq.filter (fun x -> x.Name.Value = Signatures.ClassicalControlNs)
+                        |> GlobalCallableResolutions
+        let original  = callables
+                        |> Seq.find (fun x -> x.Key.Name.Value = "Foo")
+                        |> fun x -> x.Value
+        let generated = callables
+                        |> Seq.find (fun x -> x.Key.Name.Value.EndsWith "_Foo")
+                        |> fun x -> x.Value
+
+        let GetTypeParams call =
+            call.Signature.TypeParameters
+            |> Seq.choose (function | ValidName str -> Some str.Value | InvalidName -> None)
+
+        let AssertTypeArgsMatch typeArgs1 typeArgs2 =
+            let errorMsg = "The type parameters for the original and generated operations do not match"
+            Assert.True(Seq.length typeArgs1 = Seq.length typeArgs2, errorMsg)
+
+            for pair in Seq.zip typeArgs1 typeArgs2 do
+                Assert.True(fst pair = snd pair, errorMsg)
+
+        (*Assert that the generated operation has the same type parameters as the original operation*)
+        let originalTypeParams = GetTypeParams original
+        let generatedTypeParams = GetTypeParams generated
+        AssertTypeArgsMatch originalTypeParams generatedTypeParams
+
+        (*Assert that the original operation calls the generated operation with the appropriate type arguments*)
+        let lines = GetBodyFromCallable original |> GetLinesFromSpecialization
+        let (success, _, args) = CheckIfLineIsCall BuiltIn.ApplyIfZero.Namespace.Value BuiltIn.ApplyIfZero.Name.Value lines.[1]
+        Assert.True(success, sprintf "Callable %O(%A) did not have expected content" original.FullName QsSpecializationKind.QsBody)
+
+        let (success, typeArgs, _) = IsApplyIfArgMatch args "r" generated.FullName
+        Assert.True(success, sprintf "ApplyIfZero did not have the correct arguments")
+
+        AssertTypeArgsMatch originalTypeParams <| typeArgs.Replace("'", "").Replace(" ", "").Split(",")
+
+    [<Fact>]
+    [<Trait("Category","Classical Control")>]
+    member this.``Classical Control Adjoint Support`` () =
+        let result = CompileClassicalControlTest 17
+
+        let callables = result.Namespaces
+                        |> Seq.filter (fun x -> x.Name.Value = Signatures.ClassicalControlNs)
+                        |> GlobalCallableResolutions
+
+        let selfOp = callables
+                     |> Seq.find (fun x -> x.Key.Name.Value = "Self")
+                     |> fun x -> x.Value
+        let invertOp = callables
+                       |> Seq.find (fun x -> x.Key.Name.Value = "Invert")
+                       |> fun x -> x.Value
+        let providedOp = callables
+                       |> Seq.find (fun x -> x.Key.Name.Value = "Provided")
+                       |> fun x -> x.Value
+
+        [(1, BuiltIn.ApplyIfZero)]
+        |> Seq.map (fun (i, builtin) -> (i, builtin.Namespace.Value, builtin.Name.Value))
+        |> AssertSpecializationHasContent (GetBodyFromCallable selfOp)
+
+        [(1, BuiltIn.ApplyIfZeroA)]
+        |> Seq.map (fun (i, builtin) -> (i, builtin.Namespace.Value, builtin.Name.Value))
+        |> AssertSpecializationHasContent (GetBodyFromCallable invertOp)
+
+        [(1, BuiltIn.ApplyIfZero)]
+        |> Seq.map (fun (i, builtin) -> (i, builtin.Namespace.Value, builtin.Name.Value))
+        |> AssertSpecializationHasContent (GetBodyFromCallable providedOp)
+
+        let _selfOp = callables
+                      |> Seq.find (fun x -> x.Key.Name.Value.EndsWith "_Self")
+                      |> fun x -> x.Value
+        let _invertOp = callables
+                        |> Seq.find (fun x -> x.Key.Name.Value.EndsWith "_Invert")
+                        |> fun x -> x.Value
+        let _providedOps = callables
+                           |> Seq.filter (fun x -> x.Key.Name.Value.EndsWith "_Provided")
+                           |> Seq.map (fun x -> x.Value)
+
+        Assert.True(2 = Seq.length _providedOps) // Should already be asserted by the signature check
+
+        let bodyContent =
+            [
+                (0, "SubOps", "SubOp1");
+                (1, "SubOps", "SubOp2");
+            ]
+        let adjointContent =
+            [
+                (0, "SubOps", "SubOp2");
+                (1, "SubOps", "SubOp3");
+            ]
+
+        let orderedGens = IdentifyGeneratedByContent _providedOps [bodyContent; adjointContent]
+        let bodyGen, adjGen = (Seq.item 0 orderedGens), (Seq.item 1 orderedGens)
+
+        AssertCallSupportsFunctors [] _selfOp
+        AssertCallSupportsFunctors [QsFunctor.Adjoint] _invertOp
+        AssertCallSupportsFunctors [] bodyGen
+        AssertCallSupportsFunctors [] adjGen
+
+    [<Fact>]
+    [<Trait("Category","Classical Control")>]
+    member this.``Classical Control Controlled Support`` () =
+        let result = CompileClassicalControlTest 18
+
+        let callables = result.Namespaces
+                        |> Seq.filter (fun x -> x.Name.Value = Signatures.ClassicalControlNs)
+                        |> GlobalCallableResolutions
+
+        let distributeOp = callables
+                           |> Seq.find (fun x -> x.Key.Name.Value = "Distribute")
+                           |> fun x -> x.Value
+        let providedOp = callables
+                       |> Seq.find (fun x -> x.Key.Name.Value = "Provided")
+                       |> fun x -> x.Value
+
+        [(1, BuiltIn.ApplyIfZeroC)]
+        |> Seq.map (fun (i, builtin) -> (i, builtin.Namespace.Value, builtin.Name.Value))
+        |> AssertSpecializationHasContent (GetBodyFromCallable distributeOp)
+
+        [(1, BuiltIn.ApplyIfZero)]
+        |> Seq.map (fun (i, builtin) -> (i, builtin.Namespace.Value, builtin.Name.Value))
+        |> AssertSpecializationHasContent (GetBodyFromCallable providedOp)
+
+        let _distributeOp = callables
+                            |> Seq.find (fun x -> x.Key.Name.Value.EndsWith "_Distribute")
+                            |> fun x -> x.Value
+        let _providedOps = callables
+                           |> Seq.filter (fun x -> x.Key.Name.Value.EndsWith "_Provided")
+                           |> Seq.map (fun x -> x.Value)
+
+        Assert.True(2 = Seq.length _providedOps) // Should already be asserted by the signature check
+
+        let bodyContent =
+            [
+                (0, "SubOps", "SubOp1");
+                (1, "SubOps", "SubOp2");
+            ]
+        let controlledContent =
+            [
+                (0, "SubOps", "SubOp2");
+                (1, "SubOps", "SubOp3");
+            ]
+
+        let orderedGens = IdentifyGeneratedByContent _providedOps [bodyContent; controlledContent]
+        let bodyGen, ctlGen = (Seq.item 0 orderedGens), (Seq.item 1 orderedGens)
+
+        AssertCallSupportsFunctors [QsFunctor.Controlled] _distributeOp
+        AssertCallSupportsFunctors [] bodyGen
+        AssertCallSupportsFunctors [] ctlGen
+
+    [<Fact>]
+    [<Trait("Category","Classical Control")>]
+    member this.``Classical Control Controlled Adjoint Support - Provided`` () =
+        let result = CompileClassicalControlTest 19
+
+        let callables = result.Namespaces
+                        |> Seq.filter (fun x -> x.Name.Value = Signatures.ClassicalControlNs)
+                        |> GlobalCallableResolutions
+
+        (*-----------------------------------------*)
+
+        let bodyCheck () =
+            let original = callables
+                           |> Seq.find (fun x -> x.Key.Name.Value = "ProvidedBody")
+                           |> fun x -> x.Value
+
+            [(1, BuiltIn.ApplyIfZeroCA)]
+            |> Seq.map (fun (i, builtin) -> (i, builtin.Namespace.Value, builtin.Name.Value))
+            |> AssertSpecializationHasContent (GetBodyFromCallable original)
+
+            [(1, BuiltIn.ApplyIfOne)]
+            |> Seq.map (fun (i, builtin) -> (i, builtin.Namespace.Value, builtin.Name.Value))
+            |> AssertSpecializationHasContent (GetCtlAdjFromCallable original)
+
+            let generated = callables
+                            |> Seq.filter (fun x -> x.Key.Name.Value.EndsWith "_ProvidedBody")
+                            |> Seq.map (fun x -> x.Value)
+
+            Assert.True(2 = Seq.length generated) // Should already be asserted by the signature check
+
+            let bodyContent =
+                [
+                    (0, "SubOps", "SubOp1");
+                    (1, "SubOps", "SubOp2");
+                ]
+            let ctlAdjContent =
+                [
+                    (0, "SubOps", "SubOp2");
+                    (1, "SubOps", "SubOp3");
+                ]
+
+            let orderedGens = IdentifyGeneratedByContent generated [bodyContent; ctlAdjContent]
+            let bodyGen, ctlAdjGen = (Seq.item 0 orderedGens), (Seq.item 1 orderedGens)
+
+            AssertCallSupportsFunctors [QsFunctor.Controlled;QsFunctor.Adjoint] original
+            AssertCallSupportsFunctors [QsFunctor.Controlled;QsFunctor.Adjoint] bodyGen
+            AssertCallSupportsFunctors [] ctlAdjGen
+
+        bodyCheck ()
+
+        (*-----------------------------------------*)
+
+        let controlledCheck () =
+            let original = callables
+                           |> Seq.find (fun x -> x.Key.Name.Value = "ProvidedControlled")
+                           |> fun x -> x.Value
+
+            [(1, BuiltIn.ApplyIfZeroA)]
+            |> Seq.map (fun (i, builtin) -> (i, builtin.Namespace.Value, builtin.Name.Value))
+            |> AssertSpecializationHasContent (GetBodyFromCallable original)
+
+            [(1, BuiltIn.ApplyIfOne)]
+            |> Seq.map (fun (i, builtin) -> (i, builtin.Namespace.Value, builtin.Name.Value))
+            |> AssertSpecializationHasContent (GetCtlFromCallable original)
+
+            [(1, BuiltIn.ApplyIfOne)]
+            |> Seq.map (fun (i, builtin) -> (i, builtin.Namespace.Value, builtin.Name.Value))
+            |> AssertSpecializationHasContent (GetCtlAdjFromCallable original)
+
+            let generated = callables
+                            |> Seq.filter (fun x -> x.Key.Name.Value.EndsWith "_ProvidedControlled")
+                            |> Seq.map (fun x -> x.Value)
+
+            Assert.True(3 = Seq.length generated) // Should already be asserted by the signature check
+
+            let bodyContent =
+                [
+                    (0, "SubOps", "SubOp1");
+                    (1, "SubOps", "SubOp2");
+                ]
+            let ctlContent =
+                [
+                    (0, "SubOps", "SubOp3");
+                    (1, "SubOps", "SubOp1");
+                ]
+            let ctlAdjContent =
+                [
+                    (0, "SubOps", "SubOp2");
+                    (1, "SubOps", "SubOp3");
+                ]
+
+            let orderedGens = IdentifyGeneratedByContent generated [bodyContent; ctlContent; ctlAdjContent]
+            let bodyGen, ctlGen, ctlAdjGen = (Seq.item 0 orderedGens), (Seq.item 1 orderedGens), (Seq.item 2 orderedGens)
+
+            AssertCallSupportsFunctors [QsFunctor.Controlled;QsFunctor.Adjoint] original
+            AssertCallSupportsFunctors [QsFunctor.Adjoint] bodyGen
+            AssertCallSupportsFunctors [] ctlGen
+            AssertCallSupportsFunctors [] ctlAdjGen
+
+        controlledCheck ()
+
+        (*-----------------------------------------*)
+
+        let adjointCheck () =
+            let original = callables
+                           |> Seq.find (fun x -> x.Key.Name.Value = "ProvidedAdjoint")
+                           |> fun x -> x.Value
+
+            [(1, BuiltIn.ApplyIfZeroC)]
+            |> Seq.map (fun (i, builtin) -> (i, builtin.Namespace.Value, builtin.Name.Value))
+            |> AssertSpecializationHasContent (GetBodyFromCallable original)
+
+            [(1, BuiltIn.ApplyIfOne)]
+            |> Seq.map (fun (i, builtin) -> (i, builtin.Namespace.Value, builtin.Name.Value))
+            |> AssertSpecializationHasContent (GetAdjFromCallable original)
+
+            [(1, BuiltIn.ApplyIfOne)]
+            |> Seq.map (fun (i, builtin) -> (i, builtin.Namespace.Value, builtin.Name.Value))
+            |> AssertSpecializationHasContent (GetCtlAdjFromCallable original)
+
+            let generated = callables
+                            |> Seq.filter (fun x -> x.Key.Name.Value.EndsWith "_ProvidedAdjoint")
+                            |> Seq.map (fun x -> x.Value)
+
+            Assert.True(3 = Seq.length generated) // Should already be asserted by the signature check
+
+            let bodyContent =
+                [
+                    (0, "SubOps", "SubOp1");
+                    (1, "SubOps", "SubOp2");
+                ]
+            let adjContent =
+                [
+                    (0, "SubOps", "SubOp3");
+                    (1, "SubOps", "SubOp1");
+                ]
+            let ctlAdjContent =
+                [
+                    (0, "SubOps", "SubOp2");
+                    (1, "SubOps", "SubOp3");
+                ]
+
+            let orderedGens = IdentifyGeneratedByContent generated [bodyContent; adjContent; ctlAdjContent]
+            let bodyGen, adjGen, ctlAdjGen = (Seq.item 0 orderedGens), (Seq.item 1 orderedGens), (Seq.item 2 orderedGens)
+
+            AssertCallSupportsFunctors [QsFunctor.Controlled;QsFunctor.Adjoint] original
+            AssertCallSupportsFunctors [QsFunctor.Controlled] bodyGen
+            AssertCallSupportsFunctors [] adjGen
+            AssertCallSupportsFunctors [] ctlAdjGen
+
+        adjointCheck ()
+
+        (*-----------------------------------------*)
+
+        let allCheck () =
+            let original = callables
+                           |> Seq.find (fun x -> x.Key.Name.Value = "ProvidedAll")
+                           |> fun x -> x.Value
+
+            [(1, BuiltIn.ApplyIfZero)]
+            |> Seq.map (fun (i, builtin) -> (i, builtin.Namespace.Value, builtin.Name.Value))
+            |> AssertSpecializationHasContent (GetBodyFromCallable original)
+
+            [(1, BuiltIn.ApplyIfOne)]
+            |> Seq.map (fun (i, builtin) -> (i, builtin.Namespace.Value, builtin.Name.Value))
+            |> AssertSpecializationHasContent (GetCtlFromCallable original)
+
+            [(1, BuiltIn.ApplyIfOne)]
+            |> Seq.map (fun (i, builtin) -> (i, builtin.Namespace.Value, builtin.Name.Value))
+            |> AssertSpecializationHasContent (GetAdjFromCallable original)
+
+            [(1, BuiltIn.ApplyIfOne)]
+            |> Seq.map (fun (i, builtin) -> (i, builtin.Namespace.Value, builtin.Name.Value))
+            |> AssertSpecializationHasContent (GetCtlAdjFromCallable original)
+
+            let generated = callables
+                            |> Seq.filter (fun x -> x.Key.Name.Value.EndsWith "_ProvidedAll")
+                            |> Seq.map (fun x -> x.Value)
+
+            Assert.True(4 = Seq.length generated) // Should already be asserted by the signature check
+
+            let bodyContent =
+                [
+                    (0, "SubOps", "SubOp1");
+                    (1, "SubOps", "SubOp2");
+                ]
+            let ctlContent =
+                [
+                    (0, "SubOps", "SubOp3");
+                    (1, "SubOps", "SubOp1");
+                ]
+            let adjContent =
+                [
+                    (0, "SubOps", "SubOp2");
+                    (1, "SubOps", "SubOp3");
+                ]
+            let ctlAdjContent =
+                [
+                    (2, "SubOps", "SubOp3");
+                ]
+
+            let orderedGens = IdentifyGeneratedByContent generated [bodyContent; ctlContent; adjContent; ctlAdjContent]
+            let bodyGen, ctlGen, adjGen, ctlAdjGen = (Seq.item 0 orderedGens), (Seq.item 1 orderedGens), (Seq.item 2 orderedGens), (Seq.item 3 orderedGens)
+
+            AssertCallSupportsFunctors [QsFunctor.Controlled;QsFunctor.Adjoint] original
+            AssertCallSupportsFunctors [] bodyGen
+            AssertCallSupportsFunctors [] ctlGen
+            AssertCallSupportsFunctors [] adjGen
+            AssertCallSupportsFunctors [] ctlAdjGen
+
+        allCheck ()
+
+    [<Fact>]
+    [<Trait("Category","Classical Control")>]
+    member this.``Classical Control Controlled Adjoint Support - Distribute`` ()=
+        let result = CompileClassicalControlTest 20
+
+        let callables = result.Namespaces
+                        |> Seq.filter (fun x -> x.Name.Value = Signatures.ClassicalControlNs)
+                        |> GlobalCallableResolutions
+
+        (*-----------------------------------------*)
+
+        let bodyCheck () =
+            let original = callables
+                           |> Seq.find (fun x -> x.Key.Name.Value = "DistributeBody")
+                           |> fun x -> x.Value
+
+            [(1, BuiltIn.ApplyIfZeroCA)]
+            |> Seq.map (fun (i, builtin) -> (i, builtin.Namespace.Value, builtin.Name.Value))
+            |> AssertSpecializationHasContent (GetBodyFromCallable original)
+
+            let generated = callables
+                            |> Seq.filter (fun x -> x.Key.Name.Value.EndsWith "_DistributeBody")
+                            |> Seq.map (fun x -> x.Value)
+
+            Assert.True(1 = Seq.length generated) // Should already be asserted by the signature check
+
+            let bodyContent =
+                [
+                    (0, "SubOps", "SubOp1");
+                    (1, "SubOps", "SubOp2");
+                ]
+
+            let bodyGen = (Seq.item 0 generated)
+            AssertSpecializationHasContent (GetBodyFromCallable bodyGen) bodyContent
+
+            AssertCallSupportsFunctors [QsFunctor.Controlled;QsFunctor.Adjoint] original
+            AssertCallSupportsFunctors [QsFunctor.Controlled;QsFunctor.Adjoint] bodyGen
+
+        bodyCheck ()
+
+        (*-----------------------------------------*)
+
+        let controlledCheck () =
+            let original = callables
+                           |> Seq.find (fun x -> x.Key.Name.Value = "DistributeControlled")
+                           |> fun x -> x.Value
+
+            [(1, BuiltIn.ApplyIfZeroCA)]
+            |> Seq.map (fun (i, builtin) -> (i, builtin.Namespace.Value, builtin.Name.Value))
+            |> AssertSpecializationHasContent (GetBodyFromCallable original)
+
+            [(1, BuiltIn.ApplyIfOne)]
+            |> Seq.map (fun (i, builtin) -> (i, builtin.Namespace.Value, builtin.Name.Value))
+            |> AssertSpecializationHasContent (GetCtlFromCallable original)
+
+            let generated = callables
+                            |> Seq.filter (fun x -> x.Key.Name.Value.EndsWith "_DistributeControlled")
+                            |> Seq.map (fun x -> x.Value)
+
+            Assert.True(2 = Seq.length generated) // Should already be asserted by the signature check
+
+            let bodyContent =
+                [
+                    (0, "SubOps", "SubOp1");
+                    (1, "SubOps", "SubOp2");
+                ]
+            let ctlContent =
+                [
+                    (0, "SubOps", "SubOp3");
+                    (1, "SubOps", "SubOp1");
+                ]
+
+            let orderedGens = IdentifyGeneratedByContent generated [bodyContent; ctlContent]
+            let bodyGen, ctlGen = (Seq.item 0 orderedGens), (Seq.item 1 orderedGens)
+
+            AssertCallSupportsFunctors [QsFunctor.Controlled;QsFunctor.Adjoint] original
+            AssertCallSupportsFunctors [QsFunctor.Controlled;QsFunctor.Adjoint] bodyGen
+            AssertCallSupportsFunctors [] ctlGen
+
+        controlledCheck ()
+
+        (*-----------------------------------------*)
+
+        let adjointCheck () =
+            let original = callables
+                           |> Seq.find (fun x -> x.Key.Name.Value = "DistributeAdjoint")
+                           |> fun x -> x.Value
+
+            [(1, BuiltIn.ApplyIfZeroC)]
+            |> Seq.map (fun (i, builtin) -> (i, builtin.Namespace.Value, builtin.Name.Value))
+            |> AssertSpecializationHasContent (GetBodyFromCallable original)
+
+            [(1, BuiltIn.ApplyIfOneC)]
+            |> Seq.map (fun (i, builtin) -> (i, builtin.Namespace.Value, builtin.Name.Value))
+            |> AssertSpecializationHasContent (GetAdjFromCallable original)
+
+            let generated = callables
+                            |> Seq.filter (fun x -> x.Key.Name.Value.EndsWith "_DistributeAdjoint")
+                            |> Seq.map (fun x -> x.Value)
+
+            Assert.True(2 = Seq.length generated) // Should already be asserted by the signature check
+
+            let bodyContent =
+                [
+                    (0, "SubOps", "SubOp1");
+                    (1, "SubOps", "SubOp2");
+                ]
+            let adjContent =
+                [
+                    (0, "SubOps", "SubOp3");
+                    (1, "SubOps", "SubOp1");
+                ]
+
+            let orderedGens = IdentifyGeneratedByContent generated [bodyContent; adjContent]
+            let bodyGen, adjGen = (Seq.item 0 orderedGens), (Seq.item 1 orderedGens)
+
+            AssertCallSupportsFunctors [QsFunctor.Controlled;QsFunctor.Adjoint] original
+            AssertCallSupportsFunctors [QsFunctor.Controlled] bodyGen
+            AssertCallSupportsFunctors [QsFunctor.Controlled] adjGen
+
+        adjointCheck ()
+
+        (*-----------------------------------------*)
+
+        let allCheck () =
+            let original = callables
+                           |> Seq.find (fun x -> x.Key.Name.Value = "DistributeAll")
+                           |> fun x -> x.Value
+
+            [(1, BuiltIn.ApplyIfZero)]
+            |> Seq.map (fun (i, builtin) -> (i, builtin.Namespace.Value, builtin.Name.Value))
+            |> AssertSpecializationHasContent (GetBodyFromCallable original)
+
+            [(1, BuiltIn.ApplyIfOne)]
+            |> Seq.map (fun (i, builtin) -> (i, builtin.Namespace.Value, builtin.Name.Value))
+            |> AssertSpecializationHasContent (GetCtlFromCallable original)
+
+            [(1, BuiltIn.ApplyIfOneC)]
+            |> Seq.map (fun (i, builtin) -> (i, builtin.Namespace.Value, builtin.Name.Value))
+            |> AssertSpecializationHasContent (GetAdjFromCallable original)
+
+            let generated = callables
+                            |> Seq.filter (fun x -> x.Key.Name.Value.EndsWith "_DistributeAll")
+                            |> Seq.map (fun x -> x.Value)
+
+            Assert.True(3 = Seq.length generated) // Should already be asserted by the signature check
+
+            let bodyContent =
+                [
+                    (0, "SubOps", "SubOp1");
+                    (1, "SubOps", "SubOp2");
+                ]
+            let ctlContent =
+                [
+                    (0, "SubOps", "SubOp3");
+                    (1, "SubOps", "SubOp1");
+                ]
+            let adjContent =
+                [
+                    (0, "SubOps", "SubOp2");
+                    (1, "SubOps", "SubOp3");
+                ]
+
+            let orderedGens = IdentifyGeneratedByContent generated [bodyContent; ctlContent; adjContent]
+            let bodyGen, ctlGen, adjGen = (Seq.item 0 orderedGens), (Seq.item 1 orderedGens), (Seq.item 2 orderedGens)
+
+            AssertCallSupportsFunctors [QsFunctor.Controlled;QsFunctor.Adjoint] original
+            AssertCallSupportsFunctors [] bodyGen
+            AssertCallSupportsFunctors [] ctlGen
+            AssertCallSupportsFunctors [QsFunctor.Controlled] adjGen
+
+        allCheck ()
+
+    [<Fact>]
+    [<Trait("Category","Classical Control")>]
+    member this.``Classical Control Controlled Adjoint Support - Invert`` ()=
+        let result = CompileClassicalControlTest 21
+
+        let callables = result.Namespaces
+                        |> Seq.filter (fun x -> x.Name.Value = Signatures.ClassicalControlNs)
+                        |> GlobalCallableResolutions
+
+        (*-----------------------------------------*)
+
+        let bodyCheck () =
+            let original = callables
+                           |> Seq.find (fun x -> x.Key.Name.Value = "InvertBody")
+                           |> fun x -> x.Value
+
+            [(1, BuiltIn.ApplyIfZeroCA)]
+            |> Seq.map (fun (i, builtin) -> (i, builtin.Namespace.Value, builtin.Name.Value))
+            |> AssertSpecializationHasContent (GetBodyFromCallable original)
+
+            let generated = callables
+                            |> Seq.filter (fun x -> x.Key.Name.Value.EndsWith "_InvertBody")
+                            |> Seq.map (fun x -> x.Value)
+
+            Assert.True(1 = Seq.length generated) // Should already be asserted by the signature check
+
+            let bodyContent =
+                [
+                    (0, "SubOps", "SubOp1");
+                    (1, "SubOps", "SubOp2");
+                ]
+
+            let bodyGen = (Seq.item 0 generated)
+            AssertSpecializationHasContent (GetBodyFromCallable bodyGen) bodyContent
+
+            AssertCallSupportsFunctors [QsFunctor.Controlled;QsFunctor.Adjoint] original
+            AssertCallSupportsFunctors [QsFunctor.Controlled;QsFunctor.Adjoint] bodyGen
+
+        bodyCheck ()
+
+        (*-----------------------------------------*)
+
+        let controlledCheck () =
+            let original = callables
+                           |> Seq.find (fun x -> x.Key.Name.Value = "InvertControlled")
+                           |> fun x -> x.Value
+
+            [(1, BuiltIn.ApplyIfZeroA)]
+            |> Seq.map (fun (i, builtin) -> (i, builtin.Namespace.Value, builtin.Name.Value))
+            |> AssertSpecializationHasContent (GetBodyFromCallable original)
+
+            [(1, BuiltIn.ApplyIfOneA)]
+            |> Seq.map (fun (i, builtin) -> (i, builtin.Namespace.Value, builtin.Name.Value))
+            |> AssertSpecializationHasContent (GetCtlFromCallable original)
+
+            let generated = callables
+                            |> Seq.filter (fun x -> x.Key.Name.Value.EndsWith "_InvertControlled")
+                            |> Seq.map (fun x -> x.Value)
+
+            Assert.True(2 = Seq.length generated) // Should already be asserted by the signature check
+
+            let bodyContent =
+                [
+                    (0, "SubOps", "SubOp1");
+                    (1, "SubOps", "SubOp2");
+                ]
+            let ctlContent =
+                [
+                    (0, "SubOps", "SubOp3");
+                    (1, "SubOps", "SubOp1");
+                ]
+
+            let orderedGens = IdentifyGeneratedByContent generated [bodyContent; ctlContent]
+            let bodyGen, ctlGen = (Seq.item 0 orderedGens), (Seq.item 1 orderedGens)
+
+            AssertCallSupportsFunctors [QsFunctor.Controlled;QsFunctor.Adjoint] original
+            AssertCallSupportsFunctors [QsFunctor.Adjoint] bodyGen
+            AssertCallSupportsFunctors [QsFunctor.Adjoint] ctlGen
+
+        controlledCheck ()
+
+        (*-----------------------------------------*)
+
+        let adjointCheck () =
+            let original = callables
+                           |> Seq.find (fun x -> x.Key.Name.Value = "InvertAdjoint")
+                           |> fun x -> x.Value
+
+            [(1, BuiltIn.ApplyIfZeroCA)]
+            |> Seq.map (fun (i, builtin) -> (i, builtin.Namespace.Value, builtin.Name.Value))
+            |> AssertSpecializationHasContent (GetBodyFromCallable original)
+
+            [(1, BuiltIn.ApplyIfOne)]
+            |> Seq.map (fun (i, builtin) -> (i, builtin.Namespace.Value, builtin.Name.Value))
+            |> AssertSpecializationHasContent (GetAdjFromCallable original)
+
+            let generated = callables
+                            |> Seq.filter (fun x -> x.Key.Name.Value.EndsWith "_InvertAdjoint")
+                            |> Seq.map (fun x -> x.Value)
+
+            Assert.True(2 = Seq.length generated) // Should already be asserted by the signature check
+
+            let bodyContent =
+                [
+                    (0, "SubOps", "SubOp1");
+                    (1, "SubOps", "SubOp2");
+                ]
+            let adjContent =
+                [
+                    (0, "SubOps", "SubOp3");
+                    (1, "SubOps", "SubOp1");
+                ]
+
+            let orderedGens = IdentifyGeneratedByContent generated [bodyContent; adjContent]
+            let bodyGen, adjGen = (Seq.item 0 orderedGens), (Seq.item 1 orderedGens)
+
+            AssertCallSupportsFunctors [QsFunctor.Controlled;QsFunctor.Adjoint] original
+            AssertCallSupportsFunctors [QsFunctor.Controlled;QsFunctor.Adjoint] bodyGen
+            AssertCallSupportsFunctors [] adjGen
+
+        adjointCheck ()
+
+        (*-----------------------------------------*)
+
+        let allCheck () =
+            let original = callables
+                           |> Seq.find (fun x -> x.Key.Name.Value = "InvertAll")
+                           |> fun x -> x.Value
+
+            [(1, BuiltIn.ApplyIfZero)]
+            |> Seq.map (fun (i, builtin) -> (i, builtin.Namespace.Value, builtin.Name.Value))
+            |> AssertSpecializationHasContent (GetBodyFromCallable original)
+
+            [(1, BuiltIn.ApplyIfOneA)]
+            |> Seq.map (fun (i, builtin) -> (i, builtin.Namespace.Value, builtin.Name.Value))
+            |> AssertSpecializationHasContent (GetCtlFromCallable original)
+
+            [(1, BuiltIn.ApplyIfOne)]
+            |> Seq.map (fun (i, builtin) -> (i, builtin.Namespace.Value, builtin.Name.Value))
+            |> AssertSpecializationHasContent (GetAdjFromCallable original)
+
+            let generated = callables
+                            |> Seq.filter (fun x -> x.Key.Name.Value.EndsWith "_InvertAll")
+                            |> Seq.map (fun x -> x.Value)
+
+            Assert.True(3 = Seq.length generated) // Should already be asserted by the signature check
+
+            let bodyContent =
+                [
+                    (0, "SubOps", "SubOp1");
+                    (1, "SubOps", "SubOp2");
+                ]
+            let ctlContent =
+                [
+                    (0, "SubOps", "SubOp3");
+                    (1, "SubOps", "SubOp1");
+                ]
+            let adjContent =
+                [
+                    (0, "SubOps", "SubOp2");
+                    (1, "SubOps", "SubOp3");
+                ]
+
+            let orderedGens = IdentifyGeneratedByContent generated [bodyContent; ctlContent; adjContent]
+            let bodyGen, ctlGen, adjGen = (Seq.item 0 orderedGens), (Seq.item 1 orderedGens), (Seq.item 2 orderedGens)
+
+            AssertCallSupportsFunctors [QsFunctor.Controlled;QsFunctor.Adjoint] original
+            AssertCallSupportsFunctors [] bodyGen
+            AssertCallSupportsFunctors [QsFunctor.Adjoint] ctlGen
+            AssertCallSupportsFunctors [] adjGen
+
+        allCheck ()
+
+    [<Fact>]
+    [<Trait("Category","Classical Control")>]
+    member this.``Classical Control Controlled Adjoint Support - Self`` ()=
+        let result = CompileClassicalControlTest 22
+
+        let callables = result.Namespaces
+                        |> Seq.filter (fun x -> x.Name.Value = Signatures.ClassicalControlNs)
+                        |> GlobalCallableResolutions
+
+        (*-----------------------------------------*)
+
+        let bodyCheck () =
+            let original = callables
+                           |> Seq.find (fun x -> x.Key.Name.Value = "SelfBody")
+                           |> fun x -> x.Value
+
+            [(1, BuiltIn.ApplyIfZeroC)]
+            |> Seq.map (fun (i, builtin) -> (i, builtin.Namespace.Value, builtin.Name.Value))
+            |> AssertSpecializationHasContent (GetBodyFromCallable original)
+
+            let generated = callables
+                            |> Seq.filter (fun x -> x.Key.Name.Value.EndsWith "_SelfBody")
+                            |> Seq.map (fun x -> x.Value)
+
+            Assert.True(1 = Seq.length generated) // Should already be asserted by the signature check
+
+            let bodyContent =
+                [
+                    (0, "SubOps", "SubOp1");
+                    (1, "SubOps", "SubOp2");
+                ]
+
+            let bodyGen = (Seq.item 0 generated)
+            AssertSpecializationHasContent (GetBodyFromCallable bodyGen) bodyContent
+
+            AssertCallSupportsFunctors [QsFunctor.Controlled;QsFunctor.Adjoint] original
+            AssertCallSupportsFunctors [QsFunctor.Controlled] bodyGen
+
+        bodyCheck ()
+
+        (*-----------------------------------------*)
+
+        let controlledCheck () =
+            let original = callables
+                           |> Seq.find (fun x -> x.Key.Name.Value = "SelfControlled")
+                           |> fun x -> x.Value
+
+            [(1, BuiltIn.ApplyIfZero)]
+            |> Seq.map (fun (i, builtin) -> (i, builtin.Namespace.Value, builtin.Name.Value))
+            |> AssertSpecializationHasContent (GetBodyFromCallable original)
+
+            [(1, BuiltIn.ApplyIfOne)]
+            |> Seq.map (fun (i, builtin) -> (i, builtin.Namespace.Value, builtin.Name.Value))
+            |> AssertSpecializationHasContent (GetCtlFromCallable original)
+
+            let generated = callables
+                            |> Seq.filter (fun x -> x.Key.Name.Value.EndsWith "_SelfControlled")
+                            |> Seq.map (fun x -> x.Value)
+
+            Assert.True(2 = Seq.length generated) // Should already be asserted by the signature check
+
+            let bodyContent =
+                [
+                    (0, "SubOps", "SubOp1");
+                    (1, "SubOps", "SubOp2");
+                ]
+            let ctlContent =
+                [
+                    (0, "SubOps", "SubOp3");
+                    (1, "SubOps", "SubOp1");
+                ]
+
+            let orderedGens = IdentifyGeneratedByContent generated [bodyContent; ctlContent]
+            let bodyGen, ctlGen = (Seq.item 0 orderedGens), (Seq.item 1 orderedGens)
+
+            AssertCallSupportsFunctors [QsFunctor.Controlled;QsFunctor.Adjoint] original
+            AssertCallSupportsFunctors [] bodyGen
+            AssertCallSupportsFunctors [] ctlGen
+
+        controlledCheck ()

--- a/src/QsCompiler/Tests.Compiler/ClasicalControlTests.fs
+++ b/src/QsCompiler/Tests.Compiler/ClasicalControlTests.fs
@@ -285,7 +285,7 @@ type ClassicalControlTests () =
         IsApplyIfElseArgsMatch args "r" ifOp elseOp
         |> (fun (x,_,_,_,_) -> Assert.True(x, "ApplyIfElse did not have the correct arguments"))
 
-    [<Fact(Skip="Failure Tracked")>]
+    [<Fact>]
     [<Trait("Category","Apply If Calls")>]
     member this.``Apply If One Else Zero`` () =
         let (args, ifOp, elseOp) = CompileClassicalControlTest 9 |> ApplyIfElseTest

--- a/src/QsCompiler/Tests.Compiler/LinkingTests.fs
+++ b/src/QsCompiler/Tests.Compiler/LinkingTests.fs
@@ -405,6 +405,28 @@ type LinkingTests (output:ITestOutputHelper) =
         |> (fun (x,_,_,_,_) -> Assert.True(x, errorMsg))
 
     [<Fact>]
+    [<Trait("Category","Classical Control")>]
+    member this.``Classical Control And Contidtion`` () =
+        let (args, ifOp, elseOp) = this.ApplyIfElseTest 7
+        
+        let errorMsg = "ApplyIfElse did not have the correct arguments"
+        let (success, _, subArgs, _, _) = LinkingTests.isApplyIfElseArgsMatch args "r" { Namespace = BuiltIn.ApplyIfElseR.Namespace; Name = BuiltIn.ApplyIfElseR.Name } elseOp
+        Assert.True(success, errorMsg)
+        LinkingTests.isApplyIfElseArgsMatch subArgs "r" ifOp elseOp
+        |> (fun (x,_,_,_,_) -> Assert.True(x, errorMsg))
+
+    [<Fact>]
+    [<Trait("Category","Classical Control")>]
+    member this.``Classical Control Or Contidtion`` () =
+        let (args, ifOp, elseOp) = this.ApplyIfElseTest 8
+        
+        let errorMsg = "ApplyIfElse did not have the correct arguments"
+        let (success, _, _, _, subArgs) = LinkingTests.isApplyIfElseArgsMatch args "r" ifOp { Namespace = BuiltIn.ApplyIfElseR.Namespace; Name = BuiltIn.ApplyIfElseR.Name }
+        Assert.True(success, errorMsg)
+        LinkingTests.isApplyIfElseArgsMatch subArgs "r" ifOp elseOp
+        |> (fun (x,_,_,_,_) -> Assert.True(x, errorMsg))
+
+    [<Fact>]
     member this.``Fail on multiple entry points`` () =
 
         let entryPoints = LinkingTests.ReadAndChunkSourceFile "ValidEntryPoints.qs"

--- a/src/QsCompiler/Tests.Compiler/LinkingTests.fs
+++ b/src/QsCompiler/Tests.Compiler/LinkingTests.fs
@@ -255,16 +255,45 @@ type LinkingTests (output:ITestOutputHelper) =
 
     [<Fact>]
     [<Trait("Category","Classical Control")>]
-    member this.``Classical Control Single Expression`` () =
-        // Single expressions should not be hoisted into their own operation
+    member this.``Classical Control Hoist Loops`` () =
         let testNumber = 2
         let result = this.CompileClassicalControlTest testNumber
         Signatures.SignatureCheck [Signatures.ClassicalControlNs] Signatures.ClassicalControlSignatures.[testNumber-1] result
 
     [<Fact>]
     [<Trait("Category","Classical Control")>]
-    member this.``Classical Control Use ApplyIfZero And ApplyIfOne`` () =
+    member this.``Classical Control Don't Hoist Single Call`` () =
+        // Single calls should not be hoisted into their own operation
         let testNumber = 3
+        let result = this.CompileClassicalControlTest testNumber
+        Signatures.SignatureCheck [Signatures.ClassicalControlNs] Signatures.ClassicalControlSignatures.[testNumber-1] result
+
+    [<Fact>]
+    [<Trait("Category","Classical Control")>]
+    member this.``Classical Control Hoist Single Non-Call`` () =
+        // Single expressions that are not calls should be hoisted into their own operation
+        let testNumber = 4
+        let result = this.CompileClassicalControlTest testNumber
+        Signatures.SignatureCheck [Signatures.ClassicalControlNs] Signatures.ClassicalControlSignatures.[testNumber-1] result
+
+    [<Fact>]
+    [<Trait("Category","Classical Control")>]
+    member this.``Classical Control Don't Hoist Return Statments`` () =
+        let testNumber = 5
+        let result = this.CompileClassicalControlTest testNumber
+        Signatures.SignatureCheck [Signatures.ClassicalControlNs] Signatures.ClassicalControlSignatures.[testNumber-1] result
+
+    [<Fact>]
+    [<Trait("Category","Classical Control")>]
+    member this.``Classical Control All-Or-None Hoisting`` () =
+        let testNumber = 6
+        let result = this.CompileClassicalControlTest testNumber
+        Signatures.SignatureCheck [Signatures.ClassicalControlNs] Signatures.ClassicalControlSignatures.[testNumber-1] result
+
+    [<Fact>]
+    [<Trait("Category","Classical Control")>]
+    member this.``Classical Control ApplyIfZero And ApplyIfOne`` () =
+        let testNumber = 7
         let result = this.CompileClassicalControlTest testNumber
         Signatures.SignatureCheck [Signatures.ClassicalControlNs] Signatures.ClassicalControlSignatures.[testNumber-1] result
 
@@ -335,14 +364,14 @@ type LinkingTests (output:ITestOutputHelper) =
     [<Fact>]
     [<Trait("Category","Classical Control")>]
     member this.``Classical Control Apply If Zero Else One`` () =
-        let (args, ifOp, elseOp) = this.ApplyIfElseTest 4
+        let (args, ifOp, elseOp) = this.ApplyIfElseTest 8
         LinkingTests.isApplyIfElseArgsMatch args "r" ifOp elseOp
         |> (fun (x,_,_,_,_) -> Assert.True(x, "ApplyIfElse did not have the correct arguments"))
 
     [<Fact>]
     [<Trait("Category","Classical Control")>]
     member this.``Classical Control Apply If One Else Zero`` () =
-        let (args, ifOp, elseOp) = this.ApplyIfElseTest 5
+        let (args, ifOp, elseOp) = this.ApplyIfElseTest 9
         // The operation arguments should be swapped from the previous test
         LinkingTests.isApplyIfElseArgsMatch args "r" elseOp ifOp
         |> (fun (x,_,_,_,_) -> Assert.True(x, "ApplyIfElse did not have the correct arguments"))
@@ -350,7 +379,7 @@ type LinkingTests (output:ITestOutputHelper) =
     [<Fact>]
     [<Trait("Category","Classical Control")>]
     member this.``Classical Control If Elif`` () =
-        let testNumber = 6
+        let testNumber = 10
         let result = this.CompileClassicalControlTest testNumber
         Signatures.SignatureCheck [Signatures.ClassicalControlNs] Signatures.ClassicalControlSignatures.[testNumber-1] result
 
@@ -406,8 +435,8 @@ type LinkingTests (output:ITestOutputHelper) =
 
     [<Fact>]
     [<Trait("Category","Classical Control")>]
-    member this.``Classical Control And Contidtion`` () =
-        let (args, ifOp, elseOp) = this.ApplyIfElseTest 7
+    member this.``Classical Control And Condition`` () =
+        let (args, ifOp, elseOp) = this.ApplyIfElseTest 11
         
         let errorMsg = "ApplyIfElse did not have the correct arguments"
         let (success, _, subArgs, _, _) = LinkingTests.isApplyIfElseArgsMatch args "r" { Namespace = BuiltIn.ApplyIfElseR.Namespace; Name = BuiltIn.ApplyIfElseR.Name } elseOp
@@ -417,14 +446,22 @@ type LinkingTests (output:ITestOutputHelper) =
 
     [<Fact>]
     [<Trait("Category","Classical Control")>]
-    member this.``Classical Control Or Contidtion`` () =
-        let (args, ifOp, elseOp) = this.ApplyIfElseTest 8
+    member this.``Classical Control Or Condition`` () =
+        let (args, ifOp, elseOp) = this.ApplyIfElseTest 12
         
         let errorMsg = "ApplyIfElse did not have the correct arguments"
         let (success, _, _, _, subArgs) = LinkingTests.isApplyIfElseArgsMatch args "r" ifOp { Namespace = BuiltIn.ApplyIfElseR.Namespace; Name = BuiltIn.ApplyIfElseR.Name }
         Assert.True(success, errorMsg)
         LinkingTests.isApplyIfElseArgsMatch subArgs "r" ifOp elseOp
         |> (fun (x,_,_,_,_) -> Assert.True(x, errorMsg))
+
+    [<Fact>]
+    [<Trait("Category","Classical Control")>]
+    member this.``Classical Control Don't Hoist Functions`` () =
+        let testNumber = 13
+        let result = this.CompileClassicalControlTest testNumber
+        Signatures.SignatureCheck [Signatures.ClassicalControlNs] Signatures.ClassicalControlSignatures.[testNumber-1] result
+
 
     [<Fact>]
     member this.``Fail on multiple entry points`` () =

--- a/src/QsCompiler/Tests.Compiler/LinkingTests.fs
+++ b/src/QsCompiler/Tests.Compiler/LinkingTests.fs
@@ -191,6 +191,12 @@ type LinkingTests (output:ITestOutputHelper) =
 
 
     [<Fact>]
+    [<Trait("Category","Classical Control")>]
+    member this.``Classical Control If Elif`` () =
+        this.RunClassicalControlTest 3
+
+
+    [<Fact>]
     member this.``Fail on multiple entry points`` () =
 
         let entryPoints = LinkingTests.ReadAndChunkSourceFile "ValidEntryPoints.qs"

--- a/src/QsCompiler/Tests.Compiler/TestCases/LinkingTests/ClassicalControl.qs
+++ b/src/QsCompiler/Tests.Compiler/TestCases/LinkingTests/ClassicalControl.qs
@@ -1,0 +1,48 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace SubOps {
+    operation SubOp1() : Unit { }
+    operation SubOp2() : Unit { }
+    operation SubOp3() : Unit { }
+}
+
+// =================================
+
+namespace Microsoft.Quantum.Testing.ClassicalControl {
+    open SubOps;
+
+    @EntryPoint()
+    operation ClassicalControlTest1() : Unit {
+        Foo();
+    }
+
+    operation Foo() : Unit {
+        let r = One;
+        if (r == One) {
+            SubOp1();
+            SubOp2();
+            SubOp3();
+        }
+    }
+
+}
+
+// =================================
+
+namespace Microsoft.Quantum.Testing.ClassicalControl {
+    open SubOps;
+
+    @EntryPoint()
+    operation ClassicalControlTest2() : Unit {
+        Foo();
+    }
+
+    operation Foo() : Unit {
+        let r = One;
+        if (r == One) {
+            SubOp1();
+        }
+    }
+
+}

--- a/src/QsCompiler/Tests.Compiler/TestCases/LinkingTests/ClassicalControl.qs
+++ b/src/QsCompiler/Tests.Compiler/TestCases/LinkingTests/ClassicalControl.qs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+
 namespace SubOps {
     operation SubOp1() : Unit { }
     operation SubOp2() : Unit { }
@@ -19,10 +20,19 @@ namespace Microsoft.Quantum.Testing.ClassicalControl {
 
     operation Foo() : Unit {
         let r = One;
+
         if (r == One) {
             SubOp1();
             SubOp2();
             SubOp3();
+        }
+
+        let temp = 0;
+
+        if (r == Zero) {
+            SubOp2();
+            SubOp3();
+            SubOp1();
         }
     }
 
@@ -42,6 +52,67 @@ namespace Microsoft.Quantum.Testing.ClassicalControl {
         let r = One;
         if (r == One) {
             SubOp1();
+        }
+    }
+
+}
+
+// =================================
+
+namespace Microsoft.Quantum.Testing.ClassicalControl {
+    open SubOps;
+
+    @EntryPoint()
+    operation ClassicalControlTest3() : Unit {
+        Foo();
+    }
+
+    operation Foo() : Unit {
+        let r = One;
+
+        if (r == One) {
+            SubOp1();
+            SubOp2();
+        } else {
+            SubOp2();
+            SubOp3();
+        }
+
+        let temp = 0;
+
+        if (r == Zero) {
+            SubOp1();
+            SubOp2();
+        } else {
+            SubOp2();
+            SubOp3();
+        }
+    }
+
+}
+
+// =================================
+
+namespace Microsoft.Quantum.Testing.ClassicalControl {
+    open SubOps;
+
+    @EntryPoint()
+    operation ClassicalControlTest3() : Unit {
+        Foo();
+    }
+
+    operation Foo() : Unit {
+        let r = One;
+
+        if (r == One) {
+            SubOp1();
+            SubOp2();
+        } elif (r == Zero) {
+            SubOp3();
+            SubOp1();
+        } else {
+            SubOp2();
+            SubOp3();
         }
     }
 

--- a/src/QsCompiler/Tests.Compiler/TestCases/LinkingTests/ClassicalControl.qs
+++ b/src/QsCompiler/Tests.Compiler/TestCases/LinkingTests/ClassicalControl.qs
@@ -462,3 +462,399 @@ namespace Microsoft.Quantum.Testing.ClassicalControl {
     }
 
 }
+
+// =================================
+
+namespace Microsoft.Quantum.Testing.ClassicalControl {
+    open SubOps;
+
+    operation Provided() : Unit is Ctl {
+        body (...) {
+            let r = Zero;
+
+            if (r == Zero) {
+                SubOp1();
+                SubOp2();
+            }
+        }
+
+        controlled (ctl, ...) {
+            let w = One;
+
+            if (w == One) {
+                SubOp2();
+                SubOp3();
+            }
+        }
+    }
+
+    operation Distribute() : Unit is Ctl {
+        body (...) {
+            let r = Zero;
+
+            if (r == Zero) {
+                SubOp1();
+                SubOp2();
+            }
+        }
+
+        controlled distribute;
+    }
+
+}
+
+// =================================
+
+namespace Microsoft.Quantum.Testing.ClassicalControl {
+    open SubOps;
+
+    operation ProvidedBody() : Unit is Ctl + Adj {
+        body (...) {
+            let r = Zero;
+    
+            if (r == Zero) {
+                SubOp1();
+                SubOp2();
+            }
+        }
+
+        controlled adjoint (ctl, ...) {
+            let y = One;
+    
+            if (y == One) {
+                SubOp2();
+                SubOp3();
+            }
+        }
+    }
+
+    operation ProvidedAdjoint() : Unit is Ctl + Adj {
+        body (...) {
+            let r = Zero;
+    
+            if (r == Zero) {
+                SubOp1();
+                SubOp2();
+            }
+        }
+
+        adjoint (...) {
+            let w = One;
+
+            if (w == One) {
+                SubOp3();
+                SubOp1();
+            }
+        }
+
+        controlled adjoint (ctl, ...) {
+            let y = One;
+    
+            if (y == One) {
+                SubOp2();
+                SubOp3();
+            }
+        }
+    }
+
+    operation ProvidedControlled() : Unit is Ctl + Adj {
+        body (...) {
+            let r = Zero;
+    
+            if (r == Zero) {
+                SubOp1();
+                SubOp2();
+            }
+        }
+
+        controlled (ctl, ...) {
+            let w = One;
+
+            if (w == One) {
+                SubOp3();
+                SubOp1();
+            }
+        }
+
+        controlled adjoint (ctl, ...) {
+            let y = One;
+    
+            if (y == One) {
+                SubOp2();
+                SubOp3();
+            }
+        }
+    }
+
+    operation ProvidedAll() : Unit is Ctl + Adj {
+        body (...) {
+            let r = Zero;
+    
+            if (r == Zero) {
+                SubOp1();
+                SubOp2();
+            }
+        }
+
+        controlled (ctl, ...) {
+            let w = One;
+
+            if (w == One) {
+                SubOp3();
+                SubOp1();
+            }
+        }
+
+        adjoint (...) {
+            let y = One;
+    
+            if (y == One) {
+                SubOp2();
+                SubOp3();
+            }
+        }
+
+        controlled adjoint (ctl, ...) {
+            let b = One;
+
+            if (b == One) {
+                let temp1 = 0;
+                let temp2 = 0;
+                SubOp3();
+            }
+        }
+    }
+
+}
+
+// =================================
+
+namespace Microsoft.Quantum.Testing.ClassicalControl {
+    open SubOps;
+
+    operation DistributeBody() : Unit is Ctl + Adj {
+        body (...) {
+            let r = Zero;
+    
+            if (r == Zero) {
+                SubOp1();
+                SubOp2();
+            }
+        }
+
+        controlled adjoint distribute;
+    }
+
+    operation DistributeAdjoint() : Unit is Ctl + Adj {
+        body (...) {
+            let r = Zero;
+    
+            if (r == Zero) {
+                SubOp1();
+                SubOp2();
+            }
+        }
+
+        adjoint (...) {
+            let w = One;
+
+            if (w == One) {
+                SubOp3();
+                SubOp1();
+            }
+        }
+
+        controlled adjoint distribute;
+    }
+
+    operation DistributeControlled() : Unit is Ctl + Adj {
+        body (...) {
+            let r = Zero;
+    
+            if (r == Zero) {
+                SubOp1();
+                SubOp2();
+            }
+        }
+
+        controlled (ctl, ...) {
+            let w = One;
+
+            if (w == One) {
+                SubOp3();
+                SubOp1();
+            }
+        }
+
+        controlled adjoint distribute;
+    }
+
+    operation DistributeAll() : Unit is Ctl + Adj {
+        body (...) {
+            let r = Zero;
+    
+            if (r == Zero) {
+                SubOp1();
+                SubOp2();
+            }
+        }
+
+        controlled (ctl, ...) {
+            let w = One;
+
+            if (w == One) {
+                SubOp3();
+                SubOp1();
+            }
+        }
+
+        adjoint (...) {
+            let y = One;
+    
+            if (y == One) {
+                SubOp2();
+                SubOp3();
+            }
+        }
+
+        controlled adjoint distribute;
+    }
+
+}
+
+// =================================
+
+namespace Microsoft.Quantum.Testing.ClassicalControl {
+    open SubOps;
+
+    operation InvertBody() : Unit is Ctl + Adj {
+        body (...) {
+            let r = Zero;
+    
+            if (r == Zero) {
+                SubOp1();
+                SubOp2();
+            }
+        }
+    
+        controlled adjoint invert;
+    }
+    
+    operation InvertAdjoint() : Unit is Ctl + Adj {
+        body (...) {
+            let r = Zero;
+    
+            if (r == Zero) {
+                SubOp1();
+                SubOp2();
+            }
+        }
+    
+        adjoint (...) {
+            let w = One;
+    
+            if (w == One) {
+                SubOp3();
+                SubOp1();
+            }
+        }
+    
+        controlled adjoint invert;
+    }
+    
+    operation InvertControlled() : Unit is Ctl + Adj {
+        body (...) {
+            let r = Zero;
+    
+            if (r == Zero) {
+                SubOp1();
+                SubOp2();
+            }
+        }
+    
+        controlled (ctl, ...) {
+            let w = One;
+    
+            if (w == One) {
+                SubOp3();
+                SubOp1();
+            }
+        }
+    
+        controlled adjoint invert;
+    }
+    
+    operation InvertAll() : Unit is Ctl + Adj {
+        body (...) {
+            let r = Zero;
+    
+            if (r == Zero) {
+                SubOp1();
+                SubOp2();
+            }
+        }
+    
+        controlled (ctl, ...) {
+            let w = One;
+    
+            if (w == One) {
+                SubOp3();
+                SubOp1();
+            }
+        }
+    
+        adjoint (...) {
+            let y = One;
+    
+            if (y == One) {
+                SubOp2();
+                SubOp3();
+            }
+        }
+    
+        controlled adjoint invert;
+    }
+
+}
+
+// =================================
+
+namespace Microsoft.Quantum.Testing.ClassicalControl {
+    open SubOps;
+
+    operation SelfBody() : Unit is Ctl + Adj {
+        body (...) {
+            let r = Zero;
+    
+            if (r == Zero) {
+                SubOp1();
+                SubOp2();
+            }
+        }
+    
+        controlled adjoint self;
+    }
+    
+    operation SelfControlled() : Unit is Ctl + Adj {
+        body (...) {
+            let r = Zero;
+    
+            if (r == Zero) {
+                SubOp1();
+                SubOp2();
+            }
+        }
+    
+        controlled (ctl, ...) {
+            let w = One;
+    
+            if (w == One) {
+                SubOp3();
+                SubOp1();
+            }
+        }
+    
+        controlled adjoint self;
+    }
+
+}

--- a/src/QsCompiler/Tests.Compiler/TestCases/LinkingTests/ClassicalControl.qs
+++ b/src/QsCompiler/Tests.Compiler/TestCases/LinkingTests/ClassicalControl.qs
@@ -3,9 +3,9 @@
 
 
 namespace SubOps {
-    operation SubOp1() : Unit { }
-    operation SubOp2() : Unit { }
-    operation SubOp3() : Unit { }
+    operation SubOp1() : Unit is Adj + Ctl { }
+    operation SubOp2() : Unit is Adj + Ctl { }
+    operation SubOp3() : Unit is Adj + Ctl { }
 }
 
 // =================================
@@ -406,6 +406,59 @@ namespace Microsoft.Quantum.Testing.ClassicalControl {
             SubOp1();
             SubOp2();
         }
+    }
+
+}
+
+// =================================
+
+namespace Microsoft.Quantum.Testing.ClassicalControl {
+    open SubOps;
+
+    operation Provided() : Unit is Adj {
+        body (...) {
+            let r = Zero;
+
+            if (r == Zero) {
+                SubOp1();
+                SubOp2();
+            }
+        }
+
+        adjoint (...) {
+            let w = One;
+
+            if (w == One) {
+                SubOp2();
+                SubOp3();
+            }
+        }
+    }
+
+    operation Self() : Unit is Adj {
+        body (...) {
+            let r = Zero;
+
+            if (r == Zero) {
+                SubOp1();
+                SubOp2();
+            }
+        }
+
+        adjoint self;
+    }
+
+    operation Invert() : Unit is Adj {
+        body (...) {
+            let r = Zero;
+
+            if (r == Zero) {
+                SubOp1();
+                SubOp2();
+            }
+        }
+
+        adjoint invert;
     }
 
 }

--- a/src/QsCompiler/Tests.Compiler/TestCases/LinkingTests/ClassicalControl.qs
+++ b/src/QsCompiler/Tests.Compiler/TestCases/LinkingTests/ClassicalControl.qs
@@ -346,3 +346,66 @@ namespace Microsoft.Quantum.Testing.ClassicalControl {
     }
 
 }
+
+// =================================
+
+namespace Microsoft.Quantum.Testing.ClassicalControl {
+    open SubOps;
+
+    @EntryPoint()
+    operation ClassicalControlTestMain() : Unit {
+        Foo();
+    }
+
+    function Foo() : Unit {
+        let r = Zero;
+
+        if (r == Zero) {
+            mutable temp = 3;
+            set temp = 4;
+        }
+    }
+
+}
+
+// =================================
+
+namespace Microsoft.Quantum.Testing.ClassicalControl {
+    open SubOps;
+
+    @EntryPoint()
+    operation ClassicalControlTestMain() : Unit {
+        Foo();
+    }
+
+    function Foo() : Unit {
+        let r = Zero;
+
+        mutable temp = 3;
+        if (r == Zero) {
+            set temp = 4;
+        }
+    }
+
+}
+
+// =================================
+
+namespace Microsoft.Quantum.Testing.ClassicalControl {
+    open SubOps;
+
+    @EntryPoint()
+    operation ClassicalControlTestMain() : Unit {
+        Foo<Int, Double, String>();
+    }
+
+    operation Foo<'A, 'B, 'C>() : Unit {
+        let r = Zero;
+
+        if (r == Zero) {
+            SubOp1();
+            SubOp2();
+        }
+    }
+
+}

--- a/src/QsCompiler/Tests.Compiler/TestCases/LinkingTests/ClassicalControl.qs
+++ b/src/QsCompiler/Tests.Compiler/TestCases/LinkingTests/ClassicalControl.qs
@@ -14,7 +14,7 @@ namespace Microsoft.Quantum.Testing.ClassicalControl {
     open SubOps;
 
     @EntryPoint()
-    operation ClassicalControlTest1() : Unit {
+    operation ClassicalControlTestMain() : Unit {
         Foo();
     }
 
@@ -25,6 +25,38 @@ namespace Microsoft.Quantum.Testing.ClassicalControl {
             SubOp1();
             SubOp2();
             SubOp3();
+            let temp = 4;
+            using (q = Qubit()) {
+                let temp2 = q;
+            }
+        }
+    }
+
+}
+
+// =================================
+
+namespace Microsoft.Quantum.Testing.ClassicalControl {
+
+    @EntryPoint()
+    operation ClassicalControlTestMain() : Unit {
+        Foo();
+    }
+
+    operation Foo() : Unit {
+        let r = Zero;
+
+        if (r == Zero) {
+            for (index in 0 .. 3) {
+                let temp = index;
+            }
+
+            repeat {
+                let success = true;
+            } until (success)
+            fixup {
+                let temp2 = 0;
+            }
         }
     }
 
@@ -36,7 +68,7 @@ namespace Microsoft.Quantum.Testing.ClassicalControl {
     open SubOps;
 
     @EntryPoint()
-    operation ClassicalControlTest2() : Unit {
+    operation ClassicalControlTestMain() : Unit {
         Foo();
     }
 
@@ -55,7 +87,98 @@ namespace Microsoft.Quantum.Testing.ClassicalControl {
     open SubOps;
 
     @EntryPoint()
-    operation ClassicalControlTest3() : Unit {
+    operation ClassicalControlTestMain() : Unit {
+        Foo();
+    }
+
+    operation Foo() : Unit {
+        let r = Zero;
+
+        if (r == Zero) {
+            let temp = 2;
+        }
+    }
+
+}
+
+// =================================
+
+namespace Microsoft.Quantum.Testing.ClassicalControl {
+    open SubOps;
+
+    @EntryPoint()
+    operation ClassicalControlTestMain() : Unit {
+        Foo();
+    }
+
+    operation Foo() : Unit {
+        let r = Zero;
+        if (r == Zero) {
+            SubOp1();
+            return ();
+        }
+    }
+
+}
+
+// =================================
+
+namespace Microsoft.Quantum.Testing.ClassicalControl {
+    open SubOps;
+
+    @EntryPoint()
+    operation ClassicalControlTestMain() : Unit {
+        IfInvalid();
+        ElseInvalid();
+        BothInvalid();
+    }
+
+    operation IfInvalid() : Unit {
+        let r = Zero;
+        if (r == Zero) {
+            SubOp1();
+            SubOp2();
+            return ();
+        } else {
+            SubOp2();
+            SubOp3();
+        }
+    }
+
+    operation ElseInvalid() : Unit {
+        let r = Zero;
+        if (r == Zero) {
+            SubOp1();
+            SubOp2();
+        } else {
+            SubOp2();
+            SubOp3();
+            return ();
+        }
+    }
+
+    operation BothInvalid() : Unit {
+        let r = Zero;
+        if (r == Zero) {
+            SubOp1();
+            SubOp2();
+            return ();
+        } else {
+            SubOp2();
+            SubOp3();
+            return ();
+        }
+    }
+
+}
+
+// =================================
+
+namespace Microsoft.Quantum.Testing.ClassicalControl {
+    open SubOps;
+
+    @EntryPoint()
+    operation ClassicalControlTestMain() : Unit {
         Foo();
     }
 
@@ -85,7 +208,7 @@ namespace Microsoft.Quantum.Testing.ClassicalControl {
     open SubOps;
 
     @EntryPoint()
-    operation ClassicalControlTest4() : Unit {
+    operation ClassicalControlTestMain() : Unit {
         Foo();
     }
 
@@ -109,41 +232,41 @@ namespace Microsoft.Quantum.Testing.ClassicalControl {
     open SubOps;
 
     @EntryPoint()
-    operation ClassicalControlTest5() : Unit {
+    operation ClassicalControlTestMain() : Unit {
+        Foo();
+    }
+
+    operation Foo() : Unit {
+        let r = One;
+
+        if (r == One) {
+            SubOp1();
+            SubOp2();
+        } else {
+            SubOp2();
+            SubOp3();
+        }
+    }
+
+}
+
+// =================================
+
+namespace Microsoft.Quantum.Testing.ClassicalControl {
+    open SubOps;
+
+    @EntryPoint()
+    operation ClassicalControlTestMain() : Unit {
         Foo();
     }
 
     operation Foo() : Unit {
         let r = Zero;
 
-        if (r == One) {
+        if (r == Zero) {
             SubOp1();
             SubOp2();
-        } else {
-            SubOp2();
-            SubOp3();
-        }
-    }
-
-}
-
-// =================================
-
-namespace Microsoft.Quantum.Testing.ClassicalControl {
-    open SubOps;
-
-    @EntryPoint()
-    operation ClassicalControlTest6() : Unit {
-        Foo();
-    }
-
-    operation Foo() : Unit {
-        let r = One;
-
-        if (r == One) {
-            SubOp1();
-            SubOp2();
-        } elif (r == Zero) {
+        } elif (r == One) {
             SubOp3();
             SubOp1();
         } else {
@@ -160,14 +283,14 @@ namespace Microsoft.Quantum.Testing.ClassicalControl {
     open SubOps;
 
     @EntryPoint()
-    operation ClassicalControlTest7() : Unit {
+    operation ClassicalControlTestMain() : Unit {
         Foo();
     }
 
     operation Foo() : Unit {
-        let r = One;
+        let r = Zero;
 
-        if (r == One and r == Zero) {
+        if (r == Zero and r == One) {
             SubOp1();
             SubOp2();
         } else {
@@ -184,17 +307,39 @@ namespace Microsoft.Quantum.Testing.ClassicalControl {
     open SubOps;
 
     @EntryPoint()
-    operation ClassicalControlTest8() : Unit {
+    operation ClassicalControlTestMain() : Unit {
         Foo();
     }
 
     operation Foo() : Unit {
-        let r = One;
+        let r = Zero;
 
-        if (r == One or r == Zero) {
+        if (r == Zero or r == One) {
             SubOp1();
             SubOp2();
         } else {
+            SubOp2();
+            SubOp3();
+        }
+    }
+
+}
+
+// =================================
+
+namespace Microsoft.Quantum.Testing.ClassicalControl {
+    open SubOps;
+
+    @EntryPoint()
+    operation ClassicalControlTestMain() : Unit {
+        Foo();
+    }
+
+    function Foo() : Unit {
+        let r = Zero;
+
+        if (r == Zero) {
+            SubOp1();
             SubOp2();
             SubOp3();
         }

--- a/src/QsCompiler/Tests.Compiler/TestCases/LinkingTests/ClassicalControl.qs
+++ b/src/QsCompiler/Tests.Compiler/TestCases/LinkingTests/ClassicalControl.qs
@@ -153,3 +153,51 @@ namespace Microsoft.Quantum.Testing.ClassicalControl {
     }
 
 }
+
+// =================================
+
+namespace Microsoft.Quantum.Testing.ClassicalControl {
+    open SubOps;
+
+    @EntryPoint()
+    operation ClassicalControlTest7() : Unit {
+        Foo();
+    }
+
+    operation Foo() : Unit {
+        let r = One;
+
+        if (r == One and r == Zero) {
+            SubOp1();
+            SubOp2();
+        } else {
+            SubOp2();
+            SubOp3();
+        }
+    }
+
+}
+
+// =================================
+
+namespace Microsoft.Quantum.Testing.ClassicalControl {
+    open SubOps;
+
+    @EntryPoint()
+    operation ClassicalControlTest8() : Unit {
+        Foo();
+    }
+
+    operation Foo() : Unit {
+        let r = One;
+
+        if (r == One or r == Zero) {
+            SubOp1();
+            SubOp2();
+        } else {
+            SubOp2();
+            SubOp3();
+        }
+    }
+
+}

--- a/src/QsCompiler/Tests.Compiler/TestCases/LinkingTests/ClassicalControl.qs
+++ b/src/QsCompiler/Tests.Compiler/TestCases/LinkingTests/ClassicalControl.qs
@@ -19,9 +19,9 @@ namespace Microsoft.Quantum.Testing.ClassicalControl {
     }
 
     operation Foo() : Unit {
-        let r = One;
+        let r = Zero;
 
-        if (r == One) {
+        if (r == Zero) {
             SubOp1();
             SubOp2();
             SubOp3();
@@ -41,8 +41,8 @@ namespace Microsoft.Quantum.Testing.ClassicalControl {
     }
 
     operation Foo() : Unit {
-        let r = One;
-        if (r == One) {
+        let r = Zero;
+        if (r == Zero) {
             SubOp1();
         }
     }
@@ -60,9 +60,9 @@ namespace Microsoft.Quantum.Testing.ClassicalControl {
     }
 
     operation Foo() : Unit {
-        let r = One;
+        let r = Zero;
 
-        if (r == One) {
+        if (r == Zero) {
             SubOp1();
             SubOp2();
             SubOp3();
@@ -70,7 +70,7 @@ namespace Microsoft.Quantum.Testing.ClassicalControl {
 
         let temp = 0;
 
-        if (r == Zero) {
+        if (r == One) {
             SubOp2();
             SubOp3();
             SubOp1();
@@ -90,17 +90,7 @@ namespace Microsoft.Quantum.Testing.ClassicalControl {
     }
 
     operation Foo() : Unit {
-        let r = One;
-
-        if (r == One) {
-            SubOp1();
-            SubOp2();
-        } else {
-            SubOp2();
-            SubOp3();
-        }
-
-        let temp = 0;
+        let r = Zero;
 
         if (r == Zero) {
             SubOp1();
@@ -120,6 +110,30 @@ namespace Microsoft.Quantum.Testing.ClassicalControl {
 
     @EntryPoint()
     operation ClassicalControlTest5() : Unit {
+        Foo();
+    }
+
+    operation Foo() : Unit {
+        let r = Zero;
+
+        if (r == One) {
+            SubOp1();
+            SubOp2();
+        } else {
+            SubOp2();
+            SubOp3();
+        }
+    }
+
+}
+
+// =================================
+
+namespace Microsoft.Quantum.Testing.ClassicalControl {
+    open SubOps;
+
+    @EntryPoint()
+    operation ClassicalControlTest6() : Unit {
         Foo();
     }
 

--- a/src/QsCompiler/Tests.Compiler/TestCases/LinkingTests/ClassicalControl.qs
+++ b/src/QsCompiler/Tests.Compiler/TestCases/LinkingTests/ClassicalControl.qs
@@ -26,14 +26,6 @@ namespace Microsoft.Quantum.Testing.ClassicalControl {
             SubOp2();
             SubOp3();
         }
-
-        let temp = 0;
-
-        if (r == Zero) {
-            SubOp2();
-            SubOp3();
-            SubOp1();
-        }
     }
 
 }
@@ -73,6 +65,36 @@ namespace Microsoft.Quantum.Testing.ClassicalControl {
         if (r == One) {
             SubOp1();
             SubOp2();
+            SubOp3();
+        }
+
+        let temp = 0;
+
+        if (r == Zero) {
+            SubOp2();
+            SubOp3();
+            SubOp1();
+        }
+    }
+
+}
+
+// =================================
+
+namespace Microsoft.Quantum.Testing.ClassicalControl {
+    open SubOps;
+
+    @EntryPoint()
+    operation ClassicalControlTest4() : Unit {
+        Foo();
+    }
+
+    operation Foo() : Unit {
+        let r = One;
+
+        if (r == One) {
+            SubOp1();
+            SubOp2();
         } else {
             SubOp2();
             SubOp3();
@@ -97,7 +119,7 @@ namespace Microsoft.Quantum.Testing.ClassicalControl {
     open SubOps;
 
     @EntryPoint()
-    operation ClassicalControlTest3() : Unit {
+    operation ClassicalControlTest5() : Unit {
         Foo();
     }
 

--- a/src/QsCompiler/Tests.Compiler/TestUtils/Signatures.fs
+++ b/src/QsCompiler/Tests.Compiler/TestUtils/Signatures.fs
@@ -288,5 +288,79 @@ let public ClassicalControlSignatures =
             ClassicalControlNs, "_Self", [|"Result"|], "Unit";
             ClassicalControlNs, "_Invert", [|"Result"|], "Unit";
         |]);
+        (_DefaultTypes, [|
+            ClassicalControlNs, "Provided", [||], "Unit";
+            ClassicalControlNs, "Distribute", [||], "Unit";
+            ClassicalControlNs, "_Provided", [|"Result"|], "Unit";
+            ClassicalControlNs, "_Provided", [|"Result";"Qubit[]";"Unit"|], "Unit";
+            ClassicalControlNs, "_Distribute", [|"Result"|], "Unit";
+        |]);
+        (_DefaultTypes, [|
+            ClassicalControlNs, "ProvidedBody", [||], "Unit";
+            ClassicalControlNs, "ProvidedAdjoint", [||], "Unit";
+            ClassicalControlNs, "ProvidedControlled", [||], "Unit";
+            ClassicalControlNs, "ProvidedAll", [||], "Unit";
+
+            ClassicalControlNs, "_ProvidedBody", [|"Result"|], "Unit";
+            ClassicalControlNs, "_ProvidedBody", [|"Result";"Qubit[]";"Unit"|], "Unit";
+
+            ClassicalControlNs, "_ProvidedAdjoint", [|"Result"|], "Unit";
+            ClassicalControlNs, "_ProvidedAdjoint", [|"Result"|], "Unit";
+            ClassicalControlNs, "_ProvidedAdjoint", [|"Result";"Qubit[]";"Unit"|], "Unit";
+
+            ClassicalControlNs, "_ProvidedControlled", [|"Result"|], "Unit";
+            ClassicalControlNs, "_ProvidedControlled", [|"Result";"Qubit[]";"Unit"|], "Unit";
+            ClassicalControlNs, "_ProvidedControlled", [|"Result";"Qubit[]";"Unit"|], "Unit";
+
+            ClassicalControlNs, "_ProvidedAll", [|"Result"|], "Unit";
+            ClassicalControlNs, "_ProvidedAll", [|"Result"|], "Unit";
+            ClassicalControlNs, "_ProvidedAll", [|"Result";"Qubit[]";"Unit"|], "Unit";
+            ClassicalControlNs, "_ProvidedAll", [|"Result";"Qubit[]";"Unit"|], "Unit";
+        |]);
+        (_DefaultTypes, [|
+            ClassicalControlNs, "DistributeBody", [||], "Unit";
+            ClassicalControlNs, "DistributeAdjoint", [||], "Unit";
+            ClassicalControlNs, "DistributeControlled", [||], "Unit";
+            ClassicalControlNs, "DistributeAll", [||], "Unit";
+
+            ClassicalControlNs, "_DistributeBody", [|"Result"|], "Unit";
+
+            ClassicalControlNs, "_DistributeAdjoint", [|"Result"|], "Unit";
+            ClassicalControlNs, "_DistributeAdjoint", [|"Result"|], "Unit";
+
+            ClassicalControlNs, "_DistributeControlled", [|"Result"|], "Unit";
+            ClassicalControlNs, "_DistributeControlled", [|"Result";"Qubit[]";"Unit"|], "Unit";
+
+            ClassicalControlNs, "_DistributeAll", [|"Result"|], "Unit";
+            ClassicalControlNs, "_DistributeAll", [|"Result"|], "Unit";
+            ClassicalControlNs, "_DistributeAll", [|"Result";"Qubit[]";"Unit"|], "Unit";
+        |]);
+        (_DefaultTypes, [|
+            ClassicalControlNs, "InvertBody", [||], "Unit";
+            ClassicalControlNs, "InvertAdjoint", [||], "Unit";
+            ClassicalControlNs, "InvertControlled", [||], "Unit";
+            ClassicalControlNs, "InvertAll", [||], "Unit";
+
+            ClassicalControlNs, "_InvertBody", [|"Result"|], "Unit";
+
+            ClassicalControlNs, "_InvertAdjoint", [|"Result"|], "Unit";
+            ClassicalControlNs, "_InvertAdjoint", [|"Result"|], "Unit";
+
+            ClassicalControlNs, "_InvertControlled", [|"Result"|], "Unit";
+            ClassicalControlNs, "_InvertControlled", [|"Result";"Qubit[]";"Unit"|], "Unit";
+
+            ClassicalControlNs, "_InvertAll", [|"Result"|], "Unit";
+            ClassicalControlNs, "_InvertAll", [|"Result"|], "Unit";
+            ClassicalControlNs, "_InvertAll", [|"Result";"Qubit[]";"Unit"|], "Unit";
+        |]);
+        (_DefaultTypes, [|
+            ClassicalControlNs, "SelfBody", [||], "Unit";
+            ClassicalControlNs, "SelfControlled", [||], "Unit";
+
+            ClassicalControlNs, "_SelfBody", [|"Result"|], "Unit";
+
+            ClassicalControlNs, "_SelfControlled", [|"Result"|], "Unit";
+            ClassicalControlNs, "_SelfControlled", [|"Result";"Qubit[]";"Unit"|], "Unit";
+        |]);
     |]
     |> _MakeSignatures

--- a/src/QsCompiler/Tests.Compiler/TestUtils/Signatures.fs
+++ b/src/QsCompiler/Tests.Compiler/TestUtils/Signatures.fs
@@ -228,5 +228,17 @@ let public ClassicalControlSignatures =
             ClassicalControlNs, "_Foo", [|"Result"|], "Unit";
             ClassicalControlNs, "_Foo", [|"Result"|], "Unit";
         |]);
+        (_DefaultTypes, [|
+            ClassicalControlNs, "ClassicalControlTest7", [||], "Unit";
+            ClassicalControlNs, "Foo", [||], "Unit";
+            ClassicalControlNs, "_Foo", [|"Result"|], "Unit";
+            ClassicalControlNs, "_Foo", [|"Result"|], "Unit";
+        |]);
+        (_DefaultTypes, [|
+            ClassicalControlNs, "ClassicalControlTest8", [||], "Unit";
+            ClassicalControlNs, "Foo", [||], "Unit";
+            ClassicalControlNs, "_Foo", [|"Result"|], "Unit";
+            ClassicalControlNs, "_Foo", [|"Result"|], "Unit";
+        |]);
     |]
     |> _MakeSignatures

--- a/src/QsCompiler/Tests.Compiler/TestUtils/Signatures.fs
+++ b/src/QsCompiler/Tests.Compiler/TestUtils/Signatures.fs
@@ -279,5 +279,14 @@ let public ClassicalControlSignatures =
             ClassicalControlNs, "Foo", [||], "Unit";
             ClassicalControlNs, "_Foo", [|"Result"|], "Unit";
         |]);
+        (_DefaultTypes, [|
+            ClassicalControlNs, "Provided", [||], "Unit";
+            ClassicalControlNs, "Self", [||], "Unit";
+            ClassicalControlNs, "Invert", [||], "Unit";
+            ClassicalControlNs, "_Provided", [|"Result"|], "Unit";
+            ClassicalControlNs, "_Provided", [|"Result"|], "Unit";
+            ClassicalControlNs, "_Self", [|"Result"|], "Unit";
+            ClassicalControlNs, "_Invert", [|"Result"|], "Unit";
+        |]);
     |]
     |> _MakeSignatures

--- a/src/QsCompiler/Tests.Compiler/TestUtils/Signatures.fs
+++ b/src/QsCompiler/Tests.Compiler/TestUtils/Signatures.fs
@@ -191,8 +191,7 @@ let public ClassicalControlSignatures =
         (_DefaultTypes, [|
             ClassicalControlNs, "ClassicalControlTest1", [||], "Unit";
             ClassicalControlNs, "Foo", [||], "Unit"; // The original operation
-            ClassicalControlNs, "_Foo", [|"Result"|], "Unit"; // The 1st generated operation
-            ClassicalControlNs, "_Foo", [|"Result"; "Int"|], "Unit"; // The 2nd generated operation
+            ClassicalControlNs, "_Foo", [|"Result"|], "Unit"; // The generated operation
         |]);
         (_DefaultTypes, [|
             ClassicalControlNs, "ClassicalControlTest2", [||], "Unit";

--- a/src/QsCompiler/Tests.Compiler/TestUtils/Signatures.fs
+++ b/src/QsCompiler/Tests.Compiler/TestUtils/Signatures.fs
@@ -265,5 +265,19 @@ let public ClassicalControlSignatures =
             ClassicalControlNs, "Foo", [||], "Unit";
             ClassicalControlNs, "_Foo", [|"Result"|], "Unit";
         |]);
+        (_DefaultTypes, [|
+            ClassicalControlNs, "ClassicalControlTestMain", [||], "Unit";
+            ClassicalControlNs, "Foo", [||], "Unit";
+            ClassicalControlNs, "_Foo", [|"Result"|], "Unit";
+        |]);
+        (_DefaultTypes, [|
+            ClassicalControlNs, "ClassicalControlTestMain", [||], "Unit";
+            ClassicalControlNs, "Foo", [||], "Unit";
+        |]);
+        (_DefaultTypes, [|
+            ClassicalControlNs, "ClassicalControlTestMain", [||], "Unit";
+            ClassicalControlNs, "Foo", [||], "Unit";
+            ClassicalControlNs, "_Foo", [|"Result"|], "Unit";
+        |]);
     |]
     |> _MakeSignatures

--- a/src/QsCompiler/Tests.Compiler/TestUtils/Signatures.fs
+++ b/src/QsCompiler/Tests.Compiler/TestUtils/Signatures.fs
@@ -154,33 +154,33 @@ let private _IntrinsicResolutionTypes = _MakeTypeMap [|
 let public IntrinsicResolutionSignatures =
     [|
         (_DefaultTypes, [|
-                IntrinsicResolutionNs, "IntrinsicResolutionTest1", [||], "Unit";
-                IntrinsicResolutionNs, "LocalIntrinsic", [||], "Unit";
-                IntrinsicResolutionNs, "Override", [||], "Unit";
-                IntrinsicResolutionNs, "EnvironmentIntrinsic", [||], "Unit";
+            IntrinsicResolutionNs, "IntrinsicResolutionTest1", [||], "Unit";
+            IntrinsicResolutionNs, "LocalIntrinsic", [||], "Unit";
+            IntrinsicResolutionNs, "Override", [||], "Unit";
+            IntrinsicResolutionNs, "EnvironmentIntrinsic", [||], "Unit";
         |]);
         (_IntrinsicResolutionTypes, [|
-                IntrinsicResolutionNs, "IntrinsicResolutionTest2", [||], "Unit";
-                IntrinsicResolutionNs, "Override", [||], "TestType";
-                IntrinsicResolutionNs, "TestType", [||], "TestType";
+            IntrinsicResolutionNs, "IntrinsicResolutionTest2", [||], "Unit";
+            IntrinsicResolutionNs, "Override", [||], "TestType";
+            IntrinsicResolutionNs, "TestType", [||], "TestType";
         |]);
         (_IntrinsicResolutionTypes, [|
-                IntrinsicResolutionNs, "IntrinsicResolutionTest3", [||], "Unit";
-                IntrinsicResolutionNs, "Override", [||], "TestType";
-                IntrinsicResolutionNs, "TestType", [||], "TestType";
+            IntrinsicResolutionNs, "IntrinsicResolutionTest3", [||], "Unit";
+            IntrinsicResolutionNs, "Override", [||], "TestType";
+            IntrinsicResolutionNs, "TestType", [||], "TestType";
         |]);
         (_IntrinsicResolutionTypes, [|
-                IntrinsicResolutionNs, "IntrinsicResolutionTest4", [||], "Unit";
-                IntrinsicResolutionNs, "Override", [|"TestType"|], "Unit";
-                IntrinsicResolutionNs, "TestType", [||], "TestType";
+            IntrinsicResolutionNs, "IntrinsicResolutionTest4", [||], "Unit";
+            IntrinsicResolutionNs, "Override", [|"TestType"|], "Unit";
+            IntrinsicResolutionNs, "TestType", [||], "TestType";
         |]);
         (_DefaultTypes, [|
-                IntrinsicResolutionNs, "IntrinsicResolutionTest5", [||], "Unit";
-                IntrinsicResolutionNs, "Override", [||], "Unit";
+            IntrinsicResolutionNs, "IntrinsicResolutionTest5", [||], "Unit";
+            IntrinsicResolutionNs, "Override", [||], "Unit";
         |]);
         (_DefaultTypes, [|
-                IntrinsicResolutionNs, "IntrinsicResolutionTest6", [||], "Unit";
-                IntrinsicResolutionNs, "Override", [||], "Unit";
+            IntrinsicResolutionNs, "IntrinsicResolutionTest6", [||], "Unit";
+            IntrinsicResolutionNs, "Override", [||], "Unit";
         |]);
     |]
     |> _MakeSignatures
@@ -189,13 +189,22 @@ let public IntrinsicResolutionSignatures =
 let public ClassicalControlSignatures =
     [|
         (_DefaultTypes, [|
-                ClassicalControlNs, "ClassicalControlTest1", [||], "Unit";
-                ClassicalControlNs, "Foo", [||], "Unit"; // The original operation
-                ClassicalControlNs, "Foo", [|"Result"|], "Unit"; // The generated operation
+            ClassicalControlNs, "ClassicalControlTest1", [||], "Unit";
+            ClassicalControlNs, "Foo", [||], "Unit"; // The original operation
+            ClassicalControlNs, "_Foo", [|"Result"|], "Unit"; // The 1st generated operation
+            ClassicalControlNs, "_Foo", [|"Result"; "Int"|], "Unit"; // The 2nd generated operation
         |]);
         (_DefaultTypes, [|
             ClassicalControlNs, "ClassicalControlTest2", [||], "Unit";
-            ClassicalControlNs, "Foo", [||], "Unit"; // The original operation
+            ClassicalControlNs, "Foo", [||], "Unit";
+        |]);
+        (_DefaultTypes, [|
+            ClassicalControlNs, "ClassicalControlTest3", [||], "Unit";
+            ClassicalControlNs, "Foo", [||], "Unit";
+            ClassicalControlNs, "_Foo", [|"Result"|], "Unit";
+            ClassicalControlNs, "_Foo", [|"Result"|], "Unit";
+            ClassicalControlNs, "_Foo", [|"Result"; "Int"|], "Unit";
+            ClassicalControlNs, "_Foo", [|"Result"; "Int"|], "Unit";
         |]);
     |]
     |> _MakeSignatures

--- a/src/QsCompiler/Tests.Compiler/TestUtils/Signatures.fs
+++ b/src/QsCompiler/Tests.Compiler/TestUtils/Signatures.fs
@@ -201,6 +201,24 @@ let public ClassicalControlSignatures =
             ClassicalControlNs, "ClassicalControlTest3", [||], "Unit";
             ClassicalControlNs, "Foo", [||], "Unit";
             ClassicalControlNs, "_Foo", [|"Result"|], "Unit";
+            ClassicalControlNs, "_Foo", [|"Result"; "Int"|], "Unit";
+        |]);
+        (_DefaultTypes, [|
+            ClassicalControlNs, "ClassicalControlTest4", [||], "Unit";
+            ClassicalControlNs, "Foo", [||], "Unit";
+            ClassicalControlNs, "_Foo", [|"Result"|], "Unit";
+            ClassicalControlNs, "_Foo", [|"Result"|], "Unit";
+        |]);
+        (_DefaultTypes, [|
+            ClassicalControlNs, "ClassicalControlTest5", [||], "Unit";
+            ClassicalControlNs, "Foo", [||], "Unit";
+            ClassicalControlNs, "_Foo", [|"Result"|], "Unit";
+            ClassicalControlNs, "_Foo", [|"Result"|], "Unit";
+        |]);
+        (_DefaultTypes, [|
+            ClassicalControlNs, "ClassicalControlTest6", [||], "Unit";
+            ClassicalControlNs, "Foo", [||], "Unit";
+            ClassicalControlNs, "_Foo", [|"Result"|], "Unit";
             ClassicalControlNs, "_Foo", [|"Result"|], "Unit";
             ClassicalControlNs, "_Foo", [|"Result"; "Int"|], "Unit";
             ClassicalControlNs, "_Foo", [|"Result"; "Int"|], "Unit";

--- a/src/QsCompiler/Tests.Compiler/TestUtils/Signatures.fs
+++ b/src/QsCompiler/Tests.Compiler/TestUtils/Signatures.fs
@@ -195,49 +195,74 @@ let public IntrinsicResolutionSignatures =
 let public ClassicalControlSignatures =
     [|
         (_DefaultTypes, [|
-            ClassicalControlNs, "ClassicalControlTest1", [||], "Unit";
+            ClassicalControlNs, "ClassicalControlTestMain", [||], "Unit";
             ClassicalControlNs, "Foo", [||], "Unit"; // The original operation
             ClassicalControlNs, "_Foo", [|"Result"|], "Unit"; // The generated operation
         |]);
         (_DefaultTypes, [|
-            ClassicalControlNs, "ClassicalControlTest2", [||], "Unit";
+            ClassicalControlNs, "ClassicalControlTestMain", [||], "Unit";
+            ClassicalControlNs, "Foo", [||], "Unit";
+            ClassicalControlNs, "_Foo", [|"Result"|], "Unit";
+        |]);
+        (_DefaultTypes, [|
+            ClassicalControlNs, "ClassicalControlTestMain", [||], "Unit";
             ClassicalControlNs, "Foo", [||], "Unit";
         |]);
         (_DefaultTypes, [|
-            ClassicalControlNs, "ClassicalControlTest3", [||], "Unit";
+            ClassicalControlNs, "ClassicalControlTestMain", [||], "Unit";
+            ClassicalControlNs, "Foo", [||], "Unit";
+            ClassicalControlNs, "_Foo", [|"Result"|], "Unit";
+        |]);
+        (_DefaultTypes, [|
+            ClassicalControlNs, "ClassicalControlTestMain", [||], "Unit";
+            ClassicalControlNs, "Foo", [||], "Unit";
+        |]);
+        (_DefaultTypes, [|
+            ClassicalControlNs, "ClassicalControlTestMain", [||], "Unit";
+            ClassicalControlNs, "IfInvalid", [||], "Unit";
+            ClassicalControlNs, "ElseInvalid", [||], "Unit";
+            ClassicalControlNs, "BothInvalid", [||], "Unit";
+        |]);
+        (_DefaultTypes, [|
+            ClassicalControlNs, "ClassicalControlTestMain", [||], "Unit";
             ClassicalControlNs, "Foo", [||], "Unit";
             ClassicalControlNs, "_Foo", [|"Result"|], "Unit";
             ClassicalControlNs, "_Foo", [|"Result"; "Int"|], "Unit";
         |]);
         (_DefaultTypes, [|
-            ClassicalControlNs, "ClassicalControlTest4", [||], "Unit";
+            ClassicalControlNs, "ClassicalControlTestMain", [||], "Unit";
             ClassicalControlNs, "Foo", [||], "Unit";
             ClassicalControlNs, "_Foo", [|"Result"|], "Unit";
             ClassicalControlNs, "_Foo", [|"Result"|], "Unit";
         |]);
         (_DefaultTypes, [|
-            ClassicalControlNs, "ClassicalControlTest5", [||], "Unit";
+            ClassicalControlNs, "ClassicalControlTestMain", [||], "Unit";
             ClassicalControlNs, "Foo", [||], "Unit";
             ClassicalControlNs, "_Foo", [|"Result"|], "Unit";
             ClassicalControlNs, "_Foo", [|"Result"|], "Unit";
         |]);
         (_DefaultTypes, [|
-            ClassicalControlNs, "ClassicalControlTest6", [||], "Unit";
+            ClassicalControlNs, "ClassicalControlTestMain", [||], "Unit";
             ClassicalControlNs, "Foo", [||], "Unit";
             ClassicalControlNs, "_Foo", [|"Result"|], "Unit";
             ClassicalControlNs, "_Foo", [|"Result"|], "Unit";
             ClassicalControlNs, "_Foo", [|"Result"|], "Unit";
         |]);
         (_DefaultTypes, [|
-            ClassicalControlNs, "ClassicalControlTest7", [||], "Unit";
+            ClassicalControlNs, "ClassicalControlTestMain", [||], "Unit";
             ClassicalControlNs, "Foo", [||], "Unit";
             ClassicalControlNs, "_Foo", [|"Result"|], "Unit";
             ClassicalControlNs, "_Foo", [|"Result"|], "Unit";
         |]);
         (_DefaultTypes, [|
-            ClassicalControlNs, "ClassicalControlTest8", [||], "Unit";
+            ClassicalControlNs, "ClassicalControlTestMain", [||], "Unit";
             ClassicalControlNs, "Foo", [||], "Unit";
             ClassicalControlNs, "_Foo", [|"Result"|], "Unit";
+            ClassicalControlNs, "_Foo", [|"Result"|], "Unit";
+        |]);
+        (_DefaultTypes, [|
+            ClassicalControlNs, "ClassicalControlTestMain", [||], "Unit";
+            ClassicalControlNs, "Foo", [||], "Unit";
             ClassicalControlNs, "_Foo", [|"Result"|], "Unit";
         |]);
     |]

--- a/src/QsCompiler/Tests.Compiler/TestUtils/Signatures.fs
+++ b/src/QsCompiler/Tests.Compiler/TestUtils/Signatures.fs
@@ -18,6 +18,7 @@ let private _BaseTypes =
         "Int", Int;
         "Double", Double;
         "String", String;
+        "Result", Result;
         "Qubit", Qubit;
         "Qubit[]", ResolvedType.New Qubit |> ArrayType;
     |]
@@ -95,6 +96,7 @@ let public SignatureCheck checkedNamespaces targetSignatures compilation =
 let public MonomorphizationNs = "Microsoft.Quantum.Testing.Monomorphization"
 let public GenericsNs = "Microsoft.Quantum.Testing.Generics"
 let public IntrinsicResolutionNs = "Microsoft.Quantum.Testing.IntrinsicResolution"
+let public ClassicalControlNs = "Microsoft.Quantum.Testing.ClassicalControl"
 
 /// Expected callable signatures to be found when running Monomorphization tests
 let public MonomorphizationSignatures =
@@ -179,6 +181,21 @@ let public IntrinsicResolutionSignatures =
         (_DefaultTypes, [|
                 IntrinsicResolutionNs, "IntrinsicResolutionTest6", [||], "Unit";
                 IntrinsicResolutionNs, "Override", [||], "Unit";
+        |]);
+    |]
+    |> _MakeSignatures
+
+/// Expected callable signatures to be found when running Classical Control tests
+let public ClassicalControlSignatures =
+    [|
+        (_DefaultTypes, [|
+                ClassicalControlNs, "ClassicalControlTest1", [||], "Unit";
+                ClassicalControlNs, "Foo", [||], "Unit"; // The original operation
+                ClassicalControlNs, "Foo", [|"Result"|], "Unit"; // The generated operation
+        |]);
+        (_DefaultTypes, [|
+            ClassicalControlNs, "ClassicalControlTest2", [||], "Unit";
+            ClassicalControlNs, "Foo", [||], "Unit"; // The original operation
         |]);
     |]
     |> _MakeSignatures

--- a/src/QsCompiler/Tests.Compiler/Tests.Compiler.fsproj
+++ b/src/QsCompiler/Tests.Compiler/Tests.Compiler.fsproj
@@ -134,6 +134,7 @@
     <Compile Include="TransformationTests.fs" />
     <Compile Include="ExecutionTests.fs" />
     <Compile Include="LinkingTests.fs" />
+    <Compile Include="ClasicalControlTests.fs" />
     <Compile Include="RegexTests.fs" />
     <Compile Include="SerializationTests.fs" />
     <Compile Include="CommandLineTests.fs" />

--- a/src/QsCompiler/Tests.Compiler/Tests.Compiler.fsproj
+++ b/src/QsCompiler/Tests.Compiler/Tests.Compiler.fsproj
@@ -41,6 +41,9 @@
     <None Include="TestCases\LinkingTests\IntrinsicResolution.qs">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Include="TestCases\LinkingTests\ClassicalControl.qs">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Include="TestCases\OptimizerTests\Arithmetic_output.txt">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/src/QsCompiler/Transformations/ClassicallyControlledTransformation.cs
+++ b/src/QsCompiler/Transformations/ClassicallyControlledTransformation.cs
@@ -599,7 +599,11 @@ namespace Microsoft.Quantum.QsCompiler.Transformations.ClassicallyControlledTran
                 {
                     if (adj != null && adj.Implementation is SpecializationImplementation.Generated adjGen) addAdjoint = adjGen.Item.IsInvert;
                     if (ctl != null && ctl.Implementation is SpecializationImplementation.Generated ctlGen) addControlled = ctlGen.Item.IsDistribute;
-                    //addControlledAdjoint = ctlAdj != null && ctlAdj.Implementation.IsGenerated;
+                    if (ctlAdj != null && ctlAdj.Implementation is SpecializationImplementation.Generated ctlAdjGen)
+                    {
+                        addAdjoint = addAdjoint || ctlAdjGen.Item.IsInvert && ctl.Implementation.IsGenerated;
+                        addControlled = addControlled || ctlAdjGen.Item.IsDistribute && adj.Implementation.IsGenerated;
+                    }
                 }
                 else if (ctlAdj != null && ctlAdj.Implementation is SpecializationImplementation.Generated gen)
                 {

--- a/src/QsCompiler/Transformations/ClassicallyControlledTransformation.cs
+++ b/src/QsCompiler/Transformations/ClassicallyControlledTransformation.cs
@@ -597,8 +597,8 @@ namespace Microsoft.Quantum.QsCompiler.Transformations.ClassicallyControlledTran
                 //bool addControlledAdjoint = false;
                 if (_InBody)
                 {
-                    addAdjoint = adj != null && adj.Implementation.IsGenerated;
-                    addControlled = ctl != null && ctl.Implementation.IsGenerated;
+                    if (adj != null && adj.Implementation is SpecializationImplementation.Generated adjGen) addAdjoint = adjGen.Item.IsInvert;
+                    if (ctl != null && ctl.Implementation is SpecializationImplementation.Generated ctlGen) addControlled = ctlGen.Item.IsDistribute;
                     //addControlledAdjoint = ctlAdj != null && ctlAdj.Implementation.IsGenerated;
                 }
                 else if (ctlAdj != null && ctlAdj.Implementation is SpecializationImplementation.Generated gen)

--- a/src/QsCompiler/Transformations/ClassicallyControlledTransformation.cs
+++ b/src/QsCompiler/Transformations/ClassicallyControlledTransformation.cs
@@ -204,10 +204,11 @@ namespace Microsoft.Quantum.QsCompiler.Transformations.ClassicallyControlledTran
                             controlOpType = BuiltIn.ApplyIfElseRResolvedType;
                         }
 
-                        controlArgs = CreateValueTupleExpression(
-                            conditionExpression,
-                            CreateValueTupleExpression(condId, condArgs),
-                            CreateValueTupleExpression(defaultId, defaultArgs));
+                        var (zeroOpArg, oneOpArg) = (result == QsResult.Zero)
+                            ? (CreateValueTupleExpression(condId, condArgs), CreateValueTupleExpression(defaultId, defaultArgs))
+                            : (CreateValueTupleExpression(defaultId, defaultArgs), CreateValueTupleExpression(condId, condArgs));
+
+                        controlArgs = CreateValueTupleExpression(conditionExpression, zeroOpArg, oneOpArg);
 
                         targetArgs = ImmutableArray.Create(condArgs.ResolvedType, defaultArgs.ResolvedType);
                     }
@@ -215,27 +216,27 @@ namespace Microsoft.Quantum.QsCompiler.Transformations.ClassicallyControlledTran
                     {
                         if (adj && ctl)
                         {
-                            (controlOpInfo, controlOpType) = (result == QsResult.One)
-                            ? (BuiltIn.ApplyIfOneCA, BuiltIn.ApplyIfOneCAResolvedType)
-                            : (BuiltIn.ApplyIfZeroCA, BuiltIn.ApplyIfZeroCAResolvedType);
+                            (controlOpInfo, controlOpType) = (result == QsResult.Zero)
+                            ? (BuiltIn.ApplyIfZeroCA, BuiltIn.ApplyIfZeroCAResolvedType)
+                            : (BuiltIn.ApplyIfOneCA, BuiltIn.ApplyIfOneCAResolvedType);
                         }
                         else if (adj)
                         {
-                            (controlOpInfo, controlOpType) = (result == QsResult.One)
-                            ? (BuiltIn.ApplyIfOneA, BuiltIn.ApplyIfOneAResolvedType)
-                            : (BuiltIn.ApplyIfZeroA, BuiltIn.ApplyIfZeroAResolvedType);
+                            (controlOpInfo, controlOpType) = (result == QsResult.Zero)
+                            ? (BuiltIn.ApplyIfZeroA, BuiltIn.ApplyIfZeroAResolvedType)
+                            : (BuiltIn.ApplyIfOneA, BuiltIn.ApplyIfOneAResolvedType);
                         }
                         else if (ctl)
                         {
-                            (controlOpInfo, controlOpType) = (result == QsResult.One)
-                            ? (BuiltIn.ApplyIfOneC, BuiltIn.ApplyIfOneCResolvedType)
-                            : (BuiltIn.ApplyIfZeroC, BuiltIn.ApplyIfZeroCResolvedType);
+                            (controlOpInfo, controlOpType) = (result == QsResult.Zero)
+                            ? (BuiltIn.ApplyIfZeroC, BuiltIn.ApplyIfZeroCResolvedType)
+                            : (BuiltIn.ApplyIfOneC, BuiltIn.ApplyIfOneCResolvedType);
                         }
                         else
                         {
-                            (controlOpInfo, controlOpType) = (result == QsResult.One)
-                            ? (BuiltIn.ApplyIfOne, BuiltIn.ApplyIfOneResolvedType)
-                            : (BuiltIn.ApplyIfZero, BuiltIn.ApplyIfZeroResolvedType);
+                            (controlOpInfo, controlOpType) = (result == QsResult.Zero)
+                            ? (BuiltIn.ApplyIfZero, BuiltIn.ApplyIfZeroResolvedType)
+                            : (BuiltIn.ApplyIfOne, BuiltIn.ApplyIfOneResolvedType);
                         }
 
                         controlArgs = CreateValueTupleExpression(


### PR DESCRIPTION
This PR relies on PR #287.

Fixes an issue brought to light by the Classical Control unit test <i>#</i>9, where the conversion from an if/else statement to an ApplyIfElse statement assumed the condition compared against a result literal Zero.