### PR TITLE
Prevent use of less accessible types in more accessible declarations

### DIFF
--- a/src/QsCompiler/Core/SymbolResolution.fs
+++ b/src/QsCompiler/Core/SymbolResolution.fs
@@ -273,7 +273,7 @@ module SymbolResolution =
     /// Returns the resolved type as well as an array with diagnostics.
     /// IMPORTANT: for performance reasons does *not* verify if the given the given parent and/or source file is inconsistent with the defined callables. 
     /// May throw an ArgumentException if no namespace with the given name exists, or the given source file is not listed as source of that namespace. 
-    /// Throws a NonSupportedException if the QsType to resolve contains a MissingType. 
+    /// Throws a NotSupportedException if the QsType to resolve contains a MissingType. 
     let rec internal ResolveType (processUDT, processTypeParameter) (qsType : QsType) = 
         let resolve = ResolveType (processUDT, processTypeParameter)
         let asResolvedType t = ResolvedType.New (true, t)

--- a/src/QsCompiler/Core/SymbolTable.fs
+++ b/src/QsCompiler/Core/SymbolTable.fs
@@ -975,7 +975,7 @@ and NamespaceManager
     /// IMPORTANT: for performance reasons does *not* verify if the given the given parent and/or source file is
     /// consistent with the defined callables.
     /// May throw an exception if the given parent and/or source file is inconsistent with the defined declarations. 
-    /// Throws a NonSupportedException if the QsType to resolve contains a MissingType.
+    /// Throws a NotSupportedException if the QsType to resolve contains a MissingType.
     member this.ResolveType (parent : QsQualifiedName, tpNames : ImmutableArray<_>, source : NonNullable<string>)
                             (qsType : QsType)
                             : ResolvedType * QsCompilerDiagnostic[] =
@@ -1599,4 +1599,3 @@ and NamespaceManager
             let importsHash = imports |> Seq.toList |> hash
             hash (callablesHash, typesHash), importsHash
         finally syncRoot.ExitReadLock() 
-

--- a/src/QsCompiler/Core/SymbolTable.fs
+++ b/src/QsCompiler/Core/SymbolTable.fs
@@ -816,8 +816,8 @@ and NamespaceManager
     /// unqualified) can be found. In that case, resolves the user defined type by replacing it with the Q# type
     /// denoting an invalid type.
     ///
-    /// Diagnostics can be generated in additional cases by returning an array of diagnostics from the given checkUdt
-    /// function.
+    /// Diagnostics can be generated in additional cases when UDTs are referenced by returning an array of diagnostics
+    /// from the given checkUdt function.
     ///
     /// Verifies that all used type parameters are defined in the given list of type parameters, and generates suitable
     /// diagnostics if they are not, replacing them by the Q# type denoting an invalid type. Returns the resolved type

--- a/src/QsCompiler/Core/SymbolTable.fs
+++ b/src/QsCompiler/Core/SymbolTable.fs
@@ -826,7 +826,7 @@ and NamespaceManager
     /// IMPORTANT: for performance reasons does *not* verify if the given the given parent and/or source file is
     /// consistent with the defined callables.
     /// May throw an exception if the given parent and/or source file is inconsistent with the defined declarations. 
-    /// Throws a NonSupportedException if the QsType to resolve contains a MissingType.
+    /// Throws a NotSupportedException if the QsType to resolve contains a MissingType.
     let resolveType (parent : QsQualifiedName, tpNames, source) qsType checkUdt =
         let processUDT = TryResolveTypeName (parent.Namespace, source) >> function
             | Some (udt, _, modifiers), errs -> UserDefinedType udt, Array.append errs (checkUdt (udt, modifiers))

--- a/src/QsCompiler/DataStructures/Diagnostics.fs
+++ b/src/QsCompiler/DataStructures/Diagnostics.fs
@@ -255,6 +255,8 @@ type ErrorCode =
     | RUSloopWithinAutoInversion = 6315
     | QuantumDependencyOutsideExprStatement = 6316
     | InvalidReassignmentInApplyBlock = 6317
+    | TypeLessAccessibleThanParentType = 6318
+    | TypeLessAccessibleThanParentCallable = 6319
 
     | UnexpectedCommandLineCompilerException = 7001
     | MissingInputFileOrSnippet = 7002
@@ -602,6 +604,8 @@ type DiagnosticItem =
             | ErrorCode.RUSloopWithinAutoInversion                -> "Auto-generation of inversions is not supported for operations that contain repeat-until-success-loops."
             | ErrorCode.QuantumDependencyOutsideExprStatement     -> "Auto-generation of inversions is not supported for operations that contain operation calls outside expression statements."
             | ErrorCode.InvalidReassignmentInApplyBlock           -> "Variables that are used in the within-block (specifying the outer transformation) cannot be reassigned in the apply-block (specifying the inner transformation)."
+            | ErrorCode.TypeLessAccessibleThanParentType          -> "The type {0} is less accessible than the parent type {1}."
+            | ErrorCode.TypeLessAccessibleThanParentCallable      -> "The type {0} is less accessible than the callable {1}."
 
             | ErrorCode.UnexpectedCommandLineCompilerException    -> "The command line compiler threw an exception."
             | ErrorCode.MissingInputFileOrSnippet                 -> "The command line compiler needs a list of files or a code snippet to process."


### PR DESCRIPTION
This prevents private or internal types from being exposed in places they shouldn't be; for example, a public operation returning an internal type, or an internal UDT using a private UDT as part of its underlying type.

See #259.