### PR TITLE
Name mangling for imported internal declarations (before symbol resolution)

### DIFF
--- a/src/QsCompiler/CommandLineTool/LoadContext.cs
+++ b/src/QsCompiler/CommandLineTool/LoadContext.cs
@@ -111,7 +111,7 @@ namespace Microsoft.Quantum.QsCompiler
             return path == null ? null : LoadFromAssemblyPath(path);
         }
 
-        private static ConcurrentBag<LoadContext> Loaded =
+        private static readonly ConcurrentBag<LoadContext> Loaded =
             new ConcurrentBag<LoadContext>();
 
         /// <summary>

--- a/src/QsCompiler/CompilationManager/CompilationUnit.cs
+++ b/src/QsCompiler/CompilationManager/CompilationUnit.cs
@@ -114,9 +114,22 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// </returns>
         internal static QsQualifiedName GetNewNameForInternal(string source, QsQualifiedName name)
         {
-            // TODO: This isn't necessarily unique.
-            var prefix = Regex.Replace(source, @"[^A-Za-z0-9_]", "_");
-            return new QsQualifiedName(name.Namespace, NonNullable<string>.New($"__{prefix}_{name.Name.Value}__"));
+            // Returns true if the character c is valid as part of an identifier. "_" is excluded so it can be used as
+            // an escape character.
+            static bool IsValidCharacter(char c) =>
+                'A' <= c && c <= 'Z' || 'a' <= c && c <= 'z' || '0' <= c && c <= '9';
+
+            // Converts the string s to a string where all invalid characters are escaped by "_X", where "X" is the
+            // hexadecimal representation of the character.
+            static string ToEscapedIdentifier(string s) =>
+                string.Join(
+                    "",
+                    s.Select(c => IsValidCharacter(c) ? c.ToString() : "_" + Convert.ToByte(c).ToString("X")));
+
+            var prefix = ToEscapedIdentifier(source);
+            // The name is already a valid identifier, but we also want to escape "_".
+            var escapedName = ToEscapedIdentifier(name.Name.Value);
+            return new QsQualifiedName(name.Namespace, NonNullable<string>.New($"__{prefix}_{escapedName}__"));
         }
 
         /// <summary>

--- a/src/QsCompiler/CompilationManager/CompilationUnit.cs
+++ b/src/QsCompiler/CompilationManager/CompilationUnit.cs
@@ -173,6 +173,10 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// </summary>
         public References(ImmutableDictionary<NonNullable<string>, Headers> refs, Action<ErrorCode, string[]> onError = null)
         {
+            // TODO: We mangle the names of internal declarations in references to avoid name conflicts in the symbol
+            // table. However, it might be better to instead change the symbol table so it can support duplicate names
+            // as long as they are not in overlapping scopes, which is the case with internal declarations in separate
+            // assemblies.
             this.Declarations =
                 (refs ?? throw new ArgumentNullException(nameof(refs)))
                 .Select(reference => (reference.Key, RenameInternals(reference.Key.Value, reference.Value)))

--- a/src/QsCompiler/CompilationManager/CompilationUnit.cs
+++ b/src/QsCompiler/CompilationManager/CompilationUnit.cs
@@ -99,7 +99,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
             var callables = headers.Callables.Select(rename.OnCallableDeclarationHeader);
             var specializations = headers.Specializations.Select(
                 specialization => (rename.OnSpecializationDeclarationHeader(specialization.Item1),
-                                   rename.OnSpecializationImplementation(specialization.Item2)));
+                                   rename.Namespaces.OnSpecializationImplementation(specialization.Item2)));
             var types = headers.Types.Select(rename.OnTypeDeclarationHeader);
             return new Headers(source, callables, specializations, types);
         }
@@ -461,7 +461,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
                             header.Location,
                             header.Signature,
                             header.ArgumentTuple,
-                            ImmutableArray.Create<QsSpecialization>(defaultSpec),
+                            ImmutableArray.Create(defaultSpec),
                             header.Documentation,
                             QsComments.Empty
                         );

--- a/src/QsCompiler/CompilationManager/EditorSupport/SymbolInformation.cs
+++ b/src/QsCompiler/CompilationManager/EditorSupport/SymbolInformation.cs
@@ -143,10 +143,10 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
             referenceLocations = namespaces.SelectMany(ns =>
             {
                 var locs = IdentifierReferences.Find(fullName, ns, defaultOffset, out var dLoc, limitToSourceFiles);
-                declLoc = declLoc ?? dLoc;
+                declLoc ??= dLoc;
                 return locs;
             })
-            .Distinct().Select(AsLocation).ToArray(); // ToArray is needed here to force the execution before checking declLoc
+            .Select(AsLocation).ToArray(); // ToArray is needed here to force the execution before checking declLoc
             declarationLocation = declLoc == null ? null : AsLocation(declLoc.Item1, declLoc.Item2.Offset, declLoc.Item2.Range);
             return true;
         }
@@ -218,8 +218,8 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
                     .SelectMany(spec =>
                         spec.Implementation is SpecializationImplementation.Provided impl && spec.Location.IsValue
                             ? IdentifierReferences.Find(definition.Item.Item1, impl.Item2, file.FileName, spec.Location.Item.Offset)
-                            : ImmutableArray<IdentifierReferences.Location>.Empty)
-                    .Distinct().Select(AsLocation);
+                            : ImmutableHashSet<IdentifierReferences.Location>.Empty)
+                    .Select(AsLocation);
             }
             else // the given position corresponds to a variable declared as part of a specialization declaration or implementation
             {
@@ -227,7 +227,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
                 var statements = implementation.StatementsAfterDeclaration(defStart.Subtract(specPos));
                 var scope = new QsScope(statements.ToImmutableArray(), locals);
                 var rootOffset = DiagnosticTools.AsTuple(specPos); 
-                referenceLocations = IdentifierReferences.Find(definition.Item.Item1, scope, file.FileName, rootOffset).Distinct().Select(AsLocation);
+                referenceLocations = IdentifierReferences.Find(definition.Item.Item1, scope, file.FileName, rootOffset).Select(AsLocation);
             }
             declarationLocation = AsLocation(file.FileName, definition.Item.Item2, defRange);
             return true;

