### PR TITLE
Transformation setup clean-up - Part I

### DIFF
--- a/src/QsCompiler/CompilationManager/EditorSupport/SymbolInformation.cs
+++ b/src/QsCompiler/CompilationManager/EditorSupport/SymbolInformation.cs
@@ -213,7 +213,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
                     .Where(spec => spec.SourceFile.Value == file.FileName.Value)
                     .SelectMany(spec =>
                         spec.Implementation is SpecializationImplementation.Provided impl && spec.Location.IsValue
-                            ? IdentifierLocation.Find(definition.Item.Item1, impl.Item2, file.FileName, spec.Location.Item.Offset)
+                            ? IdentifierReferences.Find(definition.Item.Item1, impl.Item2, file.FileName, spec.Location.Item.Offset)
                             : ImmutableArray<IdentifierReferences.Location>.Empty)
                     .Distinct().Select(AsLocation);
             }
@@ -223,7 +223,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
                 var statements = implementation.StatementsAfterDeclaration(defStart.Subtract(specPos));
                 var scope = new QsScope(statements.ToImmutableArray(), locals);
                 var rootOffset = DiagnosticTools.AsTuple(specPos); 
-                referenceLocations = IdentifierLocation.Find(definition.Item.Item1, scope, file.FileName, rootOffset).Distinct().Select(AsLocation);
+                referenceLocations = IdentifierReferences.Find(definition.Item.Item1, scope, file.FileName, rootOffset).Distinct().Select(AsLocation);
             }
             declarationLocation = AsLocation(file.FileName, definition.Item.Item2, defRange);
             return true;

--- a/src/QsCompiler/Core/Core.fsproj
+++ b/src/QsCompiler/Core/Core.fsproj
@@ -13,11 +13,11 @@
       <Link>DelaySign.fs</Link>
     </Compile>
     <Compile Include="AssemblyInfo.fs" />
-    <Compile Include="ConstructorExtensions.fs" />
-    <Compile Include="TransformationDefinition.fs" />    
+    <Compile Include="ConstructorExtensions.fs" />    
     <Compile Include="ExpressionTransformation.fs" />
     <Compile Include="StatementTransformation.fs" />
     <Compile Include="TreeTransformation.fs" />
+    <Compile Include="TransformationDefinition.fs" />
     <Compile Include="ExpressionWalker.fs" />
     <Compile Include="StatementWalker.fs" />
     <Compile Include="TreeWalker.fs" />

--- a/src/QsCompiler/Core/Core.fsproj
+++ b/src/QsCompiler/Core/Core.fsproj
@@ -13,7 +13,8 @@
       <Link>DelaySign.fs</Link>
     </Compile>
     <Compile Include="AssemblyInfo.fs" />
-    <Compile Include="ConstructorExtensions.fs" />    
+    <Compile Include="ConstructorExtensions.fs" />
+    <Compile Include="TransformationDefinition.fs" />    
     <Compile Include="ExpressionTransformation.fs" />
     <Compile Include="StatementTransformation.fs" />
     <Compile Include="TreeTransformation.fs" />

--- a/src/QsCompiler/Core/TransformationDefinition.fs
+++ b/src/QsCompiler/Core/TransformationDefinition.fs
@@ -2,18 +2,6 @@
 // Licensed under the MIT License.
 
 namespace Microsoft.Quantum.QsCompiler.Transformations.Core
-
-open System.Collections.Immutable
-open System.Numerics
-open System.Runtime.CompilerServices
-open Microsoft.Quantum.QsCompiler.DataTypes
-open Microsoft.Quantum.QsCompiler.SyntaxExtensions
-open Microsoft.Quantum.QsCompiler.SyntaxTokens
-open Microsoft.Quantum.QsCompiler.SyntaxTree
-open System
-
-type private ExpressionKind = QsExpressionKind<TypedExpression,Identifier,ResolvedType>
-type private ExpressionType = QsTypeKind<ResolvedType, UserDefinedType, QsTypeParameter, CallableInformation>
     
 
 type QsSyntaxTreeTransformation<'T> (state : 'T) as this =     
@@ -45,22 +33,42 @@ type QsSyntaxTreeTransformation<'T> (state : 'T) as this =
     member val StatementTransformation      = this.InitializeStatementTransformation()
     member val NamespaceTransformation      = this.InitializeNamespaceTransformation()
 
+
 and ExpressionTypeTransformation<'T>(parent) = 
+    inherit ExpressionTypeTransformation()
     member this.Parent : QsSyntaxTreeTransformation<'T> = parent
+
 
 and ExpressionKindTransformation<'T >(parent) = 
+    inherit ExpressionKindTransformation()
     member this.Parent : QsSyntaxTreeTransformation<'T> = parent
-        
+    
+    override this.ExpressionTransformation ex = this.Parent.ExpressionTransformation.Transform ex
+    override this.TypeTransformation t = this.Parent.ExpressionTypeTransformation.Transform t
+
+    
 and ExpressionTransformation<'T>(parent) = 
+    inherit ExpressionTransformation()
     member this.Parent : QsSyntaxTreeTransformation<'T> = parent
+
 
 and StatementKindTransformation<'T>(parent) = 
+    inherit StatementKindTransformation()
     member this.Parent : QsSyntaxTreeTransformation<'T> = parent
+
+    override this.ScopeTransformation scope = this.Parent.StatementTransformation.Transform scope
+    override this.ExpressionTransformation ex = this.Parent.ExpressionTransformation.Transform ex
+    override this.TypeTransformation t = this.Parent.ExpressionTypeTransformation.Transform t
+    override this.LocationTransformation loc = this.Parent.NamespaceTransformation.onLocation loc
+
 
 and StatementTransformation<'T>(parent) = 
+    inherit ScopeTransformation()
     member this.Parent : QsSyntaxTreeTransformation<'T> = parent
 
+
 and NamespaceTransformation<'T>(parent) = 
+    inherit SyntaxTreeTransformation()
     member this.Parent : QsSyntaxTreeTransformation<'T> = parent
 
 

--- a/src/QsCompiler/Core/TransformationDefinition.fs
+++ b/src/QsCompiler/Core/TransformationDefinition.fs
@@ -144,7 +144,7 @@ and StatementKindTransformation<'T> internal (parentTransformation) =
     override this.ScopeTransformation scope = this.Transformation.Statements.Transform scope
     override this.ExpressionTransformation ex = this.Transformation.Expressions.Transform ex
     override this.TypeTransformation t = this.Transformation.Types.Transform t
-    override this.LocationTransformation loc = this.Transformation.Namespaces.onLocation loc
+    override this.LocationTransformation loc = this.Transformation.Statements.onLocation loc
 
 
 and StatementTransformation<'T> internal (parentTransformation) = 

--- a/src/QsCompiler/Core/TransformationDefinition.fs
+++ b/src/QsCompiler/Core/TransformationDefinition.fs
@@ -16,27 +16,34 @@ type private ExpressionKind = QsExpressionKind<TypedExpression,Identifier,Resolv
 type private ExpressionType = QsTypeKind<ResolvedType, UserDefinedType, QsTypeParameter, CallableInformation>
     
 
-type QsSyntaxTreeTransformation<'T> private (state : 'T, init : QsSyntaxTreeTransformationInitialization<'T>) as this =     
+type QsSyntaxTreeTransformation<'T> (state : 'T) as this =     
 
     member this.InternalState = state
 
-    member val ExpressionTypeTransformation = init.ExpressionTypeTransformation this
-    member val ExpressionKindTransformation = init.ExpressionKindTransformation this
-    member val ExpressionTransformation     = init.ExpressionTransformation this
-    member val StatementKindTransformation  = init.StatementKindTransformation this
-    member val StatementTransformation      = init.StatementTransformation this
-    member val NamespaceTransformation      = init.NamespaceTransformation this
+    abstract member InitializeExpressionTypeTransformation : unit -> ExpressionTypeTransformation<'T>
+    default this.InitializeExpressionTypeTransformation () = new ExpressionTypeTransformation<'T>(this)
 
-    new (state : 'T) =
-        let init = {
-            ExpressionTypeTransformation = fun this -> new ExpressionTypeTransformation<'T> (this)
-            ExpressionKindTransformation = fun this -> new ExpressionKindTransformation<'T> (this)
-            ExpressionTransformation     = fun this -> new ExpressionTransformation<'T> (this)
-            StatementKindTransformation  = fun this -> new StatementKindTransformation<'T> (this)
-            StatementTransformation      = fun this -> new StatementTransformation<'T> (this)
-            NamespaceTransformation      = fun this -> new NamespaceTransformation<'T> (this)
-        }
-        QsSyntaxTreeTransformation(state, init)
+    abstract member InitializeExpressionKindTransformation : unit -> ExpressionKindTransformation<'T>
+    default this.InitializeExpressionKindTransformation () = new ExpressionKindTransformation<'T>(this)
+
+    abstract member InitializeExpressionTransformation : unit -> ExpressionTransformation<'T>
+    default this.InitializeExpressionTransformation () = new ExpressionTransformation<'T>(this)
+    
+    abstract member InitializeStatementKindTransformation : unit -> StatementKindTransformation<'T>
+    default this.InitializeStatementKindTransformation () = new StatementKindTransformation<'T>(this)
+    
+    abstract member InitializeStatementTransformation : unit -> StatementTransformation<'T>
+    default this.InitializeStatementTransformation () = new StatementTransformation<'T>(this)
+    
+    abstract member InitializeNamespaceTransformation : unit -> NamespaceTransformation<'T>
+    default this.InitializeNamespaceTransformation () = new NamespaceTransformation<'T>(this)
+    
+    member val ExpressionTypeTransformation = this.InitializeExpressionTypeTransformation()
+    member val ExpressionKindTransformation = this.InitializeExpressionKindTransformation()
+    member val ExpressionTransformation     = this.InitializeExpressionTransformation()
+    member val StatementKindTransformation  = this.InitializeStatementKindTransformation()
+    member val StatementTransformation      = this.InitializeStatementTransformation()
+    member val NamespaceTransformation      = this.InitializeNamespaceTransformation()
 
 and ExpressionTypeTransformation<'T>(parent) = 
     member this.Parent : QsSyntaxTreeTransformation<'T> = parent
@@ -56,13 +63,4 @@ and StatementTransformation<'T>(parent) =
 and NamespaceTransformation<'T>(parent) = 
     member this.Parent : QsSyntaxTreeTransformation<'T> = parent
 
-
-and QsSyntaxTreeTransformationInitialization<'T> = {
-    ExpressionTypeTransformation : QsSyntaxTreeTransformation<'T> -> ExpressionTypeTransformation<'T>
-    ExpressionKindTransformation : QsSyntaxTreeTransformation<'T> -> ExpressionKindTransformation<'T>
-    ExpressionTransformation : QsSyntaxTreeTransformation<'T> -> ExpressionTransformation<'T>
-    StatementKindTransformation : QsSyntaxTreeTransformation<'T> -> StatementKindTransformation<'T>
-    StatementTransformation : QsSyntaxTreeTransformation<'T> -> StatementTransformation<'T>
-    NamespaceTransformation : QsSyntaxTreeTransformation<'T> -> NamespaceTransformation<'T>
-}
 

--- a/src/QsCompiler/Core/TransformationDefinition.fs
+++ b/src/QsCompiler/Core/TransformationDefinition.fs
@@ -6,12 +6,12 @@ namespace Microsoft.Quantum.QsCompiler.Transformations.Core
 
 type QsSyntaxTreeTransformation<'T> private (state : 'T, dummy) =     
 
