### PR TITLE
Disabling incremental build support and design time builds

### DIFF
--- a/src/QsCompiler/TestTargets/Simulation/Example/Example.csproj
+++ b/src/QsCompiler/TestTargets/Simulation/Example/Example.csproj
@@ -1,69 +1,38 @@
-﻿<Project Sdk="Microsoft.NET.Sdk" InitialTargets="RecompileOnChange">
+﻿<Project Sdk="Microsoft.Quantum.Sdk/0.10.2001.2311-beta">
+
   <PropertyGroup>
+    <QscVerbosity>Detailed</QscVerbosity>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.0</TargetFramework>
-    <PlatformTarget>x64</PlatformTarget>
-    <QsharpLangVersion>0.10</QsharpLangVersion>
+    <CsharpGeneration>false</CsharpGeneration>
+    <QscExe>dotnet "../../../CommandLineTool/bin/$(Configuration)/netcoreapp3.0/qsc.dll"</QscExe>
+    <SimulationTarget>"..\Target\bin\$(Configuration)\netstandard2.1\Simulation.dll"</SimulationTarget>
+    <AdditionalQscArguments>--load $(SimulationTarget)</AdditionalQscArguments>
   </PropertyGroup>
-
-  <ItemGroup>
-    <ProjectReference Include="..\..\..\CommandLineTool\CommandLineTool.csproj">
-      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
-    </ProjectReference>
-    <ProjectReference Include="..\Target\Simulation.csproj">
-      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
-    </ProjectReference>
-    <ProjectReference Include="..\..\Libraries\Library1\Library1.csproj" />
-  </ItemGroup>
 
   <PropertyGroup>
-    <ExecutionTestsDir>ExecutionTests\</ExecutionTestsDir>
-    <GenFilesDir>generated\</GenFilesDir>
-    <SimulationTarget>"..\Target\bin\$(Configuration)\netstandard2.1\Simulation.dll"</SimulationTarget>
-    <QscExe>dotnet "../../../CommandLineTool/bin/$(Configuration)/netcoreapp3.0/qsc.dll"</QscExe>
+    <GeneratedFilesOutputPath>generated/</GeneratedFilesOutputPath>
+    <ExecutionTestsDir>ExecutionTests/</ExecutionTestsDir>
   </PropertyGroup>
 
   <ItemGroup>
-    <Folder Include="$(GenFilesDir)" />
-    <Compile Remove="..\Target\Driver.cs" />
-    <Compile Include="..\Target\Driver.cs">
+    <Folder Include="$(GeneratedFilesOutputPath)" />
+    <Compile Remove="../Target/Driver.cs" />
+    <Compile Include="../Target/Driver.cs">
       <Visible>false</Visible>
     </Compile>
-    <None Include="..\..\..\Tests.Compiler\TestCases\ExecutionTests\*.*">
+    <QsharpCompile Include="../../../Tests.Compiler/TestCases/ExecutionTests/*.*">
       <Link>$(ExecutionTestsDir)%(RecursiveDir)%(Filename)%(Extension)</Link>
-    </None>
+    </QsharpCompile>
   </ItemGroup>
 
-  <Target Name="RecompileOnChange">
-    <ItemGroup>
-      <UpToDateCheckInput Include="@(None)" />
-      <UpToDateCheckInput Include="@(Content)" />
-    </ItemGroup>
-  </Target>
+  <ItemGroup>
+    <ProjectReference Include="../../../CommandLineTool/CommandLineTool.csproj">
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+    </ProjectReference>
+    <ProjectReference Include="../../Libraries/Library1/Library1.csproj" />
+  </ItemGroup>  
   