--- a/src/QsCompiler/Core/TypeTransformation.fs
+++ b/src/QsCompiler/Core/TypeTransformation.fs
@@ -132,4 +132,5 @@ type TypeTransformationBase(options : TransformationOptions) =
             | ExpressionType.Result                      -> this.OnResult ()
             | ExpressionType.Pauli                       -> this.OnPauli ()
             | ExpressionType.Range                       -> this.OnRange ()
-        ResolvedType.New |> Node.BuildOr t transformed
+        let ResolvedType t = ResolvedType.New (true, t)
+        ResolvedType |> Node.BuildOr t transformed

--- a/src/QsCompiler/Core/TypeTransformation.fs
+++ b/src/QsCompiler/Core/TypeTransformation.fs
@@ -132,5 +132,4 @@ type TypeTransformationBase(options : TransformationOptions) =
             | ExpressionType.Result                      -> this.OnResult ()
             | ExpressionType.Pauli                       -> this.OnPauli ()
             | ExpressionType.Range                       -> this.OnRange ()
-        let ResolvedType t = ResolvedType.New (true, t)
-        ResolvedType |> Node.BuildOr t transformed
+        (fun t -> ResolvedType.New (true, t)) |> Node.BuildOr t transformed

--- a/src/QsCompiler/DataStructures/SyntaxTree.fs
+++ b/src/QsCompiler/DataStructures/SyntaxTree.fs
@@ -661,6 +661,7 @@ type QsSpecialization = {
     with
     member this.AddAttribute att = {this with Attributes = this.Attributes.Add att}
     member this.WithImplementation impl = {this with Implementation = impl}
+    member this.WithParent (getName : Func<_,_>) = {this with Parent = getName.Invoke(this.Parent)}
 
 
 /// describes a Q# function, operation, or type constructor
@@ -739,6 +740,7 @@ type QsCustomType = {
 }
     with
     member this.AddAttribute att = {this with Attributes = this.Attributes.Add att}
+    member this.WithFullName (getName : Func<_,_>) = {this with FullName = getName.Invoke(this.FullName)}
 
 
 /// Describes a valid Q# namespace element.

--- a/src/QsCompiler/TestTargets/Libraries/Library1/AccessModifiers.qs
+++ b/src/QsCompiler/TestTargets/Libraries/Library1/AccessModifiers.qs
@@ -1,15 +1,13 @@
 ﻿/// This file contains redefinitions of types and callables declared in Tests.Compiler\TestCases\AccessModifiers.qs. It
 /// is used as an assembly reference to test support for re-using names of inaccessible declarations in references.
 namespace Microsoft.Quantum.Testing.AccessModifiers {
-    // TODO: Uncomment these definitions when re-using names of inaccessible declarations in references is supported.
+    private newtype PrivateType = Unit;
 
-    // private newtype PrivateType = Unit;
+    internal newtype InternalType = Unit;
 
-    // internal newtype InternalType = Unit;
+    private function PrivateFunction () : Unit {}
 
-    // private function PrivateFunction () : Unit {}
-
-    // internal function InternalFunction () : Unit {}
+    internal function InternalFunction () : Unit {}
 }
 
 /// This namespace contains additional definitions of types and callables meant to be used by the

--- a/src/QsCompiler/Tests.Compiler/AccessModifierTests.fs
+++ b/src/QsCompiler/Tests.Compiler/AccessModifierTests.fs
@@ -65,9 +65,11 @@ type AccessModifierTests (output) =
 
     [<Fact>]
     member this.``References`` () =
-        this.Expect "CallableReferencePrivateInaccessible" [Error ErrorCode.InaccessibleCallable]
-        this.Expect "CallableReferenceInternalInaccessible" [Error ErrorCode.InaccessibleCallable]
-        this.Expect "TypeReferencePrivateInaccessible" [Error ErrorCode.InaccessibleType]
-        this.Expect "TypeConstructorReferencePrivateInaccessible" [Error ErrorCode.InaccessibleCallable]
-        this.Expect "TypeReferenceInternalInaccessible" [Error ErrorCode.InaccessibleType]
-        this.Expect "TypeConstructorReferenceInternalInaccessible" [Error ErrorCode.InaccessibleCallable]
+        // Since internal declarations in references are renamed, the errors will be for unidentified callables and
+        // types instead of inaccessible ones.
+        this.Expect "CallableReferencePrivateInaccessible" [Error ErrorCode.UnknownIdentifier]
+        this.Expect "CallableReferenceInternalInaccessible" [Error ErrorCode.UnknownIdentifier]
+        this.Expect "TypeReferencePrivateInaccessible" [Error ErrorCode.UnknownType]
+        this.Expect "TypeConstructorReferencePrivateInaccessible" [Error ErrorCode.UnknownIdentifier]
+        this.Expect "TypeReferenceInternalInaccessible" [Error ErrorCode.UnknownType]
+        this.Expect "TypeConstructorReferenceInternalInaccessible" [Error ErrorCode.UnknownIdentifier]

--- a/src/QsCompiler/Tests.Compiler/LinkingTests.fs
+++ b/src/QsCompiler/Tests.Compiler/LinkingTests.fs
@@ -41,7 +41,6 @@ type LinkingTests (output:ITestOutputHelper) =
     let countReferencesInNamespaces (name : QsQualifiedName) namespaces =
         let references = IdentifierReferences (name, defaultOffset)
         namespaces |> Seq.iter (references.Namespaces.OnNamespace >> ignore)
-        // TODO: What if name is a type? Is the type constructor included?
         if obj.ReferenceEquals (references.SharedState.DeclarationLocation, null)
         then references.SharedState.Locations.Count
         else 1 + references.SharedState.Locations.Count
@@ -310,3 +309,8 @@ type LinkingTests (output:ITestOutputHelper) =
     [<Fact>]
     member this.``Rename internal call references`` () =
         this.RunInternalRenamingTest 1
+
+    [<Fact>]
+    member this.``Rename internal type references`` () =
+        // TODO: Check that both RenameMe and Foo are renamed.
+        this.RunInternalRenamingTest 2

--- a/src/QsCompiler/Tests.Compiler/LinkingTests.fs
+++ b/src/QsCompiler/Tests.Compiler/LinkingTests.fs
@@ -28,7 +28,11 @@ type LinkingTests (output:ITestOutputHelper) =
 
     let compilationManager = new CompilationUnitManager(new Action<Exception> (fun ex -> failwith ex.Message))
 
-    let getTempFile () = new Uri(Path.GetFullPath(Path.GetRandomFileName() + ".qs"))
+    let getTempFile () =
+        // The file name needs to end in ".qs" so that it isn't ignored by the References.Headers class during the
+        // internal renaming tests.
+        new Uri(Path.GetFullPath(Path.GetRandomFileName() + ".qs"))
+
     let getManager uri content = CompilationUnitManager.InitializeFileManager(uri, content, compilationManager.PublishDiagnostics, compilationManager.LogException)
 
     let defaultOffset = {

--- a/src/QsCompiler/Tests.Compiler/LinkingTests.fs
+++ b/src/QsCompiler/Tests.Compiler/LinkingTests.fs
@@ -58,8 +58,7 @@ type LinkingTests (output:ITestOutputHelper) =
             references.Namespaces.OnDocumentation qsType.Documentation |> ignore
 
         let count =
-            // TODO: We ignore type constructors because countReferencesInNamespaces is not able to count them.
-            headers.Callables.Count(fun callable -> callable.QualifiedName = name && callable.Kind <> TypeConstructor) +
+            headers.Callables.Count(fun callable -> callable.QualifiedName = name) +
             headers.Types.Count(fun qsType -> qsType.QualifiedName = name) +
             references.SharedState.Locations.Count
         count

--- a/src/QsCompiler/Tests.Compiler/LinkingTests.fs
+++ b/src/QsCompiler/Tests.Compiler/LinkingTests.fs
@@ -36,15 +36,6 @@ type LinkingTests (output:ITestOutputHelper) =
         Range = QsCompilerDiagnostic.DefaultRange
     }
 
-    /// Counts the number of references to the qualified name in all of the namespaces. The declaration of the name is
-    /// included in the count.
-    let countReferencesInNamespaces namespaces (name : QsQualifiedName) =
-        let references = IdentifierReferences (name, defaultOffset)
-        namespaces |> Seq.iter (references.Namespaces.OnNamespace >> ignore)
-        if obj.ReferenceEquals (references.SharedState.DeclarationLocation, null)
-        then references.SharedState.Locations.Count
-        else 1 + references.SharedState.Locations.Count
-
     /// Counts the number of references to the qualified name in the headers and specialization implementations. The
     /// declaration of the name is included in the count.
     let countReferencesInHeaders (headers : References.Headers) (name : QsQualifiedName) =
@@ -58,8 +49,8 @@ type LinkingTests (output:ITestOutputHelper) =
             references.Namespaces.OnDocumentation callable.Documentation |> ignore
         for (specialization, implementation) in headers.Specializations do
             Seq.iter (references.Namespaces.OnAttribute >> ignore) specialization.Attributes
-            references.Namespaces.OnDocumentation specialization.Documentation |> ignore
             references.Namespaces.OnSpecializationImplementation implementation |> ignore
+            references.Namespaces.OnDocumentation specialization.Documentation |> ignore
         for qsType in headers.Types do
             Seq.iter (references.Namespaces.OnAttribute >> ignore) qsType.Attributes
             references.Types.OnType qsType.Type |> ignore
@@ -165,34 +156,41 @@ type LinkingTests (output:ITestOutputHelper) =
     /// Runs the nth internal renaming test, asserting that declarations with the given name and references to them have
     /// been renamed across the compilation unit.
     member private this.RunInternalRenamingTest num renamed notRenamed =
+        let dllSource = "InternalRenaming.dll"
+        let newNames = renamed |> Seq.map (dllSource |> FuncConvert.FuncFromTupled References.GetNewNameForInternal)
+
         let chunks = LinkingTests.ReadAndChunkSourceFile "InternalRenaming.qs"
         let compilation = this.BuildContent chunks.[num - 1]
+        let originalHeaders = new References.Headers(NonNullable<string>.New dllSource, compilation.BuiltCompilation.Namespaces)
 
-        let beforeCount =
-            Seq.concat [renamed; notRenamed]
-            |> Seq.map (countReferencesInNamespaces compilation.BuiltCompilation.Namespaces)
-            |> Seq.sum
-
-        let sourceName = "InternalRenaming.dll"
-        let headers = (NonNullable<_>.New sourceName, compilation.BuiltCompilation.Namespaces) |> References.Headers
-        let references =
-            [KeyValuePair.Create(NonNullable<_>.New sourceName, headers)]
+        let loadedReferences  = 
+            [KeyValuePair.Create(NonNullable<_>.New dllSource, originalHeaders)]
             |> ImmutableDictionary.CreateRange
             |> References
 
-        let oldAfterCount =
-            renamed
-            |> Seq.map (countReferencesInHeaders references.Declarations.[NonNullable<_>.New sourceName])
-            |> Seq.sum
-        let newNames = renamed |> Seq.map (sourceName |> FuncConvert.FuncFromTupled References.GetNewNameForInternal)
-        let newAfterCount =
-            Seq.concat [newNames; notRenamed]
-            |> Seq.map (countReferencesInHeaders references.Declarations.[NonNullable<_>.New sourceName])
+        let HeadersFromReference (references : References) = 
+            references.Declarations.Single().Value
+
+        let CountReferencesFor itemsToCount headers = 
+            itemsToCount 
+            |> Seq.map (countReferencesInHeaders headers)
             |> Seq.sum
 
+        let beforeCount =
+            originalHeaders
+            |> CountReferencesFor (Seq.concat [renamed; notRenamed])
+
+        let afterCount =
+            loadedReferences |> HeadersFromReference
+            |> CountReferencesFor (Seq.concat [newNames; notRenamed])
+
+        let afterCountOriginalName =
+            loadedReferences |> HeadersFromReference
+            |> CountReferencesFor renamed
+
         Assert.NotEqual (0, beforeCount)
-        Assert.Equal (0, oldAfterCount)
-        Assert.Equal (beforeCount, newAfterCount)
+        Assert.Equal (0, afterCountOriginalName)
+        Assert.Equal (beforeCount, afterCount)
 
     [<Fact>]
     member this.``Monomorphization`` () =

--- a/src/QsCompiler/Tests.Compiler/LinkingTests.fs
+++ b/src/QsCompiler/Tests.Compiler/LinkingTests.fs
@@ -73,6 +73,11 @@ type LinkingTests (output:ITestOutputHelper) =
             references.SharedState.Locations.Count
         count
 
+    let qualifiedName ns name = {
+        Namespace = NonNullable<_>.New ns
+        Name = NonNullable<_>.New name
+    }
+
     do  let addOrUpdateSourceFile filePath = getManager (new Uri(filePath)) (File.ReadAllText filePath) |> compilationManager.AddOrUpdateSourceFileAsync |> ignore
         Path.Combine ("TestCases", "LinkingTests", "Core.qs") |> Path.GetFullPath |> addOrUpdateSourceFile
 
@@ -327,22 +332,22 @@ type LinkingTests (output:ITestOutputHelper) =
     [<Fact>]
     member this.``Rename internal operation call references`` () =
         this.RunInternalRenamingTest 1
-            [{ Namespace = NonNullable<_>.New Signatures.InternalRenamingNs; Name = NonNullable<_>.New "Foo" }]
-            [{ Namespace = NonNullable<_>.New Signatures.InternalRenamingNs; Name = NonNullable<_>.New "Bar" }]
+            [qualifiedName Signatures.InternalRenamingNs "Foo"]
+            [qualifiedName Signatures.InternalRenamingNs "Bar"]
 
     [<Fact>]
     member this.``Rename internal function call references`` () =
         this.RunInternalRenamingTest 2
-            [{ Namespace = NonNullable<_>.New Signatures.InternalRenamingNs; Name = NonNullable<_>.New "Foo" }]
-            [{ Namespace = NonNullable<_>.New Signatures.InternalRenamingNs; Name = NonNullable<_>.New "Bar" }]
+            [qualifiedName Signatures.InternalRenamingNs "Foo"]
+            [qualifiedName Signatures.InternalRenamingNs "Bar"]
 
     [<Fact>]
     member this.``Rename internal type references`` () =
         this.RunInternalRenamingTest 3
             [
-                { Namespace = NonNullable<_>.New Signatures.InternalRenamingNs; Name = NonNullable<_>.New "Foo" }
-                { Namespace = NonNullable<_>.New Signatures.InternalRenamingNs; Name = NonNullable<_>.New "Bar" }
-                { Namespace = NonNullable<_>.New Signatures.InternalRenamingNs; Name = NonNullable<_>.New "Baz" }
+                qualifiedName Signatures.InternalRenamingNs "Foo"
+                qualifiedName Signatures.InternalRenamingNs "Bar"
+                qualifiedName Signatures.InternalRenamingNs "Baz"
             ]
             []
 
@@ -350,24 +355,24 @@ type LinkingTests (output:ITestOutputHelper) =
     member this.``Rename internal references across namespaces`` () =
         this.RunInternalRenamingTest 4
             [
-                { Namespace = NonNullable<_>.New Signatures.InternalRenamingNs; Name = NonNullable<_>.New "Foo" }
-                { Namespace = NonNullable<_>.New Signatures.InternalRenamingNs; Name = NonNullable<_>.New "Bar" }
-                { Namespace = NonNullable<_>.New (Signatures.InternalRenamingNs + ".Extra"); Name = NonNullable<_>.New "Qux" }
+                qualifiedName Signatures.InternalRenamingNs "Foo"
+                qualifiedName Signatures.InternalRenamingNs "Bar"
+                qualifiedName (Signatures.InternalRenamingNs + ".Extra") "Qux"
             ]
-            [{ Namespace = NonNullable<_>.New (Signatures.InternalRenamingNs + ".Extra"); Name = NonNullable<_>.New "Baz" }]
+            [qualifiedName (Signatures.InternalRenamingNs + ".Extra") "Baz"]
 
     [<Fact>]
     member this.``Rename internal qualified references`` () =
         this.RunInternalRenamingTest 5
             [
-                { Namespace = NonNullable<_>.New Signatures.InternalRenamingNs; Name = NonNullable<_>.New "Foo" }
-                { Namespace = NonNullable<_>.New Signatures.InternalRenamingNs; Name = NonNullable<_>.New "Bar" }
-                { Namespace = NonNullable<_>.New (Signatures.InternalRenamingNs + ".Extra"); Name = NonNullable<_>.New "Qux" }
+                qualifiedName Signatures.InternalRenamingNs "Foo"
+                qualifiedName Signatures.InternalRenamingNs "Bar"
+                qualifiedName (Signatures.InternalRenamingNs + ".Extra") "Qux"
             ]
-            [{ Namespace = NonNullable<_>.New (Signatures.InternalRenamingNs + ".Extra"); Name = NonNullable<_>.New "Baz" }]
+            [qualifiedName (Signatures.InternalRenamingNs + ".Extra") "Baz"]
 
     [<Fact>]
     member this.``Rename internal attribute references`` () =
         this.RunInternalRenamingTest 6
-            [{ Namespace = NonNullable<_>.New Signatures.InternalRenamingNs; Name = NonNullable<_>.New "Foo" }]
-            [{ Namespace = NonNullable<_>.New Signatures.InternalRenamingNs; Name = NonNullable<_>.New "Bar" }]
+            [qualifiedName Signatures.InternalRenamingNs "Foo"]
+            [qualifiedName Signatures.InternalRenamingNs "Bar"]

--- a/src/QsCompiler/Tests.Compiler/LinkingTests.fs
+++ b/src/QsCompiler/Tests.Compiler/LinkingTests.fs
@@ -67,7 +67,8 @@ type LinkingTests (output:ITestOutputHelper) =
             references.Namespaces.OnDocumentation qsType.Documentation |> ignore
 
         let count =
-            headers.Callables.Count(fun callable -> callable.QualifiedName = name) +
+            // TODO: We ignore type constructors because countReferencesInNamespaces is not able to count them.
+            headers.Callables.Count(fun callable -> callable.QualifiedName = name && callable.Kind <> TypeConstructor) +
             headers.Types.Count(fun qsType -> qsType.QualifiedName = name) +
             references.SharedState.Locations.Count
         count

--- a/src/QsCompiler/Tests.Compiler/LinkingTests.fs
+++ b/src/QsCompiler/Tests.Compiler/LinkingTests.fs
@@ -63,6 +63,7 @@ type LinkingTests (output:ITestOutputHelper) =
 
         let count =
             headers.Callables.Count(fun callable -> callable.QualifiedName = name) +
+            headers.Specializations.Count(fun specialization -> (fst (specialization.ToTuple ())).Parent = name) +
             headers.Types.Count(fun qsType -> qsType.QualifiedName = name) +
             references.SharedState.Locations.Count
         count
@@ -366,5 +367,11 @@ type LinkingTests (output:ITestOutputHelper) =
     [<Fact>]
     member this.``Rename internal attribute references`` () =
         this.RunInternalRenamingTest 6
+            [qualifiedName Signatures.InternalRenamingNs "Foo"]
+            [qualifiedName Signatures.InternalRenamingNs "Bar"]
+
+    [<Fact>]
+    member this.``Rename specializations for internal operations`` () =
+        this.RunInternalRenamingTest 7
             [qualifiedName Signatures.InternalRenamingNs "Foo"]
             [qualifiedName Signatures.InternalRenamingNs "Bar"]

--- a/src/QsCompiler/Tests.Compiler/LinkingTests.fs
+++ b/src/QsCompiler/Tests.Compiler/LinkingTests.fs
@@ -177,8 +177,7 @@ type LinkingTests (output:ITestOutputHelper) =
             |> ImmutableDictionary.CreateRange
             |> References
         let newNames =
-            renamed
-            |> Seq.map (dllSource |> FuncConvert.FuncFromTupled References.GetNewNameForInternal)
+            renamed |> Seq.map (0 |> FuncConvert.FuncFromTupled References.GetNewNameForInternal)
         let afterCount = references.Declarations.Single().Value |> countAll (Seq.concat [newNames; notRenamed])
 
         let afterCountOriginalName = references.Declarations.Single().Value |> countAll renamed

--- a/src/QsCompiler/Tests.Compiler/TestCases/LinkingTests/InternalRenaming.qs
+++ b/src/QsCompiler/Tests.Compiler/TestCases/LinkingTests/InternalRenaming.qs
@@ -4,93 +4,93 @@
 // Test 1: Rename internal operation call references
 
 namespace Microsoft.Quantum.Testing.InternalRenaming {
-	internal operation Foo () : Unit {
-	}
+    internal operation Foo () : Unit {
+    }
 
-	operation Bar () : Unit {
-		Foo();
-	}
+    operation Bar () : Unit {
+        Foo();
+    }
 }
 
 // =================================
 // Test 2: Rename internal function call references
 
 namespace Microsoft.Quantum.Testing.InternalRenaming {
-	internal function Foo () : Int {
-		return 42;
-	}
+    internal function Foo () : Int {
+        return 42;
+    }
 
-	function Bar () : Unit {
-		let x = Foo();
-		let y = 1 + (Foo() - 5);
-		let z = (Foo(), 9);
-	}
+    function Bar () : Unit {
+        let x = Foo();
+        let y = 1 + (Foo() - 5);
+        let z = (Foo(), 9);
+    }
 }
 
 // =================================
 // Test 3: Rename internal type references
 
 namespace Microsoft.Quantum.Testing.InternalRenaming {
-	internal newtype Foo = Unit;
+    internal newtype Foo = Unit;
 
-	internal newtype Bar = (Int, Foo);
+    internal newtype Bar = (Int, Foo);
 
-	internal function Baz (x : Foo) : Foo {
-		return Foo();
-	}
+    internal function Baz (x : Foo) : Foo {
+        return Foo();
+    }
 }
 
 // =================================
 // Test 4: Rename internal references across namespaces
 
 namespace Microsoft.Quantum.Testing.InternalRenaming {
-	internal newtype Foo = Unit;
+    internal newtype Foo = Unit;
 
-	internal function Bar () : Unit {
-	}
+    internal function Bar () : Unit {
+    }
 }
 
 namespace Microsoft.Quantum.Testing.InternalRenaming.Extra {
-	open Microsoft.Quantum.Testing.InternalRenaming;
+    open Microsoft.Quantum.Testing.InternalRenaming;
 
-	function Baz () : Unit {
-		return Bar();
-	}
+    function Baz () : Unit {
+        return Bar();
+    }
 
-	internal function Qux (x : Foo) : Foo {
-		return x;
-	}
+    internal function Qux (x : Foo) : Foo {
+        return x;
+    }
 }
 
 // =================================
 // Test 5: Rename internal qualified references
 
 namespace Microsoft.Quantum.Testing.InternalRenaming {
-	internal newtype Foo = Unit;
+    internal newtype Foo = Unit;
 
-	internal function Bar () : Unit {
-	}
+    internal function Bar () : Unit {
+    }
 }
 
 namespace Microsoft.Quantum.Testing.InternalRenaming.Extra {
-	function Baz () : Unit {
-		return Microsoft.Quantum.Testing.InternalRenaming.Bar();
-	}
+    function Baz () : Unit {
+        return Microsoft.Quantum.Testing.InternalRenaming.Bar();
+    }
 
-	internal function Qux (x : Microsoft.Quantum.Testing.InternalRenaming.Foo)
-		: Microsoft.Quantum.Testing.InternalRenaming.Foo {
-		return x;
-	}
+    internal function Qux (x : Microsoft.Quantum.Testing.InternalRenaming.Foo)
+        : Microsoft.Quantum.Testing.InternalRenaming.Foo {
+        return x;
+    }
 }
 
 // =================================
 // Test 6: Rename internal attribute references
 
 namespace Microsoft.Quantum.Testing.InternalRenaming {
-	@Attribute()
-	internal newtype Foo = Unit;
+    @Attribute()
+    internal newtype Foo = Unit;
 
-	@Foo()
-	function Bar () : Unit {
-	}
+    @Foo()
+    function Bar () : Unit {
+    }
 }

--- a/src/QsCompiler/Tests.Compiler/TestCases/LinkingTests/InternalRenaming.qs
+++ b/src/QsCompiler/Tests.Compiler/TestCases/LinkingTests/InternalRenaming.qs
@@ -3,11 +3,11 @@
 
 // Test 1
 namespace Microsoft.Quantum.Testing.InternalRenaming {
-	internal operation RenameMe () : Unit {
+	internal operation Foo () : Unit {
 	}
 
-	operation Foo () : Unit {
-		RenameMe();
+	operation Bar () : Unit {
+		Foo();
 	}
 }
 
@@ -15,8 +15,8 @@ namespace Microsoft.Quantum.Testing.InternalRenaming {
 
 // Test 2
 namespace Microsoft.Quantum.Testing.InternalRenaming {
-	internal newtype RenameMe = Unit;
+	internal newtype Foo = Unit;
 
-	internal function Foo (x : RenameMe) : Unit {
+	internal function Bar (x : Foo) : Unit {
 	}
 }

--- a/src/QsCompiler/Tests.Compiler/TestCases/LinkingTests/InternalRenaming.qs
+++ b/src/QsCompiler/Tests.Compiler/TestCases/LinkingTests/InternalRenaming.qs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+// Test 1
+namespace Microsoft.Quantum.Testing.InternalRenaming {
+	internal operation RenameMe () : Unit {
+	}
+
+	operation Foo () : Unit {
+		RenameMe();
+	}
+}
+
+// =================================

--- a/src/QsCompiler/Tests.Compiler/TestCases/LinkingTests/InternalRenaming.qs
+++ b/src/QsCompiler/Tests.Compiler/TestCases/LinkingTests/InternalRenaming.qs
@@ -101,14 +101,14 @@ namespace Microsoft.Quantum.Testing.InternalRenaming {
 namespace Microsoft.Quantum.Testing.InternalRenaming {
     internal operation Foo () : Unit is Adj {
         body {
-		}
+        }
 
         adjoint {
-		}
-	}
+        }
+    }
 
     operation Bar () : Unit {
         Foo();
         Adjoint Foo();
-	}
+    }
 }

--- a/src/QsCompiler/Tests.Compiler/TestCases/LinkingTests/InternalRenaming.qs
+++ b/src/QsCompiler/Tests.Compiler/TestCases/LinkingTests/InternalRenaming.qs
@@ -94,3 +94,21 @@ namespace Microsoft.Quantum.Testing.InternalRenaming {
     function Bar () : Unit {
     }
 }
+
+// =================================
+// Test 7: Rename specializations for internal operations
+
+namespace Microsoft.Quantum.Testing.InternalRenaming {
+    internal operation Foo () : Unit is Adj {
+        body {
+		}
+
+        adjoint {
+		}
+	}
+
+    operation Bar () : Unit {
+        Foo();
+        Adjoint Foo();
+	}
+}

--- a/src/QsCompiler/Tests.Compiler/TestCases/LinkingTests/InternalRenaming.qs
+++ b/src/QsCompiler/Tests.Compiler/TestCases/LinkingTests/InternalRenaming.qs
@@ -1,7 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-// Test 1
+// Test 1: Rename internal operation call references
+
 namespace Microsoft.Quantum.Testing.InternalRenaming {
 	internal operation Foo () : Unit {
 	}
@@ -12,11 +13,84 @@ namespace Microsoft.Quantum.Testing.InternalRenaming {
 }
 
 // =================================
+// Test 2: Rename internal function call references
 
-// Test 2
+namespace Microsoft.Quantum.Testing.InternalRenaming {
+	internal function Foo () : Int {
+		return 42;
+	}
+
+	function Bar () : Unit {
+		let x = Foo();
+		let y = 1 + (Foo() - 5);
+		let z = (Foo(), 9);
+	}
+}
+
+// =================================
+// Test 3: Rename internal type references
+
 namespace Microsoft.Quantum.Testing.InternalRenaming {
 	internal newtype Foo = Unit;
 
-	internal function Bar (x : Foo) : Unit {
+	internal newtype Bar = (Int, Foo);
+
+	internal function Baz (x : Foo) : Foo {
+		return Foo();
+	}
+}
+
+// =================================
+// Test 4: Rename internal references across namespaces
+
+namespace Microsoft.Quantum.Testing.InternalRenaming {
+	internal newtype Foo = Unit;
+
+	internal function Bar () : Unit {
+	}
+}
+
+namespace Microsoft.Quantum.Testing.InternalRenaming.Extra {
+	open Microsoft.Quantum.Testing.InternalRenaming;
+
+	function Baz () : Unit {
+		return Bar();
+	}
+
+	internal function Qux (x : Foo) : Foo {
+		return x;
+	}
+}
+
+// =================================
+// Test 5: Rename internal qualified references
+
+namespace Microsoft.Quantum.Testing.InternalRenaming {
+	internal newtype Foo = Unit;
+
+	internal function Bar () : Unit {
+	}
+}
+
+namespace Microsoft.Quantum.Testing.InternalRenaming.Extra {
+	function Baz () : Unit {
+		return Microsoft.Quantum.Testing.InternalRenaming.Bar();
+	}
+
+	internal function Qux (x : Microsoft.Quantum.Testing.InternalRenaming.Foo)
+		: Microsoft.Quantum.Testing.InternalRenaming.Foo {
+		return x;
+	}
+}
+
+// =================================
+// Test 6: Rename internal attribute references
+
+namespace Microsoft.Quantum.Testing.InternalRenaming {
+	@Attribute()
+	internal newtype Foo = Unit;
+
+	@Foo()
+	function Bar () : Unit {
 	}
 }

--- a/src/QsCompiler/Tests.Compiler/TestCases/LinkingTests/InternalRenaming.qs
+++ b/src/QsCompiler/Tests.Compiler/TestCases/LinkingTests/InternalRenaming.qs
@@ -12,3 +12,11 @@ namespace Microsoft.Quantum.Testing.InternalRenaming {
 }
 
 // =================================
+
+// Test 2
+namespace Microsoft.Quantum.Testing.InternalRenaming {
+	internal newtype RenameMe = Unit;
+
+	internal function Foo (x : RenameMe) : Unit {
+	}
+}

--- a/src/QsCompiler/Tests.Compiler/TestUtils/Signatures.fs
+++ b/src/QsCompiler/Tests.Compiler/TestUtils/Signatures.fs
@@ -113,6 +113,7 @@ let public MonomorphizationNs = "Microsoft.Quantum.Testing.Monomorphization"
 let public GenericsNs = "Microsoft.Quantum.Testing.Generics"
 let public IntrinsicResolutionNs = "Microsoft.Quantum.Testing.IntrinsicResolution"
 let public ClassicalControlNs = "Microsoft.Quantum.Testing.ClassicalControl"
+let public InternalRenamingNs = "Microsoft.Quantum.Testing.InternalRenaming"
 
 /// Expected callable signatures to be found when running Monomorphization tests
 let public MonomorphizationSignatures =

--- a/src/QsCompiler/Tests.Compiler/Tests.Compiler.fsproj
+++ b/src/QsCompiler/Tests.Compiler/Tests.Compiler.fsproj
@@ -47,6 +47,9 @@
     <None Include="TestCases\LinkingTests\ClassicalControl.qs">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Include="TestCases\LinkingTests\InternalRenaming.qs">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Include="TestCases\OptimizerTests\Arithmetic_output.txt">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/src/QsCompiler/Transformations/SearchAndReplace.cs
+++ b/src/QsCompiler/Transformations/SearchAndReplace.cs
@@ -557,10 +557,10 @@ namespace Microsoft.Quantum.QsCompiler.Transformations.SearchAndReplace
             public TypeTransformation(RenameReferences parent) : base(parent) => this.parent = parent;
 
             public override QsTypeKind OnUserDefinedType(UserDefinedType udt) =>
-                QsTypeKind.NewUserDefinedType(parent.RenameUdt(udt));
+                base.OnUserDefinedType(parent.RenameUdt(udt));
 
             public override QsTypeKind OnTypeParameter(QsTypeParameter tp) =>
-                QsTypeKind.NewTypeParameter(new QsTypeParameter(parent.GetNewName(tp.Origin), tp.TypeName, tp.Range));
+                base.OnTypeParameter(new QsTypeParameter(parent.GetNewName(tp.Origin), tp.TypeName, tp.Range));
         }
 
         private class ExpressionKindTransformation : Core.ExpressionKindTransformation
@@ -585,13 +585,14 @@ namespace Microsoft.Quantum.QsCompiler.Transformations.SearchAndReplace
 
             public NamespaceTransformation(RenameReferences parent) : base(parent) => this.parent = parent;
 
-            public override QsDeclarationAttribute OnAttribute(QsDeclarationAttribute att)
+            public override QsDeclarationAttribute OnAttribute(QsDeclarationAttribute attribute)
             {
-                var argument = parent.Expressions.OnTypedExpression(att.Argument);
-                var tId = att.TypeId.IsValue
-                    ? QsNullable<UserDefinedType>.NewValue(parent.RenameUdt(att.TypeId.Item))
-                    : att.TypeId;
-                return new QsDeclarationAttribute(tId, argument, att.Offset, att.Comments);
+                var argument = parent.Expressions.OnTypedExpression(attribute.Argument);
+                var typeId = attribute.TypeId.IsValue
+                    ? QsNullable<UserDefinedType>.NewValue(parent.RenameUdt(attribute.TypeId.Item))
+                    : attribute.TypeId;
+                return base.OnAttribute(
+                    new QsDeclarationAttribute(typeId, argument, attribute.Offset, attribute.Comments));
             }
 
             public override QsCallable OnCallableDeclaration(QsCallable callable) =>
@@ -600,7 +601,7 @@ namespace Microsoft.Quantum.QsCompiler.Transformations.SearchAndReplace
             public override QsCustomType OnTypeDeclaration(QsCustomType type) =>
                 base.OnTypeDeclaration(type.WithFullName(parent.GetNewName));
 
-            public override QsSpecialization OnSpecializationDeclaration(QsSpecialization spec) => 
+            public override QsSpecialization OnSpecializationDeclaration(QsSpecialization spec) =>
                 base.OnSpecializationDeclaration(spec.WithParent(parent.GetNewName));
         }
     }

--- a/src/QsCompiler/Transformations/SearchAndReplace.cs
+++ b/src/QsCompiler/Transformations/SearchAndReplace.cs
@@ -466,6 +466,87 @@ namespace Microsoft.Quantum.QsCompiler.Transformations.SearchAndReplace
         }
 
         /// <summary>