-    let mutable _Types           = new ExpressionTypeTransformation<'T>()
-    let mutable _ExpressionKinds = new ExpressionKindTransformation<'T>() 
-    let mutable _Expressions     = new ExpressionTransformation<'T>()     
-    let mutable _StatementKinds  = new StatementKindTransformation<'T>()  
-    let mutable _Statements      = new StatementTransformation<'T>()      
-    let mutable _Namespaces      = new NamespaceTransformation<'T>()      
+    let mutable _Types           = new ExpressionTypeTransformation<'T>(None)
+    let mutable _ExpressionKinds = new ExpressionKindTransformation<'T>(None) 
+    let mutable _Expressions     = new ExpressionTransformation<'T>(None)     
+    let mutable _StatementKinds  = new StatementKindTransformation<'T>(None)  
+    let mutable _Statements      = new StatementTransformation<'T>(None)      
+    let mutable _Namespaces      = new NamespaceTransformation<'T>(None)      
 
     member this.Types           
         with get() = _Types
@@ -68,7 +68,7 @@ type QsSyntaxTreeTransformation<'T> private (state : 'T, dummy) =
             this.Namespaces      <- this.NewNamespaceTransformation()
         
 
-and ExpressionTypeTransformation<'T> private (parentTransformation) = 
+and ExpressionTypeTransformation<'T> internal (parentTransformation) = 
     inherit ExpressionTypeTransformation()
     let mutable _Transformation : QsSyntaxTreeTransformation<'T> option = parentTransformation
 
@@ -76,11 +76,10 @@ and ExpressionTypeTransformation<'T> private (parentTransformation) =
         with get () = _Transformation.Value
         and private set value = _Transformation <- Some value
 
