### PR TITLE
Enforce access modifiers in the symbol table

### DIFF
--- a/src/QsCompiler/CompilationManager/EditorSupport/CodeCompletion.cs
+++ b/src/QsCompiler/CompilationManager/EditorSupport/CodeCompletion.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.Quantum.QsCompiler.CompilationBuilder.DataStructures;
 using Microsoft.Quantum.QsCompiler.DataTypes;
+using Microsoft.Quantum.QsCompiler.SymbolManagement;
 using Microsoft.Quantum.QsCompiler.SyntaxProcessing;
 using Microsoft.Quantum.QsCompiler.SyntaxTokens;
 using Microsoft.Quantum.QsCompiler.SyntaxTree;
@@ -499,9 +500,9 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
             {
                 case CompletionItemKind.Function:
                 case CompletionItemKind.Constructor:
-                    var callable = compilation.GlobalSymbols.TryGetCallable(
+                    var result = compilation.GlobalSymbols.TryGetCallable(
                         data.QualifiedName, data.QualifiedName.Namespace, NonNullable<string>.New(data.SourceFile));
-                    if (callable.IsNull)
+                    if (!(result is ResolutionResult<CallableDeclarationHeader>.Found callable))
                         return null;
                     var signature = callable.Item.PrintSignature();
                     var documentation = callable.Item.Documentation.PrintSummary(useMarkdown);
@@ -510,8 +511,8 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
                     var type =
                         compilation.GlobalSymbols.TryGetType(
                             data.QualifiedName, data.QualifiedName.Namespace, NonNullable<string>.New(data.SourceFile))
-                        .Item;
-                    return type?.Documentation.PrintSummary(useMarkdown).Trim();
+                        as ResolutionResult<TypeDeclarationHeader>.Found;
+                    return type?.Item.Documentation.PrintSummary(useMarkdown).Trim();
                 default:
                     return null;
             }

--- a/src/QsCompiler/CompilationManager/TypeChecking.cs
+++ b/src/QsCompiler/CompilationManager/TypeChecking.cs
@@ -1346,19 +1346,23 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
                 // check that the declarations for the types and callables to be built from the given FragmentTrees exist in the given CompilationUnit
                 var typeRoots = roots.Where(root => root.Value.Item2.Specializations == null);
                 var typeDeclarations = typeRoots.ToImmutableDictionary(
-                    root => root.Key, root =>
+                    root => root.Key,
+                    root =>
                     {
-                        var info = compilation.GlobalSymbols.TryGetType(root.Key, root.Value.Item2.Namespace, root.Value.Item2.Source);
-                        if (info.IsNull) throw new ArgumentException("type to build is no longer present in the given NamespaceManager");
-                        return info.Item;
+                        var result = compilation.GlobalSymbols.TryGetType(root.Key, root.Value.Item2.Namespace, root.Value.Item2.Source);
+                        return result is ResolutionResult<TypeDeclarationHeader>.Found type
+                            ? type.Item
+                            : throw new ArgumentException("type to build is no longer present in the given NamespaceManager");
                     });
                 var callableRoots = roots.Where(root => root.Value.Item2.Specializations != null);
                 var callableDeclarations = callableRoots.ToImmutableDictionary(
-                    root => root.Key, root => 
+                    root => root.Key,
+                    root =>
                     {
-                        var info = compilation.GlobalSymbols.TryGetCallable(root.Key, root.Value.Item2.Namespace, root.Value.Item2.Source);
-                        if (info.IsNull) throw new ArgumentException("callable to build is no longer present in the given NamespaceManager");
-                        return info.Item;
+                        var result = compilation.GlobalSymbols.TryGetCallable(root.Key, root.Value.Item2.Namespace, root.Value.Item2.Source);
+                        return result is ResolutionResult<CallableDeclarationHeader>.Found callable
+                            ? callable.Item
+                            : throw new ArgumentException("callable to build is no longer present in the given NamespaceManager");
                     });
 
                 (QsQualifiedName, ImmutableArray<QsSpecialization>) GetSpecializations

--- a/src/QsCompiler/Core/SymbolTable.fs
+++ b/src/QsCompiler/Core/SymbolTable.fs
@@ -1423,17 +1423,25 @@ and NamespaceManager
             | Some ns -> ns.Name.Value
         finally syncRoot.ExitReadLock()
 
-    /// Returns the names of all namespaces in which a callable with the given name is declared. 
-    member this.NamespacesContainingCallable cName = 
+    /// Returns the names of all namespaces in which a callable with the given name is declared, including private and
+    /// internal declarations.
+    member this.NamespacesContainingCallable cName =
         // FIXME: we need to handle the case where a callable/type with the same qualified name is declared in several references!
+        //
+        // TODO: It may be useful to limit the results to only declarations which are accessible from a given location
+        // (e.g., for code actions in the language server).
         syncRoot.EnterReadLock()
         try let tryFindCallable (ns : Namespace) = ns.TryFindCallable cName |> QsNullable<_>.Map (fun _ -> ns.Name)
             (Namespaces.Values |> QsNullable<_>.Choose tryFindCallable).ToImmutableArray()
         finally syncRoot.ExitReadLock()
 
-    /// Returns the names of all namespaces in which a type with the given name is declared. 
-    member this.NamespacesContainingType tName = 
+    /// Returns the names of all namespaces in which a type with the given name is declared, including private and
+    /// internal declarations.
+    member this.NamespacesContainingType tName =
         // FIXME: we need to handle the case where a callable/type with the same qualified name is declared in several references!
+        //
+        // TODO: It may be useful to limit the results to only declarations which are accessible from a given location
+        // (e.g., for code actions in the language server).
         syncRoot.EnterReadLock()
         try let tryFindType (ns : Namespace) = ns.TryFindType tName |> QsNullable<_>.Map (fun _ -> ns.Name)
             (Namespaces.Values |> QsNullable<_>.Choose tryFindType).ToImmutableArray()

--- a/src/QsCompiler/Core/SymbolTable.fs
+++ b/src/QsCompiler/Core/SymbolTable.fs
@@ -22,8 +22,8 @@ open Newtonsoft.Json
 type ResolutionResult<'T> =
     /// The symbol resolved successfully.
     | Found of 'T
-    /// The symbol is ambiguous, and more than one resolution is possible. Contains the list of possible namespaces in
-    /// which the symbol could be resolved to.
+    /// An unqualified symbol is ambiguous, and it is possible to resolve it to more than one namespace. Includes the
+    /// list of possible namespaces.
     | Ambiguous of NonNullable<string> seq
     /// The symbol resolved to a declaration which is not accessible from the location referencing it.
     | Inaccessible

--- a/src/QsCompiler/DataStructures/Diagnostics.fs
+++ b/src/QsCompiler/DataStructures/Diagnostics.fs
@@ -173,6 +173,7 @@ type ErrorCode =
     | TypeConstructorOverlapWithCallable = 6004
     | UnknownType = 6005
     | AmbiguousType = 6006
+    | InaccessibleType = 6007
     | AmbiguousCallable = 6008
     | TypeSpecializationMismatch = 6009
     | SpecializationForUnknownCallable = 6010
@@ -517,6 +518,7 @@ type DiagnosticItem =
             | ErrorCode.TypeConstructorOverlapWithCallable        -> "Invalid type declaration. A function or operation with the name \"{0}\" already exists."
             | ErrorCode.UnknownType                               -> "No type with the name \"{0}\" exists in any of the open namespaces."
             | ErrorCode.AmbiguousType                             -> "Multiple open namespaces contain a type with the name \"{0}\". Use a fully qualified name instead. Open namespaces containing a type with that name are {1}."
+            | ErrorCode.InaccessibleType                          -> "The type {0} exists in an open namespace, but is not accessible from here."
             | ErrorCode.AmbiguousCallable                         -> "Multiple open namespaces contain a callable with the name \"{0}\". Use a fully qualified name instead. Open namespaces containing a callable with that name are {1}." 
             | ErrorCode.TypeSpecializationMismatch                -> "Invalid specialization declaration. The type specializations do not match the expected number of type parameters. Expecting {0} type argument(s)."
             | ErrorCode.SpecializationForUnknownCallable          -> "No callable with the name \"{0}\" exists in the current namespace. Specializations need to be declared in the same namespace as the callable they extend."

--- a/src/QsCompiler/DataStructures/Diagnostics.fs
+++ b/src/QsCompiler/DataStructures/Diagnostics.fs
@@ -200,6 +200,7 @@ type ErrorCode =
     | UnknownItemName = 6108
     | NotMarkedAsAttribute = 6109
     | InaccessibleTypeInNamespace = 6110
+    | InaccessibleCallableInNamespace = 6111
 
     | ArgumentTupleShapeMismatch = 6201
     | ArgumentTupleMismatch = 6202
@@ -546,6 +547,7 @@ type DiagnosticItem =
             | ErrorCode.UnknownItemName                           -> "The type {0} does not define an item with name \"{1}\"."
             | ErrorCode.NotMarkedAsAttribute                      -> "The type {0} is not marked as an attribute. Add \"@Attribute()\" above its declaration to indicate that it may be used as attribute."
             | ErrorCode.InaccessibleTypeInNamespace               -> "The type {0} in namespace {1} is not accessible from here."
+            | ErrorCode.InaccessibleCallableInNamespace           -> "The callable {0} in namespace {1} is not accessible from here."
                                                 
             | ErrorCode.ArgumentTupleShapeMismatch                -> "The shape of the given tuple does not match the expected type. Got an argument of type {0}, expecting one of type {1} instead."
             | ErrorCode.ArgumentTupleMismatch                     -> "The type of the given tuple does not match the expected type. Got an argument of type {0}, expecting one of type {1} instead."

--- a/src/QsCompiler/DataStructures/Diagnostics.fs
+++ b/src/QsCompiler/DataStructures/Diagnostics.fs
@@ -173,7 +173,6 @@ type ErrorCode =
     | TypeConstructorOverlapWithCallable = 6004
     | UnknownType = 6005
     | AmbiguousType = 6006
-    | InaccessibleType = 6007
     | AmbiguousCallable = 6008
     | TypeSpecializationMismatch = 6009
     | SpecializationForUnknownCallable = 6010
@@ -188,6 +187,8 @@ type ErrorCode =
     | AliasForOpenedNamespace = 6019
     | InvalidNamespaceAliasName = 6020 // i.e. the chosen alias already exists
     | ConflictInReferences = 6021
+    | InaccessibleType = 6022
+    | InaccessibleCallable = 6023
 
     | ExpectingUnqualifiedSymbol = 6101
     | ExpectingItemName = 6102
@@ -519,6 +520,7 @@ type DiagnosticItem =
             | ErrorCode.UnknownType                               -> "No type with the name \"{0}\" exists in any of the open namespaces."
             | ErrorCode.AmbiguousType                             -> "Multiple open namespaces contain a type with the name \"{0}\". Use a fully qualified name instead. Open namespaces containing a type with that name are {1}."
             | ErrorCode.InaccessibleType                          -> "The type {0} exists in an open namespace, but is not accessible from here."
+            | ErrorCode.InaccessibleCallable                      -> "The callable {0} exists in an open namespace, but is not accessible from here."
             | ErrorCode.AmbiguousCallable                         -> "Multiple open namespaces contain a callable with the name \"{0}\". Use a fully qualified name instead. Open namespaces containing a callable with that name are {1}." 
             | ErrorCode.TypeSpecializationMismatch                -> "Invalid specialization declaration. The type specializations do not match the expected number of type parameters. Expecting {0} type argument(s)."
             | ErrorCode.SpecializationForUnknownCallable          -> "No callable with the name \"{0}\" exists in the current namespace. Specializations need to be declared in the same namespace as the callable they extend."

--- a/src/QsCompiler/DataStructures/Diagnostics.fs
+++ b/src/QsCompiler/DataStructures/Diagnostics.fs
@@ -197,6 +197,7 @@ type ErrorCode =
     | UnknownTypeParameterName = 6107
     | UnknownItemName = 6108
     | NotMarkedAsAttribute = 6109
+    | InaccessibleTypeInNamespace = 6110
 
     | ArgumentTupleShapeMismatch = 6201
     | ArgumentTupleMismatch = 6202
@@ -540,6 +541,7 @@ type DiagnosticItem =
             | ErrorCode.UnknownTypeParameterName                  -> "No type parameter with the name \"{0}\" exists."
             | ErrorCode.UnknownItemName                           -> "The type {0} does not define an item with name \"{1}\"."
             | ErrorCode.NotMarkedAsAttribute                      -> "The type {0} is not marked as an attribute. Add \"@Attribute()\" above its declaration to indicate that it may be used as attribute."
+            | ErrorCode.InaccessibleTypeInNamespace               -> "The type {0} in namespace {1} is not accessible from here."
                                                 
             | ErrorCode.ArgumentTupleShapeMismatch                -> "The shape of the given tuple does not match the expected type. Got an argument of type {0}, expecting one of type {1} instead."
             | ErrorCode.ArgumentTupleMismatch                     -> "The type of the given tuple does not match the expected type. Got an argument of type {0}, expecting one of type {1} instead."

--- a/src/QsCompiler/SyntaxProcessor/SyntaxExtensions.fs
+++ b/src/QsCompiler/SyntaxProcessor/SyntaxExtensions.fs
@@ -211,13 +211,13 @@ let public CallExpressions fragmentKind =
 let private tryResolveWith resolve extract (currentNS, source) = function 
     | QsSymbolKind.Symbol sym -> 
         try resolve sym (currentNS, source) |> function
-            | Value decl, _ -> Some decl, Some sym
-            | Null, _ -> None, Some sym
+            | Found decl -> Some decl, Some sym
+            | _ -> None, Some sym
         with | :? ArgumentException -> None, Some sym
     | QsSymbolKind.QualifiedSymbol (ns, sym) ->
         try extract {Namespace = ns; Name = sym} (currentNS, source) |> function
-            | Value decl -> Some decl, Some sym
-            | Null -> None, None
+            | Found decl -> Some decl, Some sym
+            | _ -> None, None
         with | :? ArgumentException -> None, None
     | _ -> None, None
 


### PR DESCRIPTION
This PR adds checks in the symbol table so that inaccessible types/callables can't be resolved. There are also new error messages for when you try to use an inaccessible type/callable.

See #259.