+        /// Renames references in the callable declaration header, including the name of the callable itself.
+        /// </summary>
+        /// <param name="callable">The callable declaration header in which to rename references.</param>
+        /// <returns>The callable declaration header with renamed references.</returns>
+        public CallableDeclarationHeader OnCallableDeclarationHeader(CallableDeclarationHeader callable) =>
+            new CallableDeclarationHeader(
+                kind: callable.Kind,
+                qualifiedName: GetNewName(callable.QualifiedName),
+                attributes: callable.Attributes.Select(Namespaces.OnAttribute).ToImmutableArray(),
+                modifiers: callable.Modifiers,
+                sourceFile: callable.SourceFile,
+                position: callable.Position,
+                symbolRange: callable.SymbolRange,
+                argumentTuple: Namespaces.OnArgumentTuple(callable.ArgumentTuple),
+                signature: Namespaces.OnSignature(callable.Signature),
+                documentation: Namespaces.OnDocumentation(callable.Documentation));
+
+        /// <summary>
+        /// Renames references in the specialization declaration header, including the name of the specialization
+        /// itself.
+        /// </summary>
+        /// <param name="specialization">The specialization declaration header in which to rename references.</param>
+        /// <returns>The specialization declaration header with renamed references.</returns>
+        public SpecializationDeclarationHeader OnSpecializationDeclarationHeader(
+            SpecializationDeclarationHeader specialization)
+        {
+            var typeArguments =
+                specialization.TypeArguments.IsValue
+                ? QsNullable<ImmutableArray<ResolvedType>>.NewValue(
+                    specialization.TypeArguments.Item.Select(Types.OnType).ToImmutableArray())
+                : QsNullable<ImmutableArray<ResolvedType>>.Null;
+            return new SpecializationDeclarationHeader(
+                kind: specialization.Kind,
+                typeArguments: typeArguments,
+                information: specialization.Information,
+                parent: GetNewName(specialization.Parent),
+                attributes: specialization.Attributes.Select(Namespaces.OnAttribute).ToImmutableArray(),
+                sourceFile: specialization.SourceFile,
+                position: specialization.Position,
+                headerRange: specialization.HeaderRange,
+                documentation: Namespaces.OnDocumentation(specialization.Documentation));
+        }
+
+        /// <summary>
+        /// Renames references in the specialization implementation.
+        /// </summary>
+        /// <param name="specialization">The specialization implementation in which to rename references.</param>
+        /// <returns>The specialization implementation with renamed references.</returns>
+        public SpecializationImplementation OnSpecializationImplementation(SpecializationImplementation implementation)
+        {
+            if (implementation is SpecializationImplementation.Provided provided)
+            {
+                return SpecializationImplementation.NewProvided(Namespaces.OnArgumentTuple(provided.Item1),
+                                                                Statements.OnScope(provided.Item2));
+            }
+            else
+            {
+                return implementation;
+            }
+        }
+
+        /// <summary>
+        /// Renames references in the type declaration header, including the name of the type itself.
+        /// </summary>
+        /// <param name="type">The type declaration header in which to rename references.</param>
+        /// <returns>The type declaration header with renamed references.</returns>
+        public TypeDeclarationHeader OnTypeDeclarationHeader(TypeDeclarationHeader type)
+        {
+            return new TypeDeclarationHeader(
+                qualifiedName: GetNewName(type.QualifiedName),
+                attributes: type.Attributes.Select(Namespaces.OnAttribute).ToImmutableArray(),
+                modifiers: type.Modifiers,
+                sourceFile: type.SourceFile,
+                position: type.Position,
+                symbolRange: type.SymbolRange,
+                type: Types.OnType(type.Type),
+                typeItems: Namespaces.OnTypeItems(type.TypeItems),
+                documentation: Namespaces.OnDocumentation(type.Documentation));
+        }
+
+        /// <summary>
         /// Gets the renamed version of the qualified name if one exists; otherwise, returns the original name.
         /// </summary>
         /// <param name="name">The qualified name to rename.</param>