-    internal new() = ExpressionTypeTransformation<'T>(None)
     new (parentTransformation : QsSyntaxTreeTransformation<'T>) = ExpressionTypeTransformation<'T>(Some parentTransformation)
 
 
-and ExpressionKindTransformation<'T> private (parentTransformation) = 
+and ExpressionKindTransformation<'T> internal (parentTransformation) = 
     inherit ExpressionKindTransformation()
     let mutable _Transformation : QsSyntaxTreeTransformation<'T> option = parentTransformation
 
@@ -88,14 +87,13 @@ and ExpressionKindTransformation<'T> private (parentTransformation) =
         with get () = _Transformation.Value
         and private set value = _Transformation <- Some value
 
-    internal new() = ExpressionKindTransformation<'T>(None)
     new (parentTransformation : QsSyntaxTreeTransformation<'T>) = ExpressionKindTransformation<'T>(Some parentTransformation)
     
     override this.ExpressionTransformation ex = this.Transformation.Expressions.Transform ex
     override this.TypeTransformation t = this.Transformation.Types.Transform t
 
     
-and ExpressionTransformation<'T> private (parentTransformation) = 
+and ExpressionTransformation<'T> internal (parentTransformation) = 
     inherit ExpressionTransformation()
     let mutable _Transformation : QsSyntaxTreeTransformation<'T> option = parentTransformation
 
@@ -103,14 +101,13 @@ and ExpressionTransformation<'T> private (parentTransformation) =
         with get () = _Transformation.Value
         and private set value = _Transformation <- Some value
 
-    internal new() = ExpressionTransformation<'T>(None)
     new (parentTransformation : QsSyntaxTreeTransformation<'T>) = ExpressionTransformation<'T>(Some parentTransformation)
 
     override this.Kind = upcast this.Transformation.ExpressionKinds
     override this.Type = upcast this.Transformation.Types
 
 
-and StatementKindTransformation<'T> private (parentTransformation) = 
+and StatementKindTransformation<'T> internal (parentTransformation) = 
     inherit StatementKindTransformation()
     let mutable _Transformation : QsSyntaxTreeTransformation<'T> option = parentTransformation
 
@@ -118,7 +115,6 @@ and StatementKindTransformation<'T> private (parentTransformation) =
         with get () = _Transformation.Value
         and private set value = _Transformation <- Some value
 
-    internal new() = StatementKindTransformation<'T>(None)
     new (parentTransformation : QsSyntaxTreeTransformation<'T>) = StatementKindTransformation<'T>(Some parentTransformation)
 
     override this.ScopeTransformation scope = this.Transformation.Statements.Transform scope
@@ -127,11 +123,10 @@ and StatementKindTransformation<'T> private (parentTransformation) =
     override this.LocationTransformation loc = this.Transformation.Namespaces.onLocation loc
 
 
-and StatementTransformation<'T> private (parentTransformation) = 
+and StatementTransformation<'T> internal (parentTransformation) = 
     inherit ScopeTransformation()
     let mutable _Transformation : QsSyntaxTreeTransformation<'T> option = parentTransformation
 
-    internal new() = StatementTransformation<'T>(None)
     new (parentTransformation : QsSyntaxTreeTransformation<'T>) = StatementTransformation<'T>(Some parentTransformation)
 
     member this.Transformation 
@@ -142,11 +137,10 @@ and StatementTransformation<'T> private (parentTransformation) =
     override this.StatementKind = upcast this.Transformation.StatementKinds
 
 
-and NamespaceTransformation<'T> private (parentTransformation) = 
+and NamespaceTransformation<'T> internal (parentTransformation) = 
     inherit SyntaxTreeTransformation()
     let mutable _Transformation : QsSyntaxTreeTransformation<'T> option = parentTransformation
 
-    internal new() = NamespaceTransformation<'T>(None)
     new (parentTransformation : QsSyntaxTreeTransformation<'T>) = NamespaceTransformation<'T>(Some parentTransformation)
 
     member this.Transformation 

--- a/src/QsCompiler/Core/TransformationDefinition.fs
+++ b/src/QsCompiler/Core/TransformationDefinition.fs
@@ -8,30 +8,30 @@ type QsSyntaxTreeTransformation<'T> (state : 'T) as this =
 
     member this.InternalState = state
 
-    abstract member InitializeExpressionTypeTransformation : unit -> ExpressionTypeTransformation<'T>
-    default this.InitializeExpressionTypeTransformation () = new ExpressionTypeTransformation<'T>(this)
+    abstract member NewExpressionTypeTransformation : unit -> ExpressionTypeTransformation<'T>
+    default this.NewExpressionTypeTransformation () = new ExpressionTypeTransformation<'T>(this)
 
-    abstract member InitializeExpressionKindTransformation : unit -> ExpressionKindTransformation<'T>
-    default this.InitializeExpressionKindTransformation () = new ExpressionKindTransformation<'T>(this)
+    abstract member NewExpressionKindTransformation : unit -> ExpressionKindTransformation<'T>
+    default this.NewExpressionKindTransformation () = new ExpressionKindTransformation<'T>(this)
 
-    abstract member InitializeExpressionTransformation : unit -> ExpressionTransformation<'T>
-    default this.InitializeExpressionTransformation () = new ExpressionTransformation<'T>(this)
+    abstract member NewExpressionTransformation : unit -> ExpressionTransformation<'T>
+    default this.NewExpressionTransformation () = new ExpressionTransformation<'T>(this)
     
-    abstract member InitializeStatementKindTransformation : unit -> StatementKindTransformation<'T>
-    default this.InitializeStatementKindTransformation () = new StatementKindTransformation<'T>(this)
+    abstract member NewStatementKindTransformation : unit -> StatementKindTransformation<'T>
+    default this.NewStatementKindTransformation () = new StatementKindTransformation<'T>(this)
     
-    abstract member InitializeStatementTransformation : unit -> StatementTransformation<'T>
-    default this.InitializeStatementTransformation () = new StatementTransformation<'T>(this)
+    abstract member NewStatementTransformation : unit -> StatementTransformation<'T>
+    default this.NewStatementTransformation () = new StatementTransformation<'T>(this)
     
-    abstract member InitializeNamespaceTransformation : unit -> NamespaceTransformation<'T>
-    default this.InitializeNamespaceTransformation () = new NamespaceTransformation<'T>(this)
+    abstract member NewNamespaceTransformation : unit -> NamespaceTransformation<'T>
+    default this.NewNamespaceTransformation () = new NamespaceTransformation<'T>(this)
     
-    member val ExpressionTypeTransformation = this.InitializeExpressionTypeTransformation()
-    member val ExpressionKindTransformation = this.InitializeExpressionKindTransformation()
-    member val ExpressionTransformation     = this.InitializeExpressionTransformation()
-    member val StatementKindTransformation  = this.InitializeStatementKindTransformation()
-    member val StatementTransformation      = this.InitializeStatementTransformation()
-    member val NamespaceTransformation      = this.InitializeNamespaceTransformation()
+    member val Types           = this.NewExpressionTypeTransformation()
+    member val ExpressionKinds = this.NewExpressionKindTransformation()
+    member val Expressions     = this.NewExpressionTransformation()
+    member val StatementKind   = this.NewStatementKindTransformation()
+    member val Statements      = this.NewStatementTransformation()
+    member val Namespaces      = this.NewNamespaceTransformation()
 
 
 and ExpressionTypeTransformation<'T>(parent) = 
@@ -43,8 +43,8 @@ and ExpressionKindTransformation<'T >(parent) =
     inherit ExpressionKindTransformation()
     member this.Parent : QsSyntaxTreeTransformation<'T> = parent
     
-    override this.ExpressionTransformation ex = this.Parent.ExpressionTransformation.Transform ex
-    override this.TypeTransformation t = this.Parent.ExpressionTypeTransformation.Transform t
+    override this.ExpressionTransformation ex = this.Parent.Expressions.Transform ex
+    override this.TypeTransformation t = this.Parent.Types.Transform t
 
     
 and ExpressionTransformation<'T>(parent) = 
@@ -56,10 +56,10 @@ and StatementKindTransformation<'T>(parent) =
     inherit StatementKindTransformation()
     member this.Parent : QsSyntaxTreeTransformation<'T> = parent
 
-    override this.ScopeTransformation scope = this.Parent.StatementTransformation.Transform scope
-    override this.ExpressionTransformation ex = this.Parent.ExpressionTransformation.Transform ex
-    override this.TypeTransformation t = this.Parent.ExpressionTypeTransformation.Transform t
-    override this.LocationTransformation loc = this.Parent.NamespaceTransformation.onLocation loc
+    override this.ScopeTransformation scope = this.Parent.Statements.Transform scope
+    override this.ExpressionTransformation ex = this.Parent.Expressions.Transform ex
+    override this.TypeTransformation t = this.Parent.Types.Transform t
+    override this.LocationTransformation loc = this.Parent.Namespaces.onLocation loc
 
 
 and StatementTransformation<'T>(parent) = 

--- a/src/QsCompiler/Core/TransformationDefinition.fs
+++ b/src/QsCompiler/Core/TransformationDefinition.fs
@@ -79,6 +79,7 @@ and ExpressionTypeTransformation<'T> private (parentTransformation) =
     internal new() = ExpressionTypeTransformation<'T>(None)
     new (parentTransformation : QsSyntaxTreeTransformation<'T>) = ExpressionTypeTransformation<'T>(Some parentTransformation)
 
+
 and ExpressionKindTransformation<'T> private (parentTransformation) = 
     inherit ExpressionKindTransformation()
     let mutable _Transformation : QsSyntaxTreeTransformation<'T> option = parentTransformation

--- a/src/QsCompiler/Core/TransformationDefinition.fs
+++ b/src/QsCompiler/Core/TransformationDefinition.fs
@@ -61,18 +61,56 @@ and NamespaceTransformation<'T when 'T :> QsSyntaxTreeTransformation>() =
 
 and QsSyntaxTreeTransformation private (dummy) = 
 
-    member val ExpressionTypeTransformation = new ExpressionTypeTransformation<_> ()
-    member val ExpressionKindTransformation = new ExpressionKindTransformation<_> ()
-    member val ExpressionTransformation = new ExpressionTransformation<_> ()
-    member val StatementKindTransformation  = new StatementKindTransformation<_> ()
-    member val StatementTransformation = new StatementTransformation<_> ()
-    member val NamespaceTransformation = new NamespaceTransformation<_> ()
+    let mutable _ExpressionTypeTransformation = new ExpressionTypeTransformation<_> ()
+    let mutable _ExpressionKindTransformation = new ExpressionKindTransformation<_> ()
+    let mutable _ExpressionTransformation = new ExpressionTransformation<_> ()
+    let mutable _StatementKindTransformation  = new StatementKindTransformation<_> ()
+    let mutable _StatementTransformation = new StatementTransformation<_> ()
+    let mutable _NamespaceTransformation = new NamespaceTransformation<_> ()
 
-    new() as this = QsSyntaxTreeTransformation(0) then 
-        this.ExpressionTypeTransformation.Parent <- this
-        this.ExpressionKindTransformation.Parent <- this
-        this.ExpressionTransformation.Parent <- this
-        this.StatementKindTransformation.Parent <- this
-        this.StatementTransformation.Parent <- this
-        this.NamespaceTransformation.Parent <- this
+    member this.ExpressionTypeTransformation
+        with get () = _ExpressionTypeTransformation
+        and private set t = 
+            _ExpressionTypeTransformation <- t
+            t.Parent <- this
+
+    member this.ExpressionKindTransformation 
+        with get () = _ExpressionKindTransformation
+        and private set t = 
+            _ExpressionKindTransformation <- t
+            t.Parent <- this
+
+    member this.ExpressionTransformation 
+        with get () = _ExpressionTransformation
+        and private set t = 
+            _ExpressionTransformation <- t
+            t.Parent <- this
+
+    member this.StatementKindTransformation 
+        with get () = _StatementKindTransformation
+        and private set t = 
+            _StatementKindTransformation <- t
+            t.Parent <- this
+
+    member this.StatementTransformation
+        with get () = _StatementTransformation
+        and private set t = 
+            _StatementTransformation <- t
+            t.Parent <- this
+
+    member this.NamespaceTransformation 
+        with get () = _NamespaceTransformation
+        and private set t = 
+            _NamespaceTransformation <- t
+            t.Parent <- this
+
+    new() as this = 
+        let foo = ()
+        QsSyntaxTreeTransformation(0) then 
+            this.ExpressionTypeTransformation.Parent <- this
+            this.ExpressionKindTransformation.Parent <- this
+            this.ExpressionTransformation.Parent <- this
+            this.StatementKindTransformation.Parent <- this
+            this.StatementTransformation.Parent <- this
+            this.NamespaceTransformation.Parent <- this
 

--- a/src/QsCompiler/Core/TransformationDefinition.fs
+++ b/src/QsCompiler/Core/TransformationDefinition.fs
@@ -4,7 +4,39 @@
 namespace Microsoft.Quantum.QsCompiler.Transformations.Core
     
 
-type QsSyntaxTreeTransformation<'T> (state : 'T) as this =     
+type QsSyntaxTreeTransformation<'T> (state : 'T, dummy) =     
+
+    let mutable _Types           = new ExpressionTypeTransformation<'T>()
+    let mutable _ExpressionKinds = new ExpressionKindTransformation<'T>() 
+    let mutable _Expressions     = new ExpressionTransformation<'T>()     
+    let mutable _StatementKinds  = new StatementKindTransformation<'T>()  
+    let mutable _Statements      = new StatementTransformation<'T>()      
+    let mutable _Namespaces      = new NamespaceTransformation<'T>()      
+
+    member this.Types           
+        with get() = _Types
+        and private set value = _Types <- value
+
+    member this.ExpressionKinds 
+        with get() = _ExpressionKinds
+        and private set value = _ExpressionKinds <- value
+
+    member this.Expressions     
+        with get() = _Expressions
+        and private set value = _Expressions <- value
+
+    member this.StatementKinds  
+        with get() = _StatementKinds
+        and private set value = _StatementKinds <- value
+
+    member this.Statements      
+        with get() = _Statements
+        and private set value = _Statements <- value
+
+    member this.Namespaces      
+        with get() = _Namespaces
+        and private set value = _Namespaces <- value
+
 
     member this.InternalState = state
 
@@ -26,35 +58,67 @@ type QsSyntaxTreeTransformation<'T> (state : 'T) as this =
     abstract member NewNamespaceTransformation : unit -> NamespaceTransformation<'T>
     default this.NewNamespaceTransformation () = new NamespaceTransformation<'T>(this)
     
-    member val Types           = this.NewExpressionTypeTransformation()
-    member val ExpressionKinds = this.NewExpressionKindTransformation()
-    member val Expressions     = this.NewExpressionTransformation()
-    member val StatementKind   = this.NewStatementKindTransformation()
-    member val Statements      = this.NewStatementTransformation()
-    member val Namespaces      = this.NewNamespaceTransformation()
+    new (state) as this = 
+        QsSyntaxTreeTransformation(state, 0) then
+            this.Types           <- this.NewExpressionTypeTransformation()
+            this.ExpressionKinds <- this.NewExpressionKindTransformation()
+            this.Expressions     <- this.NewExpressionTransformation()
+            this.StatementKinds  <- this.NewStatementKindTransformation()
+            this.Statements      <- this.NewStatementTransformation()
+            this.Namespaces      <- this.NewNamespaceTransformation()
+        
 
-
-and ExpressionTypeTransformation<'T>(parent) = 
+and ExpressionTypeTransformation<'T> private (parent) = 
     inherit ExpressionTypeTransformation()
-    member this.Parent : QsSyntaxTreeTransformation<'T> = parent
+    let mutable _Parent : QsSyntaxTreeTransformation<'T> option = parent
 
+    member this.Parent 
+        with get () = _Parent.Value
+        and private set value = _Parent <- Some value
 
-and ExpressionKindTransformation<'T >(parent) = 
+    internal new() = ExpressionTypeTransformation<'T>(None)
+    new (parent : QsSyntaxTreeTransformation<'T>) = ExpressionTypeTransformation<'T>(Some parent)
+
+and ExpressionKindTransformation<'T> private (parent) = 
     inherit ExpressionKindTransformation()
-    member this.Parent : QsSyntaxTreeTransformation<'T> = parent
+    let mutable _Parent : QsSyntaxTreeTransformation<'T> option = parent
+
+    member this.Parent 
+        with get () = _Parent.Value
+        and private set value = _Parent <- Some value
+
+    internal new() = ExpressionKindTransformation<'T>(None)
+    new (parent : QsSyntaxTreeTransformation<'T>) = ExpressionKindTransformation<'T>(Some parent)
     
     override this.ExpressionTransformation ex = this.Parent.Expressions.Transform ex
     override this.TypeTransformation t = this.Parent.Types.Transform t
 
     
-and ExpressionTransformation<'T>(parent) = 
+and ExpressionTransformation<'T> private (parent) = 
     inherit ExpressionTransformation()
-    member this.Parent : QsSyntaxTreeTransformation<'T> = parent
+    let mutable _Parent : QsSyntaxTreeTransformation<'T> option = parent
+
+    member this.Parent 
+        with get () = _Parent.Value
+        and private set value = _Parent <- Some value
+
+    internal new() = ExpressionTransformation<'T>(None)
+    new (parent : QsSyntaxTreeTransformation<'T>) = ExpressionTransformation<'T>(Some parent)
+
+    override this.Kind = upcast this.Parent.ExpressionKinds
+    override this.Type = upcast this.Parent.Types
 
 
-and StatementKindTransformation<'T>(parent) = 
+and StatementKindTransformation<'T> private (parent) = 
     inherit StatementKindTransformation()
-    member this.Parent : QsSyntaxTreeTransformation<'T> = parent
+    let mutable _Parent : QsSyntaxTreeTransformation<'T> option = parent
+
+    member this.Parent 
+        with get () = _Parent.Value
+        and private set value = _Parent <- Some value
+
+    internal new() = StatementKindTransformation<'T>(None)
+    new (parent : QsSyntaxTreeTransformation<'T>) = StatementKindTransformation<'T>(Some parent)
 
     override this.ScopeTransformation scope = this.Parent.Statements.Transform scope
     override this.ExpressionTransformation ex = this.Parent.Expressions.Transform ex
@@ -62,13 +126,32 @@ and StatementKindTransformation<'T>(parent) =
     override this.LocationTransformation loc = this.Parent.Namespaces.onLocation loc
 
 
-and StatementTransformation<'T>(parent) = 
+and StatementTransformation<'T> private (parent) = 
     inherit ScopeTransformation()
-    member this.Parent : QsSyntaxTreeTransformation<'T> = parent
+    let mutable _Parent : QsSyntaxTreeTransformation<'T> option = parent
+
+    internal new() = StatementTransformation<'T>(None)
+    new (parent : QsSyntaxTreeTransformation<'T>) = StatementTransformation<'T>(Some parent)
+
+    member this.Parent 
+        with get () = _Parent.Value
+        and private set value = _Parent <- Some value
+
+    override this.Expression = upcast this.Parent.Expressions
+    override this.StatementKind = upcast this.Parent.StatementKinds
 
 
-and NamespaceTransformation<'T>(parent) = 
+and NamespaceTransformation<'T> private (parent) = 
     inherit SyntaxTreeTransformation()
-    member this.Parent : QsSyntaxTreeTransformation<'T> = parent
+    let mutable _Parent : QsSyntaxTreeTransformation<'T> option = parent
+
+    internal new() = NamespaceTransformation<'T>(None)
+    new (parent : QsSyntaxTreeTransformation<'T>) = NamespaceTransformation<'T>(Some parent)
+
+    member this.Parent 
+        with get () = _Parent.Value
+        and private set value = _Parent <- Some value
+
+    override this.Scope = upcast this.Parent.Statements
 
 

--- a/src/QsCompiler/Core/TransformationDefinition.fs
+++ b/src/QsCompiler/Core/TransformationDefinition.fs
@@ -2,38 +2,38 @@
 // Licensed under the MIT License.
 
 namespace Microsoft.Quantum.QsCompiler.Transformations.Core
-    
 
-type QsSyntaxTreeTransformation<'T> private (state : 'T, dummy) =     
+
+type QsSyntaxTreeTransformation<'T> private (state : 'T, dummy) =
 
     let mutable _Types           = new ExpressionTypeTransformation<'T>(None)
-    let mutable _ExpressionKinds = new ExpressionKindTransformation<'T>(None) 
-    let mutable _Expressions     = new ExpressionTransformation<'T>(None)     
-    let mutable _StatementKinds  = new StatementKindTransformation<'T>(None)  
-    let mutable _Statements      = new StatementTransformation<'T>(None)      
-    let mutable _Namespaces      = new NamespaceTransformation<'T>(None)      
+    let mutable _ExpressionKinds = new ExpressionKindTransformation<'T>(None)
+    let mutable _Expressions     = new ExpressionTransformation<'T>(None)
+    let mutable _StatementKinds  = new StatementKindTransformation<'T>(None)
+    let mutable _Statements      = new StatementTransformation<'T>(None)
+    let mutable _Namespaces      = new NamespaceTransformation<'T>(None)
 
-    member this.Types           
+    member this.Types
         with get() = _Types
         and private set value = _Types <- value
 
-    member this.ExpressionKinds 
+    member this.ExpressionKinds
         with get() = _ExpressionKinds
         and private set value = _ExpressionKinds <- value
 
-    member this.Expressions     
+    member this.Expressions
         with get() = _Expressions
         and private set value = _Expressions <- value
 
-    member this.StatementKinds  
+    member this.StatementKinds
         with get() = _StatementKinds
         and private set value = _StatementKinds <- value
 
-    member this.Statements      
+    member this.Statements
         with get() = _Statements
         and private set value = _Statements <- value
 
-    member this.Namespaces      
+    member this.Namespaces
         with get() = _Namespaces
         and private set value = _Namespaces <- value
 
@@ -48,17 +48,17 @@ type QsSyntaxTreeTransformation<'T> private (state : 'T, dummy) =
 
     abstract member NewExpressionTransformation : unit -> ExpressionTransformation<'T>
     default this.NewExpressionTransformation () = new ExpressionTransformation<'T>(this)
-    
+
     abstract member NewStatementKindTransformation : unit -> StatementKindTransformation<'T>
     default this.NewStatementKindTransformation () = new StatementKindTransformation<'T>(this)
-    
+
     abstract member NewStatementTransformation : unit -> StatementTransformation<'T>
     default this.NewStatementTransformation () = new StatementTransformation<'T>(this)
-    
+
     abstract member NewNamespaceTransformation : unit -> NamespaceTransformation<'T>
     default this.NewNamespaceTransformation () = new NamespaceTransformation<'T>(this)
-    
-    new (state) as this = 
+
+    new (state) as this =
         QsSyntaxTreeTransformation(state, 0) then
             this.Types           <- this.NewExpressionTypeTransformation()
             this.ExpressionKinds <- this.NewExpressionKindTransformation()
@@ -66,57 +66,57 @@ type QsSyntaxTreeTransformation<'T> private (state : 'T, dummy) =
             this.StatementKinds  <- this.NewStatementKindTransformation()
             this.Statements      <- this.NewStatementTransformation()
             this.Namespaces      <- this.NewNamespaceTransformation()
-        
 
-and ExpressionTypeTransformation<'T> internal (parentTransformation) = 
+
+and ExpressionTypeTransformation<'T> internal (parentTransformation) =
     inherit ExpressionTypeTransformation()
     let mutable _Transformation : QsSyntaxTreeTransformation<'T> option = parentTransformation
 
-    member this.Transformation 
+    member this.Transformation
         with get () = _Transformation.Value
         and private set value = _Transformation <- Some value
 
     new (parentTransformation : QsSyntaxTreeTransformation<'T>) = ExpressionTypeTransformation<'T>(Some parentTransformation)
-    new (sharedInternalState : 'T) as this = 
+    new (sharedInternalState : 'T) as this =
         ExpressionTypeTransformation<'T>(None) then
-            this.Transformation <- { 
+            this.Transformation <- {
                 new QsSyntaxTreeTransformation<'T>(sharedInternalState) with
                     override parent.NewExpressionTypeTransformation () = this
             }
 
 
-and ExpressionKindTransformation<'T> internal (parentTransformation) = 
+and ExpressionKindTransformation<'T> internal (parentTransformation) =
     inherit ExpressionKindTransformation()
     let mutable _Transformation : QsSyntaxTreeTransformation<'T> option = parentTransformation
 
-    member this.Transformation 
+    member this.Transformation
         with get () = _Transformation.Value
         and private set value = _Transformation <- Some value
 
     new (parentTransformation : QsSyntaxTreeTransformation<'T>) = ExpressionKindTransformation<'T>(Some parentTransformation)
-    new (sharedInternalState : 'T) as this = 
+    new (sharedInternalState : 'T) as this =
         ExpressionKindTransformation<'T>(None) then
-            this.Transformation <- { 
+            this.Transformation <- {
                 new QsSyntaxTreeTransformation<'T>(sharedInternalState) with
                     override parent.NewExpressionKindTransformation () = this
             }
-    
+
     override this.ExpressionTransformation ex = this.Transformation.Expressions.Transform ex
     override this.TypeTransformation t = this.Transformation.Types.Transform t
 
-    
-and ExpressionTransformation<'T> internal (parentTransformation) = 
+
+and ExpressionTransformation<'T> internal (parentTransformation) =
     inherit ExpressionTransformation()
     let mutable _Transformation : QsSyntaxTreeTransformation<'T> option = parentTransformation
 
-    member this.Transformation 
+    member this.Transformation
         with get () = _Transformation.Value
         and private set value = _Transformation <- Some value
 
     new (parentTransformation : QsSyntaxTreeTransformation<'T>) = ExpressionTransformation<'T>(Some parentTransformation)
-    new (sharedInternalState : 'T) as this = 
+    new (sharedInternalState : 'T) as this =
         ExpressionTransformation<'T>(None) then
-            this.Transformation <- { 
+            this.Transformation <- {
                 new QsSyntaxTreeTransformation<'T>(sharedInternalState) with
                     override parent.NewExpressionTransformation () = this
             }
@@ -125,18 +125,18 @@ and ExpressionTransformation<'T> internal (parentTransformation) =
     override this.Type = upcast this.Transformation.Types
 
 
-and StatementKindTransformation<'T> internal (parentTransformation) = 
+and StatementKindTransformation<'T> internal (parentTransformation) =
     inherit StatementKindTransformation()
     let mutable _Transformation : QsSyntaxTreeTransformation<'T> option = parentTransformation
 
-    member this.Transformation 
+    member this.Transformation
         with get () = _Transformation.Value
         and private set value = _Transformation <- Some value
 
     new (parentTransformation : QsSyntaxTreeTransformation<'T>) = StatementKindTransformation<'T>(Some parentTransformation)
-    new (sharedInternalState : 'T) as this = 
+    new (sharedInternalState : 'T) as this =
         StatementKindTransformation<'T>(None) then
-            this.Transformation <- { 
+            this.Transformation <- {
                 new QsSyntaxTreeTransformation<'T>(sharedInternalState) with
                     override parent.NewStatementKindTransformation () = this
             }
@@ -147,19 +147,19 @@ and StatementKindTransformation<'T> internal (parentTransformation) =
     override this.LocationTransformation loc = this.Transformation.Statements.onLocation loc
 
 
-and StatementTransformation<'T> internal (parentTransformation) = 
+and StatementTransformation<'T> internal (parentTransformation) =
     inherit ScopeTransformation()
     let mutable _Transformation : QsSyntaxTreeTransformation<'T> option = parentTransformation
 
     new (parentTransformation : QsSyntaxTreeTransformation<'T>) = StatementTransformation<'T>(Some parentTransformation)
-    new (sharedInternalState : 'T) as this = 
+    new (sharedInternalState : 'T) as this =
         StatementTransformation<'T>(None) then
-            this.Transformation <- { 
+            this.Transformation <- {
                 new QsSyntaxTreeTransformation<'T>(sharedInternalState) with
                     override parent.NewStatementTransformation () = this
             }
 
-    member this.Transformation 
+    member this.Transformation
         with get () = _Transformation.Value
         and private set value = _Transformation <- Some value
 
@@ -167,19 +167,19 @@ and StatementTransformation<'T> internal (parentTransformation) =
     override this.StatementKind = upcast this.Transformation.StatementKinds
 
 
-and NamespaceTransformation<'T> internal (parentTransformation) = 
+and NamespaceTransformation<'T> internal (parentTransformation) =
     inherit SyntaxTreeTransformation()
     let mutable _Transformation : QsSyntaxTreeTransformation<'T> option = parentTransformation
 
     new (parentTransformation : QsSyntaxTreeTransformation<'T>) = NamespaceTransformation<'T>(Some parentTransformation)
-    new (sharedInternalState : 'T) as this = 
+    new (sharedInternalState : 'T) as this =
         NamespaceTransformation<'T>(None) then
-            this.Transformation <- { 
+            this.Transformation <- {
                 new QsSyntaxTreeTransformation<'T>(sharedInternalState) with
                     override parent.NewNamespaceTransformation () = this
             }
 
-    member this.Transformation 
+    member this.Transformation
         with get () = _Transformation.Value
         and private set value = _Transformation <- Some value
 

--- a/src/QsCompiler/Core/TransformationDefinition.fs
+++ b/src/QsCompiler/Core/TransformationDefinition.fs
@@ -16,101 +16,53 @@ type private ExpressionKind = QsExpressionKind<TypedExpression,Identifier,Resolv
 type private ExpressionType = QsTypeKind<ResolvedType, UserDefinedType, QsTypeParameter, CallableInformation>
     
 
-type ExpressionTypeTransformation<'T when 'T :> QsSyntaxTreeTransformation>() = 
+type QsSyntaxTreeTransformation<'T> private (state : 'T, init : QsSyntaxTreeTransformationInitialization<'T>) as this =     
 
-    let mutable _Parent : 'T option = None
-    member this.Parent 
-        with get () = _Parent.Value
-        and internal set value = _Parent <- Some value
+    member this.InternalState = state
 
-and ExpressionKindTransformation<'T when 'T :> QsSyntaxTreeTransformation>() = 
+    member val ExpressionTypeTransformation = init.ExpressionTypeTransformation this
+    member val ExpressionKindTransformation = init.ExpressionKindTransformation this
+    member val ExpressionTransformation     = init.ExpressionTransformation this
+    member val StatementKindTransformation  = init.StatementKindTransformation this
+    member val StatementTransformation      = init.StatementTransformation this
+    member val NamespaceTransformation      = init.NamespaceTransformation this
 
-    let mutable _Parent : 'T option = None
-    member this.Parent 
-        with get () = _Parent.Value
-        and internal set value = _Parent <- Some value
+    new (state : 'T) =
+        let init = {
+            ExpressionTypeTransformation = fun this -> new ExpressionTypeTransformation<'T> (this)
+            ExpressionKindTransformation = fun this -> new ExpressionKindTransformation<'T> (this)
+            ExpressionTransformation     = fun this -> new ExpressionTransformation<'T> (this)
+            StatementKindTransformation  = fun this -> new StatementKindTransformation<'T> (this)
+            StatementTransformation      = fun this -> new StatementTransformation<'T> (this)
+            NamespaceTransformation      = fun this -> new NamespaceTransformation<'T> (this)
+        }
+        QsSyntaxTreeTransformation(state, init)
+
+and ExpressionTypeTransformation<'T>(parent) = 
+    member this.Parent : QsSyntaxTreeTransformation<'T> = parent
+
+and ExpressionKindTransformation<'T >(parent) = 
+    member this.Parent : QsSyntaxTreeTransformation<'T> = parent
         
-and ExpressionTransformation<'T when 'T :> QsSyntaxTreeTransformation>() = 
+and ExpressionTransformation<'T>(parent) = 
+    member this.Parent : QsSyntaxTreeTransformation<'T> = parent
 
-    let mutable _Parent : 'T option = None
-    member this.Parent 
-        with get () = _Parent.Value
-        and internal set value = _Parent <- Some value
+and StatementKindTransformation<'T>(parent) = 
+    member this.Parent : QsSyntaxTreeTransformation<'T> = parent
 
-and StatementKindTransformation<'T when 'T :> QsSyntaxTreeTransformation>() = 
+and StatementTransformation<'T>(parent) = 
+    member this.Parent : QsSyntaxTreeTransformation<'T> = parent
 
-    let mutable _Parent : 'T option = None
-    member this.Parent 
-        with get () = _Parent.Value
-        and internal set value = _Parent <- Some value
-
-and StatementTransformation<'T when 'T :> QsSyntaxTreeTransformation>() = 
-
-    let mutable _Parent : 'T option = None
-    member this.Parent 
-        with get () = _Parent.Value
-        and internal set value = _Parent <- Some value
-
-and NamespaceTransformation<'T when 'T :> QsSyntaxTreeTransformation>() = 
-
-    let mutable _Parent : 'T option = None
-    member this.Parent 
-        with get () = _Parent.Value
-        and internal set value = _Parent <- Some value
+and NamespaceTransformation<'T>(parent) = 
+    member this.Parent : QsSyntaxTreeTransformation<'T> = parent
 
 
-and QsSyntaxTreeTransformation private (dummy) = 
-
-    let mutable _ExpressionTypeTransformation = new ExpressionTypeTransformation<_> ()
-    let mutable _ExpressionKindTransformation = new ExpressionKindTransformation<_> ()
-    let mutable _ExpressionTransformation = new ExpressionTransformation<_> ()
-    let mutable _StatementKindTransformation  = new StatementKindTransformation<_> ()
-    let mutable _StatementTransformation = new StatementTransformation<_> ()
-    let mutable _NamespaceTransformation = new NamespaceTransformation<_> ()
-
-    member this.ExpressionTypeTransformation
-        with get () = _ExpressionTypeTransformation
-        and private set t = 
-            _ExpressionTypeTransformation <- t
-            t.Parent <- this
-
-    member this.ExpressionKindTransformation 
-        with get () = _ExpressionKindTransformation
-        and private set t = 
-            _ExpressionKindTransformation <- t
-            t.Parent <- this
-
-    member this.ExpressionTransformation 
-        with get () = _ExpressionTransformation
-        and private set t = 
-            _ExpressionTransformation <- t
-            t.Parent <- this
-
-    member this.StatementKindTransformation 
-        with get () = _StatementKindTransformation
-        and private set t = 
-            _StatementKindTransformation <- t
-            t.Parent <- this
-
-    member this.StatementTransformation
-        with get () = _StatementTransformation
-        and private set t = 
-            _StatementTransformation <- t
-            t.Parent <- this
-
-    member this.NamespaceTransformation 
-        with get () = _NamespaceTransformation
-        and private set t = 
-            _NamespaceTransformation <- t
-            t.Parent <- this
-
-    new() as this = 
-        let foo = ()
-        QsSyntaxTreeTransformation(0) then 
-            this.ExpressionTypeTransformation.Parent <- this
-            this.ExpressionKindTransformation.Parent <- this
-            this.ExpressionTransformation.Parent <- this
-            this.StatementKindTransformation.Parent <- this
-            this.StatementTransformation.Parent <- this
-            this.NamespaceTransformation.Parent <- this
+and QsSyntaxTreeTransformationInitialization<'T> = {
+    ExpressionTypeTransformation : QsSyntaxTreeTransformation<'T> -> ExpressionTypeTransformation<'T>
+    ExpressionKindTransformation : QsSyntaxTreeTransformation<'T> -> ExpressionKindTransformation<'T>
+    ExpressionTransformation : QsSyntaxTreeTransformation<'T> -> ExpressionTransformation<'T>
+    StatementKindTransformation : QsSyntaxTreeTransformation<'T> -> StatementKindTransformation<'T>
+    StatementTransformation : QsSyntaxTreeTransformation<'T> -> StatementTransformation<'T>
+    NamespaceTransformation : QsSyntaxTreeTransformation<'T> -> NamespaceTransformation<'T>
+}
 

--- a/src/QsCompiler/Core/TransformationDefinition.fs
+++ b/src/QsCompiler/Core/TransformationDefinition.fs
@@ -1,0 +1,78 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace Microsoft.Quantum.QsCompiler.Transformations.Core
+
+open System.Collections.Immutable
+open System.Numerics
+open System.Runtime.CompilerServices
+open Microsoft.Quantum.QsCompiler.DataTypes
+open Microsoft.Quantum.QsCompiler.SyntaxExtensions
+open Microsoft.Quantum.QsCompiler.SyntaxTokens
+open Microsoft.Quantum.QsCompiler.SyntaxTree
+open System
+
+type private ExpressionKind = QsExpressionKind<TypedExpression,Identifier,ResolvedType>
+type private ExpressionType = QsTypeKind<ResolvedType, UserDefinedType, QsTypeParameter, CallableInformation>
+    
+
+type ExpressionTypeTransformation<'T when 'T :> QsSyntaxTreeTransformation>() = 
+
+    let mutable _Parent : 'T option = None
+    member this.Parent 
+        with get () = _Parent.Value
+        and internal set value = _Parent <- Some value
+
+and ExpressionKindTransformation<'T when 'T :> QsSyntaxTreeTransformation>() = 
+
+    let mutable _Parent : 'T option = None
+    member this.Parent 
+        with get () = _Parent.Value
+        and internal set value = _Parent <- Some value
+        
+and ExpressionTransformation<'T when 'T :> QsSyntaxTreeTransformation>() = 
+
+    let mutable _Parent : 'T option = None
+    member this.Parent 
+        with get () = _Parent.Value
+        and internal set value = _Parent <- Some value
+
+and StatementKindTransformation<'T when 'T :> QsSyntaxTreeTransformation>() = 
+
+    let mutable _Parent : 'T option = None
+    member this.Parent 
+        with get () = _Parent.Value
+        and internal set value = _Parent <- Some value
+
+and StatementTransformation<'T when 'T :> QsSyntaxTreeTransformation>() = 
+
+    let mutable _Parent : 'T option = None
+    member this.Parent 
+        with get () = _Parent.Value
+        and internal set value = _Parent <- Some value
+
+and NamespaceTransformation<'T when 'T :> QsSyntaxTreeTransformation>() = 
+
+    let mutable _Parent : 'T option = None
+    member this.Parent 
+        with get () = _Parent.Value
+        and internal set value = _Parent <- Some value
+
+
+and QsSyntaxTreeTransformation private (dummy) = 
+
+    member val ExpressionTypeTransformation = new ExpressionTypeTransformation<_> ()
+    member val ExpressionKindTransformation = new ExpressionKindTransformation<_> ()
+    member val ExpressionTransformation = new ExpressionTransformation<_> ()
+    member val StatementKindTransformation  = new StatementKindTransformation<_> ()
+    member val StatementTransformation = new StatementTransformation<_> ()
+    member val NamespaceTransformation = new NamespaceTransformation<_> ()
+
+    new() as this = QsSyntaxTreeTransformation(0) then 
+        this.ExpressionTypeTransformation.Parent <- this
+        this.ExpressionKindTransformation.Parent <- this
+        this.ExpressionTransformation.Parent <- this
+        this.StatementKindTransformation.Parent <- this
+        this.StatementTransformation.Parent <- this
+        this.NamespaceTransformation.Parent <- this
+

--- a/src/QsCompiler/Core/TransformationDefinition.fs
+++ b/src/QsCompiler/Core/TransformationDefinition.fs
@@ -77,6 +77,12 @@ and ExpressionTypeTransformation<'T> internal (parentTransformation) =
         and private set value = _Transformation <- Some value
 
     new (parentTransformation : QsSyntaxTreeTransformation<'T>) = ExpressionTypeTransformation<'T>(Some parentTransformation)
+    new (sharedInternalState : 'T) as this = 
+        ExpressionTypeTransformation<'T>(None) then
+            this.Transformation <- { 
+                new QsSyntaxTreeTransformation<'T>(sharedInternalState) with
+                    override parent.NewExpressionTypeTransformation () = this
+            }
 
 
 and ExpressionKindTransformation<'T> internal (parentTransformation) = 
@@ -88,6 +94,12 @@ and ExpressionKindTransformation<'T> internal (parentTransformation) =
         and private set value = _Transformation <- Some value
 
     new (parentTransformation : QsSyntaxTreeTransformation<'T>) = ExpressionKindTransformation<'T>(Some parentTransformation)
+    new (sharedInternalState : 'T) as this = 
+        ExpressionKindTransformation<'T>(None) then
+            this.Transformation <- { 
+                new QsSyntaxTreeTransformation<'T>(sharedInternalState) with
+                    override parent.NewExpressionKindTransformation () = this
+            }
     
     override this.ExpressionTransformation ex = this.Transformation.Expressions.Transform ex
     override this.TypeTransformation t = this.Transformation.Types.Transform t
@@ -102,6 +114,12 @@ and ExpressionTransformation<'T> internal (parentTransformation) =
         and private set value = _Transformation <- Some value
 
     new (parentTransformation : QsSyntaxTreeTransformation<'T>) = ExpressionTransformation<'T>(Some parentTransformation)
+    new (sharedInternalState : 'T) as this = 
+        ExpressionTransformation<'T>(None) then
+            this.Transformation <- { 
+                new QsSyntaxTreeTransformation<'T>(sharedInternalState) with
+                    override parent.NewExpressionTransformation () = this
+            }
 
     override this.Kind = upcast this.Transformation.ExpressionKinds
     override this.Type = upcast this.Transformation.Types
@@ -116,6 +134,12 @@ and StatementKindTransformation<'T> internal (parentTransformation) =
         and private set value = _Transformation <- Some value
 
     new (parentTransformation : QsSyntaxTreeTransformation<'T>) = StatementKindTransformation<'T>(Some parentTransformation)
+    new (sharedInternalState : 'T) as this = 
+        StatementKindTransformation<'T>(None) then
+            this.Transformation <- { 
+                new QsSyntaxTreeTransformation<'T>(sharedInternalState) with
+                    override parent.NewStatementKindTransformation () = this
+            }
 
     override this.ScopeTransformation scope = this.Transformation.Statements.Transform scope
     override this.ExpressionTransformation ex = this.Transformation.Expressions.Transform ex
@@ -128,6 +152,12 @@ and StatementTransformation<'T> internal (parentTransformation) =
     let mutable _Transformation : QsSyntaxTreeTransformation<'T> option = parentTransformation
 
     new (parentTransformation : QsSyntaxTreeTransformation<'T>) = StatementTransformation<'T>(Some parentTransformation)
+    new (sharedInternalState : 'T) as this = 
+        StatementTransformation<'T>(None) then
+            this.Transformation <- { 
+                new QsSyntaxTreeTransformation<'T>(sharedInternalState) with
+                    override parent.NewStatementTransformation () = this
+            }
 
     member this.Transformation 
         with get () = _Transformation.Value
@@ -142,6 +172,12 @@ and NamespaceTransformation<'T> internal (parentTransformation) =
     let mutable _Transformation : QsSyntaxTreeTransformation<'T> option = parentTransformation
 
     new (parentTransformation : QsSyntaxTreeTransformation<'T>) = NamespaceTransformation<'T>(Some parentTransformation)
+    new (sharedInternalState : 'T) as this = 
+        NamespaceTransformation<'T>(None) then
+            this.Transformation <- { 
+                new QsSyntaxTreeTransformation<'T>(sharedInternalState) with
+                    override parent.NewNamespaceTransformation () = this
+            }
 
     member this.Transformation 
         with get () = _Transformation.Value

--- a/src/QsCompiler/Core/TransformationDefinition.fs
+++ b/src/QsCompiler/Core/TransformationDefinition.fs
@@ -4,7 +4,7 @@
 namespace Microsoft.Quantum.QsCompiler.Transformations.Core
     
 
-type QsSyntaxTreeTransformation<'T> (state : 'T, dummy) =     
+type QsSyntaxTreeTransformation<'T> private (state : 'T, dummy) =     
 
     let mutable _Types           = new ExpressionTypeTransformation<'T>()
     let mutable _ExpressionKinds = new ExpressionKindTransformation<'T>() 
@@ -68,90 +68,90 @@ type QsSyntaxTreeTransformation<'T> (state : 'T, dummy) =
             this.Namespaces      <- this.NewNamespaceTransformation()
         
 
-and ExpressionTypeTransformation<'T> private (parent) = 
+and ExpressionTypeTransformation<'T> private (parentTransformation) = 
     inherit ExpressionTypeTransformation()
-    let mutable _Parent : QsSyntaxTreeTransformation<'T> option = parent
+    let mutable _Transformation : QsSyntaxTreeTransformation<'T> option = parentTransformation
 
-    member this.Parent 
-        with get () = _Parent.Value
-        and private set value = _Parent <- Some value
+    member this.Transformation 
+        with get () = _Transformation.Value
+        and private set value = _Transformation <- Some value
 
     internal new() = ExpressionTypeTransformation<'T>(None)
-    new (parent : QsSyntaxTreeTransformation<'T>) = ExpressionTypeTransformation<'T>(Some parent)
+    new (parentTransformation : QsSyntaxTreeTransformation<'T>) = ExpressionTypeTransformation<'T>(Some parentTransformation)
 
-and ExpressionKindTransformation<'T> private (parent) = 
+and ExpressionKindTransformation<'T> private (parentTransformation) = 
     inherit ExpressionKindTransformation()
-    let mutable _Parent : QsSyntaxTreeTransformation<'T> option = parent
+    let mutable _Transformation : QsSyntaxTreeTransformation<'T> option = parentTransformation
 
-    member this.Parent 
-        with get () = _Parent.Value
-        and private set value = _Parent <- Some value
+    member this.Transformation 
+        with get () = _Transformation.Value
+        and private set value = _Transformation <- Some value
 
     internal new() = ExpressionKindTransformation<'T>(None)
-    new (parent : QsSyntaxTreeTransformation<'T>) = ExpressionKindTransformation<'T>(Some parent)
+    new (parentTransformation : QsSyntaxTreeTransformation<'T>) = ExpressionKindTransformation<'T>(Some parentTransformation)
     
-    override this.ExpressionTransformation ex = this.Parent.Expressions.Transform ex
-    override this.TypeTransformation t = this.Parent.Types.Transform t
+    override this.ExpressionTransformation ex = this.Transformation.Expressions.Transform ex
+    override this.TypeTransformation t = this.Transformation.Types.Transform t
 
     
-and ExpressionTransformation<'T> private (parent) = 
+and ExpressionTransformation<'T> private (parentTransformation) = 
     inherit ExpressionTransformation()
-    let mutable _Parent : QsSyntaxTreeTransformation<'T> option = parent
+    let mutable _Transformation : QsSyntaxTreeTransformation<'T> option = parentTransformation
 
-    member this.Parent 
-        with get () = _Parent.Value
-        and private set value = _Parent <- Some value
+    member this.Transformation 
+        with get () = _Transformation.Value
+        and private set value = _Transformation <- Some value
 
     internal new() = ExpressionTransformation<'T>(None)
-    new (parent : QsSyntaxTreeTransformation<'T>) = ExpressionTransformation<'T>(Some parent)
+    new (parentTransformation : QsSyntaxTreeTransformation<'T>) = ExpressionTransformation<'T>(Some parentTransformation)
 
-    override this.Kind = upcast this.Parent.ExpressionKinds
-    override this.Type = upcast this.Parent.Types
+    override this.Kind = upcast this.Transformation.ExpressionKinds
+    override this.Type = upcast this.Transformation.Types
 
 
-and StatementKindTransformation<'T> private (parent) = 
+and StatementKindTransformation<'T> private (parentTransformation) = 
     inherit StatementKindTransformation()
-    let mutable _Parent : QsSyntaxTreeTransformation<'T> option = parent
+    let mutable _Transformation : QsSyntaxTreeTransformation<'T> option = parentTransformation
 
-    member this.Parent 
-        with get () = _Parent.Value
-        and private set value = _Parent <- Some value
+    member this.Transformation 
+        with get () = _Transformation.Value
+        and private set value = _Transformation <- Some value
 
     internal new() = StatementKindTransformation<'T>(None)
-    new (parent : QsSyntaxTreeTransformation<'T>) = StatementKindTransformation<'T>(Some parent)
+    new (parentTransformation : QsSyntaxTreeTransformation<'T>) = StatementKindTransformation<'T>(Some parentTransformation)
 
-    override this.ScopeTransformation scope = this.Parent.Statements.Transform scope
-    override this.ExpressionTransformation ex = this.Parent.Expressions.Transform ex
-    override this.TypeTransformation t = this.Parent.Types.Transform t
-    override this.LocationTransformation loc = this.Parent.Namespaces.onLocation loc
+    override this.ScopeTransformation scope = this.Transformation.Statements.Transform scope
+    override this.ExpressionTransformation ex = this.Transformation.Expressions.Transform ex
+    override this.TypeTransformation t = this.Transformation.Types.Transform t
+    override this.LocationTransformation loc = this.Transformation.Namespaces.onLocation loc
 
 
-and StatementTransformation<'T> private (parent) = 
+and StatementTransformation<'T> private (parentTransformation) = 
     inherit ScopeTransformation()
-    let mutable _Parent : QsSyntaxTreeTransformation<'T> option = parent
+    let mutable _Transformation : QsSyntaxTreeTransformation<'T> option = parentTransformation
 
     internal new() = StatementTransformation<'T>(None)
-    new (parent : QsSyntaxTreeTransformation<'T>) = StatementTransformation<'T>(Some parent)
+    new (parentTransformation : QsSyntaxTreeTransformation<'T>) = StatementTransformation<'T>(Some parentTransformation)
 
-    member this.Parent 
-        with get () = _Parent.Value
-        and private set value = _Parent <- Some value
+    member this.Transformation 
+        with get () = _Transformation.Value
+        and private set value = _Transformation <- Some value
 
-    override this.Expression = upcast this.Parent.Expressions
-    override this.StatementKind = upcast this.Parent.StatementKinds
+    override this.Expression = upcast this.Transformation.Expressions
+    override this.StatementKind = upcast this.Transformation.StatementKinds
 
 
-and NamespaceTransformation<'T> private (parent) = 
+and NamespaceTransformation<'T> private (parentTransformation) = 
     inherit SyntaxTreeTransformation()
-    let mutable _Parent : QsSyntaxTreeTransformation<'T> option = parent
+    let mutable _Transformation : QsSyntaxTreeTransformation<'T> option = parentTransformation
 
     internal new() = NamespaceTransformation<'T>(None)
-    new (parent : QsSyntaxTreeTransformation<'T>) = NamespaceTransformation<'T>(Some parent)
+    new (parentTransformation : QsSyntaxTreeTransformation<'T>) = NamespaceTransformation<'T>(Some parentTransformation)
 
-    member this.Parent 
-        with get () = _Parent.Value
-        and private set value = _Parent <- Some value
+    member this.Transformation 
+        with get () = _Transformation.Value
+        and private set value = _Transformation <- Some value
 
-    override this.Scope = upcast this.Parent.Statements
+    override this.Scope = upcast this.Transformation.Statements
 
 

--- a/src/QsCompiler/SyntaxProcessor/StatementVerification.fs
+++ b/src/QsCompiler/SyntaxProcessor/StatementVerification.fs
@@ -266,12 +266,12 @@ let NewConjugation (outer : QsPositionedBlock, inner : QsPositionedBlock) =
         | Value loc -> loc
     let usedInOuter = 
         let accumulate = new AccumulateIdentifiers()
-        accumulate.Transform outer.Body |> ignore
-        accumulate.UsedLocalVariables
+        accumulate.Statements.Transform outer.Body |> ignore
+        accumulate.InternalState.UsedLocalVariables
     let updatedInInner = 
         let accumulate = new AccumulateIdentifiers()
-        accumulate.Transform inner.Body |> ignore
-        accumulate.ReassignedVariables
+        accumulate.Statements.Transform inner.Body |> ignore
+        accumulate.InternalState.ReassignedVariables
     let updateErrs = 
         updatedInInner |> Seq.filter (fun updated -> usedInOuter.Contains updated.Key) |> Seq.collect id
         |> Seq.map (fun loc -> (loc.Offset, loc.Range |> QsCompilerDiagnostic.Error (ErrorCode.InvalidReassignmentInApplyBlock, []))) |> Seq.toArray

--- a/src/QsCompiler/Tests.Compiler/RegexTests.fs
+++ b/src/QsCompiler/Tests.Compiler/RegexTests.fs
@@ -87,19 +87,19 @@ let ``Strip unique variable name resolution`` () =
     |> List.iter Assert.Equal
 
     origNames
-    |> List.map NameResolution.GenerateUniqueName
-    |> List.map (fun unique -> unique, NameResolution.GenerateUniqueName unique)
+    |> List.map NameResolution.InternalState.GenerateUniqueName
+    |> List.map (fun unique -> unique, NameResolution.InternalState.GenerateUniqueName unique)
     |> List.map (fun (unique, twiceWrapped) -> unique, NameResolution.StripUniqueName twiceWrapped)
     |> List.iter Assert.Equal
 
     origNames
-    |> List.map (fun var -> var, NameResolution.GenerateUniqueName var)
-    |> List.map (fun (var, unique) -> var, NameResolution.GenerateUniqueName unique)
+    |> List.map (fun var -> var, NameResolution.InternalState.GenerateUniqueName var)
+    |> List.map (fun (var, unique) -> var, NameResolution.InternalState.GenerateUniqueName unique)
     |> List.map (fun (var, twiceWrapped) -> var, NameResolution.StripUniqueName twiceWrapped)
     |> List.map (fun (var, unique) -> var, NameResolution.StripUniqueName unique)
     |> List.iter Assert.Equal
 
     origNames
-    |> List.map (fun var -> var, NameResolution.GenerateUniqueName var)
+    |> List.map (fun var -> var, NameResolution.InternalState.GenerateUniqueName var)
     |> List.map (fun (var, unique) -> var, NameResolution.StripUniqueName unique)
     |> List.iter Assert.Equal

--- a/src/QsCompiler/Tests.Compiler/TestCases/ExecutionTests/LoggingBasedTests.qs
+++ b/src/QsCompiler/Tests.Compiler/TestCases/ExecutionTests/LoggingBasedTests.qs
@@ -33,10 +33,12 @@ namespace Microsoft.Quantum.Testing.ExecutionTests {
             ULog("V1");
 
             within {
+                let dummy = 0;
                 ULog("U3");
                 ULog("V3");
             }
             apply {
+                let dummy = 0;
                 ULog("Core3");
             }
         }

--- a/src/QsCompiler/Transformations/BasicTransformations.cs
+++ b/src/QsCompiler/Transformations/BasicTransformations.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Quantum.QsCompiler.Transformations.BasicTransformations
     {
         public class TransformationState
         {
-            internal readonly HashSet<NonNullable<string>> SourceFiles = 
+            internal readonly HashSet<NonNullable<string>> SourceFiles =
                 new HashSet<NonNullable<string>>();
         }
 
@@ -36,7 +36,7 @@ namespace Microsoft.Quantum.QsCompiler.Transformations.BasicTransformations
 
         /// <summary>
         /// Returns a hash set containing all source files in the given namespaces.
-        /// Throws an ArgumentNullException if the given sequence or any of the given namespaces is null. 
+        /// Throws an ArgumentNullException if the given sequence or any of the given namespaces is null.
         /// </summary>
         public static ImmutableHashSet<NonNullable<string>> Apply(IEnumerable<QsNamespace> namespaces)
         {
@@ -48,7 +48,7 @@ namespace Microsoft.Quantum.QsCompiler.Transformations.BasicTransformations
 
         /// <summary>
         /// Returns a hash set containing all source files in the given namespace(s).
-        /// Throws an ArgumentNullException if any of the given namespaces is null. 
+        /// Throws an ArgumentNullException if any of the given namespaces is null.
         /// </summary>
         public static ImmutableHashSet<NonNullable<string>> Apply(params QsNamespace[] namespaces) =>
             Apply((IEnumerable<QsNamespace>)namespaces);
@@ -81,20 +81,20 @@ namespace Microsoft.Quantum.QsCompiler.Transformations.BasicTransformations
 
     /// <summary>
     /// Calling Transform on a syntax tree returns a new tree that only contains the type and callable declarations
-    /// that are defined in the source file with the identifier given upon initialization. 
-    /// The transformation also ensures that the elements in each namespace are ordered according to 
+    /// that are defined in the source file with the identifier given upon initialization.
+    /// The transformation also ensures that the elements in each namespace are ordered according to
     /// the location at which they are defined in the file. Auto-generated declarations will be ordered alphabetically.
     /// </summary>
     public class FilterBySourceFile :
         QsSyntaxTreeTransformation<FilterBySourceFile.TransformationState>
-    { 
-        public class TransformationState 
+    {
+        public class TransformationState
         {
             internal readonly Func<NonNullable<string>, bool> Predicate;
             internal readonly List<(int?, QsNamespaceElement)> Elements =
                 new List<(int?, QsNamespaceElement)>();
 
-            public TransformationState(Func<NonNullable<string>, bool> predicate) => 
+            public TransformationState(Func<NonNullable<string>, bool> predicate) =>
                 this.Predicate = predicate ?? throw new ArgumentNullException(nameof(predicate));
         }
 
@@ -123,9 +123,9 @@ namespace Microsoft.Quantum.QsCompiler.Transformations.BasicTransformations
         }
 
 
-        // helper classes 
+        // helper classes
 
-        public class NamespaceTransformation : 
+        public class NamespaceTransformation :
             NamespaceTransformation<TransformationState>
         {
             public NamespaceTransformation(QsSyntaxTreeTransformation<TransformationState> parent)
@@ -141,7 +141,7 @@ namespace Microsoft.Quantum.QsCompiler.Transformations.BasicTransformations
                 return t;
             }
 
-            public override QsCallable onCallableImplementation(QsCallable c) 
+            public override QsCallable onCallableImplementation(QsCallable c)
             {
                 if (this.Transformation.InternalState.Predicate(c.SourceFile))
                 { this.Transformation.InternalState.Elements.Add((c.Location.IsValue ? c.Location.Item.Offset.Item1 : (int?)null, QsNamespaceElement.NewQsCallable(c))); }
@@ -168,10 +168,10 @@ namespace Microsoft.Quantum.QsCompiler.Transformations.BasicTransformations
     // scope transformations
 
     /// <summary>
-    /// Class that allows to transform scopes by keeping only statements whose expressions satisfy a certain criterion. 
-    /// Calling Transform will build a new Scope that contains only the statements for which the fold of a given condition 
-    /// over all contained expressions evaluates to true. 
-    /// If evaluateOnSubexpressions is set to true, the fold is evaluated on all subexpressions as well. 
+    /// Class that allows to transform scopes by keeping only statements whose expressions satisfy a certain criterion.
+    /// Calling Transform will build a new Scope that contains only the statements for which the fold of a given condition
+    /// over all contained expressions evaluates to true.
+    /// If evaluateOnSubexpressions is set to true, the fold is evaluated on all subexpressions as well.
     /// </summary>
     public class SelectByFoldingOverExpressions<K> :
         ScopeTransformation<K, FoldOverExpressions<bool>>
@@ -197,7 +197,7 @@ namespace Microsoft.Quantum.QsCompiler.Transformations.BasicTransformations
             this.Seed = seed;
         }
 
-        protected new Core.StatementKindTransformation _StatementKind => base.StatementKind; 
+        protected new Core.StatementKindTransformation _StatementKind => base.StatementKind;
         public override Core.StatementKindTransformation StatementKind
         {
             get
@@ -219,7 +219,7 @@ namespace Microsoft.Quantum.QsCompiler.Transformations.BasicTransformations
             var statements = new List<QsStatement>();
             foreach (var statement in scope.Statements)
             {
-                // StatementKind.Transform sets a new Subselector that walks all expressions contained in statement, 
+                // StatementKind.Transform sets a new Subselector that walks all expressions contained in statement,
                 // and sets its satisfiesCondition to true if one of them satisfies the condition given on initialization
                 var transformed = this.onStatement(statement);
                 if (this.SubSelector.SatisfiesCondition) statements.Add(transformed);
@@ -229,10 +229,10 @@ namespace Microsoft.Quantum.QsCompiler.Transformations.BasicTransformations
     }
 
     /// <summary>
-    /// Class that allows to transform scopes by keeping only statements that contain certain expressions. 
-    /// Calling Transform will build a new Scope that contains only the statements 
-    /// which contain an expression or subexpression (only if evaluateOnSubexpressions is set to true) 
-    /// that satisfies the condition given on initialization. 
+    /// Class that allows to transform scopes by keeping only statements that contain certain expressions.
+    /// Calling Transform will build a new Scope that contains only the statements
+    /// which contain an expression or subexpression (only if evaluateOnSubexpressions is set to true)
+    /// that satisfies the condition given on initialization.
     /// </summary>
     public class SelectByAnyContainedExpression<K> :
         SelectByFoldingOverExpressions<K>
@@ -250,8 +250,8 @@ namespace Microsoft.Quantum.QsCompiler.Transformations.BasicTransformations
     }
 
     /// <summary>
-    /// Class that allows to transform scopes by keeping only statements whose expressions satisfy a certain criterion. 
-    /// Calling Transform will build a new Scope that contains only the statements 
+    /// Class that allows to transform scopes by keeping only statements whose expressions satisfy a certain criterion.
+    /// Calling Transform will build a new Scope that contains only the statements
     /// for which all contained expressions or subexpressions satisfy the condition given on initialization.
     /// Note that subexpressions will only be verified if evaluateOnSubexpressions is set to true (default value).
     /// </summary>
@@ -274,23 +274,23 @@ namespace Microsoft.Quantum.QsCompiler.Transformations.BasicTransformations
     // expression transformations
 
     /// <summary>
-    /// Class that evaluates a fold on Transform. 
-    /// If recur is set to true on initialization (default value), 
+    /// Class that evaluates a fold on Transform.
+    /// If recur is set to true on initialization (default value),
     /// the fold function given on initialization is applied to all subexpressions as well as the expression itself -
-    /// i.e. the fold it take starting on inner expressions (from the inside out). 
-    /// Otherwise the set Action is only applied to the expression itself. 
-    /// The result of the fold is accessible via the Result property. 
+    /// i.e. the fold it take starting on inner expressions (from the inside out).
+    /// Otherwise the set Action is only applied to the expression itself.
+    /// The result of the fold is accessible via the Result property.
     /// </summary>
     public class FoldOverExpressions<T> :
         ExpressionTransformation<ExpressionKindTransformation<FoldOverExpressions<T>>>
     {
         private static readonly Func<
-            ExpressionTransformation<ExpressionKindTransformation<FoldOverExpressions<T>>, Core.ExpressionTypeTransformation>, 
+            ExpressionTransformation<ExpressionKindTransformation<FoldOverExpressions<T>>, Core.ExpressionTypeTransformation>,
             ExpressionKindTransformation<FoldOverExpressions<T>>> InitializeKind =
             e => new ExpressionKindTransformation<FoldOverExpressions<T>>(e as FoldOverExpressions<T>);
 
         internal readonly bool recur;
-        public readonly Func<TypedExpression, T, T> Fold; 
+        public readonly Func<TypedExpression, T, T> Fold;
         public T Result { get; set; }
 
         public FoldOverExpressions(Func<TypedExpression, T, T> fold, T seed, bool recur = true) :

--- a/src/QsCompiler/Transformations/CodeTransformations.cs
+++ b/src/QsCompiler/Transformations/CodeTransformations.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Quantum.QsCompiler
         {
             // Since we are pulling purely classical statements up, we are potentially changing the order of declarations.
             // We therefore need to generate unique variable names before reordering the statements.
-            scope = new UniqueVariableNames().Transform(scope);
+            scope = new UniqueVariableNames().Statements.Transform(scope);
             scope = ApplyFunctorToOperationCalls.ApplyAdjoint(scope);
             scope = new ReverseOrderOfOperationCalls().Transform(scope);
             return StripPositionInfo.Apply(scope);

--- a/src/QsCompiler/Transformations/Conjugations.cs
+++ b/src/QsCompiler/Transformations/Conjugations.cs
@@ -55,11 +55,11 @@ namespace Microsoft.Quantum.QsCompiler.Transformations.Conjugations
         : ScopeTransformation<StatementKindTransformation<InlineConjugationStatements>, NoExpressionTransformations>
     {
         private Func<QsScope, QsScope> ResolveNames;
-        internal void Reset() => this.ResolveNames = new UniqueVariableNames().Transform;
+        internal void Reset() => this.ResolveNames = new UniqueVariableNames().Statements.Transform;
 
         public InlineConjugationStatements()
             : base(s => new StatementKindTransformation<InlineConjugationStatements>(s as InlineConjugationStatements), new NoExpressionTransformations()) =>
-            this.ResolveNames = new UniqueVariableNames().Transform;
+            this.ResolveNames = new UniqueVariableNames().Statements.Transform;
 
         public override QsScope Transform(QsScope scope)
         {

--- a/src/QsCompiler/Transformations/SearchAndReplace.cs
+++ b/src/QsCompiler/Transformations/SearchAndReplace.cs
@@ -229,7 +229,7 @@ namespace Microsoft.Quantum.QsCompiler.Transformations.SearchAndReplace
             public override QsNullable<QsLocation> onLocation(QsNullable<QsLocation> loc)
             {
                 this.Transformation.InternalState.CurrentLocation = loc.IsValue ? loc.Item : null;
-                return base.onLocation(loc);
+                return loc;
             }
         }
 

--- a/src/QsCompiler/Transformations/SearchAndReplace.cs
+++ b/src/QsCompiler/Transformations/SearchAndReplace.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Quantum.QsCompiler.Transformations.SearchAndReplace
 
     /// <summary>
     /// Class that allows to walk the syntax tree and find all locations where a certain identifier occurs.
-    /// If a set of source file names is given on initialization, the search is limited to callables and specializations in those files. 
+    /// If a set of source file names is given on initialization, the search is limited to callables and specializations in those files.
     /// </summary>
     public class IdentifierReferences
          : QsSyntaxTreeTransformation<IdentifierReferences.TransformationState>
@@ -76,9 +76,9 @@ namespace Microsoft.Quantum.QsCompiler.Transformations.SearchAndReplace
 
         /// <summary>
         /// Class used to track the internal state for a transformation that finds all locations where a certain identifier occurs.
-        /// If no source file is specified prior to transformation, its name is set to the empty string. 
+        /// If no source file is specified prior to transformation, its name is set to the empty string.
         /// The DeclarationOffset needs to be set prior to transformation, and in particular after defining a source file.
-        /// If no defaultOffset is specified upon initialization then only the locations of occurrences within statements are logged. 
+        /// If no defaultOffset is specified upon initialization then only the locations of occurrences within statements are logged.
         /// </summary>
         public class TransformationState
         {
@@ -95,8 +95,8 @@ namespace Microsoft.Quantum.QsCompiler.Transformations.SearchAndReplace
                 this.RelevantSourseFiles?.Contains(source) ?? true;
 
 
-            internal TransformationState(Func<Identifier, bool> trackId, 
-                QsLocation defaultOffset = null, IImmutableSet<NonNullable<string>> limitToSourceFiles = null) 
+            internal TransformationState(Func<Identifier, bool> trackId,
+                QsLocation defaultOffset = null, IImmutableSet<NonNullable<string>> limitToSourceFiles = null)
             {
                 this.TrackIdentifier = trackId ?? throw new ArgumentNullException(nameof(trackId));
                 this.RelevantSourseFiles = limitToSourceFiles;
@@ -166,12 +166,12 @@ namespace Microsoft.Quantum.QsCompiler.Transformations.SearchAndReplace
         public override StatementTransformation<TransformationState> NewStatementTransformation() =>
             new StatementTransformation(this);
 
-        public override NamespaceTransformation<TransformationState> NewNamespaceTransformation() => 
+        public override NamespaceTransformation<TransformationState> NewNamespaceTransformation() =>
             new NamespaceTransformation(this);
 
 
         // static methods for convenience
-        
+
         public static IEnumerable<Location> Find(NonNullable<string> idName, QsScope scope,
             NonNullable<string> sourceFile, Tuple<int, int> rootLoc)
         {
@@ -288,9 +288,9 @@ namespace Microsoft.Quantum.QsCompiler.Transformations.SearchAndReplace
     // routines for finding all symbols/identifiers
 
     /// <summary>
-    /// Generates a look-up for all used local variables and their location in any of the transformed scopes, 
-    /// as well as one for all local variables reassigned in any of the transformed scopes and their locations. 
-    /// Note that the location information is relative to the root node, i.e. the start position of the containing specialization declaration. 
+    /// Generates a look-up for all used local variables and their location in any of the transformed scopes,
+    /// as well as one for all local variables reassigned in any of the transformed scopes and their locations.
+    /// Note that the location information is relative to the root node, i.e. the start position of the containing specialization declaration.
     /// </summary>
     public class AccumulateIdentifiers
          : QsSyntaxTreeTransformation<AccumulateIdentifiers.TransformationState>
@@ -303,7 +303,7 @@ namespace Microsoft.Quantum.QsCompiler.Transformations.SearchAndReplace
             private readonly List<(NonNullable<string>, QsLocation)> UpdatedLocals = new List<(NonNullable<string>, QsLocation)>();
             private readonly List<(NonNullable<string>, QsLocation)> UsedLocals = new List<(NonNullable<string>, QsLocation)>();
 
-            internal TransformationState() => 
+            internal TransformationState() =>
                 this.UpdatedExpression = new TypedExpressionWalker<TransformationState>(this.UpdatedLocal, this).Transform;
 
             public ILookup<NonNullable<string>, QsLocation> ReassignedVariables =>
@@ -342,7 +342,7 @@ namespace Microsoft.Quantum.QsCompiler.Transformations.SearchAndReplace
             new StatementTransformation(this);
 
 
-        // helper classes 
+        // helper classes
 
         private class StatementTransformation :
             StatementTransformation<TransformationState>
@@ -380,8 +380,8 @@ namespace Microsoft.Quantum.QsCompiler.Transformations.SearchAndReplace
 
     /// <summary>
     /// Upon transformation, assigns each defined variable a unique name, independent on the scope, and replaces all references to it accordingly.
-    /// The original variable name can be recovered by using the static method StripUniqueName.  
-    /// This class is *not* threadsafe. 
+    /// The original variable name can be recovered by using the static method StripUniqueName.
+    /// This class is *not* threadsafe.
     /// </summary>
     public class UniqueVariableNames
          : QsSyntaxTreeTransformation<UniqueVariableNames.TransformationState>
@@ -398,7 +398,7 @@ namespace Microsoft.Quantum.QsCompiler.Transformations.SearchAndReplace
                     : QsExpressionKind.NewIdentifier(sym, tArgs);
 
             /// <summary>
-            /// Will overwrite the dictionary entry mapping a variable name to the corresponding unique name if the key already exists. 
+            /// Will overwrite the dictionary entry mapping a variable name to the corresponding unique name if the key already exists.
             /// </summary>
             internal NonNullable<string> GenerateUniqueName(NonNullable<string> varName)
             {
@@ -464,13 +464,13 @@ namespace Microsoft.Quantum.QsCompiler.Transformations.SearchAndReplace
     // general purpose helpers
 
     /// <summary>
-    /// Upon transformation, applies the specified action to each expression and subexpression. 
-    /// The action to apply is specified upon construction, and will be applied before recurring into subexpressions. 
+    /// Upon transformation, applies the specified action to each expression and subexpression.
+    /// The action to apply is specified upon construction, and will be applied before recurring into subexpressions.
     /// </summary>
     public class TypedExpressionWalker<T> :
         Core.ExpressionTransformation<T>
     {
-        public TypedExpressionWalker(Action<TypedExpression> onExpression, QsSyntaxTreeTransformation<T> parent) 
+        public TypedExpressionWalker(Action<TypedExpression> onExpression, QsSyntaxTreeTransformation<T> parent)
             : base(parent) =>
             this.OnExpression = onExpression ?? throw new ArgumentNullException(nameof(onExpression));
 

--- a/src/QsCompiler/Transformations/SearchAndReplace.cs
+++ b/src/QsCompiler/Transformations/SearchAndReplace.cs
@@ -396,7 +396,7 @@ namespace Microsoft.Quantum.QsCompiler.Transformations.SearchAndReplace
 
         private const string Prefix = "qsVar";
         private const string OrigVarName = "origVarName";
-        private static Regex WrappedVarName = new Regex($"^__{Prefix}[0-9]*__(?<{OrigVarName}>.*)__$");
+        private static readonly Regex WrappedVarName = new Regex($"^__{Prefix}[0-9]*__(?<{OrigVarName}>.*)__$");
 
         public NonNullable<string> StripUniqueName(NonNullable<string> uniqueName)
         {

--- a/src/QsCompiler/Transformations/SearchAndReplace.cs
+++ b/src/QsCompiler/Transformations/SearchAndReplace.cs
@@ -429,7 +429,7 @@ namespace Microsoft.Quantum.QsCompiler.Transformations.SearchAndReplace
                 syms is SymbolTuple.VariableNameTuple tuple
                     ? SymbolTuple.NewVariableNameTuple(tuple.Item.Select(this.onSymbolTuple).ToImmutableArray())
                     : syms is SymbolTuple.VariableName varName
-                    ? SymbolTuple.NewVariableName(this.Parent.InternalState.GenerateUniqueName(varName.Item))
+                    ? SymbolTuple.NewVariableName(this.Transformation.InternalState.GenerateUniqueName(varName.Item))
                     : syms;
         }
 
@@ -441,7 +441,7 @@ namespace Microsoft.Quantum.QsCompiler.Transformations.SearchAndReplace
             { }
 
             public override QsExpressionKind onIdentifier(Identifier sym, QsNullable<ImmutableArray<ResolvedType>> tArgs) =>
-                this.Parent.InternalState.AdaptIdentifier(sym, tArgs);
+                this.Transformation.InternalState.AdaptIdentifier(sym, tArgs);
         }
     }
 

--- a/src/QsCompiler/Transformations/SearchAndReplace.cs
+++ b/src/QsCompiler/Transformations/SearchAndReplace.cs
@@ -9,7 +9,7 @@ using System.Text.RegularExpressions;
 using Microsoft.Quantum.QsCompiler.DataTypes;
 using Microsoft.Quantum.QsCompiler.SyntaxTokens;
 using Microsoft.Quantum.QsCompiler.SyntaxTree;
-
+using Microsoft.Quantum.QsCompiler.Transformations.Core;
 
 namespace Microsoft.Quantum.QsCompiler.Transformations.SearchAndReplace
 {
@@ -19,6 +19,20 @@ namespace Microsoft.Quantum.QsCompiler.Transformations.SearchAndReplace
 
 
     // routines for finding occurrences of symbols/identifiers
+
+    public class __IdentifierReferences__
+         : QsSyntaxTreeTransformation<__IdentifierReferences__.TransformationState>
+    {
+
+        public class TransformationState
+        {
+
+        }
+
+        public __IdentifierReferences__() :
+            base(new TransformationState())
+        { }
+    }
 
     /// <summary>
     /// Class that allows to walk the syntax tree and find all locations where a certain identifier occurs.
@@ -264,6 +278,20 @@ namespace Microsoft.Quantum.QsCompiler.Transformations.SearchAndReplace
 
     // routines for finding all symbols/identifiers
 
+    public class __AccumulateIdentifiers__
+         : QsSyntaxTreeTransformation<__AccumulateIdentifiers__.TransformationState>
+    {
+
+        public class TransformationState
+        {
+
+        }
+
+        public __AccumulateIdentifiers__() :
+            base(new TransformationState())
+        { }
+    }
+
     /// <summary>
     /// Generates a look-up for all used local variables and their location in any of the transformed scopes, 
     /// as well as one for all local variables reassigned in any of the transformed scopes and their locations. 
@@ -334,6 +362,21 @@ namespace Microsoft.Quantum.QsCompiler.Transformations.SearchAndReplace
 
 
     // routines for replacing symbols/identifiers
+
+    public class __UniqueVariableNames__
+         : QsSyntaxTreeTransformation<__UniqueVariableNames__.TransformationState>
+    {
+
+        public class TransformationState
+        { 
+        
+        }
+
+        public __UniqueVariableNames__() :
+            base(new TransformationState())
+        { }
+    }
+
 
     /// <summary>
     /// Upon transformation, assigns each defined variable a unique name, independent on the scope, and replaces all references to it accordingly.


### PR DESCRIPTION
I added a revised setup for the transformations provided in the Core project. The idea is to build all transformations on top of this setup, which in particular eliminates the C# wrapper in the transformation project. 
A syntax tree transformation is structured into the same subtransformations as now, but the shared internal state is now handled much cleaner, eliminating the need for the rather cumbersome type parametrizations on construction. Right now the actual transformation on individual nodes is still the same, with the idea to revise that slightly in a subsequent step. 
What is also still missing is a neat way to disable certain subtransformations.
So far I've migrated the transformations in SearchAndReplace, and I'll see that I can migrate some more. 