### PR TITLE
Updating Sdk readme and adding an example for defining custom compiler extensions

### DIFF
--- a/examples/CompilerExtensions/CompilerExtensions.sln
+++ b/examples/CompilerExtensions/CompilerExtensions.sln
@@ -1,0 +1,31 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.29613.14
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Demo", "Demo\Demo.csproj", "{9EFAE282-6480-48EA-B90C-B69CD6050029}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CustomExtension", "CustomExtension\CustomExtension.csproj", "{3AB91EBB-F33B-4DB8-B11C-AD78E4DCA235}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{9EFAE282-6480-48EA-B90C-B69CD6050029}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9EFAE282-6480-48EA-B90C-B69CD6050029}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9EFAE282-6480-48EA-B90C-B69CD6050029}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9EFAE282-6480-48EA-B90C-B69CD6050029}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3AB91EBB-F33B-4DB8-B11C-AD78E4DCA235}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3AB91EBB-F33B-4DB8-B11C-AD78E4DCA235}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3AB91EBB-F33B-4DB8-B11C-AD78E4DCA235}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3AB91EBB-F33B-4DB8-B11C-AD78E4DCA235}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {6EC8747D-C4D6-4CEA-A4C2-0D176A3ECF13}
+	EndGlobalSection
+EndGlobal

--- a/examples/CompilerExtensions/CustomExtension/CustomExtension.csproj
+++ b/examples/CompilerExtensions/CustomExtension/CustomExtension.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Compiler" Version="0.10.2001.2831" />
+    <PackageReference Include="Microsoft.Quantum.Compiler" Version="0.10.2002.104-beta" />
   </ItemGroup>
 
 </Project>

--- a/examples/CompilerExtensions/CustomExtension/CustomExtension.csproj
+++ b/examples/CompilerExtensions/CustomExtension/CustomExtension.csproj
@@ -1,0 +1,11 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.1</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Quantum.Compiler" Version="0.10.2001.2831" />
+  </ItemGroup>
+
+</Project>

--- a/examples/CompilerExtensions/CustomExtension/Display.cs
+++ b/examples/CompilerExtensions/CustomExtension/Display.cs
@@ -1,0 +1,46 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using Microsoft.Quantum.QsCompiler;
+using Microsoft.Quantum.QsCompiler.SyntaxTree;
+
+
+namespace Microsoft.Quantum.Demos.CompilerExtensions.Demo
+{
+    /// <summary>
+    /// Provides a compilation step that can be executed during the compilation of a Q# project.  
+    /// The compilation step does not implement any transformations, 
+    /// but instead merely displays the current state of the Q# compilation as source code. 
+    /// If no editor is found to open a txt file, the output is logged to the console.  
+    /// </summary>
+    public class DisplayQsharpCode : IRewriteStep
+    {
+        public DisplayQsharpCode() =>
+            this.AssemblyConstants = new Dictionary<string, string>(); // will be populated by the Q# compiler
+
+        public string Name => "DisplayQsharpCode";
+        public int Priority => 0; // only compared within this dll
+
+        public IDictionary<string, string> AssemblyConstants { get; }
+        public IEnumerable<IRewriteStep.Diagnostic> GeneratedDiagnostics => null; // this compilation step does not generate any diagnostics
+
+        public bool ImplementsPreconditionVerification => true;
+        public bool ImplementsTransformation => false;
+        public bool ImplementsPostconditionVerification => false;
+
+        public bool PreconditionVerification(QsCompilation compilation)
+        {
+            var display = new Display(compilation);
+            display.Show();
+            return true;
+        }
+
+        public bool Transformation(QsCompilation compilation, out QsCompilation transformed) =>
+            throw new NotImplementedException();
+
+        public bool PostconditionVerification(QsCompilation compilation) =>
+            throw new NotImplementedException();
+    }
+}

