### PR TITLE
Add a performance measurement option to the command line tool

### DIFF
--- a/src/QsCompiler/CommandLineTool/Commands/Build.cs
+++ b/src/QsCompiler/CommandLineTool/Commands/Build.cs
@@ -141,7 +141,10 @@ namespace Microsoft.Quantum.QsCompiler.CommandLineCompiler
                 EnableAdditionalChecks = false // todo: enable debug mode?
             }; 
 
+            // ToDo: check options before using the OnCompilationEvent handler.
             var loaded = new CompilationLoader(options.LoadSourcesOrSnippet(logger), options.References, loadOptions, logger, CompilationTracker.OnCompilationEvent);
+            // ToDo: check options before publishing results.
+            CompilationTracker.PublishResults();
             return ReturnCode.Status(loaded);
         }
     }

--- a/src/QsCompiler/CommandLineTool/Commands/Build.cs
+++ b/src/QsCompiler/CommandLineTool/Commands/Build.cs
@@ -135,7 +135,7 @@ namespace Microsoft.Quantum.QsCompiler.CommandLineCompiler
                 DocumentationOutputFolder = options.DocFolder,
                 BuildOutputFolder = options.OutputFolder ?? (usesPlugins ? "." : null),
                 DllOutputPath = options.EmitDll ? " " : null, // set to e.g. an empty space to generate the dll in the same location as the .bson file
-                RewriteSteps = options.Plugins?.Select(step => (step, (string)null)) ?? ImmutableArray<(string, string)>.Empty, 
+                RewriteSteps = options.Plugins?.Select(step => (step, (string)null)) ?? ImmutableArray<(string, string)>.Empty,
                 EnableAdditionalChecks = false // todo: enable debug mode?
             }; 
 

--- a/src/QsCompiler/CommandLineTool/Commands/Build.cs
+++ b/src/QsCompiler/CommandLineTool/Commands/Build.cs
@@ -108,8 +108,6 @@ namespace Microsoft.Quantum.QsCompiler.CommandLineCompiler
             );
         }
 
-        
-
 
         // publicly accessible routines 
 

--- a/src/QsCompiler/CommandLineTool/Commands/Build.cs
+++ b/src/QsCompiler/CommandLineTool/Commands/Build.cs
@@ -108,6 +108,8 @@ namespace Microsoft.Quantum.QsCompiler.CommandLineCompiler
             );
         }
 
+        
+
 
         // publicly accessible routines 
 
@@ -139,7 +141,7 @@ namespace Microsoft.Quantum.QsCompiler.CommandLineCompiler
                 EnableAdditionalChecks = false // todo: enable debug mode?
             }; 
 
-            var loaded = new CompilationLoader(options.LoadSourcesOrSnippet(logger), options.References, loadOptions, logger);
+            var loaded = new CompilationLoader(options.LoadSourcesOrSnippet(logger), options.References, loadOptions, logger, CompilationTracker.OnCompilationEvent);
             return ReturnCode.Status(loaded);
         }
     }

--- a/src/QsCompiler/CommandLineTool/Commands/Build.cs
+++ b/src/QsCompiler/CommandLineTool/Commands/Build.cs
@@ -139,12 +139,16 @@ namespace Microsoft.Quantum.QsCompiler.CommandLineCompiler
                 DllOutputPath = options.EmitDll ? " " : null, // set to e.g. an empty space to generate the dll in the same location as the .bson file
                 RewriteSteps = options.Plugins?.Select(step => (step, (string)null)) ?? ImmutableArray<(string, string)>.Empty,
                 EnableAdditionalChecks = false // todo: enable debug mode?
-            }; 
+            };
 
-            // ToDo: check options before using the OnCompilationEvent handler.
+            // Note that performance is evaluated only if the performance folder option is present.
+            CompilationLoader.CompilationProcessEventHandler onCompilationProcessEvent = options.PerfFolder != null ? CompilationTracker.OnCompilationEvent : (CompilationLoader.CompilationProcessEventHandler)null;
             var loaded = new CompilationLoader(options.LoadSourcesOrSnippet(logger), options.References, loadOptions, logger, CompilationTracker.OnCompilationEvent);
-            // ToDo: check options before publishing results.
-            CompilationTracker.PublishResults();
+            if (options.PerfFolder != null)
+            {
+                CompilationTracker.PublishResults(options.PerfFolder);
+            }
+
             return ReturnCode.Status(loaded);
         }
     }