--- a/src/QsCompiler/Transformations/SearchAndReplace.cs
+++ b/src/QsCompiler/Transformations/SearchAndReplace.cs
@@ -608,6 +608,21 @@ namespace Microsoft.Quantum.QsCompiler.Transformations.SearchAndReplace
                     typeItems: type.TypeItems,
                     documentation: type.Documentation,
                     comments: type.Comments));
+
+            public override QsDeclarationAttribute OnAttribute(QsDeclarationAttribute attribute)
+            {
+                var newTypeId = QsNullable<UserDefinedType>.Null;
+                if (attribute.TypeId.IsValue)
+                {
+                    var newName = parent.GetNewName(new QsQualifiedName(attribute.TypeId.Item.Namespace,
+                                                                        attribute.TypeId.Item.Name));
+                    newTypeId = QsNullable<UserDefinedType>.NewValue(
+                        new UserDefinedType(newName.Namespace, newName.Name, attribute.TypeId.Item.Range));
+                }
+                var newArgument = parent.Expressions.OnTypedExpression(attribute.Argument);
+                return base.OnAttribute(
+                    new QsDeclarationAttribute(newTypeId, newArgument, attribute.Offset, attribute.Comments));
+            }
         }
     }
 


### PR DESCRIPTION
Use name mangling so that internal declarations in references can't conflict with each other or with the source files in the compilation unit.

Part of #259.