--- a/examples/CompilerExtensions/CustomExtension/Optimize.cs
+++ b/examples/CompilerExtensions/CustomExtension/Optimize.cs
@@ -1,0 +1,78 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.Quantum.QsCompiler;
+using Microsoft.Quantum.QsCompiler.Experimental;
+using Microsoft.Quantum.QsCompiler.SyntaxTree;
+
+
+namespace Microsoft.Quantum.Demos.CompilerExtensions.Demo
+{
+    /// <summary>
+    /// Provides a compilation step that can be executed during the compilation of a Q# project.  
+    /// The compilation step executes selective transformations provided in the Microsoft.Quantum.QsCompiler.Experimental namespace. 
+    /// </summary>
+    public class CustomCompilerExtension : IRewriteStep
+    {
+        private readonly List<IRewriteStep.Diagnostic> Diagnostics;
+
+        public CustomCompilerExtension()
+        {
+            this.AssemblyConstants = new Dictionary<string, string>(); // will be populated by the Q# compiler
+            this.Diagnostics = new List<IRewriteStep.Diagnostic>(); // collects diagnostics that will be displayed to the user
+        }
+
+
+        public string Name => "CustomCompilerExtension";
+        public int Priority => 1; // only compared within this dll
+
+        public IDictionary<string, string> AssemblyConstants { get; }
+        public IEnumerable<IRewriteStep.Diagnostic> GeneratedDiagnostics => this.Diagnostics;
+
+        public bool ImplementsPreconditionVerification => true;
+        public bool ImplementsTransformation => true;
+        public bool ImplementsPostconditionVerification => false;
+
+
+        public bool PreconditionVerification(QsCompilation compilation)
+        {
+            var preconditionPassed = true; // nothing to check
+            if (preconditionPassed)
+            {
+                // Diagnostics with severity Info or lower usually won't be displayed to the user. 
+                // If the severity is Error or Warning the diagnostic is shown to the user like any other compiler diagnostic, 
+                // and if the Source property is set to the absolute path of an existing file, 
+                // the user will be directed to the file when double clicking the diagnostics.
+                this.Diagnostics.Add(new IRewriteStep.Diagnostic
+                {
+                    Severity = DiagnosticSeverity.Info,
+                    Message = $"Precondition for {this.Name} was {(preconditionPassed ? "satisfied" : "not satisfied")}.",
+                    Stage = IRewriteStep.Stage.PreconditionVerification
+                });
+            }
+            return preconditionPassed;
+        }
+
+        public bool Transformation(QsCompilation compilation, out QsCompilation transformed)
+        {
+            // Defines the transformations to execute in each iteration spawned during PreEvaluation. 
+            // The PreEvaluation invokes these transformations as long as the previous invokation resulted in a non-trivial change. 
+            static OptimizingTransformation[] Script(ImmutableDictionary<QsQualifiedName, QsCallable> callables) => new OptimizingTransformation[]
+            {
+                new ConstantPropagation(callables),
+                new VariableRemoval(),
+                new StatementRemoval(true),
+            };
+
+            transformed = PreEvaluation.WithScript(Script, compilation);
+            return true;
+        }
+
+        public bool PostconditionVerification(QsCompilation compilation) =>
+            throw new NotImplementedException();
+    }
+}

--- a/examples/CompilerExtensions/CustomExtension/Utils.cs
+++ b/examples/CompilerExtensions/CustomExtension/Utils.cs
@@ -1,0 +1,69 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using Microsoft.Quantum.QsCompiler.DataTypes;
+using Microsoft.Quantum.QsCompiler.SyntaxTree;
+using Microsoft.Quantum.QsCompiler.Transformations.BasicTransformations;
+using Microsoft.Quantum.QsCompiler.Transformations.QsCodeOutput;
+
+
+namespace Microsoft.Quantum.Demos.CompilerExtensions.Demo
+{
+    /// <summary>
+    /// Used to display the current state of a Q# compilation as source code. 
+    /// </summary>
+    internal class Display
+    {
+        private readonly QsCompilation Compilation;
+        private readonly ImmutableHashSet<NonNullable<string>> SourceFiles;
+        private readonly ImmutableDictionary<NonNullable<string>, ImmutableArray<(NonNullable<string>, string)>> Imports;
+
+        internal Display(QsCompilation compilation)
+        {
+            this.Compilation = compilation;
+            this.SourceFiles = GetSourceFiles.Apply(compilation.Namespaces);
+            this.Imports = compilation.Namespaces.ToImmutableDictionary(ns => ns.Name, _ => ImmutableArray<(NonNullable<string>, string)>.Empty);
+        }
+
+        /// <summary>
+        /// Extracts the compiled data structures for all type and callables defined in the specified sourceFile. 
+        /// Generates the corresponding Q# code, which represents the implementation after compilation opposed to the original source code. 
+        /// Displays the generated code using the default editor for text files. 
+        /// If no editor is found to open a text file, the output is logged to the console.  
+        /// If no sourceFile is specified, then the implementation for the compiled types and callables defined in all source files are displayed to the user. 
+        /// </summary>
+        public void Show(string sourceFile = null)
+        {
+            var filesToShow = sourceFile == null
+                ? this.SourceFiles.Where(f => f.Value.EndsWith(".qs")).OrderBy(f => f).Select(f => (f, this.Imports)).ToArray()
+                : new[] { (NonNullable<string>.New(sourceFile), this.Imports) };
+
+            SyntaxTreeToQs.Apply(out List<ImmutableDictionary<NonNullable<string>, string>> generated, this.Compilation.Namespaces, filesToShow);
+            var code = generated.SelectMany((namespaces, sourceIndex) =>
+                namespaces.Values
+                .Prepend($"// Compiled Q# code from file \"{filesToShow[sourceIndex].Item1.Value}\":")
+                .Select(nsCode => $"{nsCode}{Environment.NewLine}"));
+
+            try
+            {
+                var tempFile = Path.GetTempFileName() + ".txt";
+                File.WriteAllLines(tempFile, code);
+                if (Environment.OSVersion.Platform != PlatformID.Win32NT) Process.Start(tempFile);
+                else Process.Start("notepad.exe", tempFile);
+            }
+            catch 
+            {
+                Console.WriteLine($"{Environment.NewLine}******");
+                Console.Write(String.Join(Environment.NewLine, code));
+                Console.WriteLine("******");
+            }
+        }
+
+    }
+}

