### PR TITLE
Upgraded everything to .NET Core 3.1

### DIFF
--- a/examples/CompilerExtensions/Demo/Demo.csproj
+++ b/examples/CompilerExtensions/Demo/Demo.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <QscVerbosity>Detailed</QscVerbosity>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
 

--- a/src/ProjectTemplates/Quantum.App1/Quantum.App1.csproj.v.template
+++ b/src/ProjectTemplates/Quantum.App1/Quantum.App1.csproj.v.template
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
 </Project>

--- a/src/ProjectTemplates/Quantum.Test1/Quantum.Test1.csproj.v.template
+++ b/src/ProjectTemplates/Quantum.Test1/Quantum.Test1.csproj.v.template
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.Quantum.Sdk/#NUGET_VERSION#">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/src/QsCompiler/CommandLineTool/CommandLineTool.csproj
+++ b/src/QsCompiler/CommandLineTool/CommandLineTool.csproj
@@ -4,7 +4,7 @@
   <PropertyGroup>
     <AssemblyName>qsc</AssemblyName>
     <AssemblyTitle>Microsoft Q# compiler command line tool.</AssemblyTitle>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
 

--- a/src/QsCompiler/LanguageServer/LanguageServer.csproj
+++ b/src/QsCompiler/LanguageServer/LanguageServer.csproj
@@ -2,7 +2,7 @@
   <Import Project="..\..\Common\AssemblyCommon.props" />
   <PropertyGroup>
     <AssemblyName>Microsoft.Quantum.QsLanguageServer</AssemblyName>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/QsCompiler/TestProjects/test13/Driver.cs
+++ b/src/QsCompiler/TestProjects/test13/Driver.cs
@@ -1,0 +1,13 @@
+﻿using Microsoft.Quantum.Simulation.Core;
+using Microsoft.Quantum.Simulation.Simulators;
+
+namespace test3
+{
+    class Driver
+    {
+        static void Main(string[] args)
+        {
+
+        }
+    }
+}

--- a/src/QsCompiler/TestProjects/test13/Operation13.qs
+++ b/src/QsCompiler/TestProjects/test13/Operation13.qs
@@ -1,0 +1,10 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace test3 {
+    open Microsoft.Quantum.Canon;
+    open Microsoft.Quantum.Intrinsic;
+
+    operation Operation () : Unit {
+    }
+}

--- a/src/QsCompiler/TestProjects/test13/test13.csproj
+++ b/src/QsCompiler/TestProjects/test13/test13.csproj
@@ -1,0 +1,14 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <PlatformTarget>x64</PlatformTarget>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Quantum.Standard" Version="0.6.1905.301" />
+    <PackageReference Include="Microsoft.Quantum.Development.Kit" Version="0.6.1905.301" />
+  </ItemGroup>
+
+</Project>

--- a/src/QsCompiler/TestTargets/Libraries/Library1/Library1.csproj
+++ b/src/QsCompiler/TestTargets/Libraries/Library1/Library1.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk" InitialTargets="RecompileOnChange">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>
     <QsharpLangVersion>0.10</QsharpLangVersion>
   </PropertyGroup>
@@ -17,7 +17,7 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <QscExe>dotnet "../../../CommandLineTool/bin/$(Configuration)/netcoreapp3.0/qsc.dll"</QscExe>
+    <QscExe>dotnet "../../../CommandLineTool/bin/$(Configuration)/netcoreapp3.1/qsc.dll"</QscExe>
   </PropertyGroup>
 
   <Target Name="RecompileOnChange">

--- a/src/QsCompiler/TestTargets/Simulation/Example/Example.csproj
+++ b/src/QsCompiler/TestTargets/Simulation/Example/Example.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <QscVerbosity>Detailed</QscVerbosity>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <IncludeQsharpCorePackages>false</IncludeQsharpCorePackages>
     <CsharpGeneration>false</CsharpGeneration> <!--we provide our own C# generation for the sake of also generating C# for all references-->
     <NoWarn>0219</NoWarn> <!-- suppress C# warning for unused variables -->
@@ -14,7 +14,7 @@
     <ExecutionTestsDir>ExecutionTests/</ExecutionTestsDir>
     <SimulationTarget>../Target/bin/$(Configuration)/netstandard2.1/Simulation.dll</SimulationTarget>
     <AdditionalQscArguments> --load $(SimulationTarget)</AdditionalQscArguments>
