### PR TITLE
Undo checks for current namespace in code actions/completion

### DIFF
--- a/src/QsCompiler/CompilationManager/EditorSupport/CodeActions.cs
+++ b/src/QsCompiler/CompilationManager/EditorSupport/CodeActions.cs
@@ -41,10 +41,10 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// <summary>
         /// Returns all namespaces in which a callable with the name of the symbol at the given position in the given
         /// file belongs to.
-        /// 
+        ///
         /// Returns an empty collection if any of the arguments is null, if no unqualified symbol exists at that
         /// location, or if the position is not part of a namespace.
-        /// 
+        ///
         /// Returns the name of the identifier as an out parameter if an unqualified symbol exists at that location.
         /// </summary>
         private static IEnumerable<NonNullable<string>> NamespaceSuggestionsForIdAtPosition
@@ -52,8 +52,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         {
             var variables = file?.TryGetQsSymbolInfo(pos, true, out CodeFragment _)?.UsedVariables;
             idName = variables != null && variables.Any() ? variables.Single().Symbol.AsDeclarationName(null) : null;
-            var nsName = file.TryGetNamespaceAt(pos);
-            return idName != null && compilation != null && nsName != null
+            return idName != null && compilation != null
                 ? compilation.GlobalSymbols.NamespacesContainingCallable(NonNullable<string>.New(idName))
                 : ImmutableArray<NonNullable<string>>.Empty;
         }
@@ -61,10 +60,10 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// <summary>
         /// Returns all namespaces in which a type with the name of the symbol at the given position in the given file
         /// belongs to.
-        /// 
+        ///
         /// Returns an empty collection if any of the arguments is null, if no unqualified symbol exists at that
         /// location, or if the position is not part of a namespace.
-        /// 
+        ///
         /// Returns the name of the type as an out parameter if an unqualified symbol exists at that location.
         /// </summary>
         private static IEnumerable<NonNullable<string>> NamespaceSuggestionsForTypeAtPosition
@@ -74,8 +73,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
             typeName = types != null && types.Any() &&
                 types.Single().Type is QsTypeKind<QsType, QsSymbol, QsSymbol, Characteristics>.UserDefinedType udt
                 ? udt.Item.Symbol.AsDeclarationName(null) : null;
-            var nsName = file.TryGetNamespaceAt(pos);
-            return typeName != null && compilation != null && nsName != null
+            return typeName != null && compilation != null
                 ? compilation.GlobalSymbols.NamespacesContainingType(NonNullable<string>.New(typeName))
                 : ImmutableArray<NonNullable<string>>.Empty;
         }

--- a/src/QsCompiler/CompilationManager/EditorSupport/CodeCompletion.cs
+++ b/src/QsCompiler/CompilationManager/EditorSupport/CodeCompletion.cs
@@ -216,7 +216,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
                         .Concat(GetGlobalNamespaceCompletions(compilation, namespacePrefix))
                         .Concat(GetNamespaceAliasCompletions(file, compilation, position, namespacePrefix));
                 case CompletionKind.Tags.NamedItem:
-                    return GetNamedItemCompletions(compilation, currentNamespace);
+                    return GetNamedItemCompletions(compilation);
                 case CompletionKind.Tags.Namespace:
                     return
                         GetGlobalNamespaceCompletions(compilation, namespacePrefix)
@@ -312,7 +312,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
 
         /// <summary>
         /// Returns completions for all accessible callables given the current namespace and the list of open
-        /// namespaces, or an empty enumerable if the current namespace is null or symbols haven't been resolved yet.
+        /// namespaces, or an empty enumerable if symbols haven't been resolved yet.
         /// </summary>
         /// <exception cref="ArgumentNullException">
         /// Thrown when any argument except <paramref name="currentNamespace"/> is null.
@@ -330,7 +330,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
             if (openNamespaces == null)
                 throw new ArgumentNullException(nameof(openNamespaces));
 
-            if (currentNamespace == null || !compilation.GlobalSymbols.ContainsResolutions)
+            if (!compilation.GlobalSymbols.ContainsResolutions)
                 return Array.Empty<CompletionItem>();
             return
                 compilation.GlobalSymbols.AccessibleCallables()
@@ -351,7 +351,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
 
         /// <summary>
         /// Returns completions for all accessible types given the current namespace and the list of open namespaces, or
-        /// an empty enumerable if the current namespace is null or symbols haven't been resolved yet.
+        /// an empty enumerable if symbols haven't been resolved yet.
         /// </summary>
         /// <exception cref="ArgumentNullException">
         /// Thrown when any argument except <paramref name="currentNamespace"/> is null.
@@ -369,7 +369,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
             if (openNamespaces == null)
                 throw new ArgumentNullException(nameof(openNamespaces));
 
-            if (currentNamespace == null || !compilation.GlobalSymbols.ContainsResolutions)
+            if (!compilation.GlobalSymbols.ContainsResolutions)
                 return Array.Empty<CompletionItem>();
             return
                 compilation.GlobalSymbols.AccessibleTypes()
@@ -387,19 +387,16 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         }
 
         /// <summary>
-        /// Returns completions for all named items in any type that are accessible from the given namespace, or an
-        /// empty enumerable if the current namespace is null or symbols haven't been resolved yet.
+        /// Returns completions for all named items in any accessible type, or an empty enumerable if symbols haven't
+        /// been resolved yet.
         /// </summary>
-        /// <exception cref="ArgumentNullException">
-        /// Thrown when any argument except <paramref name="currentNamespace"/> is null.
-        /// </exception>
-        private static IEnumerable<CompletionItem> GetNamedItemCompletions(
-            CompilationUnit compilation, string currentNamespace)
+        /// <exception cref="ArgumentNullException">Thrown when the argument is null.</exception>
+        private static IEnumerable<CompletionItem> GetNamedItemCompletions(CompilationUnit compilation)
         {
             if (compilation == null)
                 throw new ArgumentNullException(nameof(compilation));
 
-            if (currentNamespace == null || !compilation.GlobalSymbols.ContainsResolutions)
+            if (!compilation.GlobalSymbols.ContainsResolutions)
                 return Array.Empty<CompletionItem>();
             return compilation.GlobalSymbols.AccessibleTypes()
                 .SelectMany(type => ExtractItems(type.TypeItems))

--- a/src/QsCompiler/CompilationManager/EditorSupport/EditorCommands.cs
+++ b/src/QsCompiler/CompilationManager/EditorSupport/EditorCommands.cs
@@ -249,7 +249,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
 
             // extracting and adapting the relevant information for the called callable
 
-            ResolutionResult<CallableDeclarationHeader>.Found methodDecl;
+            ResolutionResult<CallableDeclarationHeader>.Found methodDecl = null;
             if (id.Item1.Symbol is QsSymbolKind<QsSymbol>.Symbol sym)
             {
                 methodDecl =
@@ -266,7 +266,8 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
                                                              file.FileName)
                     as ResolutionResult<CallableDeclarationHeader>.Found;
             }
-            else
+
+            if (methodDecl == null)
             {
                 return null;
             }


### PR DESCRIPTION
This addresses comments from @bettinaheim in #345.

Also, add a quick null check in SignatureHelp, in case the callable name is not found.