--- a/examples/CompilerExtensions/Demo/Demo.csproj
+++ b/examples/CompilerExtensions/Demo/Demo.csproj
@@ -1,0 +1,14 @@
+﻿<Project Sdk="Microsoft.Quantum.Sdk/0.10.2001.2831">
+
+  <PropertyGroup>
+    <QscVerbosity>Detailed</QscVerbosity>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\CustomExtension\CustomExtension.csproj" IsQscReference="true" Priority="0" />
+  </ItemGroup>
+ 
+</Project>

--- a/examples/CompilerExtensions/Demo/Demo.csproj
+++ b/examples/CompilerExtensions/Demo/Demo.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.Quantum.Sdk/0.10.2001.2831">
+﻿<Project Sdk="Microsoft.Quantum.Sdk/0.10.2002.104-beta">
 
   <PropertyGroup>
     <QscVerbosity>Detailed</QscVerbosity>

--- a/examples/CompilerExtensions/Demo/Driver.cs
+++ b/examples/CompilerExtensions/Demo/Driver.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Quantum.Demo
         {
             using var qsim = new QuantumSimulator();
             SampleProgram.Run(qsim).Wait();
-            Console.WriteLine("SampleProgram executed sucessfully!");
+            Console.WriteLine("SampleProgram executed successfully!");
         }
     }
 }

--- a/examples/CompilerExtensions/Demo/Driver.cs
+++ b/examples/CompilerExtensions/Demo/Driver.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using Microsoft.Quantum.Simulation.Simulators;
+
+namespace Microsoft.Quantum.Demo
+{
+    class Driver
+    {
+        static void Main(string[] args)
+        {
+            using var qsim = new QuantumSimulator();
+            SampleProgram.Run(qsim).Wait();
+            Console.WriteLine("SampleProgram executed sucessfully!");
+        }
+    }
+}

--- a/examples/CompilerExtensions/Demo/Program.qs
+++ b/examples/CompilerExtensions/Demo/Program.qs
@@ -1,0 +1,11 @@
+﻿namespace Microsoft.Quantum.Demo {
+    
+    function GetPair (n : Int) : (Int, Int) {
+        return (n, n+1);
+    }
+
+    operation SampleProgram () : Int {
+        let (a, b) = GetPair(5);
+        return a + b;
+    }
+}

--- a/src/QsCompiler/TestTargets/Libraries/Library1/Library1.csproj
+++ b/src/QsCompiler/TestTargets/Libraries/Library1/Library1.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Simulators" Version="0.10.1912.1204-alpha" />
+    <PackageReference Include="Microsoft.Quantum.Simulators" Version="0.10.2001.2831" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/QsCompiler/TestTargets/Simulation/Example/Example.csproj
+++ b/src/QsCompiler/TestTargets/Simulation/Example/Example.csproj
@@ -1,69 +1,47 @@
-﻿<Project Sdk="Microsoft.NET.Sdk" InitialTargets="RecompileOnChange">
+﻿<Project Sdk="Microsoft.Quantum.Sdk/0.10.2001.2502-alpha">
+
   <PropertyGroup>
+    <QscVerbosity>Detailed</QscVerbosity>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.0</TargetFramework>
-    <PlatformTarget>x64</PlatformTarget>
-    <QsharpLangVersion>0.10</QsharpLangVersion>
+    <CsharpGeneration>false</CsharpGeneration> <!--we provide our own C# generation for the sake of also generating C# for all references-->
   </PropertyGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\..\..\CommandLineTool\CommandLineTool.csproj">
-      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
-    </ProjectReference>
-    <ProjectReference Include="..\Target\Simulation.csproj">
-      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
-    </ProjectReference>
-    <ProjectReference Include="..\..\Libraries\Library1\Library1.csproj" />
-  </ItemGroup>
-
   <PropertyGroup>
-    <ExecutionTestsDir>ExecutionTests\</ExecutionTestsDir>
-    <GenFilesDir>generated\</GenFilesDir>
-    <SimulationTarget>"..\Target\bin\$(Configuration)\netstandard2.1\Simulation.dll"</SimulationTarget>
+    <GeneratedFilesOutputPath>generated/</GeneratedFilesOutputPath>
+    <ExecutionTestsDir>ExecutionTests/</ExecutionTestsDir>
+    <SimulationTarget>../Target/bin/$(Configuration)/netstandard2.1/Simulation.dll</SimulationTarget>
+    <AdditionalQscArguments> --load $(SimulationTarget)</AdditionalQscArguments>
     <QscExe>dotnet "../../../CommandLineTool/bin/$(Configuration)/netcoreapp3.0/qsc.dll"</QscExe>
   </PropertyGroup>
 
   <ItemGroup>