--- a/src/QsCompiler/CommandLineTool/Commands/Build.cs
+++ b/src/QsCompiler/CommandLineTool/Commands/Build.cs
@@ -139,11 +139,23 @@ namespace Microsoft.Quantum.QsCompiler.CommandLineCompiler
                 EnableAdditionalChecks = false // todo: enable debug mode?
             }; 
 
-            var onCompilationProcessEvent = options.PerfFolder != null ? CompilationTracker.OnCompilationTaskEvent : (CompilationLoader.CompilationTaskEventHandler)null;
-            var loaded = new CompilationLoader(options.LoadSourcesOrSnippet(logger), options.References, loadOptions, logger, CompilationTracker.OnCompilationTaskEvent);
             if (options.PerfFolder != null)
             {
-                CompilationTracker.PublishResults(options.PerfFolder);
+                CompilationLoader.CompilationTaskEvent += CompilationTracker.OnCompilationTaskEvent;
+            }
+
+            var loaded = new CompilationLoader(options.LoadSourcesOrSnippet(logger), options.References, loadOptions, logger);
+            if (options.PerfFolder != null)
+            {
+                try
+                {
+                    CompilationTracker.PublishResults(options.PerfFolder);
+                }
+                catch (Exception ex)
+                {
+                    logger.Log(ErrorCode.PublishingPerfResultsFailed, new string[]{options.PerfFolder});
+                    logger.Log(ex);
+                }
             }
 
             return ReturnCode.Status(loaded);

--- a/src/QsCompiler/CommandLineTool/Commands/Build.cs
+++ b/src/QsCompiler/CommandLineTool/Commands/Build.cs
@@ -141,9 +141,8 @@ namespace Microsoft.Quantum.QsCompiler.CommandLineCompiler
                 EnableAdditionalChecks = false // todo: enable debug mode?
             };
 
-            // Note that performance is evaluated only if the performance folder option is present.
-            CompilationLoader.CompilationProcessEventHandler onCompilationProcessEvent = options.PerfFolder != null ? CompilationTracker.OnCompilationEvent : (CompilationLoader.CompilationProcessEventHandler)null;
-            var loaded = new CompilationLoader(options.LoadSourcesOrSnippet(logger), options.References, loadOptions, logger, CompilationTracker.OnCompilationEvent);
+            CompilationLoader.CompilationTaskEventHandler onCompilationProcessEvent = options.PerfFolder != null ? CompilationTracker.OnCompilationTaskEvent : (CompilationLoader.CompilationTaskEventHandler)null;
+            var loaded = new CompilationLoader(options.LoadSourcesOrSnippet(logger), options.References, loadOptions, logger, CompilationTracker.OnCompilationTaskEvent);
             if (options.PerfFolder != null)
             {
                 CompilationTracker.PublishResults(options.PerfFolder);

--- a/src/QsCompiler/CommandLineTool/Commands/Build.cs
+++ b/src/QsCompiler/CommandLineTool/Commands/Build.cs
@@ -61,6 +61,10 @@ namespace Microsoft.Quantum.QsCompiler.CommandLineCompiler
             [Option("emit-dll", Required = false, Default = false, SetName = CODE_MODE,
             HelpText = "Specifies whether the compiler should emit a .NET Core dll containing the compiled Q# code.")]
             public bool EmitDll { get; set; }
+
+            [Option('p', "perf", Required = false, SetName = CODE_MODE,
+            HelpText = "Destination folder where the output of the performance assessment will be generated.")]
+            public string PerfFolder { get; set; }
         }
 
         /// <summary>

--- a/src/QsCompiler/CommandLineTool/Commands/Build.cs
+++ b/src/QsCompiler/CommandLineTool/Commands/Build.cs
@@ -137,7 +137,7 @@ namespace Microsoft.Quantum.QsCompiler.CommandLineCompiler
                 DllOutputPath = options.EmitDll ? " " : null, // set to e.g. an empty space to generate the dll in the same location as the .bson file
                 RewriteSteps = options.Plugins?.Select(step => (step, (string)null)) ?? ImmutableArray<(string, string)>.Empty,
                 EnableAdditionalChecks = false // todo: enable debug mode?
