### PR TITLE
Updating name dependencies for classically controlled operations

### DIFF
--- a/src/QsCompiler/Core/Dependencies.fs
+++ b/src/QsCompiler/Core/Dependencies.fs
@@ -272,7 +272,7 @@ type BuiltIn = {
         Namespace = BuiltIn.ClassicallyControlledNamespace
         TypeParameters = ImmutableArray.Create("T" |> NonNullable<string>.New, "U" |> NonNullable<string>.New)
     }
-    static member ApplyIfElseCAResolvedType = BuiltIn._MakeApplyIfElseResolvedType BuiltIn.ApplyIfElseCA [OpProperty.Adjointable; OpProperty.Controllable]
+    static member ApplyIfElseRCAResolvedType = BuiltIn._MakeApplyIfElseResolvedType BuiltIn.ApplyIfElseRCA [OpProperty.Adjointable; OpProperty.Controllable]
 
     // "weak dependencies" in other namespaces (e.g. things used for code actions)
 

--- a/src/QsCompiler/Core/Dependencies.fs
+++ b/src/QsCompiler/Core/Dependencies.fs
@@ -22,7 +22,7 @@ type BuiltIn = {
     static member IntrinsicNamespace = NonNullable<string>.New "Microsoft.Quantum.Intrinsic"
     static member StandardArrayNamespace = NonNullable<string>.New "Microsoft.Quantum.Arrays"
     static member DiagnosticsNamespace = NonNullable<string>.New "Microsoft.Quantum.Diagnostics"
-    static member ClassicallyControlledNamespace = NonNullable<string>.New "Microsoft.Quantum.ClassicallyControlled"
+    static member ClassicallyControlledNamespace = NonNullable<string>.New "Microsoft.Quantum.Simulation.QuantumProcessor.Extensions"
 
     /// Returns the set of namespaces that is automatically opened for each compilation.
     static member NamespacesToAutoOpen = ImmutableHashSet.Create (BuiltIn.CoreNamespace)
@@ -267,8 +267,8 @@ type BuiltIn = {
     static member ApplyIfElseRCResolvedType = BuiltIn._MakeApplyIfElseResolvedType BuiltIn.ApplyIfElseRC [OpProperty.Controllable]
 
     // This is expected to have type <'T, 'U>((Result, (('T => Unit is Adj + Ctl), 'T), (('U => Unit is Adj + Ctl), 'U)) => Unit is Adj + Ctl)
-    static member ApplyIfElseCA = {
-        Name = "ApplyIfElseCA" |> NonNullable<string>.New
+    static member ApplyIfElseRCA = {
+        Name = "ApplyIfElseRCA" |> NonNullable<string>.New
         Namespace = BuiltIn.ClassicallyControlledNamespace
         TypeParameters = ImmutableArray.Create("T" |> NonNullable<string>.New, "U" |> NonNullable<string>.New)
     }

--- a/src/QsCompiler/Transformations/ClassicallyControlledTransformation.cs
+++ b/src/QsCompiler/Transformations/ClassicallyControlledTransformation.cs
@@ -185,8 +185,8 @@ namespace Microsoft.Quantum.QsCompiler.Transformations.ClassicallyControlledTran
                     {
                         if (adj && ctl)
                         {
-                            controlOpInfo = BuiltIn.ApplyIfElseCA;
-                            controlOpType = BuiltIn.ApplyIfElseCAResolvedType;
+                            controlOpInfo = BuiltIn.ApplyIfElseRCA;
+                            controlOpType = BuiltIn.ApplyIfElseRCAResolvedType;
                         }
                         else if (adj)
                         {


### PR DESCRIPTION
I believe there is one typo, and the namespace where classically controlled operations live has changed since this work started. 