### PR TITLE
Add parsing for access modifiers using alternative syntax

### DIFF
--- a/src/QsCompiler/CompilationManager/EditorSupport/CodeActions.cs
+++ b/src/QsCompiler/CompilationManager/EditorSupport/CodeActions.cs
@@ -233,9 +233,9 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
                 IEnumerable<Characteristics> GetCharacteristics(QsTuple<Tuple<QsSymbol, QsType>> argTuple) =>
                     SyntaxGenerator.ExtractItems(argTuple).SelectMany(item => item.Item2.ExtractCharacteristics()).Distinct();
                 var characteristicsInFragment =
-                    fragment?.Kind is QsFragmentKind.FunctionDeclaration function ? GetCharacteristics(function.Item2.Argument) :
-                    fragment?.Kind is QsFragmentKind.OperationDeclaration operation ? GetCharacteristics(operation.Item2.Argument) :
-                    fragment?.Kind is QsFragmentKind.TypeDefinition type ? GetCharacteristics(type.Item2) :
+                    fragment?.Kind is QsFragmentKind.FunctionDeclaration function ? GetCharacteristics(function.Item3.Argument) :
+                    fragment?.Kind is QsFragmentKind.OperationDeclaration operation ? GetCharacteristics(operation.Item3.Argument) :
+                    fragment?.Kind is QsFragmentKind.TypeDefinition type ? GetCharacteristics(type.Item3) :
                     Enumerable.Empty<Characteristics>();
 
                 //var symbolInfo = file.TryGetQsSymbolInfo(d.Range.Start, false, out var fragment);
@@ -437,11 +437,11 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
             var docString = $"{docPrefix}# Summary{endLine}{docPrefix}{endLine}";
 
             var (argTuple, typeParams) =
-                callableDecl.IsValue ? (callableDecl.Item.Item2.Item2.Argument,
-                                        callableDecl.Item.Item2.Item2.TypeParameters)
-                : typeDecl.IsValue ? (typeDecl.Item.Item2.Item1, ImmutableArray<QsSymbol>.Empty)
+                callableDecl.IsValue ? (callableDecl.Item.Item2.Item3.Argument,
+                                        callableDecl.Item.Item2.Item3.TypeParameters)
+                : typeDecl.IsValue ? (typeDecl.Item.Item2.Item2, ImmutableArray<QsSymbol>.Empty)
                 : (null, ImmutableArray<QsSymbol>.Empty);