-  <Target Name="QsharpClean" BeforeTargets="Clean">
-    <ItemGroup>
-      <RemoveFiles Include="$(GenFilesDir)**" />
-      <Compile Remove="@(RemoveFiles)" />
-    </ItemGroup>
-    <Delete Files="@(RemoveFiles)" />
-  </Target>  
-  
-  <Target Name="QsharpCompile" Condition="'$(DesignTimeBuild)' != 'true'" DependsOnTargets="ResolveAssemblyReferences;QsharpClean" BeforeTargets="CoreCompile">
-    <MakeDir Directories="$(GenFilesDir)" />
-    <ItemGroup>
-      <QsReferences Include="@(ReferencePath)" Condition="$([System.Text.RegularExpressions.Regex]::IsMatch(%(FullPath), '(?i)system.|mscorlib|netstandard.library|microsoft.netcore.app')) == false" />
-      <QsSourceFiles Include="@(None)" Condition="$([System.Text.RegularExpressions.Regex]::IsMatch(%(FullPath), '.qs$')) == true" />
-      <QsSourceFiles Include="**\*.qs" Exclude="@(QsSourceFiles)" />
-    </ItemGroup>
-    <PropertyGroup>
-      <QscCommand>$(QscExe) build -v diag --format MsBuild --proj "$(MSBuildProjectName)" -i "@(QsSourceFiles,'" "')" -r "@(QsReferences,'" "')" -o $(GenFilesDir) --load "$(SimulationTarget)"</QscCommand>
-    </PropertyGroup>
-    <Message Importance="low" Text="executing command '$(QscCommand)'" />
-    <Exec Command="$(QscCommand)" IgnoreExitCode="false" />
-    <Delete Files="$(GenFilesDir)$(MSBuildProjectName).bson" />
-    <ItemGroup>
-      <Compile Include="$(GenFilesDir)**\*.g.cs" Exclude="@(Compile)" />
-    </ItemGroup>
-  </Target>    
 </Project>
+
+

--- a/src/QsCompiler/TestTargets/Simulation/Example/Example.csproj
+++ b/src/QsCompiler/TestTargets/Simulation/Example/Example.csproj
@@ -4,15 +4,15 @@
     <QscVerbosity>Detailed</QscVerbosity>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.0</TargetFramework>
-    <CsharpGeneration>false</CsharpGeneration>
-    <QscExe>dotnet "../../../CommandLineTool/bin/$(Configuration)/netcoreapp3.0/qsc.dll"</QscExe>
-    <SimulationTarget>"..\Target\bin\$(Configuration)\netstandard2.1\Simulation.dll"</SimulationTarget>
-    <AdditionalQscArguments>--load $(SimulationTarget)</AdditionalQscArguments>
+    <CsharpGeneration>false</CsharpGeneration> <!--we provide our own C# generation for the sake of also generating C# for all references-->
   </PropertyGroup>
 
   <PropertyGroup>
     <GeneratedFilesOutputPath>generated/</GeneratedFilesOutputPath>
     <ExecutionTestsDir>ExecutionTests/</ExecutionTestsDir>
+    <SimulationTarget>"..\Target\bin\$(Configuration)\netstandard2.1\Simulation.dll"</SimulationTarget>
+    <AdditionalQscArguments>--load $(SimulationTarget)</AdditionalQscArguments>
+    <QscExe>dotnet "../../../CommandLineTool/bin/$(Configuration)/netcoreapp3.0/qsc.dll"</QscExe>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/QsCompiler/TestTargets/Simulation/Example/Example.csproj
+++ b/src/QsCompiler/TestTargets/Simulation/Example/Example.csproj
@@ -10,8 +10,8 @@
   <PropertyGroup>
     <GeneratedFilesOutputPath>generated/</GeneratedFilesOutputPath>
     <ExecutionTestsDir>ExecutionTests/</ExecutionTestsDir>
-    <SimulationTarget>"..\Target\bin\$(Configuration)\netstandard2.1\Simulation.dll"</SimulationTarget>
-    <AdditionalQscArguments>--load $(SimulationTarget)</AdditionalQscArguments>
+    <SimulationTarget>../Target/bin/$(Configuration)/netstandard2.1/Simulation.dll</SimulationTarget>
+    <AdditionalQscArguments> --load $(SimulationTarget)</AdditionalQscArguments>
     <QscExe>dotnet "../../../CommandLineTool/bin/$(Configuration)/netcoreapp3.0/qsc.dll"</QscExe>
   </PropertyGroup>
 
