### PR TITLE
updated the app template to use async Main as entry point

### DIFF
--- a/src/ProjectTemplates/Quantum.App1/Driver.cs
+++ b/src/ProjectTemplates/Quantum.App1/Driver.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading.Tasks;
 
 using Microsoft.Quantum.Simulation.Core;
 using Microsoft.Quantum.Simulation.Simulators;
@@ -7,11 +8,11 @@ namespace Quantum.App1
 {
     class Driver
     {
-        static void Main(string[] args)
+        static async Task Main(string[] args)
         {
             using (var qsim = new QuantumSimulator())
             {
-                HelloQ.Run(qsim).Wait();
+                await HelloQ.Run(qsim);
             }
         }
     }


### PR DESCRIPTION
This doesn't really solve any problem, but - at least to me - avoiding the explicit blocking is a slightly more elegant version for the intro template.
There is no corresponding open issue for that, and given the small change I felt like there was no need to open one.