### PR TITLE
Migrate docgen TOC merging to dictionaries

### DIFF
--- a/src/QsCompiler/DocumentationParser/DocNamespace.cs
+++ b/src/QsCompiler/DocumentationParser/DocNamespace.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 #nullable enable
@@ -122,6 +122,17 @@ namespace Microsoft.Quantum.QsCompiler.Documentation
                 else { return null; }
             }
 
+            string? TryGetName(YamlNode node)
+            {
+                if (node is YamlMappingNode mappingNode)
+                {
+                    mappingNode.Children.TryGetValue(Utils.NameKey, out var nameNode);
+                    return (nameNode as YamlScalarNode)?.Value;
+                }
+                else { return null; }
+            }
+
+
             int CompareUids(YamlNode node1, YamlNode node2) =>
                 String.Compare(
                     TryGetUid(node1),
@@ -152,21 +163,32 @@ namespace Microsoft.Quantum.QsCompiler.Documentation
                 namespaceNode.Add(Utils.ItemsKey, itemListNode);
             }
 
-            foreach (var item in items)
+            var itemsByUid = items
+                .GroupBy(item => item.Uid)
+                .ToDictionary(
+                    group => group.Key,
+                    group => group
+                        .Select(item => item.Name)
+                        .Single()
+                );
+
+            // Update itemsByUid with any items that may already exist.
+            foreach (var existingChild in itemListNode.Children)
             {
-                if (!itemListNode.Children.Any(c => MatchByUid(c, item.Uid)))
+                var uid = TryGetUid(existingChild);
+                if (uid != null)
                 {
-                    itemListNode.Add(Utils.BuildMappingNode(Utils.NameKey, item.Name, Utils.UidKey, item.Uid));
+                    itemsByUid[uid] = TryGetName(existingChild) ?? "";
                 }
             }
 
-            var children = itemListNode
-                .Children
-                .OrderBy((node1, node2) => CompareUids(node1, node2))
-                .GroupBy(node => TryGetUid(node))
-                .Select(group => group.First());
             itemListNode.Children.Clear();
-            itemListNode.Children.AddRange(children);
+            foreach (var (uid, name) in itemsByUid)
+            {
+                itemListNode.Add(Utils.BuildMappingNode(
+                    Utils.NameKey, name, Utils.UidKey, uid
+                ));
+            }
         }
 
         /// <summary>

--- a/src/QsCompiler/DocumentationParser/DocNamespace.cs
+++ b/src/QsCompiler/DocumentationParser/DocNamespace.cs
@@ -183,7 +183,7 @@ namespace Microsoft.Quantum.QsCompiler.Documentation
             }
 
             itemListNode.Children.Clear();
-            foreach (var (uid, name) in itemsByUid)
+            foreach (var (uid, name) in itemsByUid.OrderBy(item => item.Key))
             {
                 itemListNode.Add(Utils.BuildMappingNode(
                     Utils.NameKey, name, Utils.UidKey, uid

--- a/src/QsCompiler/DocumentationParser/DocNamespace.cs
+++ b/src/QsCompiler/DocumentationParser/DocNamespace.cs
@@ -160,7 +160,13 @@ namespace Microsoft.Quantum.QsCompiler.Documentation
                 }
             }
 
-            itemListNode.Children.Sort((node1, node2) => CompareUids(node1, node2));
+            var children = itemListNode
+                .Children
+                .OrderBy((node1, node2) => CompareUids(node1, node2))
+                .GroupBy(node => TryGetUid(node))
+                .Select(group => group.First());
+            itemListNode.Children.Clear();
+            itemListNode.Children.AddRange(children);
         }
 
         /// <summary>

--- a/src/QsCompiler/DocumentationParser/Utils.cs
+++ b/src/QsCompiler/DocumentationParser/Utils.cs
@@ -475,6 +475,21 @@ namespace Microsoft.Quantum.QsCompiler.Documentation
     // See https://stackoverflow.com/a/5037815/267841.
     internal static class SortExtensions
     {
+        internal static void AddRange<T>(this IList<T> list, IEnumerable<T> source)
+        {
+            if (list is List<T> concreteList)
+            {
+                concreteList.AddRange(source);
+            }
+            else
+            {
+                foreach (var element in list)
+                {
+                    list.Add(element);
+                }
+            }
+        }
+
         //  Sorts an IList<T> in place.
         internal static void Sort<T>(this IList<T> list, Comparison<T> comparison)
         {


### PR DESCRIPTION
This PR moves TOC merging over to using dictionaries, so as to guarantee that UIDs each have a unique mapping to TOC items.