@@ -27,12 +27,21 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\Target\Simulation.csproj">
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+    </ProjectReference>
     <ProjectReference Include="../../../CommandLineTool/CommandLineTool.csproj">
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
     </ProjectReference>
     <ProjectReference Include="../../Libraries/Library1/Library1.csproj" />
-  </ItemGroup>  
-  
+  </ItemGroup>
+
+  <Target Name="BeforeCsharpCompile">
+    <ItemGroup>
+      <Compile Include="$(GeneratedFilesOutputPath)**/*.cs" Exclude="@(Compile)" AutoGen="true" />
+    </ItemGroup>
+  </Target>
+
 </Project>
 
 

--- a/src/QsCompiler/TestTargets/Simulation/Example/Example.csproj
+++ b/src/QsCompiler/TestTargets/Simulation/Example/Example.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.Quantum.Sdk/0.10.2001.2311-beta">
+﻿<Project Sdk="Microsoft.Quantum.Sdk/0.10.2001.2502-alpha">
 
   <PropertyGroup>
     <QscVerbosity>Detailed</QscVerbosity>

--- a/src/QsCompiler/Tests.Compiler/ExecutionTests.fs
+++ b/src/QsCompiler/Tests.Compiler/ExecutionTests.fs
@@ -40,7 +40,7 @@ type ExecutionTests (output:ITestOutputHelper) =
         AssertEqual expectedOutput out
 
 
-    [<Fact>]
+    //[<Fact>]
     member this.``Specialization Generation for Conjugations`` () = 
         ExecuteAndCompareOutput 
             "ConjugationsInBody" "
@@ -139,7 +139,7 @@ type ExecutionTests (output:ITestOutputHelper) =
             "
 
 
-    [<Fact>]
+    //[<Fact>]
     member this.``Referencing Projects and Packages`` () = 
         ExecuteAndCompareOutput 
             "PackageAndProjectReference" "

--- a/src/QsCompiler/Tests.Compiler/ExecutionTests.fs
+++ b/src/QsCompiler/Tests.Compiler/ExecutionTests.fs
@@ -40,7 +40,7 @@ type ExecutionTests (output:ITestOutputHelper) =
         AssertEqual expectedOutput out
 
 
-    //[<Fact>]
+    [<Fact>]
     member this.``Specialization Generation for Conjugations`` () = 
         ExecuteAndCompareOutput 
             "ConjugationsInBody" "
@@ -139,7 +139,7 @@ type ExecutionTests (output:ITestOutputHelper) =
             "
 
 
-    //[<Fact>]
+    [<Fact>]
     member this.``Referencing Projects and Packages`` () = 
         ExecuteAndCompareOutput 
             "PackageAndProjectReference" "

--- a/src/QuantumSdk/DefaultItems/DefaultItems.targets
+++ b/src/QuantumSdk/DefaultItems/DefaultItems.targets
@@ -42,12 +42,15 @@
     <PathCompatibleAssemblyName>$([System.String]::Copy('$(AssemblyName)').Replace(' ',''))</PathCompatibleAssemblyName>
     <!-- output path for files generated during compilation -->
     <GeneratedFilesOutputPath Condition="'$(GeneratedFilesOutputPath)' == ''">$(BaseIntermediateOutputPath)qsharp/</GeneratedFilesOutputPath>
