### PR TITLE
Diagnostics Bug Fix

### DIFF
--- a/src/QsCompiler/Compiler/RewriteSteps/Monomorphization.cs
+++ b/src/QsCompiler/Compiler/RewriteSteps/Monomorphization.cs
@@ -26,8 +26,7 @@ namespace Microsoft.Quantum.QsCompiler.BuiltInRewriteSteps
             AssemblyConstants = new Dictionary<string, string>();
         }
 
-        public bool PreconditionVerification(QsCompilation compilation) =>
-            compilation != null && compilation.EntryPoints.Any();
+        public bool PreconditionVerification(QsCompilation compilation) => compilation.EntryPoints.Any();
 
         public bool Transformation(QsCompilation compilation, out QsCompilation transformed)
         {


### PR DESCRIPTION
Fixed a bug where Error diagnostics would not effect the status of a rewrite step. Also dropped a redundant null check in Monomorphization precondition validation. 