-            };
+            }; 
 
             CompilationLoader.CompilationTaskEventHandler onCompilationProcessEvent = options.PerfFolder != null ? CompilationTracker.OnCompilationTaskEvent : (CompilationLoader.CompilationTaskEventHandler)null;
             var loaded = new CompilationLoader(options.LoadSourcesOrSnippet(logger), options.References, loadOptions, logger, CompilationTracker.OnCompilationTaskEvent);

--- a/src/QsCompiler/CommandLineTool/Commands/Build.cs
+++ b/src/QsCompiler/CommandLineTool/Commands/Build.cs
@@ -135,7 +135,7 @@ namespace Microsoft.Quantum.QsCompiler.CommandLineCompiler
                 DocumentationOutputFolder = options.DocFolder,
                 BuildOutputFolder = options.OutputFolder ?? (usesPlugins ? "." : null),
                 DllOutputPath = options.EmitDll ? " " : null, // set to e.g. an empty space to generate the dll in the same location as the .bson file
-                RewriteSteps = options.Plugins?.Select(step => (step, (string)null)) ?? ImmutableArray<(string, string)>.Empty,
+                RewriteSteps = options.Plugins?.Select(step => (step, (string)null)) ?? ImmutableArray<(string, string)>.Empty, 
                 EnableAdditionalChecks = false // todo: enable debug mode?
             }; 
 

--- a/src/QsCompiler/CommandLineTool/Commands/Build.cs
+++ b/src/QsCompiler/CommandLineTool/Commands/Build.cs
@@ -139,7 +139,7 @@ namespace Microsoft.Quantum.QsCompiler.CommandLineCompiler
                 EnableAdditionalChecks = false // todo: enable debug mode?
             }; 
 