-    <Folder Include="$(GenFilesDir)" />
-    <Compile Remove="..\Target\Driver.cs" />
-    <Compile Include="..\Target\Driver.cs">
+    <Folder Include="$(GeneratedFilesOutputPath)" />
+    <Compile Remove="../Target/Driver.cs" />
+    <Compile Include="../Target/Driver.cs">
       <Visible>false</Visible>
     </Compile>
-    <None Include="..\..\..\Tests.Compiler\TestCases\ExecutionTests\*.*">
+    <QsharpCompile Include="../../../Tests.Compiler/TestCases/ExecutionTests/*.*">
       <Link>$(ExecutionTestsDir)%(RecursiveDir)%(Filename)%(Extension)</Link>
-    </None>
+    </QsharpCompile>
   </ItemGroup>
 
-  <Target Name="RecompileOnChange">
+  <ItemGroup>
+    <ProjectReference Include="..\Target\Simulation.csproj">
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+    </ProjectReference>
+    <ProjectReference Include="../../../CommandLineTool/CommandLineTool.csproj">
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+    </ProjectReference>
+    <ProjectReference Include="../../Libraries/Library1/Library1.csproj" />
+  </ItemGroup>
+
+  <Target Name="BeforeCsharpCompile">
     <ItemGroup>
-      <UpToDateCheckInput Include="@(None)" />
-      <UpToDateCheckInput Include="@(Content)" />
+      <Compile Include="$(GeneratedFilesOutputPath)**/*.cs" Exclude="@(Compile)" AutoGen="true" />
     </ItemGroup>
   </Target>
-  
-  <Target Name="QsharpClean" BeforeTargets="Clean">
-    <ItemGroup>
-      <RemoveFiles Include="$(GenFilesDir)**" />
-      <Compile Remove="@(RemoveFiles)" />
-    </ItemGroup>
-    <Delete Files="@(RemoveFiles)" />
-  </Target>  
-  
-  <Target Name="QsharpCompile" Condition="'$(DesignTimeBuild)' != 'true'" DependsOnTargets="ResolveAssemblyReferences;QsharpClean" BeforeTargets="CoreCompile">
-    <MakeDir Directories="$(GenFilesDir)" />
-    <ItemGroup>
-      <QsReferences Include="@(ReferencePath)" Condition="$([System.Text.RegularExpressions.Regex]::IsMatch(%(FullPath), '(?i)system.|mscorlib|netstandard.library|microsoft.netcore.app')) == false" />
-      <QsSourceFiles Include="@(None)" Condition="$([System.Text.RegularExpressions.Regex]::IsMatch(%(FullPath), '.qs$')) == true" />
-      <QsSourceFiles Include="**\*.qs" Exclude="@(QsSourceFiles)" />
-    </ItemGroup>
-    <PropertyGroup>
-      <QscCommand>$(QscExe) build -v diag --format MsBuild --proj "$(MSBuildProjectName)" -i "@(QsSourceFiles,'" "')" -r "@(QsReferences,'" "')" -o $(GenFilesDir) --load "$(SimulationTarget)"</QscCommand>
-    </PropertyGroup>
-    <Message Importance="low" Text="executing command '$(QscCommand)'" />
-    <Exec Command="$(QscCommand)" IgnoreExitCode="false" />
-    <Delete Files="$(GenFilesDir)$(MSBuildProjectName).bson" />
-    <ItemGroup>
-      <Compile Include="$(GenFilesDir)**\*.g.cs" Exclude="@(Compile)" />
-    </ItemGroup>
-  </Target>    
+
 </Project>
+
+

--- a/src/QsCompiler/TestTargets/Simulation/Example/Example.csproj
+++ b/src/QsCompiler/TestTargets/Simulation/Example/Example.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.Quantum.Sdk/0.10.2001.2502-alpha">
+﻿<Project Sdk="Microsoft.Quantum.Sdk/0.10.2001.2831">
 
   <PropertyGroup>
     <QscVerbosity>Detailed</QscVerbosity>

--- a/src/QsCompiler/TestTargets/Simulation/Target/Simulation.csproj
+++ b/src/QsCompiler/TestTargets/Simulation/Target/Simulation.csproj
@@ -12,7 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.CsharpGeneration" Version="0.10.2001.1502-alpha" />
+    <PackageReference Include="Microsoft.Quantum.CsharpGeneration" Version="0.10.2001.2831" />
   </ItemGroup>
 
 </Project>

--- a/src/QuantumSdk/DefaultItems/DefaultItems.targets
+++ b/src/QuantumSdk/DefaultItems/DefaultItems.targets
@@ -42,12 +42,15 @@
     <PathCompatibleAssemblyName>$([System.String]::Copy('$(AssemblyName)').Replace(' ',''))</PathCompatibleAssemblyName>
     <!-- output path for files generated during compilation -->
     <GeneratedFilesOutputPath Condition="'$(GeneratedFilesOutputPath)' == ''">$(BaseIntermediateOutputPath)qsharp/</GeneratedFilesOutputPath>