+    <GeneratedFilesOutputPath>$([MSBuild]::Unescape('$(GeneratedFilesOutputPath)').Replace('\','/'))</GeneratedFilesOutputPath>
     <GeneratedFilesOutputPath Condition="!HasTrailingSlash('$(GeneratedFilesOutputPath)')">$(GeneratedFilesOutputPath)/</GeneratedFilesOutputPath>
     <!-- output path for generating documentation -->
     <QsharpDocsOutputPath Condition="'$(QsharpDocsOutputPath)' == ''">$(GeneratedFilesOutputPath)docs/</QsharpDocsOutputPath>
+    <QsharpDocsOutputPath>$([MSBuild]::Unescape('$(QsharpDocsOutputPath)').Replace('\','/'))</QsharpDocsOutputPath>
     <QsharpDocsOutputPath Condition="!HasTrailingSlash('$(QsharpDocsOutputPath)')">$(QsharpDocsOutputPath)/</QsharpDocsOutputPath>
     <!-- output path for generating qsc config file -->
     <QscBuildConfigOutputPath Condition="'$(QscBuildConfigOutputPath)' == ''">$(GeneratedFilesOutputPath)config/</QscBuildConfigOutputPath>
+    <QscBuildConfigOutputPath>$([MSBuild]::Unescape('$(QscBuildConfigOutputPath)').Replace('\','/'))</QscBuildConfigOutputPath>
     <QscBuildConfigOutputPath Condition="!HasTrailingSlash('$(QscBuildConfigOutputPath)')">$(QscBuildConfigOutputPath)/</QscBuildConfigOutputPath>
   </PropertyGroup>
 
@@ -56,30 +59,23 @@
   <Target Name="ResolveQscReferences" DependsOnTargets="ResolveProjectReferences;ResolveAssemblyReferences;Restore" BeforeTargets="BeforeQsharpCompile">
     <!-- get the assembly path for all relevant project references which are passed as qsc references -->
     <ItemGroup>
-      <QscProjectReference Remove="@(QscProjectReference)"/>
       <QscProjectReference Include="@(_ResolvedProjectReferencePaths)" Condition="@(_ResolvedProjectReferencePaths->Count()) &gt; 0 And %(_ResolvedProjectReferencePaths.IsQscReference)" />
-      <_RelevantQscProjectReference Remove="@(_RelevantQscProjectReference)"/>
       <_RelevantQscProjectReference Include="@(QscProjectReference->WithMetadataValue('ExecutionTarget',''))" /> 
       <_RelevantQscProjectReference Include="@(QscProjectReference->WithMetadataValue('ExecutionTarget','Any'))" /> 
       <_RelevantQscProjectReference Include="@(QscProjectReference->WithMetadataValue('ExecutionTarget','$(ExecutionTarget)'))" /> 
     </ItemGroup>
     <!-- get the path property name for all relevant package references which are passed as qsc references -->
     <ItemGroup>
-      <QscPackageReference Remove="@(QscPackageReference)"/>
       <QscPackageReference Include="@(PackageReference)" Condition="@(PackageReference->Count()) &gt; 0 And %(PackageReference.IsQscReference)" />
-      <_RelevantQscPackageReference Remove="@(_RelevantQscPackageReference)"/>
       <_RelevantQscPackageReference Include="@(QscPackageReference->WithMetadataValue('ExecutionTarget',''))" /> 
       <_RelevantQscPackageReference Include="@(QscPackageReference->WithMetadataValue('ExecutionTarget','Any'))" /> 
       <_RelevantQscPackageReference Include="@(QscPackageReference->WithMetadataValue('ExecutionTarget','$(ExecutionTarget)'))" /> 
-      <_RelevantQscPackageReferencePathProperty Remove="@(_RelevantQscPackageReferencePathProperty)"/>
       <_RelevantQscPackageReferencePathProperty Include="@(_RelevantQscPackageReference->'Pkg$([System.String]::Copy('%(_RelevantQscPackageReference.Identity)').Replace('.','_'))')" /> 
     </ItemGroup>
     <!-- add the assembly paths for all relevant qsc references and their priorities to ResolvedQscReferences -->
     <ItemGroup>
-      <ResolvedQscReferences Remove="@(ResolvedQscReferences)"/>
       <ResolvedQscReferences Include="%(_RelevantQscProjectReference.Identity)" Priority="%(_RelevantQscProjectReference.Priority)" />
       <ResolvedQscReferences Include="$(%(_RelevantQscPackageReferencePathProperty.Identity))/lib/**/*.dll" Priority="%(_RelevantQscPackageReferencePathProperty.Priority)" /> 
-      <ResolvedQscReferencesAndPriorities Remove="@(ResolvedQscReferencesAndPriorities)"/>
       <ResolvedQscReferencesAndPriorities Include="(%(ResolvedQscReferences.Identity), %(ResolvedQscReferences.Priority))" /> 
     </ItemGroup>
     <Message 

--- a/src/QuantumSdk/QuantumSdk.nuspec
+++ b/src/QuantumSdk/QuantumSdk.nuspec
@@ -19,10 +19,10 @@
     </packageTypes>
   </metadata>
   <files>
-    <file src="Sdk\**\*" target="Sdk" exclude="**\*.v.template"/>
-    <file src="DefaultItems\**\*" target="DefaultItems" exclude="**\*.v.template"/>
-    <file src="ProjectSystem\**\*" target="ProjectSystem" exclude="**\*.v.template"/>
-    <file src="Tools\BuildConfiguration\bin\$Configuration$\netcoreapp3.0\publish\**" target="tools\utils" exclude="**\*.pdb" />
-    <file src="..\QsCompiler\CommandLineTool\bin\$Configuration$\netcoreapp3.0\publish\**" target="tools\qsc" exclude="**\*.pdb" />
+    <file src="Sdk/**/*" target="Sdk" exclude="**/*.v.template"/>
+    <file src="DefaultItems/**/*" target="DefaultItems" exclude="**/*.v.template"/>
+    <file src="ProjectSystem/**/*" target="ProjectSystem" exclude="**/*.v.template"/>
+    <file src="Tools/BuildConfiguration/bin/$Configuration$/netcoreapp3.0/publish/**" target="tools/utils" exclude="**/*.pdb" />
+    <file src="../QsCompiler/CommandLineTool/bin/$Configuration$/netcoreapp3.0/publish/**" target="tools/qsc" exclude="**/*.pdb" />
   </files>
 </package>

--- a/src/QuantumSdk/README.md
+++ b/src/QuantumSdk/README.md
@@ -93,6 +93,9 @@ The NuGet version of the Sdk package.
 
 The following properties can be configured to customize the build: 
 
+- `AdditionalQscArguments`:    
+May contain additional arguments to pass to the Q# command line compiler. Valid additional arguments are `--emit-dll`, or `--no-warn` followed by any number of integers specifying the warnings to ignore.   
+
 - `CsharpGeneration`:    
 Specifies whether to generate C# code as part of the compilation process. Setting this property to false may prevent certain interoperability features or integration with other pieces of the Quantum Development Kit. 
 

--- a/src/QuantumSdk/README.md
+++ b/src/QuantumSdk/README.md
@@ -116,6 +116,22 @@ Directory where any generated documentation will be saved.
 
 [comment]: # (TODO: document QscBuildConfigExe, QscBuildConfigOutputPath)
 
+## Defined item groups ##
+
+The following configurable item groups are used by the Sdk: 
+
+- `PackageLoadFallbackFolder`:    
+Contains the directories where the Q# compiler will look for a suitable dll if a qsc reference or one if its dependencies cannot be found. By default, the project output path is included in this item group. 
+
+- `PackageReference`:    
+Contains all referenced NuGet packages. Package references for which the `IsQscReference` attribute is set to "true" may extend the Q# compiler and any implemented rewrite steps will be executed as part of the compilation process. See [this section](#extending-the-q#-compiler) for more details.
+
+- `ProjectReference`:    
+Contains all referenced projects. Project references for which the `IsQscReference` attribute is set to "true" may extend the Q# compiler and any implemented rewrite steps will be executed as part of the compilation process. See [this section](#extending-the-q#-compiler) for more details.
+
+- `QsharpCompile`:    
+Contains all Q# source files included in the compilation.
+
 # Sdk Packages #
 
 To understand how the content in this package works it is useful to understand how the properties, item groups, and targets defined in the Sdk are combined with those defined by a specific project. 

--- a/src/QuantumSdk/Sdk/Sdk.targets
+++ b/src/QuantumSdk/Sdk/Sdk.targets
@@ -62,6 +62,8 @@
       <Output TaskParameter="Lines" ItemName="_PrioritizedResolvedQscReferences"/>
     </ReadLinesFromFile>
     <ItemGroup>
+      <PackageLoadFallbackFolder Include="$(MSBuildProjectDirectory)/$(OutputPath)" Condition="'$(OutputPath)' != '' And '$(MSBuildProjectDirectory)' != ''" />
+      <ResolvedPackageLoadFallbackFolders Include="@(PackageLoadFallbackFolder->'$([MSBuild]::Unescape('%(PackageLoadFallbackFolder.Identity)').Replace('\','/').DistinctWithCase())')" />
       <ResolvedQsharpReferences Include="@(ReferencePath)" Condition="$([System.Text.RegularExpressions.Regex]::IsMatch(%(FullPath), '(?i)system.|mscorlib|netstandard.library|microsoft.netcore.app|csharp|fsharp|microsoft.visualstudio|microsoft.testplatform|microsoft.codeanalysis|fparsec|newtonsoft|roslynwrapper|yamldotnet')) == false" />
     </ItemGroup>
     <!-- invoke the Q# command line compiler -->
@@ -71,7 +73,7 @@
       <_QscCommandInputFlag Condition="@(QsharpCompile->Count()) &gt; 0">--input "@(QsharpCompile,'" "')"</_QscCommandInputFlag>
       <_QscCommandReferencesFlag Condition="@(ResolvedQsharpReferences->Count()) &gt; 0">--references "@(ResolvedQsharpReferences,'" "')"</_QscCommandReferencesFlag>
       <_QscCommandLoadFlag Condition="@(_PrioritizedResolvedQscReferences->Count()) &gt; 0">--load "@(_PrioritizedResolvedQscReferences,'" "')"</_QscCommandLoadFlag>
-      <_QscPackageLoadFallbackFoldersFlag Condition="'$(OutputPath)' != '' And '$(MSBuildProjectDirectory)' != ''">--package-load-fallback-folders $(MSBuildProjectDirectory)/$(OutputPath)</_QscPackageLoadFallbackFoldersFlag> <!-- since we have no quotations this needs to be last -->
+      <_QscPackageLoadFallbackFoldersFlag Condition="@(ResolvedPackageLoadFallbackFolders->Count()) &gt; 0">--package-load-fallback-folders "@(ResolvedPackageLoadFallbackFolders,'" "')"</_QscPackageLoadFallbackFoldersFlag>
       <_QscCommandArgs>--proj "$(PathCompatibleAssemblyName)" $(_QscCommandDocsFlag) $(_QscCommandInputFlag) $(_QscCommandOutputFlag) $(_QscCommandReferencesFlag) $(_QscCommandLoadFlag) $(_QscPackageLoadFallbackFoldersFlag) $(AdditionalQscArguments)</_QscCommandArgs>
       <_QscCommandArgsFile>$(QscBuildConfigOutputPath)qsc.rsp</_QscCommandArgsFile>
       <QscCommand>$(QscExe) build --format MsBuild $(_VerbosityFlag) --response-files $(_QscCommandArgsFile)</QscCommand>

--- a/src/QuantumSdk/Sdk/Sdk.targets
+++ b/src/QuantumSdk/Sdk/Sdk.targets
@@ -42,6 +42,7 @@
 
   <!-- Invokes the Q# command line compiler to build the project. -->
   <Target Name="QsharpCompile" 
+          Condition="'$(DesignTimeBuild)' != 'true'"
           DependsOnTargets="ResolveAssemblyReferences;ResolveQscReferences;BeforeQsharpCompile;_CopyFilesMarkedCopyLocal" 
           BeforeTargets="BeforeCsharpCompile;BeforeBuild">
     <MakeDir Directories="$(GeneratedFilesOutputPath)" />

--- a/src/QuantumSdk/Sdk/Sdk.targets
+++ b/src/QuantumSdk/Sdk/Sdk.targets
@@ -43,25 +43,7 @@
   <!-- Invokes the Q# command line compiler to build the project. -->
   <Target Name="QsharpCompile" 
           DependsOnTargets="ResolveAssemblyReferences;ResolveQscReferences;BeforeQsharpCompile;_CopyFilesMarkedCopyLocal" 
-          BeforeTargets="BeforeCsharpCompile;BeforeBuild"
-          Inputs="$(MSBuildAllProjects);
-                  @(QsharpCompile);
-                  @(ReferencePath);
-                  @(ResolvedQscReferences);
-                  @(ResolvedQscReferencesAndPriorities);
-                  $(PathCompatibleAssemblyName);
-                  $(GeneratedFilesOutputPath);
-                  $(QscBuildConfigOutputPath);
-                  $(QsharpDocsOutputPath);
-                  $(QsharpDocsGeneration);
-                  $(CsharpGeneration);
-                  $(QscBuildConfigExe);
-                  $(QscExe)"
-          Outputs="@(ResolvedQsharpReferences);
-                  @(Compile);
-                  $(QscBuildConfigGeneration);
-                  $(QscCommand);
-                  $(GeneratedFilesOutputPath)$(PathCompatibleAssemblyName).bson">
+          BeforeTargets="BeforeCsharpCompile;BeforeBuild">
     <MakeDir Directories="$(GeneratedFilesOutputPath)" />
     <MakeDir Directories="$(QscBuildConfigOutputPath)" />
     <MakeDir Condition="$(QsharpDocsGeneration)" Directories="$(QsharpDocsOutputPath)" />
@@ -89,7 +71,7 @@
       <_QscCommandReferencesFlag Condition="@(ResolvedQsharpReferences->Count()) &gt; 0">--references "@(ResolvedQsharpReferences,'" "')"</_QscCommandReferencesFlag>
       <_QscCommandLoadFlag Condition="@(_PrioritizedResolvedQscReferences->Count()) &gt; 0">--load "@(_PrioritizedResolvedQscReferences,'" "')"</_QscCommandLoadFlag>
       <_QscPackageLoadFallbackFoldersFlag Condition="'$(OutputPath)' != '' And '$(MSBuildProjectDirectory)' != ''">--package-load-fallback-folders $(MSBuildProjectDirectory)/$(OutputPath)</_QscPackageLoadFallbackFoldersFlag> <!-- since we have no quotations this needs to be last -->
-      <_QscCommandArgs>--proj "$(PathCompatibleAssemblyName)" $(_QscCommandDocsFlag) $(_QscCommandInputFlag) $(_QscCommandOutputFlag) $(_QscCommandReferencesFlag) $(_QscCommandLoadFlag) $(_QscPackageLoadFallbackFoldersFlag)</_QscCommandArgs>
+      <_QscCommandArgs>--proj "$(PathCompatibleAssemblyName)" $(_QscCommandDocsFlag) $(_QscCommandInputFlag) $(_QscCommandOutputFlag) $(_QscCommandReferencesFlag) $(_QscCommandLoadFlag) $(_QscPackageLoadFallbackFoldersFlag) $(AdditionalQscArguments)</_QscCommandArgs>
       <_QscCommandArgsFile>$(QscBuildConfigOutputPath)qsc.rsp</_QscCommandArgsFile>
       <QscCommand>$(QscExe) build --format MsBuild $(_VerbosityFlag) --response-files $(_QscCommandArgsFile)</QscCommand>
     </PropertyGroup>


### PR DESCRIPTION
The incremental build doesn't seem to behave as it should, causing some occasional issues when debugging (the debugger complaining fails changed, because the design time build re-generated C# files). 
Also: adding a AdditionalQscArguments property, and switching to using the Sdk for the Example project.