-            CompilationLoader.CompilationTaskEventHandler onCompilationProcessEvent = options.PerfFolder != null ? CompilationTracker.OnCompilationTaskEvent : (CompilationLoader.CompilationTaskEventHandler)null;
+            var onCompilationProcessEvent = options.PerfFolder != null ? CompilationTracker.OnCompilationTaskEvent : (CompilationLoader.CompilationTaskEventHandler)null;
             var loaded = new CompilationLoader(options.LoadSourcesOrSnippet(logger), options.References, loadOptions, logger, CompilationTracker.OnCompilationTaskEvent);
             if (options.PerfFolder != null)
             {

--- a/src/QsCompiler/CommandLineTool/CompilationTracker.cs
+++ b/src/QsCompiler/CommandLineTool/CompilationTracker.cs
@@ -27,19 +27,19 @@ namespace Microsoft.Quantum.QsCompiler.CommandLineCompiler
 
             public CompilationProcess(string parentName, string name)
             {
-                this.ParentName = parentName;
-                this.Name = name;
-                this.UtcStart = DateTime.UtcNow;
-                this.UtcEnd = null;
-                this.DurationInMs = null;
-                this.Watch = Stopwatch.StartNew();
+                ParentName = parentName;
+                Name = name;
+                UtcStart = DateTime.UtcNow;
+                UtcEnd = null;
+                DurationInMs = null;
+                Watch = Stopwatch.StartNew();
             }
 
             public void End()
             {
-                this.UtcEnd = DateTime.UtcNow;
-                this.Watch.Stop();
-                this.DurationInMs = this.Watch.ElapsedMilliseconds;
+                UtcEnd = DateTime.UtcNow;
+                Watch.Stop();
+                DurationInMs = Watch.ElapsedMilliseconds;
             }
 
             public string Key()
@@ -49,7 +49,7 @@ namespace Microsoft.Quantum.QsCompiler.CommandLineCompiler
 
             public bool IsInProgress()
             {
-                return this.Watch.IsRunning;
+                return Watch.IsRunning;
             }
 
             public override string ToString()
@@ -74,9 +74,9 @@ namespace Microsoft.Quantum.QsCompiler.CommandLineCompiler
 
             public Warning(WarningType type, string key)
             {
-                this.UtcDateTime = DateTime.UtcNow;
-                this.Type = type;
-                this.Key = key;
+                UtcDateTime = DateTime.UtcNow;
+                Type = type;
+                Key = key;
             }
 
             public override string ToString()

--- a/src/QsCompiler/CommandLineTool/CompilationTracker.cs
+++ b/src/QsCompiler/CommandLineTool/CompilationTracker.cs
@@ -14,8 +14,8 @@ namespace Microsoft.Quantum.QsCompiler.CommandLineCompiler
         {
             public readonly string ParentName;
             public readonly string Name;
-            public readonly DateTime UtcStartDateTime;
-            public DateTime? UtcEndDateTime;
+            public readonly DateTime UtcStart;
+            public DateTime? UtcEnd;
             public long? DurationInMs;
             private readonly Stopwatch Watch;
 
@@ -24,15 +24,15 @@ namespace Microsoft.Quantum.QsCompiler.CommandLineCompiler
             {
                 this.ParentName = parentName;
                 this.Name = name;
-                this.UtcStartDateTime = DateTime.UtcNow;
-                this.UtcEndDateTime = null;
+                this.UtcStart = DateTime.UtcNow;
+                this.UtcEnd = null;
                 this.DurationInMs = null;
                 this.Watch = Stopwatch.StartNew();
             }
 
             public void End()
             {
-                this.UtcEndDateTime = DateTime.UtcNow;
+                this.UtcEnd = DateTime.UtcNow;
                 this.Watch.Stop();
                 this.DurationInMs = this.Watch.ElapsedMilliseconds;
             }
@@ -40,6 +40,11 @@ namespace Microsoft.Quantum.QsCompiler.CommandLineCompiler
             public bool IsInProgress()
             {
                 return this.Watch.IsRunning;
+            }
+
+            public override string ToString()
+            {
+                return String.Format("Parent: {0}, Name: {1}, UtcStart: {2}, UtcEnd: {3}, DurationInMs: {4}", ParentName ?? "ROOT", Name, UtcStart, UtcEnd, DurationInMs);
             }
         }
 
@@ -68,7 +73,7 @@ namespace Microsoft.Quantum.QsCompiler.CommandLineCompiler
         private delegate void CompilationEventTypeHandler(CompilationLoader.CompilationProcessEventArgs eventArgs);
         private static void CompilationEventStartHandler(CompilationLoader.CompilationProcessEventArgs eventArgs)
         {
-            string key = String.Format("{0}.{1}", eventArgs.ParentName ?? "", eventArgs.Name);
+            string key = String.Format("{0}.{1}", eventArgs.ParentName ?? "ROOT", eventArgs.Name);
             // ToDo: remove.
             Console.WriteLine(key);
             if (CompilationProcesses.ContainsKey(key))
@@ -82,7 +87,7 @@ namespace Microsoft.Quantum.QsCompiler.CommandLineCompiler
 
         private static void CompilationEventEndHandler(CompilationLoader.CompilationProcessEventArgs eventArgs)
         {
-            string key = String.Format("{0}.{1}", eventArgs.ParentName ?? "", eventArgs.Name);
+            string key = String.Format("{0}.{1}", eventArgs.ParentName ?? "ROOT", eventArgs.Name);
             // ToDo: remove.
             Console.WriteLine(key);
             if (!CompilationProcesses.TryGetValue(key, out CompilationProcess process))
@@ -114,7 +119,12 @@ namespace Microsoft.Quantum.QsCompiler.CommandLineCompiler
 
         public static void PublishResults()
         {
-            Console.WriteLine(CompilationProcesses);
+
+            Console.WriteLine("\n>> RESULTS <<");
+            foreach (KeyValuePair<string, CompilationProcess> entry in CompilationProcesses)
+            {
+                Console.WriteLine(String.Format("[{0}] {1}", entry.Key, entry.Value));
+            }
         }
     }
 }

--- a/src/QsCompiler/CommandLineTool/CompilationTracker.cs
+++ b/src/QsCompiler/CommandLineTool/CompilationTracker.cs
@@ -52,7 +52,7 @@ namespace Microsoft.Quantum.QsCompiler.CommandLineCompiler
             /// <summary>
             /// Generates a key that uniquely identifies a task in the compilation process based on the task's name and its parent's name.
             /// </summary>
-            public static string GenerateKey(string parentName, string name)
+            internal static string GenerateKey(string parentName, string name)
             {
                 return String.Format("{0}.{1}", parentName ?? "ROOT", name);
             }

--- a/src/QsCompiler/CommandLineTool/CompilationTracker.cs
+++ b/src/QsCompiler/CommandLineTool/CompilationTracker.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Text;
 using Microsoft.Quantum.QsCompiler;
 
@@ -8,9 +9,112 @@ namespace Microsoft.Quantum.QsCompiler.CommandLineCompiler
 {
     public static class CompilationTracker
     {
+
+        private class CompilationProcess
+        {
+            public readonly string ParentName;
+            public readonly string Name;
+            public readonly DateTime UtcStartDateTime;
+            public DateTime? UtcEndDateTime;
+            public long? DurationInMs;
+            private readonly Stopwatch Watch;
+
+
+            public CompilationProcess(string parentName, string name)
+            {
+                this.ParentName = parentName;
+                this.Name = name;
+                this.UtcStartDateTime = DateTime.UtcNow;
+                this.UtcEndDateTime = null;
+                this.DurationInMs = null;
+                this.Watch = Stopwatch.StartNew();
+            }
+
+            public void End()
+            {
+                this.UtcEndDateTime = DateTime.UtcNow;
+                this.Watch.Stop();
+                this.DurationInMs = this.Watch.ElapsedMilliseconds;
+            }
+
+            public bool IsInProgress()
+            {
+                return this.Watch.IsRunning;
+            }
+        }
+
+        private enum WarningType
+        {
+            ProcessAlreadyExists,
+            ProcessDoesNotExist,
+            ProcessAlreadyEnded
+        }
+
+        private class Warning
+        {
+            public readonly WarningType Type;
+            public readonly DateTime UtcDateTime;
+            public readonly CompilationLoader.CompilationProcessEventArgs Args;
+
+            public Warning(WarningType type, CompilationLoader.CompilationProcessEventArgs args)
+            {
+                this.UtcDateTime = DateTime.UtcNow;
+                this.Type = type;
+                this.Args = args;
+            }
+        }
+
+        private static readonly IDictionary<string, CompilationProcess> CompilationProcesses = new Dictionary<string, CompilationProcess>();
+        private delegate void CompilationEventTypeHandler(CompilationLoader.CompilationProcessEventArgs eventArgs);
+        private static void CompilationEventStartHandler(CompilationLoader.CompilationProcessEventArgs eventArgs)
+        {
+            string key = String.Format("{0}.{1}", eventArgs.ParentName ?? "", eventArgs.Name);
+            // ToDo: remove.
+            Console.WriteLine(key);
+            if (CompilationProcesses.ContainsKey(key))
+            {
+                Warnings.Add(new Warning(WarningType.ProcessAlreadyExists, eventArgs));
+                return;
+            }
+
+            CompilationProcesses.Add(key, new CompilationProcess(eventArgs.ParentName, eventArgs.Name));
+        }
+
+        private static void CompilationEventEndHandler(CompilationLoader.CompilationProcessEventArgs eventArgs)
+        {
+            string key = String.Format("{0}.{1}", eventArgs.ParentName ?? "", eventArgs.Name);
+            // ToDo: remove.
+            Console.WriteLine(key);
+            if (!CompilationProcesses.TryGetValue(key, out CompilationProcess process))
+            {
+                Warnings.Add(new Warning(WarningType.ProcessDoesNotExist, eventArgs));
+                return;
+            }
+
+            if (!process.IsInProgress())
+            {
+                Warnings.Add(new Warning(WarningType.ProcessAlreadyEnded, eventArgs));
+                return;
+            }
+
+            process.End();
+        }
+
+        private static readonly IDictionary<CompilationLoader.CompilationProcessEventType, CompilationEventTypeHandler> CompilationEventTypeHandlers = new Dictionary<CompilationLoader.CompilationProcessEventType, CompilationEventTypeHandler>
+        {
+            { CompilationLoader.CompilationProcessEventType.Start, CompilationEventStartHandler },
+            { CompilationLoader.CompilationProcessEventType.End, CompilationEventEndHandler }
+        };
+
+        private static readonly IList<Warning> Warnings = new List<Warning>();
         public static void OnCompilationEvent(object sender, CompilationLoader.CompilationProcessEventArgs args)
         {
-            Console.WriteLine(">> " + args.Name + " " + args.Type);
+            CompilationEventTypeHandlers[args.Type](args);
+        }
+
+        public static void PublishResults()
+        {
+            Console.WriteLine(CompilationProcesses);
         }
     }
 }

--- a/src/QsCompiler/CommandLineTool/CompilationTracker.cs
+++ b/src/QsCompiler/CommandLineTool/CompilationTracker.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Microsoft.Quantum.QsCompiler;
+
+
+namespace Microsoft.Quantum.QsCompiler.CommandLineCompiler
+{
+    public static class CompilationTracker
+    {
+        public static void OnCompilationEvent(object sender, CompilationLoader.CompilationProcessEventArgs args)
+        {
+            Console.WriteLine(">> " + args.Name + " " + args.Type);
+        }
+    }
+}

--- a/src/QsCompiler/CommandLineTool/CompilationTracker.cs
+++ b/src/QsCompiler/CommandLineTool/CompilationTracker.cs
@@ -162,16 +162,16 @@ namespace Microsoft.Quantum.QsCompiler.CommandLineCompiler
         /// </summary>
         private static IList<CompilationTaskNode> BuildCompilationTasksHierarchy()
         {
-            IList<CompilationTaskNode> compilationTasksForest = new List<CompilationTaskNode>();
-            Queue<CompilationTaskNode> toFindChildrenNodes = new Queue<CompilationTaskNode>();
+            var compilationTasksForest = new List<CompilationTaskNode>();
+            var toFindChildrenNodes = new Queue<CompilationTaskNode>();
 
             // First add the roots (top-level tasks) of all trees to the forest.
 
-            foreach (KeyValuePair<string, CompilationTask> entry in CompilationTasks)
+            foreach (var entry in CompilationTasks)
             {
                 if (entry.Value.ParentName == null)
                 {
-                    CompilationTaskNode node = new CompilationTaskNode(entry.Value);
+                    var node = new CompilationTaskNode(entry.Value);
                     compilationTasksForest.Add(node);
                     toFindChildrenNodes.Enqueue(node);
                 }
@@ -181,12 +181,12 @@ namespace Microsoft.Quantum.QsCompiler.CommandLineCompiler
 
             while (toFindChildrenNodes.Count > 0)
             {
-                CompilationTaskNode parentNode = toFindChildrenNodes.Dequeue();
-                foreach (KeyValuePair<string, CompilationTask> entry in CompilationTasks)
+                var parentNode = toFindChildrenNodes.Dequeue();
+                foreach (var entry in CompilationTasks)
                 {
                     if (parentNode.Task.Name.Equals(entry.Value.ParentName))
                     {
-                        CompilationTaskNode childNode = new CompilationTaskNode(entry.Value);
+                        var childNode = new CompilationTaskNode(entry.Value);
                         parentNode.Children.Add(childNode.Task.Name, childNode);
                         toFindChildrenNodes.Enqueue(childNode);
                     }
@@ -216,20 +216,20 @@ namespace Microsoft.Quantum.QsCompiler.CommandLineCompiler
         /// </summary>
         private static void CompilationEventEndHandler(CompilationLoader.CompilationTaskEventArgs eventArgs)
         {
-            string key = CompilationTask.GenerateKey(eventArgs.ParentTaskName, eventArgs.TaskName);
-            if (!CompilationTasks.TryGetValue(key, out CompilationTask process))
+            var key = CompilationTask.GenerateKey(eventArgs.ParentTaskName, eventArgs.TaskName);
+            if (!CompilationTasks.TryGetValue(key, out var task))
             {
                 Warnings.Add(new Warning(WarningType.ProcessDoesNotExist, key));
                 return;
             }
 
-            if (!process.IsInProgress())
+            if (!task.IsInProgress())
             {
                 Warnings.Add(new Warning(WarningType.ProcessAlreadyEnded, key));
                 return;
             }
 
-            process.End();
+            task.End();
         }
 
         // Public methods.
@@ -247,17 +247,17 @@ namespace Microsoft.Quantum.QsCompiler.CommandLineCompiler
         /// </summary>
         public static void PublishResults(string outputFolder)
         {
-            IList<CompilationTaskNode> compilationProcessesForest = BuildCompilationTasksHierarchy();
-            string outputPath = Path.GetFullPath(outputFolder);
-            DirectoryInfo outputDirectoryInfo = new DirectoryInfo(outputPath);
+            var compilationProcessesForest = BuildCompilationTasksHierarchy();
+            var outputPath = Path.GetFullPath(outputFolder);
+            var outputDirectoryInfo = new DirectoryInfo(outputPath);
             if (!outputDirectoryInfo.Exists)
             {
                 outputDirectoryInfo.Create();
             }
 
-            using (StreamWriter file = File.CreateText(Path.Combine(outputPath, "compilationPerf.json")))
+            using (var file = File.CreateText(Path.Combine(outputPath, "compilationPerf.json")))
             {
-                JsonSerializer serializer = new JsonSerializer
+                var serializer = new JsonSerializer
                 {
                     Formatting = Formatting.Indented
                 };
@@ -266,9 +266,9 @@ namespace Microsoft.Quantum.QsCompiler.CommandLineCompiler
             }
 
             if (Warnings.Count > 0) {
-                using (StreamWriter file = File.CreateText(Path.Combine(outputPath, "compilationPerfWarnings.json")))
+                using (var file = File.CreateText(Path.Combine(outputPath, "compilationPerfWarnings.json")))
                 {
-                    JsonSerializer serializer = new JsonSerializer
+                    var serializer = new JsonSerializer
                     {
                         Formatting = Formatting.Indented
                     };

--- a/src/QsCompiler/Compiler/CompilationLoader.cs
+++ b/src/QsCompiler/Compiler/CompilationLoader.cs
@@ -111,7 +111,12 @@ namespace Microsoft.Quantum.QsCompiler
             /// However, the compiler may overwrite the assembly constants defined for the Q# compilation unit in the dictionary of the loaded step.
             /// The given dictionary in this configuration is left unchanged in any case. 
             /// </summary>
-            public IReadOnlyDictionary<string, string> AssemblyConstants; 
+            public IReadOnlyDictionary<string, string> AssemblyConstants;
+            /// <summary>
+            /// Directory where the output of the perfomance assessment will be generated. 
+            /// No perfomance assessment will be done unless this path is specified and valid. 
+            /// </summary>
+            public string PerfOutputFolder;
 
             /// <summary>
             /// Indicates whether a serialization of the syntax tree needs to be generated. 

--- a/src/QsCompiler/Compiler/CompilationLoader.cs
+++ b/src/QsCompiler/Compiler/CompilationLoader.cs
@@ -135,7 +135,7 @@ namespace Microsoft.Quantum.QsCompiler
             /// </summary>
             internal string ProjectNameWithoutExtension =>
                 this.ProjectName == null ? null :
-                Path.GetExtension(this.ProjectName).EndsWith("proj") ? Path.GetFileNameWithoutExtension(this.ProjectName) : 
+                Path.GetExtension(this.ProjectName).EndsWith("proj") ? Path.GetFileNameWithoutExtension(this.ProjectName) :
                 this.ProjectName;
         }
 

--- a/src/QsCompiler/Compiler/CompilationLoader.cs
+++ b/src/QsCompiler/Compiler/CompilationLoader.cs
@@ -112,11 +112,6 @@ namespace Microsoft.Quantum.QsCompiler
             /// The given dictionary in this configuration is left unchanged in any case. 
             /// </summary>
             public IReadOnlyDictionary<string, string> AssemblyConstants;
-            /// <summary>
-            /// Directory where the output of the perfomance assessment will be generated. 
-            /// No perfomance assessment will be done unless this path is specified and valid. 
-            /// </summary>
-            public string PerfOutputFolder;
 
             /// <summary>
             /// Indicates whether a serialization of the syntax tree needs to be generated. 
@@ -140,7 +135,7 @@ namespace Microsoft.Quantum.QsCompiler
             /// </summary>
             internal string ProjectNameWithoutExtension =>
                 this.ProjectName == null ? null :
-                Path.GetExtension(this.ProjectName).EndsWith("proj") ? Path.GetFileNameWithoutExtension(this.ProjectName) :
+                Path.GetExtension(this.ProjectName).EndsWith("proj") ? Path.GetFileNameWithoutExtension(this.ProjectName) : 
                 this.ProjectName;
         }
 

--- a/src/QsCompiler/Compiler/CompilationLoader.cs
+++ b/src/QsCompiler/Compiler/CompilationLoader.cs
@@ -111,7 +111,7 @@ namespace Microsoft.Quantum.QsCompiler
             /// However, the compiler may overwrite the assembly constants defined for the Q# compilation unit in the dictionary of the loaded step.
             /// The given dictionary in this configuration is left unchanged in any case. 
             /// </summary>
-            public IReadOnlyDictionary<string, string> AssemblyConstants;
+            public IReadOnlyDictionary<string, string> AssemblyConstants; 
 
             /// <summary>
             /// Indicates whether a serialization of the syntax tree needs to be generated. 
@@ -126,7 +126,7 @@ namespace Microsoft.Quantum.QsCompiler
             /// </summary>
             internal string ProjectNameWithExtension =>
                 this.ProjectName == null ? null :
-                this.ProjectName.EndsWith("proj") ? this.ProjectName :
+                this.ProjectName.EndsWith("proj") ? this.ProjectName : 
                 $"{this.ProjectName}.qsproj";
 
             /// <summary>

--- a/src/QsCompiler/DataStructures/Diagnostics.fs
+++ b/src/QsCompiler/DataStructures/Diagnostics.fs
@@ -284,6 +284,8 @@ type ErrorCode =
 
     | CsharpGenerationGeneratedError = 8001
 
+    | PublishingPerfResultsFailed = 9001
+
 
 type WarningCode = 
     | ExcessSemicolon = 2001
@@ -634,6 +636,8 @@ type DiagnosticItem =
             | ErrorCode.PostconditionVerificationFailed           -> "The postcondition for the compilation step \"{0}\" loaded from \"{1}\" was not satisfied. The transformation has produced incorrect output and should be excluded from the compilation process."
 
             | ErrorCode.CsharpGenerationGeneratedError            -> ""
+
+            | ErrorCode.PublishingPerfResultsFailed               -> "Performance results failed to be published at \"{0}\"."
             | _                                                   -> ""
         code |> ApplyArguments             
              


### PR DESCRIPTION
This change adds a performance measurement option (-p --perf) to the command line tool.

The overview of the change is that the compiler raises events when a task or sub-task starts or ends. Those events are tracked by a sub-component of the command line tool (CompilationTracker.cs) when the perf option is present. After the compilation process is done, the command line tool invokes the compilation tracker to publish the results of the tracking.

In a bit more detail, the compilation tracker builds a hierarchy of tasks and sub-tasks, and then writes that to a json file that contains the start time, end time and duration of each task and sub-task.

Here's an example of what the json looks like:
`[
  {
    "Task": {
      "ParentName": null,
      "Name": "OverallCompilation",
      "UtcStart": "2020-01-31T00:41:20.8402258Z",
      "UtcEnd": "2020-01-31T00:41:32.0618253Z",
      "DurationInMs": 11221
    },
    "Children": {
      "SourcesLoading": {
        "Task": {
          "ParentName": "OverallCompilation",
          "Name": "SourcesLoading",
          "UtcStart": "2020-01-31T00:41:20.8481749Z",
          "UtcEnd": "2020-01-31T00:41:21.4133199Z",
          "DurationInMs": 565
        },
        "Children": {}
      },
      "ReferenceLoading": {
        "Task": {
          "ParentName": "OverallCompilation",
          "Name": "ReferenceLoading",
          "UtcStart": "2020-01-31T00:41:21.4133437Z",
          "UtcEnd": "2020-01-31T00:41:23.1862459Z",
          "DurationInMs": 1772
        },
        "Children": {}
      },
      "Build": {
        "Task": {
          "ParentName": "OverallCompilation",
          "Name": "Build",
          "UtcStart": "2020-01-31T00:41:23.186258Z",
          "UtcEnd": "2020-01-31T00:41:30.1440662Z",
          "DurationInMs": 6957
        },
        "Children": {}
      },
      "OutputGeneration": {
        "Task": {
          "ParentName": "OverallCompilation",
          "Name": "OutputGeneration",
          "UtcStart": "2020-01-31T00:41:30.1440802Z",
          "UtcEnd": "2020-01-31T00:41:32.0618242Z",
          "DurationInMs": 1917
        },
        "Children": {
          "SyntaxTreeSerialization": {
            "Task": {
              "ParentName": "OutputGeneration",
              "Name": "SyntaxTreeSerialization",
              "UtcStart": "2020-01-31T00:41:30.1440903Z",
              "UtcEnd": "2020-01-31T00:41:32.0235554Z",
              "DurationInMs": 1879
            },
            "Children": {}
          },
          "BinaryGeneration": {
            "Task": {
              "ParentName": "OutputGeneration",
              "Name": "BinaryGeneration",
              "UtcStart": "2020-01-31T00:41:32.0235699Z",
              "UtcEnd": "2020-01-31T00:41:32.0618029Z",
              "DurationInMs": 38
            },
            "Children": {}
          }
        }
      }
    }
  }
]`