+    <GeneratedFilesOutputPath>$([MSBuild]::Unescape('$(GeneratedFilesOutputPath)').Replace('\','/'))</GeneratedFilesOutputPath>
     <GeneratedFilesOutputPath Condition="!HasTrailingSlash('$(GeneratedFilesOutputPath)')">$(GeneratedFilesOutputPath)/</GeneratedFilesOutputPath>
     <!-- output path for generating documentation -->
     <QsharpDocsOutputPath Condition="'$(QsharpDocsOutputPath)' == ''">$(GeneratedFilesOutputPath)docs/</QsharpDocsOutputPath>
+    <QsharpDocsOutputPath>$([MSBuild]::Unescape('$(QsharpDocsOutputPath)').Replace('\','/'))</QsharpDocsOutputPath>
     <QsharpDocsOutputPath Condition="!HasTrailingSlash('$(QsharpDocsOutputPath)')">$(QsharpDocsOutputPath)/</QsharpDocsOutputPath>
     <!-- output path for generating qsc config file -->
     <QscBuildConfigOutputPath Condition="'$(QscBuildConfigOutputPath)' == ''">$(GeneratedFilesOutputPath)config/</QscBuildConfigOutputPath>
+    <QscBuildConfigOutputPath>$([MSBuild]::Unescape('$(QscBuildConfigOutputPath)').Replace('\','/'))</QscBuildConfigOutputPath>
     <QscBuildConfigOutputPath Condition="!HasTrailingSlash('$(QscBuildConfigOutputPath)')">$(QscBuildConfigOutputPath)/</QscBuildConfigOutputPath>
   </PropertyGroup>
 
@@ -56,30 +59,23 @@
   <Target Name="ResolveQscReferences" DependsOnTargets="ResolveProjectReferences;ResolveAssemblyReferences;Restore" BeforeTargets="BeforeQsharpCompile">
     <!-- get the assembly path for all relevant project references which are passed as qsc references -->
     <ItemGroup>
-      <QscProjectReference Remove="@(QscProjectReference)"/>
       <QscProjectReference Include="@(_ResolvedProjectReferencePaths)" Condition="@(_ResolvedProjectReferencePaths->Count()) &gt; 0 And %(_ResolvedProjectReferencePaths.IsQscReference)" />
-      <_RelevantQscProjectReference Remove="@(_RelevantQscProjectReference)"/>
       <_RelevantQscProjectReference Include="@(QscProjectReference->WithMetadataValue('ExecutionTarget',''))" /> 
       <_RelevantQscProjectReference Include="@(QscProjectReference->WithMetadataValue('ExecutionTarget','Any'))" /> 
       <_RelevantQscProjectReference Include="@(QscProjectReference->WithMetadataValue('ExecutionTarget','$(ExecutionTarget)'))" /> 
     </ItemGroup>
     <!-- get the path property name for all relevant package references which are passed as qsc references -->
     <ItemGroup>
-      <QscPackageReference Remove="@(QscPackageReference)"/>
       <QscPackageReference Include="@(PackageReference)" Condition="@(PackageReference->Count()) &gt; 0 And %(PackageReference.IsQscReference)" />
-      <_RelevantQscPackageReference Remove="@(_RelevantQscPackageReference)"/>
       <_RelevantQscPackageReference Include="@(QscPackageReference->WithMetadataValue('ExecutionTarget',''))" /> 
       <_RelevantQscPackageReference Include="@(QscPackageReference->WithMetadataValue('ExecutionTarget','Any'))" /> 
       <_RelevantQscPackageReference Include="@(QscPackageReference->WithMetadataValue('ExecutionTarget','$(ExecutionTarget)'))" /> 
-      <_RelevantQscPackageReferencePathProperty Remove="@(_RelevantQscPackageReferencePathProperty)"/>
       <_RelevantQscPackageReferencePathProperty Include="@(_RelevantQscPackageReference->'Pkg$([System.String]::Copy('%(_RelevantQscPackageReference.Identity)').Replace('.','_'))')" /> 
     </ItemGroup>
     <!-- add the assembly paths for all relevant qsc references and their priorities to ResolvedQscReferences -->
     <ItemGroup>
-      <ResolvedQscReferences Remove="@(ResolvedQscReferences)"/>
       <ResolvedQscReferences Include="%(_RelevantQscProjectReference.Identity)" Priority="%(_RelevantQscProjectReference.Priority)" />
       <ResolvedQscReferences Include="$(%(_RelevantQscPackageReferencePathProperty.Identity))/lib/**/*.dll" Priority="%(_RelevantQscPackageReferencePathProperty.Priority)" /> 
-      <ResolvedQscReferencesAndPriorities Remove="@(ResolvedQscReferencesAndPriorities)"/>
       <ResolvedQscReferencesAndPriorities Include="(%(ResolvedQscReferences.Identity), %(ResolvedQscReferences.Priority))" /> 
     </ItemGroup>
     <Message 

--- a/src/QuantumSdk/README.md
+++ b/src/QuantumSdk/README.md
@@ -93,6 +93,9 @@ The NuGet version of the Sdk package.
 
 The following properties can be configured to customize the build: 
 
+- `AdditionalQscArguments`:    
+May contain additional arguments to pass to the Q# command line compiler. Valid additional arguments are `--emit-dll`, or `--no-warn` followed by any number of integers specifying the warnings to ignore.   
+
 - `CsharpGeneration`:    
 Specifies whether to generate C# code as part of the compilation process. Setting this property to false may prevent certain interoperability features or integration with other pieces of the Quantum Development Kit. 
 
@@ -112,6 +115,22 @@ Specified whether to generate yml documentation for the compiled Q# code. The de
 Directory where any generated documentation will be saved. 
 
 [comment]: # (TODO: document QscBuildConfigExe, QscBuildConfigOutputPath)
+
+## Defined item groups ##
+
+The following configurable item groups are used by the Sdk: 
+
+- `PackageLoadFallbackFolder`:    
+Contains the directories where the Q# compiler will look for a suitable dll if a qsc reference or one if its dependencies cannot be found. By default, the project output path is included in this item group. 
+
+- `PackageReference`:    
+Contains all referenced NuGet packages. Package references for which the `IsQscReference` attribute is set to "true" may extend the Q# compiler and any implemented rewrite steps will be executed as part of the compilation process. See [this section](#extending-the-q#-compiler) for more details.
+
+- `ProjectReference`:    
+Contains all referenced projects. Project references for which the `IsQscReference` attribute is set to "true" may extend the Q# compiler and any implemented rewrite steps will be executed as part of the compilation process. See [this section](#extending-the-q#-compiler) for more details.
+
+- `QsharpCompile`:    
+Contains all Q# source files included in the compilation.
 
 # Sdk Packages #
 

--- a/src/QuantumSdk/README.md
+++ b/src/QuantumSdk/README.md
@@ -71,7 +71,7 @@ For example, if a qsc reference contains a rewrite step that generates C# code d
   </Target>  
 ```
 
-### Trouble shooting compiler extensions ###
+### Troubleshooting compiler extensions ###
 
 The compiler attempts to load rewrite steps even if these have been compiled against a different compiler version. While we do our best to mitigate issue due to a version mismatch, it is generally recommended to use compiler extensions that are compiled against the same compiler package version as the Sdk version of the project. 
 
@@ -81,12 +81,12 @@ When a rewrite steps fails to execute, setting the `QscVerbosity` to "Detailed" 
 ```
 A `FileNotFoundException` will be raised if a compiler extension attempts to load a reference that either could not be found, or could not be loaded for other reasons. 
 By default, the compiler will search the project output directory for a suitable assembly in case a dependency cannot be found.
-If such an exception occurs during a compilation step loaded from a package reference, adding the package containing the dll that could not be found to the project or to copying the missing dll to the output directory may resolve the issue. 
-If such an exception occurs during a compilation step loaded from a project reference, then defining the property
+If such an exception occurs during a compilation step loaded from a package reference, the issue may be resolved by adding the package containing the missing dll to the project or by copying the missing dll to the output directory. 
+If such an exception occurs during a compilation step loaded from a project reference, issue may be resolved by defining the property
 ```
   <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
 ```
-in the project that implements the compilation step may resolve the issue. 
+in the project that implements the compilation step. 
 
 ## Defined project properties ##
 

--- a/src/QuantumSdk/README.md
+++ b/src/QuantumSdk/README.md
@@ -79,7 +79,14 @@ When a rewrite steps fails to execute, setting the `QscVerbosity` to "Detailed" 
 ```
   <QscVerbosity>Detailed</QscVerbosity>
 ```
-By default, the compiler will search the project output directory for a suitable assembly in case a dependency cannot be found. In case of a `FileNotFoundException`, and option may be to add the corresponding reference to the project, or to copy the missing dll to the output directory. 
+A `FileNotFoundException` will be raised if a compiler extension attempts to load a reference that either could not be found, or could not be loaded for other reasons. 
+By default, the compiler will search the project output directory for a suitable assembly in case a dependency cannot be found.
+If such an exception occurs during a compilation step loaded from a package reference, adding the package containing the dll that could not be found to the project or to copying the missing dll to the output directory may resolve the issue. 
+If such an exception occurs during a compilation step loaded from a project reference, then defining the property
+```
+  <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+```
+in the project that implements the compilation step may resolve the issue. 
 
 ## Defined project properties ##
 

--- a/src/QuantumSdk/README.md
+++ b/src/QuantumSdk/README.md
@@ -48,6 +48,8 @@ Steps defined within packages or projects with higher priority are executed firs
 
 If you develop a NuGet package to extend the Q# compilation process, we recommend to distribute it as a self-contained package to avoid issues due to references that could not be resolved. Each qsc reference is loaded into its own context to avoid issues when several references depend on different versions of the same package. 
 
+An example for defining custom compilation steps in a referenced .NET Core project can be found [here](https://github.com/microsoft/qsharp-compiler/tree/master/examples). 
+
 ### Injected C# code ###
 
 It is possible to inject C# code into Q# packages e.g. for integration purposes. By default the Sdk is configured to do just that, see also the section on [defined properties](#defined-project-properties). That code may be generated as part of a custom rewrite step, e.g. if the code generation requires information about the Q# compilation. 

--- a/src/QuantumSdk/Sdk/Sdk.props
+++ b/src/QuantumSdk/Sdk/Sdk.props
@@ -28,17 +28,17 @@
   <!-- Q# package references included by default. -->
   <ItemGroup>
     <!-- Packages and libraries included for all execution targets. -->
-    <PackageReference Condition="$(IncludeQsharpCorePackages)" Include="Microsoft.Quantum.QSharp.Core" Version="0.10.1912.2604-alpha" />
-    <PackageReference Condition="$(IncludeQsharpCorePackages)" Include="Microsoft.Quantum.Standard" Version="0.10.1912.2603-alpha" />
+    <PackageReference Condition="$(IncludeQsharpCorePackages)" Include="Microsoft.Quantum.QSharp.Core" Version="0.10.2001.2831" />
+    <PackageReference Condition="$(IncludeQsharpCorePackages)" Include="Microsoft.Quantum.Standard" Version="0.10.2001.2831" />
     <!-- Packages included for specific execution targets. -->
-    <PackageReference Condition="'$(ResolvedQsharpExecutionTarget)' == 'SimulatorBackend'" Include="Microsoft.Quantum.Simulators" Version="0.10.1912.2604-alpha" IsImplicitlyDefined="$(CsharpGeneration)" />
+    <PackageReference Condition="'$(ResolvedQsharpExecutionTarget)' == 'SimulatorBackend'" Include="Microsoft.Quantum.Simulators" Version="0.10.2001.2831" IsImplicitlyDefined="$(CsharpGeneration)" />
   </ItemGroup>
 
   <!-- Packages containing rewrite steps that are executed during compilation. -->
   <ItemGroup>
-    <PackageReference Condition="$(CsharpGeneration)" Include="Microsoft.Quantum.Runtime.Core" Version="0.10.1912.2604-alpha" IsImplicitlyDefined="true" />
+    <PackageReference Condition="$(CsharpGeneration)" Include="Microsoft.Quantum.Runtime.Core" Version="0.10.2001.2831" IsImplicitlyDefined="true" />
     <PackageReference Condition="$(CsharpGeneration)" PrivateAssets="All"
-      Include="Microsoft.Quantum.CsharpGeneration" Version="0.10.1912.2604-alpha" IsImplicitlyDefined="true" 
+      Include="Microsoft.Quantum.CsharpGeneration" Version="0.10.2001.2831" IsImplicitlyDefined="true" 
       IsQscReference ="true" ExecutionTarget="Any" Priority="-1" />
   </ItemGroup>
 

--- a/src/QuantumSdk/Sdk/Sdk.targets
+++ b/src/QuantumSdk/Sdk/Sdk.targets
@@ -64,7 +64,7 @@
     <ItemGroup>
       <PackageLoadFallbackFolder Include="$(MSBuildProjectDirectory)/$(OutputPath)" Condition="'$(OutputPath)' != '' And '$(MSBuildProjectDirectory)' != ''" />
       <ResolvedPackageLoadFallbackFolders Include="@(PackageLoadFallbackFolder->'$([MSBuild]::Unescape('%(PackageLoadFallbackFolder.Identity)').Replace('\','/'))')" />
-      <ResolvedQsharpReferences Include="@(ReferencePath)" Condition="$([System.Text.RegularExpressions.Regex]::IsMatch(%(FullPath), '(?i)system.|mscorlib|netstandard.library|microsoft.netcore.app|csharp|fsharp|microsoft.visualstudio|microsoft.testplatform|microsoft.codeanalysis|fparsec|newtonsoft|roslynwrapper|yamldotnet')) == false" />
+      <ResolvedQsharpReferences Include="@(ReferencePath)" Condition="$([System.Text.RegularExpressions.Regex]::IsMatch(%(FullPath), '(?i)system.|mscorlib|netstandard.library|microsoft.netcore.app|csharp|fsharp|microsoft.visualstudio|microsoft.testplatform|microsoft.codeanalysis|fparsec|newtonsoft|roslynwrapper|yamldotnet|markdig')) == false" />
     </ItemGroup>
     <!-- invoke the Q# command line compiler -->
     <PropertyGroup>

--- a/src/QuantumSdk/Sdk/Sdk.targets
+++ b/src/QuantumSdk/Sdk/Sdk.targets
@@ -42,26 +42,9 @@
 
   <!-- Invokes the Q# command line compiler to build the project. -->
   <Target Name="QsharpCompile" 
+          Condition="'$(DesignTimeBuild)' != 'true'"
           DependsOnTargets="ResolveAssemblyReferences;ResolveQscReferences;BeforeQsharpCompile;_CopyFilesMarkedCopyLocal" 
-          BeforeTargets="BeforeCsharpCompile;BeforeBuild"
-          Inputs="$(MSBuildAllProjects);
-                  @(QsharpCompile);
-                  @(ReferencePath);
-                  @(ResolvedQscReferences);
-                  @(ResolvedQscReferencesAndPriorities);
-                  $(PathCompatibleAssemblyName);
-                  $(GeneratedFilesOutputPath);
-                  $(QscBuildConfigOutputPath);
-                  $(QsharpDocsOutputPath);
-                  $(QsharpDocsGeneration);
-                  $(CsharpGeneration);
-                  $(QscBuildConfigExe);
-                  $(QscExe)"
-          Outputs="@(ResolvedQsharpReferences);
-                  @(Compile);
-                  $(QscBuildConfigGeneration);
-                  $(QscCommand);
-                  $(GeneratedFilesOutputPath)$(PathCompatibleAssemblyName).bson">
+          BeforeTargets="BeforeCsharpCompile;BeforeBuild">
     <MakeDir Directories="$(GeneratedFilesOutputPath)" />
     <MakeDir Directories="$(QscBuildConfigOutputPath)" />
     <MakeDir Condition="$(QsharpDocsGeneration)" Directories="$(QsharpDocsOutputPath)" />
@@ -79,6 +62,8 @@
       <Output TaskParameter="Lines" ItemName="_PrioritizedResolvedQscReferences"/>
     </ReadLinesFromFile>
     <ItemGroup>
+      <PackageLoadFallbackFolder Include="$(MSBuildProjectDirectory)/$(OutputPath)" Condition="'$(OutputPath)' != '' And '$(MSBuildProjectDirectory)' != ''" />
+      <ResolvedPackageLoadFallbackFolders Include="@(PackageLoadFallbackFolder->'$([MSBuild]::Unescape('%(PackageLoadFallbackFolder.Identity)').Replace('\','/'))')" />
       <ResolvedQsharpReferences Include="@(ReferencePath)" Condition="$([System.Text.RegularExpressions.Regex]::IsMatch(%(FullPath), '(?i)system.|mscorlib|netstandard.library|microsoft.netcore.app|csharp|fsharp|microsoft.visualstudio|microsoft.testplatform|microsoft.codeanalysis|fparsec|newtonsoft|roslynwrapper|yamldotnet')) == false" />
     </ItemGroup>
     <!-- invoke the Q# command line compiler -->
@@ -88,8 +73,8 @@
       <_QscCommandInputFlag Condition="@(QsharpCompile->Count()) &gt; 0">--input "@(QsharpCompile,'" "')"</_QscCommandInputFlag>
       <_QscCommandReferencesFlag Condition="@(ResolvedQsharpReferences->Count()) &gt; 0">--references "@(ResolvedQsharpReferences,'" "')"</_QscCommandReferencesFlag>
       <_QscCommandLoadFlag Condition="@(_PrioritizedResolvedQscReferences->Count()) &gt; 0">--load "@(_PrioritizedResolvedQscReferences,'" "')"</_QscCommandLoadFlag>
-      <_QscPackageLoadFallbackFoldersFlag Condition="'$(OutputPath)' != '' And '$(MSBuildProjectDirectory)' != ''">--package-load-fallback-folders $(MSBuildProjectDirectory)/$(OutputPath)</_QscPackageLoadFallbackFoldersFlag> <!-- since we have no quotations this needs to be last -->
-      <_QscCommandArgs>--proj "$(PathCompatibleAssemblyName)" $(_QscCommandDocsFlag) $(_QscCommandInputFlag) $(_QscCommandOutputFlag) $(_QscCommandReferencesFlag) $(_QscCommandLoadFlag) $(_QscPackageLoadFallbackFoldersFlag)</_QscCommandArgs>
+      <_QscPackageLoadFallbackFoldersFlag Condition="@(ResolvedPackageLoadFallbackFolders->Count()) &gt; 0">--package-load-fallback-folders "@(ResolvedPackageLoadFallbackFolders,'" "')"</_QscPackageLoadFallbackFoldersFlag>
+      <_QscCommandArgs>--proj "$(PathCompatibleAssemblyName)" $(_QscCommandDocsFlag) $(_QscCommandInputFlag) $(_QscCommandOutputFlag) $(_QscCommandReferencesFlag) $(_QscCommandLoadFlag) $(_QscPackageLoadFallbackFoldersFlag) $(AdditionalQscArguments)</_QscCommandArgs>
       <_QscCommandArgsFile>$(QscBuildConfigOutputPath)qsc.rsp</_QscCommandArgsFile>
       <QscCommand>$(QscExe) build --format MsBuild $(_VerbosityFlag) --response-files $(_QscCommandArgsFile)</QscCommand>
     </PropertyGroup>


### PR DESCRIPTION
Mathias ran into an issue where a rewrite step defined in a project reference failed with a FileNotFoundException despite that that dll was present in the project output directory. Updated to section on how to troubleshoot extensions to suggest how that case may be fixed. 

I also decided that it would be helpful to have an example for how to define custom compilation steps, and cleaned up and added the demo. 
Also, updating the used packages to the latest release. 