-    <QscExe>dotnet "../../../CommandLineTool/bin/$(Configuration)/netcoreapp3.0/qsc.dll"</QscExe>
+    <QscExe>dotnet "../../../CommandLineTool/bin/$(Configuration)/netcoreapp3.1/qsc.dll"</QscExe>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/QsCompiler/Tests.Compiler/Tests.Compiler.fsproj
+++ b/src/QsCompiler/Tests.Compiler/Tests.Compiler.fsproj
@@ -2,7 +2,7 @@
   <Import Project="..\..\Common\AssemblyCommon.props" />
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <IsPackable>false</IsPackable>
     <AssemblyName>Tests.Microsoft.Quantum.QsCompiler</AssemblyName>
     <OutputType>Library</OutputType>
@@ -169,7 +169,7 @@
 
   <Target Name="PrepareExecutionTests" Condition="'$(DesignTimeBuild)' != 'true'" BeforeTargets="CoreCompile">
     <PropertyGroup>
-      <ExecutionTarget>"$(MSBuildThisFileDirectory)..\TestTargets\Simulation\Example\bin\$(Configuration)\netcoreapp3.0\Example.dll"</ExecutionTarget>
+      <ExecutionTarget>"$(MSBuildThisFileDirectory)..\TestTargets\Simulation\Example\bin\$(Configuration)\netcoreapp3.1\Example.dll"</ExecutionTarget>
     </PropertyGroup>
     <WriteLinesToFile File="$(OutputPath)ExecutionTarget.txt" Lines="$(ExecutionTarget)" Overwrite="true" />
   </Target>

--- a/src/QsCompiler/Tests.DocGenerator/Tests.DocGenerator.csproj
+++ b/src/QsCompiler/Tests.DocGenerator/Tests.DocGenerator.csproj
@@ -2,7 +2,7 @@
   <Import Project="..\..\Common\AssemblyCommon.props" />
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <IsPackable>false</IsPackable>
     <RootNamespace>Microsoft.Quantum.QsCompiler.Documentation.Testing</RootNamespace>
     <AssemblyName>Tests.Microsoft.Quantum.QsDocumentationParser</AssemblyName>

--- a/src/QsCompiler/Tests.LanguageServer/ProjectLoaderTests.cs
+++ b/src/QsCompiler/Tests.LanguageServer/ProjectLoaderTests.cs
@@ -52,6 +52,7 @@ namespace Microsoft.Quantum.QsLanguageServer.Testing
             Assert.IsTrue(loader.IsSupportedQsFramework("netcoreapp2.1"));
             Assert.IsTrue(loader.IsSupportedQsFramework("netcoreapp2.2"));
             Assert.IsTrue(loader.IsSupportedQsFramework("netcoreapp3.0"));
+            Assert.IsTrue(loader.IsSupportedQsFramework("netcoreapp3.1"));
         }
 
         [TestMethod]
@@ -80,6 +81,7 @@ namespace Microsoft.Quantum.QsLanguageServer.Testing
                 ("test10", "netcoreapp2.1"),
                 ("test11", "netcoreapp3.0"),
                 ("test12", "netstandard2.1"),
+                ("test13", "netcoreapp3.1")
             };
 
             foreach (var (project, framework) in testProjects)

--- a/src/QsCompiler/Tests.LanguageServer/Tests.LanguageServer.csproj
+++ b/src/QsCompiler/Tests.LanguageServer/Tests.LanguageServer.csproj
@@ -2,7 +2,7 @@
   <Import Project="..\..\Common\AssemblyCommon.props" />
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <IsPackable>false</IsPackable>
     <AssemblyName>Tests.Microsoft.Quantum.QsLanguageServer</AssemblyName>
     <OutputType>Library</OutputType>

--- a/src/QuantumSdk/QuantumSdk.nuspec
+++ b/src/QuantumSdk/QuantumSdk.nuspec
@@ -22,7 +22,7 @@
     <file src="Sdk\**\*" target="Sdk" exclude="**\*.v.template"/>
     <file src="DefaultItems\**\*" target="DefaultItems" exclude="**\*.v.template"/>
     <file src="ProjectSystem\**\*" target="ProjectSystem" exclude="**\*.v.template"/>
