### PR TITLE
Update namespace suggestions code action for access modifiers

### DIFF
--- a/src/QsCompiler/CompilationManager/EditorSupport/CodeActions.cs
+++ b/src/QsCompiler/CompilationManager/EditorSupport/CodeActions.cs
@@ -306,16 +306,18 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
 
             // Ensure that the IndexRange library function exists in this compilation unit.
             var nsName = file.TryGetNamespaceAt(range.Start);
+            if (nsName == null)
+            {
+                return Enumerable.Empty<(string, WorkspaceEdit)>();
+            }
             var indexRange = compilation.GlobalSymbols.TryGetCallable(
                 new QsQualifiedName(BuiltIn.IndexRange.Namespace, BuiltIn.IndexRange.Name),
                 NonNullable<string>.New(nsName),
                 file.FileName);
-            if (nsName == null || !indexRange.IsFound)
+            if (!indexRange.IsFound)
             {
                 return Enumerable.Empty<(string, WorkspaceEdit)>();
             }
-
-            var suggestedOpenDir = file.OpenDirectiveSuggestions(range.Start.Line, BuiltIn.IndexRange.Namespace);
 
             /// Returns true the given expression is of the form "0 .. Length(args) - 1", 
             /// as well as the range of the entire expression and the argument tuple "(args)" as out parameters. 
@@ -361,6 +363,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
 
             var fragments = file.FragmentsOverlappingWithRange(range);
             var edits = fragments.SelectMany(IndexRangeEdits);
+            var suggestedOpenDir = file.OpenDirectiveSuggestions(range.Start.Line, BuiltIn.IndexRange.Namespace);
             return edits.Any() 
                 ? new[] { ("Use IndexRange to iterate over indices.", file.GetWorkspaceEdit(suggestedOpenDir.Concat(edits).ToArray())) } 
                 : Enumerable.Empty<(string, WorkspaceEdit)>();

--- a/src/QsCompiler/CompilationManager/EditorSupport/CodeActions.cs
+++ b/src/QsCompiler/CompilationManager/EditorSupport/CodeActions.cs
@@ -39,9 +39,13 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         }
 
         /// <summary>
-        /// Returns all namespaces in which a callable with the name of the symbol at the given position in the given file belongs to.
-        /// Returns an empty collection if any of the arguments is null or if no valid unqualified symbol exists at that location. 
-        /// Returns the name of the identifier as out parameter if an unqualified symbol exists at that location.
+        /// Returns all namespaces in which a callable with the name of the symbol at the given position in the given
+        /// file belongs to.
+        /// 
+        /// Returns an empty collection if any of the arguments is null, if no unqualified symbol exists at that
+        /// location, or if the position is not part of a namespace.
+        /// 
+        /// Returns the name of the identifier as an out parameter if an unqualified symbol exists at that location.
         /// </summary>
         private static IEnumerable<NonNullable<string>> NamespaceSuggestionsForIdAtPosition
             (this FileContentManager file, Position pos, CompilationUnit compilation, out string idName)
@@ -56,9 +60,13 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         }
 
         /// <summary>
-        /// Returns all namespaces in which a type with the name of the symbol at the given position in the given file belongs to.
-        /// Returns an empty collection if any of the arguments is null or if no valid unqualified symbol exists at that location. 
-        /// Returns the name of the type as out parameter if an unqualified symbol exists at that location.
+        /// Returns all namespaces in which a type with the name of the symbol at the given position in the given file
+        /// belongs to.
+        /// 
+        /// Returns an empty collection if any of the arguments is null, if no unqualified symbol exists at that
+        /// location, or if the position is not part of a namespace.
+        /// 
+        /// Returns the name of the type as an out parameter if an unqualified symbol exists at that location.
         /// </summary>
         private static IEnumerable<NonNullable<string>> NamespaceSuggestionsForTypeAtPosition
             (this FileContentManager file, Position pos, CompilationUnit compilation, out string typeName)

