### PR TITLE
Removing the publishSingleFile options for the VS language server

### DIFF
--- a/src/VisualStudioExtension/QsharpVSIX/QsharpVSIX.csproj
+++ b/src/VisualStudioExtension/QsharpVSIX/QsharpVSIX.csproj
@@ -151,6 +151,6 @@
       <RemoveFiles Include="$(LanguageServerPath)**" />
     </ItemGroup>
     <Delete Files="@(RemoveFiles)" />
-    <Exec Command="dotnet publish $(ProjectDir)..\..\QsCompiler\LanguageServer\LanguageServer.csproj --self-contained true /p:PublishSingleFile=true --runtime win10-x64 -c $(ConfigurationName) -o $(ProjectDir)$(LanguageServerPath)" />
+    <Exec Command="dotnet publish $(ProjectDir)..\..\QsCompiler\LanguageServer\LanguageServer.csproj --self-contained true --runtime win10-x64 -c $(ConfigurationName) -o $(ProjectDir)$(LanguageServerPath)" />
   </Target>
 </Project>


### PR DESCRIPTION
That should fix a weird issue where on some systems the language server stops launching after some time, and reinstalling fixes the issue. 