-    <file src="Tools\BuildConfiguration\bin\$Configuration$\netcoreapp3.0\publish\**" target="tools\utils" exclude="**\*.pdb" />
-    <file src="..\QsCompiler\CommandLineTool\bin\$Configuration$\netcoreapp3.0\publish\**" target="tools\qsc" exclude="**\*.pdb" />
+    <file src="Tools\BuildConfiguration\bin\$Configuration$\netcoreapp3.1\publish\**" target="tools\utils" exclude="**\*.pdb" />
+    <file src="..\QsCompiler\CommandLineTool\bin\$Configuration$\netcoreapp3.1\publish\**" target="tools\qsc" exclude="**\*.pdb" />
   </files>
 </package>

--- a/src/QuantumSdk/Tools/BuildConfiguration/BuildConfiguration.csproj
+++ b/src/QuantumSdk/Tools/BuildConfiguration/BuildConfiguration.csproj
@@ -3,7 +3,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <AssemblyName>Microsoft.Quantum.Sdk.BuildConfiguration</AssemblyName>
     <AssemblyTitle>Build configuration tools included in the Microsoft Quantum Sdk.</AssemblyTitle>
   </PropertyGroup>

--- a/src/VSCodeExtension/BUILDING.md
+++ b/src/VSCodeExtension/BUILDING.md
@@ -4,7 +4,7 @@
 
 - npm and vsce
 - PowerShell Core (6.0 or later)
-- .NET Core SDK 3.0 or later
+- .NET Core SDK 3.1 or later
 
 ### Obtaining npm and vsce ###
 
@@ -67,7 +67,7 @@ PS> dotnet publish --self-contained --runtime win10-x64
 To get the value that you need for the `quantumDevKit.languageServerPath` preference:
 
 ```
-PS> Resolve-Path bin/Debug/netcoreapp3.0/win10-x64/publish/Microsoft.Quantum.QsLanguageServer.exe
+PS> Resolve-Path bin/Debug/netcoreapp3.1/win10-x64/publish/Microsoft.Quantum.QsLanguageServer.exe
 ```
 
 ## Debugging ##

--- a/src/VisualStudioExtension/QsharpAppTemplate/AppProjectTemplate.xml.v.template
+++ b/src/VisualStudioExtension/QsharpAppTemplate/AppProjectTemplate.xml.v.template
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
 </Project>

--- a/src/VisualStudioExtension/QsharpTestTemplate/TestProjectTemplate.xml.v.template
+++ b/src/VisualStudioExtension/QsharpTestTemplate/TestProjectTemplate.xml.v.template
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.Quantum.Sdk/#NUGET_VERSION#">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/src/VisualStudioExtension/QsharpVSIX/QsharpVSIX.csproj
+++ b/src/VisualStudioExtension/QsharpVSIX/QsharpVSIX.csproj
@@ -16,7 +16,7 @@
     <RootNamespace>Microsoft.Quantum.VisualStudio</RootNamespace>
     <AssemblyName>Microsoft.Quantum.VisualStudio.Extension</AssemblyName>
     <TargetVsixContainerName>Microsoft.Quantum.Development.Kit-$(AssemblyVersion).vsix</TargetVsixContainerName>
-    <LanguageServerPath>..\..\QsCompiler\LanguageServer\bin\$(Configuration)\netcoreapp3.0\publish\</LanguageServerPath>
+    <LanguageServerPath>..\..\QsCompiler\LanguageServer\bin\$(Configuration)\netcoreapp3.1\publish\</LanguageServerPath>
     <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <GeneratePkgDefFile>false</GeneratePkgDefFile>
     <UseCodebase>true</UseCodebase>


### PR DESCRIPTION
Since .NET Core 3.0 [reach end of life on March 3, 2020](https://devblogs.microsoft.com/dotnet/net-core-3-0-end-of-life/) I thought it would make sense to bump to 3.1 here.

All .NET Core 3.0 projects are now updated 3.1. All of the library code is `netstandard2.1` already so no change needed there.
The build agent has 3.1 SDK already too, so that SDK was already used for building this repo anyway.

If there is some other reason why it hasn't been updated to 3.1 yet that I am not aware of, please disregard this PR 😀