--- a/src/QsCompiler/CompilationManager/EditorSupport/CodeActions.cs
+++ b/src/QsCompiler/CompilationManager/EditorSupport/CodeActions.cs
@@ -305,11 +305,12 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
             }
 
             // Ensure that the IndexRange library function exists in this compilation unit.
-            var indexRange = new QsQualifiedName(BuiltIn.IndexRange.Namespace, BuiltIn.IndexRange.Name);
             var nsName = file.TryGetNamespaceAt(range.Start);
-            if (nsName == null || !compilation.GlobalSymbols.TryGetCallable(indexRange,
-                                                                            NonNullable<string>.New(nsName),
-                                                                            file.FileName).IsFound)
+            var indexRange = compilation.GlobalSymbols.TryGetCallable(
+                new QsQualifiedName(BuiltIn.IndexRange.Namespace, BuiltIn.IndexRange.Name),
+                NonNullable<string>.New(nsName),
+                file.FileName);
+            if (nsName == null || !indexRange.IsFound)
             {
                 return Enumerable.Empty<(string, WorkspaceEdit)>();
             }

--- a/src/QsCompiler/Core/SymbolTable.fs
+++ b/src/QsCompiler/Core/SymbolTable.fs
@@ -1492,14 +1492,10 @@ and NamespaceManager
         syncRoot.EnterReadLock()
         try
             let tryFindCallable (ns : Namespace) =
-                // TODO: Add QsNullable<_>.Bind and refactor this.
-                ns.TryFindCallable cName
-                |> QsNullable<_>.Fold
-                    (fun _ (_, _, sameAssembly, modifiers) ->
-                        if IsDeclarationAccessible sameAssembly (nsName = ns.Name) modifiers
-                        then Value ns.Name
-                        else Null)
-                    Null
+                ns.TryFindCallable cName |> QsNullable<_>.Bind (fun (_, _, sameAssembly, modifiers) ->
+                    if IsDeclarationAccessible sameAssembly (nsName = ns.Name) modifiers
+                    then Value ns.Name
+                    else Null)
             (Namespaces.Values |> QsNullable<_>.Choose tryFindCallable).ToImmutableArray()
         finally syncRoot.ExitReadLock()
 
@@ -1510,14 +1506,10 @@ and NamespaceManager
         syncRoot.EnterReadLock()
         try
             let tryFindType (ns : Namespace) =
-                // TODO: Add QsNullable<_>.Bind and refactor this.
-                ns.TryFindType tName
-                |> QsNullable<_>.Fold
-                    (fun _ (_, _, sameAssembly, modifiers) ->
-                        if IsDeclarationAccessible sameAssembly (nsName = ns.Name) modifiers
-                        then Value ns.Name
-                        else Null)
-                    Null
+                ns.TryFindType tName |> QsNullable<_>.Bind (fun (_, _, sameAssembly, modifiers) ->
+                    if IsDeclarationAccessible sameAssembly (nsName = ns.Name) modifiers
+                    then Value ns.Name
+                    else Null)
             (Namespaces.Values |> QsNullable<_>.Choose tryFindType).ToImmutableArray()
         finally syncRoot.ExitReadLock()
 

--- a/src/QsCompiler/DataStructures/DataTypes.fs
+++ b/src/QsCompiler/DataStructures/DataTypes.fs
@@ -13,11 +13,16 @@ type QsNullable<'T> = // to avoid having to include the F# core in the C# part o
 | Null
 | Value of 'T
 
+    /// If the given nullable has a value, applies the given function to it and returns the result, which must be
+    /// another nullable. Returns Null otherwise.
+    static member Bind fct = function
+        | Null -> Null
+        | Value v -> fct v
+
     /// If the given nullable has a value, applies the given function to it and returns the result as Value,
     /// and returns Null otherwise.
-    static member Map fct = function 
-        | Null -> Null
-        | Value v -> Value (fct v)
+    static member Map fct =
+        QsNullable<_>.Bind (fct >> Value)
 
     /// If the given nullable has a value, applies the given function to it.
     static member Iter fct = function 


### PR DESCRIPTION
This updates the code action that adds missing open directives, so that it doesn't suggest namespaces which have an inaccessible declaration with the given name.

Part of #259.