-            var hasOutput = callableDecl.IsValue && !callableDecl.Item.Item2.Item2.ReturnType.Type.IsUnitType;
+            var hasOutput = callableDecl.IsValue && !callableDecl.Item.Item2.Item3.ReturnType.Type.IsUnitType;
 
             var args = argTuple == null ? ImmutableArray<Tuple<QsSymbol, QsType>>.Empty : SyntaxGenerator.ExtractItems(argTuple);
             docString = String.Concat(

--- a/src/QsCompiler/CompilationManager/TypeChecking.cs
+++ b/src/QsCompiler/CompilationManager/TypeChecking.cs
@@ -111,13 +111,13 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// <summary>
         /// Returns the HeaderItems corresponding to all type declarations with a valid name in the given file, or null if the given file is null. 
         /// </summary>
-        private static IEnumerable<(CodeFragment.TokenIndex, HeaderEntry<Tuple<QsTuple<Tuple<QsSymbol, QsType>>, Modifiers>>)> GetTypeDeclarationHeaderItems
+        private static IEnumerable<(CodeFragment.TokenIndex, HeaderEntry<Tuple<Modifiers, QsTuple<Tuple<QsSymbol, QsType>>>>)> GetTypeDeclarationHeaderItems
             (this FileContentManager file) => file.GetHeaderItems(file?.TypeDeclarationTokens(), frag => frag.Kind.DeclaredType(), null);
 
         /// <summary>
         /// Returns the HeaderItems corresponding to all callable declarations with a valid name in the given file, or null if the given file is null.
         /// </summary>
-        private static IEnumerable<(CodeFragment.TokenIndex, HeaderEntry<Tuple<QsCallableKind, CallableSignature, Modifiers>>)> GetCallableDeclarationHeaderItems
+        private static IEnumerable<(CodeFragment.TokenIndex, HeaderEntry<Tuple<QsCallableKind, Modifiers, CallableSignature>>)> GetCallableDeclarationHeaderItems
             (this FileContentManager file) => file.GetHeaderItems(file?.CallableDeclarationTokens(), frag => frag.Kind.DeclaredCallable(), null);
 
         /// <summary>
@@ -128,7 +128,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// The function returns Null if the Kind of the given fragment is null.
         /// </summary>
         private static QsNullable<Tuple<QsSymbol, (QsSpecializationKind, QsSpecializationGenerator, Tuple<QsPositionInfo, QsPositionInfo>)>> SpecializationDeclaration
-            (HeaderEntry<Tuple<QsCallableKind, CallableSignature, Modifiers>> parent, CodeFragment fragment)
+            (HeaderEntry<Tuple<QsCallableKind, Modifiers, CallableSignature>> parent, CodeFragment fragment)
         {
             var specDecl = fragment.Kind?.DeclaredSpecialization();
             var Null = QsNullable<Tuple<QsSymbol, (QsSpecializationKind, QsSpecializationGenerator, Tuple<QsPositionInfo, QsPositionInfo>)>>.Null;
@@ -226,7 +226,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
 
                 // add all type declarations
                 var typesToCompile = AddItems(file.GetTypeDeclarationHeaderItems(),
-                    (pos, name, decl, att, doc) => (ContainingParent(pos, namespaces)).TryAddType(file.FileName, Location(pos, name.Item2), name, decl.Item1, att, decl.Item2, doc),
+                    (pos, name, decl, att, doc) => (ContainingParent(pos, namespaces)).TryAddType(file.FileName, Location(pos, name.Item2), name, decl.Item2, att, decl.Item1, doc),
                     file.FileName.Value, diagnostics);
 
                 var tokensToCompile = new List<(QsQualifiedName, (QsComments, IEnumerable<CodeFragment.TokenIndex>))>();
@@ -238,7 +238,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
 
                 // add all callable declarations
                 var callablesToCompile = AddItems(file.GetCallableDeclarationHeaderItems(),
-                    (pos, name, decl, att, doc) => (ContainingParent(pos, namespaces)).TryAddCallableDeclaration(file.FileName, Location(pos, name.Item2), name, Tuple.Create(decl.Item1, decl.Item2), att, decl.Item3, doc),
+                    (pos, name, decl, att, doc) => (ContainingParent(pos, namespaces)).TryAddCallableDeclaration(file.FileName, Location(pos, name.Item2), name, Tuple.Create(decl.Item1, decl.Item3), att, decl.Item2, doc),
                     file.FileName.Value, diagnostics);
 
                 // add all callable specilizations -> TOOD: needs to be adapted for specializations outside the declaration body (not yet supported)
@@ -271,7 +271,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// Throws an ArgumentNullException if either the given namespace or diagnostics are null.
         /// </summary>
         private static List<CodeFragment.TokenIndex> AddSpecializationsToNamespace(FileContentManager file, Namespace ns,
-            (CodeFragment.TokenIndex, HeaderEntry<Tuple<QsCallableKind, CallableSignature, Modifiers>>) parent, List<Diagnostic> diagnostics)
+            (CodeFragment.TokenIndex, HeaderEntry<Tuple<QsCallableKind, Modifiers, CallableSignature>>) parent, List<Diagnostic> diagnostics)
         {
             if (ns == null) throw new ArgumentNullException(nameof(ns));
             if (diagnostics == null) throw new ArgumentNullException(nameof(diagnostics));

--- a/src/QsCompiler/DataStructures/ReservedKeywords.fs
+++ b/src/QsCompiler/DataStructures/ReservedKeywords.fs
@@ -155,6 +155,11 @@ module Declarations =
 
     /// keyword for a Q# declaration
     let Namespace   = "namespace"
+    
+    /// keyword for a Q# declaration modifier
+    let Private     = "private"
+    /// keyword for a Q# declaration modifier
+    let Internal    = "internal"
 
 
 /// contains keywords for Q# directives

--- a/src/QsCompiler/DataStructures/SyntaxTokens.fs
+++ b/src/QsCompiler/DataStructures/SyntaxTokens.fs
@@ -234,9 +234,9 @@ type QsFragmentKind =
 | AdjointDeclaration            of QsSpecializationGenerator
 | ControlledDeclaration         of QsSpecializationGenerator
 | ControlledAdjointDeclaration  of QsSpecializationGenerator
-| OperationDeclaration          of QsSymbol * CallableSignature * Modifiers
-| FunctionDeclaration           of QsSymbol * CallableSignature * Modifiers
-| TypeDefinition                of QsSymbol * QsTuple<QsSymbol * QsType> * Modifiers
+| OperationDeclaration          of Modifiers * QsSymbol * CallableSignature
+| FunctionDeclaration           of Modifiers * QsSymbol * CallableSignature
+| TypeDefinition                of Modifiers * QsSymbol * QsTuple<QsSymbol * QsType>
 | DeclarationAttribute          of QsSymbol * QsExpression
 | OpenDirective                 of QsSymbol * QsNullable<QsSymbol>
 | NamespaceDeclaration          of QsSymbol

--- a/src/QsCompiler/SyntaxProcessor/DeclarationVerification.fs
+++ b/src/QsCompiler/SyntaxProcessor/DeclarationVerification.fs
@@ -71,7 +71,7 @@ let public OpenedNamespaceName this onInvalid =
 [<Extension>]
 let public DeclaredType this =
     match this with 
-    | TypeDefinition (sym, decl, modifiers) -> (sym, (decl, modifiers)) |> Value
+    | TypeDefinition (mods, sym, decl) -> (sym, (mods, decl)) |> Value
     | _ -> Null
 
 /// If the given fragment kind is a type declaration,
@@ -88,8 +88,8 @@ let public DeclaredTypeName this onInvalid =
 [<Extension>]
 let public DeclaredCallable this =
     match this with 
-    | FunctionDeclaration (sym, decl, modifiers) -> (sym, (QsCallableKind.Function, decl, modifiers)) |> Value
-    | OperationDeclaration (sym, decl, modifiers) -> (sym, (QsCallableKind.Operation, decl, modifiers)) |> Value
+    | FunctionDeclaration (mods, sym, decl) -> (sym, (QsCallableKind.Function, mods, decl)) |> Value
+    | OperationDeclaration (mods, sym, decl) -> (sym, (QsCallableKind.Operation, mods, decl)) |> Value
     | _ -> Null
 
 /// If the given fragment kind is a callable declaration,

--- a/src/QsCompiler/SyntaxProcessor/SyntaxExtensions.fs
+++ b/src/QsCompiler/SyntaxProcessor/SyntaxExtensions.fs
@@ -173,9 +173,9 @@ let public SymbolInformation fragmentKind =
     | QsFragmentKind.AdjointDeclaration                 gen -> gen |> SymbolsInGenerator, ([], [], [])
     | QsFragmentKind.ControlledDeclaration              gen -> gen |> SymbolsInGenerator, ([], [], [])
     | QsFragmentKind.ControlledAdjointDeclaration       gen -> gen |> SymbolsInGenerator, ([], [], [])
-    | QsFragmentKind.OperationDeclaration (n, signature, _) -> (n, signature)                                   |> SymbolsInCallableDeclaration
-    | QsFragmentKind.FunctionDeclaration  (n, signature, _) -> (n, signature)                                   |> SymbolsInCallableDeclaration
-    | QsFragmentKind.TypeDefinition             (sym, t, _) -> (sym, t)                                         |> SymbolsInArgumentTuple
+    | QsFragmentKind.OperationDeclaration (_, n, signature) -> (n, signature)                                   |> SymbolsInCallableDeclaration
+    | QsFragmentKind.FunctionDeclaration  (_, n, signature) -> (n, signature)                                   |> SymbolsInCallableDeclaration
+    | QsFragmentKind.TypeDefinition             (_, sym, t) -> (sym, t)                                         |> SymbolsInArgumentTuple
     | QsFragmentKind.DeclarationAttribute         (sym, ex) -> [], ([AttributeAsCallExpr (sym, ex)], [])        |> collectWith SymbolsFromExpr |> addVariable sym    
     | QsFragmentKind.NamespaceDeclaration               sym -> sym |> SymbolDeclarations, ([], [], [])
     | QsFragmentKind.OpenDirective          (nsName, alias) -> [alias] |> chooseValues,   ([nsName], [], [])

--- a/src/QsCompiler/TextProcessor/QsFragmentParsing.fs
+++ b/src/QsCompiler/TextProcessor/QsFragmentParsing.fs
@@ -116,7 +116,7 @@ let private allocationScope =
 /// Parses keywords that modify the visibility or behavior of a declaration.
 let private modifiers =
     let accessModifier = (qsPrivate.parse >>% Private) <|> (qsInternal.parse >>% Internal) <|>% DefaultAccess
-    accessModifier |>> fun access -> { Access = access }
+    accessModifier |>> fun access -> {Access = access}
 
 /// Parses a Q# operation or function signature. 
 /// Expects type annotations for each symbol in the argument tuple, and raises Missing- or InvalidTypeAnnotation errors otherwise. 

--- a/src/QsCompiler/TextProcessor/QsFragmentParsing.fs
+++ b/src/QsCompiler/TextProcessor/QsFragmentParsing.fs
@@ -154,6 +154,7 @@ let private signature =
     let returnTypeAnnotation = expected (typeAnnotation eof) ErrorCode.InvalidReturnTypeAnnotation ErrorCode.MissingReturnTypeAnnotation invalidType eof
     let characteristicsAnnotation = opt (qsCharacteristics.parse >>. expectedCharacteristics eof) |>> Option.defaultValue ((EmptySet, Null) |> Characteristics.New)
     let signature = genericParamList .>>. (argumentTuple .>>. returnTypeAnnotation) .>>. characteristicsAnnotation |>> CallableSignature.New
+    // TODO: Parse modifiers before the "operation" and "function" keywords.
     tuple3 modifiers symbolDeclaration signature
 
 /// Parses a Q# functor generator directive. 
@@ -302,7 +303,8 @@ and private udtDeclaration =
             let tupleItem = attempt namedItem <|> (typeParser typeTuple |>> asAnonymousItem) // namedItem needs to be first, and we can't be permissive for tuple types!
             buildTupleItem tupleItem (fst >> QsTuple) ErrorCode.InvalidUdtItemDeclaration ErrorCode.MissingUdtItemDeclaration invalidArgTupleItem eof
         let invalidNamedSingle = followedBy namedItem >>. optTupleBrackets namedItem |>> fst
-        invalidNamedSingle <|> udtTupleItem // require parenthesis for a single named item 
+        invalidNamedSingle <|> udtTupleItem // require parenthesis for a single named item
+    // TODO: Parse modifiers before the "operation" and "function" keywords.
     let declBody = tuple3 modifiers (expectedIdentifierDeclaration equal .>> equal) udtTuple
     buildFragment typeDeclHeader.parse declBody invalid TypeDefinition eof
 

--- a/src/QsCompiler/TextProcessor/QsKeywords.fs
+++ b/src/QsCompiler/TextProcessor/QsKeywords.fs
@@ -200,6 +200,11 @@ let typeDeclHeader = addFragmentHeader Declarations.Type
 /// keyword for a Q# declaration (QsFragmentHeader)
 let namespaceDeclHeader = addFragmentHeader Declarations.Namespace
 
+/// keyword for a Q# declaration modifier (QsLanguageKeyword)
+let qsPrivate = addLanguageKeyword Declarations.Private
+/// keyword for a Q# declaration modifier (QsLanguageKeyword)
+let qsInternal = addLanguageKeyword Declarations.Internal
+
 // directives
 
 /// keyword for a Q# directive (QsFragmentHeader)

--- a/src/VSCodeExtension/syntaxes/qsharp.tmLanguage.json.v.template
+++ b/src/VSCodeExtension/syntaxes/qsharp.tmLanguage.json.v.template
@@ -50,7 +50,7 @@
         },
         {
           "name": "keyword.other.qsharp",
-          "match": "\\b(new|not|and|or|w\/)\\b"
+          "match": "\\b(new|not|and|or|w\/|private|internal)\\b"
         },
         {
           "comment": "C# reserved words which can't be used in Q#, A-D",
@@ -60,12 +60,12 @@
         {
           "comment": "C# reserved words which can't be used in Q#, E-L",
           "name": "invalid.illegal.el.qsharp",
-          "match": "\\b(enum|event|explicit|extern|finally|fixed|float|foreach|goto|implicit|int|interface|internal|lock|long)\\b"
+          "match": "\\b(enum|event|explicit|extern|finally|fixed|float|foreach|goto|implicit|int|interface|lock|long)\\b"
         },
         {
           "comment": "C# reserved words which can't be used in Q#, N-S",
           "name": "invalid.illegal.ns.qsharp",
-          "match": "\\b(null|object|operator|out|override|params|private|protected|public|readonly|ref|sbyte|sealed|short|sizeof|stackalloc)\\b"
+          "match": "\\b(null|object|operator|out|override|params|protected|public|readonly|ref|sbyte|sealed|short|sizeof|stackalloc)\\b"
         },
         {
           "comment": "C# reserved words which can't be used in Q#, S-V",


### PR DESCRIPTION
This adds parsing using the syntax where the access modifier comes after the fragment header and before the symbol. For example, `operation private Foo () : Unit`. The syntax will be changed to `private operation Foo () : Unit` in another PR.

See #259.