### PR TITLE
General tool for combining and verifying type resolution dictionaries

### DIFF
--- a/src/QsCompiler/Core/ConstructorExtensions.fs
+++ b/src/QsCompiler/Core/ConstructorExtensions.fs
@@ -83,7 +83,7 @@ type TypedExpression with
     /// the ResolvedType is set to the type constructed by resolving it using ResolveTypeParameters and the given look-up.
     static member New (expr, typeParamResolutions : ImmutableDictionary<_,_>, exType, exInfo, range) = {
         Expression = expr
-        TypeArguments = typeParamResolutions |> Seq.map (fun kv -> fst kv.Key, snd kv.Key, kv.Value) |> ImmutableArray.CreateRange
+        TypeArguments = typeParamResolutions |> TypedExpression.AsTypeArguments
         ResolvedType = ResolvedType.ResolveTypeParameters typeParamResolutions exType
         InferredInformation = exInfo
         Range = range

--- a/src/QsCompiler/DataStructures/SyntaxTree.fs
+++ b/src/QsCompiler/DataStructures/SyntaxTree.fs
@@ -364,6 +364,11 @@ type TypedExpression = {
     member this.TypeParameterResolutions =
         this.TypeArguments.ToImmutableDictionary((fun (origin, name, _) -> origin, name), (fun (_,_,t) -> t))
 
+    /// Given a dictionary containing the type resolutions for an expression, 
+    /// returns the corresponding ImmutableArray to initialize the TypeArguments with. 
+    static member AsTypeArguments (typeParamResolutions : ImmutableDictionary<_,_>) = 
+        typeParamResolutions |> Seq.map (fun kv -> fst kv.Key, snd kv.Key, kv.Value) |> ImmutableArray.CreateRange
+
     /// Returns true if the expression is a call-like expression, and the arguments contain a missing expression.
     /// Returns false otherwise.
     static member public IsPartialApplication kind =

--- a/src/QsCompiler/SyntaxProcessor/SyntaxExtensions.fs
+++ b/src/QsCompiler/SyntaxProcessor/SyntaxExtensions.fs
@@ -101,9 +101,9 @@ and private SymbolsFromExpr item : QsSymbol list * QsType list * QsExpression li
     | QsExpressionKind.InvalidExpr                            -> [], [], [item]
 
 let private AttributeAsCallExpr (sym : QsSymbol, ex : QsExpression) = 
-    let compinedRange = QsPositionInfo.CombinedRange (sym.Range, ex.Range)
+    let combinedRange = QsPositionInfo.CombinedRange (sym.Range, ex.Range)
     let id = {Expression = QsExpressionKind.Identifier (sym, Null); Range = sym.Range}
-    {Expression = QsExpressionKind.CallLikeExpression(id, ex); Range = compinedRange} 
+    {Expression = QsExpressionKind.CallLikeExpression(id, ex); Range = combinedRange} 
 
 let rec private SymbolDeclarations (sym : QsSymbol) = 
     match sym.Symbol with 

--- a/src/QsCompiler/Tests.Compiler/CallGraphTests.fs
+++ b/src/QsCompiler/Tests.Compiler/CallGraphTests.fs
@@ -51,11 +51,11 @@ type CallGraphTests (output:ITestOutputHelper) =
 
     static member AssertResolution (parent, expected, [<ParamArray>] resolutions) = 
         let success = CallGraphTests.CheckResolution (parent, expected, resolutions)
-        Assert.True(success, "overall status indicated as not successful")
+        Assert.True(success, "Combining type resolutions was not successful.")
 
     static member AssertResolutionFailure (parent, expected, [<ParamArray>] resolutions) = 
         let success = CallGraphTests.CheckResolution (parent, expected, resolutions)
-        Assert.False(success, "overall status indicated as success")
+        Assert.False(success, "Combining type resolutions should have failed.")
 
 
     [<Fact>]

--- a/src/QsCompiler/Tests.Compiler/CallGraphTests.fs
+++ b/src/QsCompiler/Tests.Compiler/CallGraphTests.fs
@@ -101,6 +101,21 @@ type CallGraphTests (output:ITestOutputHelper) =
         CallGraphTests.AssertResolution(Foo, expected, res1, res2)
 
         let res1 = resolution [
+            (FooA, BarA |> TypeParameter)
+        ]
+        let res2 = resolution [
+            (FooB, BarA |> TypeParameter)
+        ]
+        let res3 = resolution [
+            (BarA, Int)
+        ]
+        let expected = resolution [
+            (FooA, Int)
+            (FooB, Int)
+        ]
+        CallGraphTests.AssertResolution(Foo, expected, res1, res2, res3)
+
+        let res1 = resolution [
             (FooA, FooA |> TypeParameter)
         ]
         let expected = resolution [
@@ -150,3 +165,56 @@ type CallGraphTests (output:ITestOutputHelper) =
             (FooA, Double)
         ]
         CallGraphTests.AssertResolutionFailure(Foo, expected, res1, res2)
+
+        let res1 = resolution [
+            (FooA, BarA |> TypeParameter)
+        ]
+        let res2 = resolution [
+            (BarA, FooB |> TypeParameter)
+        ]
+        let expected = resolution [
+            (FooA, FooB |> TypeParameter)
+        ]
+        CallGraphTests.AssertResolutionFailure(Foo, expected, res1, res2)
+
+        let res1 = resolution [
+            (FooA, BarA |> TypeParameter)
+        ]
+        let res2 = resolution [
+            (BarA, BazA |> TypeParameter)
+        ]
+        let res3 = resolution [
+            (BazA, FooB |> TypeParameter)
+        ]
+        let expected = resolution [
+            (FooA, FooB |> TypeParameter)
+        ]
+        CallGraphTests.AssertResolutionFailure(Foo, expected, res1, res2, res3)
+
+        let res1 = resolution [
+            (FooA, BarA |> TypeParameter)
+        ]
+        let res2 = resolution [
+            (BarA, BazA |> TypeParameter)
+        ]
+        let res3 = resolution [
+            (BazA, FooA |> TypeParameter)
+        ]
+        let expected = resolution [
+            (FooA, FooA |> TypeParameter)
+        ]
+        CallGraphTests.AssertResolution(Foo, expected, res1, res2, res3)
+
+        let res1 = resolution [
+            (FooA, BarA |> TypeParameter)
+        ]
+        let res2 = resolution [
+            (BarA, BazA |> TypeParameter)
+        ]
+        let res3 = resolution [
+            (BazA, BarC |> TypeParameter) // FIXME: THIS SHOULD NOT BE OK
+        ]
+        let expected = resolution [
+            (FooA, BarC |> TypeParameter)
+        ]
+        CallGraphTests.AssertResolution(Foo, expected, res1, res2, res3)

--- a/src/QsCompiler/Tests.Compiler/CallGraphTests.fs
+++ b/src/QsCompiler/Tests.Compiler/CallGraphTests.fs
@@ -1,0 +1,65 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace Microsoft.Quantum.QsCompiler.Testing
+
+open System.Collections.Generic
+open System.Collections.Immutable
+open Microsoft.Quantum.QsCompiler.DataTypes
+open Microsoft.Quantum.QsCompiler.SyntaxExtensions
+open Microsoft.Quantum.QsCompiler.SyntaxTokens
+open Microsoft.Quantum.QsCompiler.SyntaxTree
+open Microsoft.Quantum.QsCompiler.Transformations
+open Xunit
+open Xunit.Abstractions
+
+
+type CallGraphTests (output:ITestOutputHelper) =
+
+    let qualifiedName name = 
+        ("NS" |> NonNullable<string>.New, name |> NonNullable<string>.New) |> QsQualifiedName.New
+
+    let typeParameter (id : string) = 
+        let pieces = id.Split(".")
+        Assert.True(pieces.Length = 2)
+        let parent = qualifiedName pieces.[0]
+        let name = pieces.[1] |> NonNullable<string>.New
+        QsTypeParameter.New (parent, name, Null)
+    
+    let resolution (res : (QsTypeParameter * QsTypeKind<_,_,_,_>) list) =
+        res.ToImmutableDictionary((fun (tp,_) -> tp.Origin, tp.TypeName), snd >> ResolvedType.New)
+
+    let compareDict (d1 : ImmutableDictionary<_,_>) (d2 : ImmutableDictionary<_,_>) = 
+        let keysMismatch = new HashSet<_>(d1.Keys)
+        keysMismatch.SymmetricExceptWith d2.Keys 
+        keysMismatch.Count = 0 && d1 |> Seq.exists (fun kv -> d2.[kv.Key] <> kv.Value) |> not
+
+    let Foo  = qualifiedName "Foo"
+    let Bar  = qualifiedName "Bar"
+
+    let FooA = typeParameter "Foo.A"
+    let FooB = typeParameter "Foo.B"
+    let BarA = typeParameter "Bar.A"
+    let BarC = typeParameter "Bar.C"
+    let BazA = typeParameter "Baz.A"
+
+
+    [<Fact>]
+    member this.``Type resolution`` () = 
+
+        let res1 = resolution [
+            (FooA, BarA |> TypeParameter)
+            (FooB, Int)
+        ]
+        let res2 = resolution [
+            (BarA, Int)
+        ]
+        let expected = resolution [
+            (FooA, Int)
+            (FooB, Int)
+        ]
+
+        let mutable combined = ImmutableDictionary.Empty
+        let success = CallGraph.TryCombineTypeResolutions(Foo, &combined, res1, res2)
+        Assert.True(success)
+        Assert.True(compareDict expected combined)

--- a/src/QsCompiler/Tests.Compiler/CallGraphTests.fs
+++ b/src/QsCompiler/Tests.Compiler/CallGraphTests.fs
@@ -59,7 +59,8 @@ type CallGraphTests (output:ITestOutputHelper) =
 
 
     [<Fact>]
-    member this.``Type resolution`` () = 
+    [<Trait("Category","Type resolution")>]
+    member this.``Type resolution: resolution to concrete`` () = 
 
         let res1 = resolution [
             (FooA, BarA |> TypeParameter)
@@ -74,6 +75,40 @@ type CallGraphTests (output:ITestOutputHelper) =
         ]
         CallGraphTests.AssertResolution(Foo, expected, res1, res2)
 
+    [<Fact>]
+    [<Trait("Category","Type resolution")>]
+    member this.``Type resolution: resolution to type parameter`` () = 
+
+        let res1 = resolution [
+            (FooA, BarA |> TypeParameter)
+        ]
+        let res2 = resolution [
+            (BarA, BazA |> TypeParameter)
+        ]
+        let expected = resolution [
+            (FooA, BazA |> TypeParameter)
+        ]
+        CallGraphTests.AssertResolution(Foo, expected, res1, res2)
+
+    [<Fact>]
+    [<Trait("Category","Type resolution")>]
+    member this.``Type resolution: resolution via identity mapping`` () = 
+
+        let res1 = resolution [
+            (FooA, FooA |> TypeParameter)
+        ]
+        let res2 = resolution [
+            (FooA, Int)
+        ]
+        let expected = resolution [
+            (FooA, Int)
+        ]
+        CallGraphTests.AssertResolution(Foo, expected, res1, res2)
+
+    [<Fact>]
+    [<Trait("Category","Type resolution")>]
+    member this.``Type resolution: multi-stage resolution`` () = 
+
         let res1 = resolution [
             (FooA, BarA |> TypeParameter)
         ]
@@ -86,6 +121,10 @@ type CallGraphTests (output:ITestOutputHelper) =
             (FooB, Int)
         ]
         CallGraphTests.AssertResolution(Foo, expected, res1, res2)
+
+    [<Fact>]
+    [<Trait("Category","Type resolution")>]
+    member this.``Type resolution: multiple resolutions to concrete`` () = 
 
         let res1 = resolution [
             (FooA, BarA |> TypeParameter)
@@ -99,6 +138,30 @@ type CallGraphTests (output:ITestOutputHelper) =
             (FooB, Int)
         ]
         CallGraphTests.AssertResolution(Foo, expected, res1, res2)
+
+    [<Fact>]
+    [<Trait("Category","Type resolution")>]
+    member this.``Type resolution: multiple resolutions to type parameter`` () = 
+
+        let res1 = resolution [
+            (FooA, BarA |> TypeParameter)
+            (FooB, BarA |> TypeParameter)
+        ]
+        let res2 = resolution [
+            (BarA, BazA |> TypeParameter)
+        ]
+        let res3 = resolution [
+            (BazA, Double)
+        ]
+        let expected = resolution [
+            (FooA, Double)
+            (FooB, Double)
+        ]
+        CallGraphTests.AssertResolution(Foo, expected, res1, res2, res3)
+
+    [<Fact>]
+    [<Trait("Category","Type resolution")>]
+    member this.``Type resolution: multi-stage resolution of multiple resolutions to concrete`` () = 
 
         let res1 = resolution [
             (FooA, BarA |> TypeParameter)
@@ -115,32 +178,29 @@ type CallGraphTests (output:ITestOutputHelper) =
         ]
         CallGraphTests.AssertResolution(Foo, expected, res1, res2, res3)
 
-        let res1 = resolution [
-            (FooA, FooA |> TypeParameter)
-        ]
-        let expected = resolution [
-            (FooA, FooA |> TypeParameter)
-        ]
-        CallGraphTests.AssertResolution(Foo, expected, res1)
+    [<Fact>]
+    [<Trait("Category","Type resolution")>]
+    member this.``Type resolution: multi-stage resolution of multiple resolutions to type parameter`` () = 
 
         let res1 = resolution [
-            (FooA, FooA |> TypeParameter)
+            (FooA, BarA |> TypeParameter)
         ]
         let res2 = resolution [
-            (FooA, Int)
+            (BarA, BazA |> TypeParameter)
+            (FooB, BarA |> TypeParameter)
+        ]
+        let res3 = resolution [
+            (BazA, Int)
         ]
         let expected = resolution [
             (FooA, Int)
+            (FooB, Int)
         ]
-        CallGraphTests.AssertResolution(Foo, expected, res1, res2)
+        CallGraphTests.AssertResolution(Foo, expected, res1, res2, res3)
 
-        let res1 = resolution [
-            (FooA, FooB |> TypeParameter)
-        ]
-        let expected = resolution [
-            (FooA, FooB |> TypeParameter)
-        ]
-        CallGraphTests.AssertResolutionFailure(Foo, expected, res1)
+    [<Fact>]
+    [<Trait("Category","Type resolution")>]
+    member this.``Type resolution: redundant resolution to concrete`` () = 
 
         let res1 = resolution [
             (FooA, BarA |> TypeParameter)
@@ -154,28 +214,9 @@ type CallGraphTests (output:ITestOutputHelper) =
         ]
         CallGraphTests.AssertResolution(Foo, expected, res1, res2)
 
-        let res1 = resolution [
-            (FooA, BarA |> TypeParameter)
-        ]
-        let res2 = resolution [
-            (BarA, Int)
-            (FooA, Double)
-        ]
-        let expected = resolution [
-            (FooA, Double)
-        ]
-        CallGraphTests.AssertResolutionFailure(Foo, expected, res1, res2)
-
-        let res1 = resolution [
-            (FooA, BarA |> TypeParameter)
-        ]
-        let res2 = resolution [
-            (BarA, FooB |> TypeParameter)
-        ]
-        let expected = resolution [
-            (FooA, FooB |> TypeParameter)
-        ]
-        CallGraphTests.AssertResolutionFailure(Foo, expected, res1, res2)
+    [<Fact>]
+    [<Trait("Category","Type resolution")>]
+    member this.``Type resolution: redundant resolution to type parameter`` () = 
 
         let res1 = resolution [
             (FooA, BarA |> TypeParameter)
@@ -184,12 +225,60 @@ type CallGraphTests (output:ITestOutputHelper) =
             (BarA, BazA |> TypeParameter)
         ]
         let res3 = resolution [
-            (BazA, FooB |> TypeParameter)
+            (FooA, BazA |> TypeParameter)
         ]
         let expected = resolution [
-            (FooA, FooB |> TypeParameter)
+            (FooA, BazA |> TypeParameter)
         ]
-        CallGraphTests.AssertResolutionFailure(Foo, expected, res1, res2, res3)
+        CallGraphTests.AssertResolution(Foo, expected, res1, res2, res3)
+
+    [<Fact>]
+    [<Trait("Category","Type resolution")>]
+    member this.``Type resolution: conflicting resolution to concrete`` () = 
+
+        let res1 = resolution [
+            (FooA, BarA |> TypeParameter)
+        ]
+        let res2 = resolution [
+            (BarA, Int)
+            (FooA, Double)
+        ]
+        let expected = resolution [
+            (FooA, Double)
+        ]
+        CallGraphTests.AssertResolutionFailure(Foo, expected, res1, res2)
+
+    [<Fact>]
+    [<Trait("Category","Type resolution")>]
+    member this.``Type resolution: conflicting resolution to type parameter`` () = 
+
+        let res1 = resolution [
+            (FooA, BarA |> TypeParameter)
+        ]
+        let res2 = resolution [
+            (BarA, BazA |> TypeParameter)
+            (FooA, BarC |> TypeParameter)
+        ]
+        let expected = resolution [
+            (FooA, BarC |> TypeParameter)
+        ]
+        CallGraphTests.AssertResolutionFailure(Foo, expected, res1, res2)
+
+    [<Fact>]
+    [<Trait("Category","Type resolution")>]
+    member this.``Type resolution: direct resolution to native`` () = 
+
+        let res1 = resolution [
+            (FooA, FooA |> TypeParameter)
+        ]
+        let expected = resolution [
+            (FooA, FooA |> TypeParameter)
+        ]
+        CallGraphTests.AssertResolution(Foo, expected, res1)
+
+    [<Fact>]
+    [<Trait("Category","Type resolution")>]
+    member this.``Type resolution: indirect resolution to native`` () = 
 
         let res1 = resolution [
             (FooA, BarA |> TypeParameter)
@@ -205,16 +294,21 @@ type CallGraphTests (output:ITestOutputHelper) =
         ]
         CallGraphTests.AssertResolution(Foo, expected, res1, res2, res3)
 
+    [<Fact>]
+    [<Trait("Category","Type resolution")>]
+    member this.``Type resolution: direct resolution constrains native`` () = 
+
         let res1 = resolution [
-            (FooA, BarA |> TypeParameter)
-        ]
-        let res2 = resolution [
-            (BarA, BazA |> TypeParameter)
+            (FooA, FooB |> TypeParameter)
         ]
         let expected = resolution [
-            (FooA, BazA |> TypeParameter)
+            (FooA, FooB |> TypeParameter)
         ]
-        CallGraphTests.AssertResolution(Foo, expected, res1, res2)
+        CallGraphTests.AssertResolutionFailure(Foo, expected, res1)
+
+    [<Fact>]
+    [<Trait("Category","Type resolution")>]
+    member this.``Type resolution: indirect resolution constrains native`` () = 
 
         let res1 = resolution [
             (FooA, BarA |> TypeParameter)
@@ -223,12 +317,16 @@ type CallGraphTests (output:ITestOutputHelper) =
             (BarA, BazA |> TypeParameter)
         ]
         let res3 = resolution [
-            (FooA, BazA |> TypeParameter)
+            (BazA, FooB |> TypeParameter)
         ]
         let expected = resolution [
-            (FooA, BazA |> TypeParameter)
+            (FooA, FooB |> TypeParameter)
         ]
-        CallGraphTests.AssertResolution(Foo, expected, res1, res2, res3)
+        CallGraphTests.AssertResolutionFailure(Foo, expected, res1, res2, res3)
+
+    [<Fact(Skip="Not yet supported")>]
+    [<Trait("Category","Type resolution")>]
+    member this.``Type resolution: inner cycle constrains type parameter`` () = 
 
         let res1 = resolution [
             (FooA, BarA |> TypeParameter)
@@ -242,4 +340,4 @@ type CallGraphTests (output:ITestOutputHelper) =
         let expected = resolution [
             (FooA, BarC |> TypeParameter)
         ]
-        CallGraphTests.AssertResolution(Foo, expected, res1, res2, res3)
+        CallGraphTests.AssertResolutionFailure(Foo, expected, res1, res2, res3)

--- a/src/QsCompiler/Tests.Compiler/CallGraphTests.fs
+++ b/src/QsCompiler/Tests.Compiler/CallGraphTests.fs
@@ -178,26 +178,6 @@ type CallGraphTests (output:ITestOutputHelper) =
         ]
         CallGraphTests.AssertResolution(Foo, expected, res1, res2, res3)
 
-    [<Fact(Skip="Not yet supported")>]
-    [<Trait("Category","Type resolution")>]
-    member this.``Type resolution: multi-stage resolution of multiple resolutions to type parameter`` () = 
-
-        let res1 = resolution [
-            (FooA, BarA |> TypeParameter)
-        ]
-        let res2 = resolution [
-            (BarA, BazA |> TypeParameter)
-            (FooB, BarA |> TypeParameter)
-        ]
-        let res3 = resolution [
-            (BazA, Int)
-        ]
-        let expected = resolution [
-            (FooA, Int)
-            (FooB, Int)
-        ]
-        CallGraphTests.AssertResolution(Foo, expected, res1, res2, res3)
-
     [<Fact>]
     [<Trait("Category","Type resolution")>]
     member this.``Type resolution: redundant resolution to concrete`` () = 
@@ -324,20 +304,3 @@ type CallGraphTests (output:ITestOutputHelper) =
         ]
         CallGraphTests.AssertResolutionFailure(Foo, expected, res1, res2, res3)
 
-    [<Fact(Skip="Not yet supported")>]
-    [<Trait("Category","Type resolution")>]
-    member this.``Type resolution: inner cycle constrains type parameter`` () = 
-
-        let res1 = resolution [
-            (FooA, BarA |> TypeParameter)
-        ]
-        let res2 = resolution [
-            (BarA, BazA |> TypeParameter)
-        ]
-        let res3 = resolution [
-            (BazA, BarC |> TypeParameter) // TODO: for performance reasons it would be nice to detect this case as well and error here
-        ]
-        let expected = resolution [
-            (FooA, BarC |> TypeParameter)
-        ]
-        CallGraphTests.AssertResolutionFailure(Foo, expected, res1, res2, res3)

--- a/src/QsCompiler/Tests.Compiler/CallGraphTests.fs
+++ b/src/QsCompiler/Tests.Compiler/CallGraphTests.fs
@@ -178,7 +178,7 @@ type CallGraphTests (output:ITestOutputHelper) =
         ]
         CallGraphTests.AssertResolution(Foo, expected, res1, res2, res3)
 
-    [<Fact>]
+    [<Fact(Skip="Not yet supported")>]
     [<Trait("Category","Type resolution")>]
     member this.``Type resolution: multi-stage resolution of multiple resolutions to type parameter`` () = 
 

--- a/src/QsCompiler/Tests.Compiler/CallGraphTests.fs
+++ b/src/QsCompiler/Tests.Compiler/CallGraphTests.fs
@@ -39,14 +39,14 @@ type CallGraphTests (output:ITestOutputHelper) =
     let BarC = typeParameter "Bar.C"
     let BazA = typeParameter "Baz.A"
 
-    static member CheckResolution (parent, expected, [<ParamArray>] resolutions) = 
-        let compareDict (d1 : ImmutableDictionary<_,_>) (d2 : ImmutableDictionary<_,_>) = 
-            let keysMismatch = new HashSet<_>(d1.Keys)
-            keysMismatch.SymmetricExceptWith d2.Keys 
-            keysMismatch.Count = 0 && d1 |> Seq.exists (fun kv -> d2.[kv.Key] <> kv.Value) |> not
+    static member CheckResolution (parent, expected : IDictionary<_,_>, [<ParamArray>] resolutions) = 
+        let expectedKeys = ImmutableHashSet.CreateRange(expected.Keys) 
+        let compareWithExpected (d : ImmutableDictionary<_,_>) = 
+            let keysMismatch = expectedKeys.SymmetricExcept d.Keys 
+            keysMismatch.Count = 0 && expected |> Seq.exists (fun kv -> d.[kv.Key] <> kv.Value) |> not
         let mutable combined = ImmutableDictionary.Empty
         let success = CallGraph.TryCombineTypeResolutions(parent, &combined, resolutions)
-        Assert.True(compareDict expected combined, "combined resolutions did not match the expected ones")
+        Assert.True(compareWithExpected combined, "combined resolutions did not match the expected ones")
         success
 
     static member AssertResolution (parent, expected, [<ParamArray>] resolutions) = 

--- a/src/QsCompiler/Tests.Compiler/CallGraphTests.fs
+++ b/src/QsCompiler/Tests.Compiler/CallGraphTests.fs
@@ -212,7 +212,7 @@ type CallGraphTests (output:ITestOutputHelper) =
             (BarA, BazA |> TypeParameter)
         ]
         let res3 = resolution [
-            (BazA, BarC |> TypeParameter) // FIXME: THIS SHOULD NOT BE OK
+            (BazA, BarC |> TypeParameter) // TODO: for performance reasons it would be nice to detect this case as well and error here
         ]
         let expected = resolution [
             (FooA, BarC |> TypeParameter)

--- a/src/QsCompiler/Tests.Compiler/CallGraphTests.fs
+++ b/src/QsCompiler/Tests.Compiler/CallGraphTests.fs
@@ -3,6 +3,7 @@
 
 namespace Microsoft.Quantum.QsCompiler.Testing
 
+open System
 open System.Collections.Generic
 open System.Collections.Immutable
 open Microsoft.Quantum.QsCompiler.DataTypes
@@ -29,11 +30,6 @@ type CallGraphTests (output:ITestOutputHelper) =
     let resolution (res : (QsTypeParameter * QsTypeKind<_,_,_,_>) list) =
         res.ToImmutableDictionary((fun (tp,_) -> tp.Origin, tp.TypeName), snd >> ResolvedType.New)
 
-    let compareDict (d1 : ImmutableDictionary<_,_>) (d2 : ImmutableDictionary<_,_>) = 
-        let keysMismatch = new HashSet<_>(d1.Keys)
-        keysMismatch.SymmetricExceptWith d2.Keys 
-        keysMismatch.Count = 0 && d1 |> Seq.exists (fun kv -> d2.[kv.Key] <> kv.Value) |> not
-
     let Foo  = qualifiedName "Foo"
     let Bar  = qualifiedName "Bar"
 
@@ -42,6 +38,24 @@ type CallGraphTests (output:ITestOutputHelper) =
     let BarA = typeParameter "Bar.A"
     let BarC = typeParameter "Bar.C"
     let BazA = typeParameter "Baz.A"
+
+    static member CheckResolution (parent, expected, [<ParamArray>] resolutions) = 
+        let compareDict (d1 : ImmutableDictionary<_,_>) (d2 : ImmutableDictionary<_,_>) = 
+            let keysMismatch = new HashSet<_>(d1.Keys)
+            keysMismatch.SymmetricExceptWith d2.Keys 
+            keysMismatch.Count = 0 && d1 |> Seq.exists (fun kv -> d2.[kv.Key] <> kv.Value) |> not
+        let mutable combined = ImmutableDictionary.Empty
+        let success = CallGraph.TryCombineTypeResolutions(parent, &combined, resolutions)
+        Assert.True(compareDict expected combined)
+        success
+
+    static member AssertResolution (parent, expected, [<ParamArray>] resolutions) = 
+        let success = CallGraphTests.CheckResolution (parent, expected, resolutions)
+        Assert.True(success)
+
+    static member AssertResolutionFailure (parent, expected, [<ParamArray>] resolutions) = 
+        let success = CallGraphTests.CheckResolution (parent, expected, resolutions)
+        Assert.False(success)
 
 
     [<Fact>]
@@ -58,8 +72,49 @@ type CallGraphTests (output:ITestOutputHelper) =
             (FooA, Int)
             (FooB, Int)
         ]
+        CallGraphTests.AssertResolution(Foo, expected, res1, res2)
 
-        let mutable combined = ImmutableDictionary.Empty
-        let success = CallGraph.TryCombineTypeResolutions(Foo, &combined, res1, res2)
-        Assert.True(success)
-        Assert.True(compareDict expected combined)
+        let res1 = resolution [
+            (FooA, BarA |> TypeParameter)
+        ]
+        let res2 = resolution [
+            (BarA, Int)
+            (FooB, Int)
+        ]
+        let expected = resolution [
+            (FooA, Int)
+            (FooB, Int)
+        ]
+        CallGraphTests.AssertResolution(Foo, expected, res1, res2)
+
+        let res1 = resolution [
+            (FooA, BarA |> TypeParameter)
+            (FooB, BarA |> TypeParameter)
+        ]
+        let res2 = resolution [
+            (BarA, Int)
+        ]
+        let expected = resolution [
+            (FooA, Int)
+            (FooB, Int)
+        ]
+        CallGraphTests.AssertResolution(Foo, expected, res1, res2)
+
+        let res1 = resolution [
+            (FooA, FooA |> TypeParameter)
+        ]
+        let expected = resolution [
+            (FooA, FooA |> TypeParameter)
+        ]
+        CallGraphTests.AssertResolution(Foo, expected, res1)
+
+        let res1 = resolution [
+            (FooA, FooA |> TypeParameter)
+        ]
+        let res2 = resolution [
+            (FooA, Int)
+        ]
+        let expected = resolution [
+            (FooA, Int)
+        ]
+        CallGraphTests.AssertResolution(Foo, expected, res1, res2)

--- a/src/QsCompiler/Tests.Compiler/CallGraphTests.fs
+++ b/src/QsCompiler/Tests.Compiler/CallGraphTests.fs
@@ -211,6 +211,31 @@ type CallGraphTests (output:ITestOutputHelper) =
         let res2 = resolution [
             (BarA, BazA |> TypeParameter)
         ]
+        let expected = resolution [
+            (FooA, BazA |> TypeParameter)
+        ]
+        CallGraphTests.AssertResolution(Foo, expected, res1, res2)
+
+        let res1 = resolution [
+            (FooA, BarA |> TypeParameter)
+        ]
+        let res2 = resolution [
+            (BarA, BazA |> TypeParameter)
+        ]
+        let res3 = resolution [
+            (FooA, BazA |> TypeParameter)
+        ]
+        let expected = resolution [
+            (FooA, BazA |> TypeParameter)
+        ]
+        CallGraphTests.AssertResolution(Foo, expected, res1, res2, res3)
+
+        let res1 = resolution [
+            (FooA, BarA |> TypeParameter)
+        ]
+        let res2 = resolution [
+            (BarA, BazA |> TypeParameter)
+        ]
         let res3 = resolution [
             (BazA, BarC |> TypeParameter) // TODO: for performance reasons it would be nice to detect this case as well and error here
         ]

--- a/src/QsCompiler/Tests.Compiler/Tests.Compiler.fsproj
+++ b/src/QsCompiler/Tests.Compiler/Tests.Compiler.fsproj
@@ -143,6 +143,7 @@
     <Compile Include="TransformationTests.fs" />
     <Compile Include="ExecutionTests.fs" />
     <Compile Include="LinkingTests.fs" />
+    <Compile Include="CallGraphTests.fs" />
     <Compile Include="ClassicalControlTests.fs" />
     <Compile Include="RegexTests.fs" />
     <Compile Include="SerializationTests.fs" />
@@ -179,9 +180,7 @@
       <ExecutionTarget>$(MSBuildThisFileDirectory)..\TestTargets\Simulation\Example\bin\$(Configuration)\netcoreapp3.1\Example.dll</ExecutionTarget>
       <LibraryTarget>$(MSBuildThisFileDirectory)..\TestTargets\Libraries\Library1\bin\$(Configuration)\netcoreapp3.1\Library1.dll</LibraryTarget>
     </PropertyGroup>
-    <WriteLinesToFile File="$(OutputPath)ReferenceTargets.txt"
-                      Lines="$(ExecutionTarget); $(LibraryTarget)"
-                      Overwrite="true" />
+    <WriteLinesToFile File="$(OutputPath)ReferenceTargets.txt" Lines="$(ExecutionTarget); $(LibraryTarget)" Overwrite="true" />
   </Target>
 
 </Project>

--- a/src/QsCompiler/TextProcessor/QsKeywords.fs
+++ b/src/QsCompiler/TextProcessor/QsKeywords.fs
@@ -47,7 +47,7 @@ let private addFragmentHeader word =
     _FragmentHeaders.Add  word |> ignore
     qsKeyword word
 
-/// Given the keyword for two functors, constructs and returns the keyword for the compined functor 
+/// Given the keyword for two functors, constructs and returns the keyword for the combined functor 
 /// under the assumption tha the order of the functors does not matter.
 /// Adds the keyword for the combined functor to the list of QsReservedKeywords, QsLanguageKeywords and QsFragmentHeaders.
 let private addFunctorCombination (word1 : QsKeyword, word2 : QsKeyword) = 

--- a/src/QsCompiler/TextProcessor/QsTypeParsing.fs
+++ b/src/QsCompiler/TextProcessor/QsTypeParsing.fs
@@ -25,7 +25,7 @@ let private characteristicsExpression = new OperatorPrecedenceParser<Characteris
 /// builds the corresponding expression with its range set to the combined range. 
 /// If either one of given ranges is Null, builds an invalid expression with its range set to Null. 
 let private buildCombinedExpression kind (lRange, rRange) = 
-    QsPositionInfo.WithCombinedRange (lRange, rRange) kind InvalidSetExpr |> Characteristics.New  // *needs* to be invalid if the compined range is Null!
+    QsPositionInfo.WithCombinedRange (lRange, rRange) kind InvalidSetExpr |> Characteristics.New  // *needs* to be invalid if the combined range is Null!
 
 let private applyBinary operator _ (left : Characteristics) (right : Characteristics) = 
     buildCombinedExpression (operator (left, right)) (left.Range, right.Range)
@@ -186,7 +186,7 @@ let internal typeParser tupleType =
         ]
     let buildArrays p = 
         let combine kind (lRange, rRange) = 
-            QsPositionInfo.WithCombinedRange (lRange, rRange) kind InvalidType |> QsType.New // *needs* to be invalid if the compined range is Null!
+            QsPositionInfo.WithCombinedRange (lRange, rRange) kind InvalidType |> QsType.New // *needs* to be invalid if the combined range is Null!
         let rec applyArrays (t : QsType, item) = 
             match item with
             | [] -> t

--- a/src/QsCompiler/TextProcessor/SyntaxExtensions.fs
+++ b/src/QsCompiler/TextProcessor/SyntaxExtensions.fs
@@ -16,7 +16,7 @@ type QsPositionInfo with
     static member Range (pos1, pos2) = 
         Value (QsPositionInfo.New pos1, QsPositionInfo.New pos2)
 
-    /// If the given right and left range both have contain a Value, returns the given kind as well as a Value with the compined range.
+    /// If the given right and left range both have contain a Value, returns the given kind as well as a Value with the combined range.
     /// Returns the given fallback and Null otherwise. 
     static member WithCombinedRange (lRange, rRange) kind fallback = 
         match (lRange, rRange) with

--- a/src/QsCompiler/Transformations/CallGraphWalker.cs
+++ b/src/QsCompiler/Transformations/CallGraphWalker.cs
@@ -93,8 +93,8 @@ namespace Microsoft.Quantum.QsCompiler.Transformations
                     if (entry.Key.Item1.Equals(parent))
                     {
                         // A native type parameter cannot be resolved to another native type parameter, since this would constrain them. 
-                        var nontrivialResolutionToNative = isResolutionToNative && entry.Key.Item2.Value != resolutionToTypeParam.Item.TypeName.Value;
-                        success = success && !nontrivialResolutionToNative;
+                        var inconsistentResolutionToNative = isResolutionToNative && entry.Key.Item2.Value != resolutionToTypeParam.Item.TypeName.Value;
+                        success = success && !inconsistentResolutionToNative;
                         // Check that there is no conflicting resolution already defined.
                         var conflictingResolutionExists = combinedBuilder.TryGetValue(entry.Key, out var current)
                             && !current.Equals(entry.Value) && !ResolutionToTypeParameter(entry.Key, current);
@@ -109,8 +109,8 @@ namespace Microsoft.Quantum.QsCompiler.Transformations
                         {
                             // If one of the values is a type parameter from the parent callable, 
                             // but it isn't mapped to itself then the combined resolution is invalid. 
-                            var nontrivialResolutionToNative = isResolutionToNative && keyInCombined.Item2.Value != resolutionToTypeParam.Item.TypeName.Value;
-                            success = success && !nontrivialResolutionToNative;
+                            var inconsistentResolutionToNative = isResolutionToNative && keyInCombined.Item2.Value != resolutionToTypeParam.Item.TypeName.Value;
+                            success = success && !inconsistentResolutionToNative;
                             combinedBuilder[keyInCombined] = entry.Value;
                         }
                     }

--- a/src/QsCompiler/Transformations/CallGraphWalker.cs
+++ b/src/QsCompiler/Transformations/CallGraphWalker.cs
@@ -38,9 +38,8 @@ namespace Microsoft.Quantum.QsCompiler.Transformations
         internal static bool VerifyCycle(CallGraphNode rootNode, params CallGraphEdge[] edges)
         {
             var parent = rootNode.CallableName;
-            bool EqualsParent(QsQualifiedName origin) => origin.Namespace.Value == parent.Namespace.Value && origin.Name.Value == parent.Name.Value;
             var validResolution = TryCombineTypeResolutions(parent, out var combined, edges.Select(edge => edge.ParamResolutions).ToArray());
-            var resolvedToConcrete = combined.Values.All(res => !(res.Resolution is ResolvedTypeKind.TypeParameter tp) || EqualsParent(tp.Item.Origin));
+            var resolvedToConcrete = combined.Values.All(res => !(res.Resolution is ResolvedTypeKind.TypeParameter tp) || tp.Item.Origin.Equals(parent));
             return validResolution && resolvedToConcrete;
             //var isClosedCycle = validCycle && combined.Values.Any(res => res.Resolution is ResolvedTypeKind.TypeParameter tp && EqualsParent(tp.Item.Origin));
             // TODO: check that monomorphization correctly processes closed cycles - meaning add a test...

--- a/src/QsCompiler/Transformations/CallGraphWalker.cs
+++ b/src/QsCompiler/Transformations/CallGraphWalker.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Quantum.QsCompiler.Transformations
         // This is the method that should be invoked to verify cycles of interest,
         // i.e. where each callable in the cycle is type parametrized.
         // It should probably generate diagnostics; I'll add the doc comment once its use is fully defined. 
-        private static bool VerifyCycle(CallGraphNode rootNode, params CallGraphEdge[] edges)
+        internal static bool VerifyCycle(CallGraphNode rootNode, params CallGraphEdge[] edges)
         {
             var parent = rootNode.CallableName;
             bool EqualsParent(QsQualifiedName origin) => origin.Namespace.Value == parent.Namespace.Value && origin.Name.Value == parent.Name.Value;

--- a/src/QsCompiler/Transformations/CallGraphWalker.cs
+++ b/src/QsCompiler/Transformations/CallGraphWalker.cs
@@ -71,6 +71,8 @@ namespace Microsoft.Quantum.QsCompiler.Transformations
             static bool ResolutionToTypeParameter(Tuple<QsQualifiedName, NonNullable<string>> typeParam, ResolvedType res) =>
                 res.Resolution is ResolvedTypeKind.TypeParameter tp && tp.Item.Origin.Equals(typeParam.Item1) && tp.Item.TypeName.Equals(typeParam.Item2);
 
+            // Returns true if the given resolution for the given key constrains the type parameter 
+            // by mapping it to a different type parameter belonging to the same callable. 
             bool InconsistentResolutionToNative(Tuple<QsQualifiedName, NonNullable<string>> key, ResolvedType resolution)
             {
                 var resolutionToTypeParam = resolution.Resolution as ResolvedTypeKind.TypeParameter;
@@ -127,7 +129,6 @@ namespace Microsoft.Quantum.QsCompiler.Transformations
                         // belonging to multiple callables can/should be treated as concrete types simultaneously. 
                         throw new ArgumentException("attempting to define resolution for type parameter that does not belong to parent callable");
                     }
-
                 }
             }
 

--- a/src/QsCompiler/Transformations/CallGraphWalker.cs
+++ b/src/QsCompiler/Transformations/CallGraphWalker.cs
@@ -71,6 +71,8 @@ namespace Microsoft.Quantum.QsCompiler.Transformations
 
             bool EqualsParent(QsQualifiedName origin) => origin.Namespace.Value == parent.Namespace.Value && origin.Name.Value == parent.Name.Value;
             static Tuple<QsQualifiedName, NonNullable<string>> AsTypeResolutionKey(QsTypeParameter tp) => Tuple.Create(tp.Origin, tp.TypeName);
+            static bool ResolutionToTypeParameter(Tuple<QsQualifiedName, NonNullable<string>> typeParam, ResolvedType res) =>
+                res.Resolution is ResolvedTypeKind.TypeParameter tp && tp.Item.Origin.Equals(typeParam.Item1) && tp.Item.TypeName.Equals(typeParam.Item2);
 
             foreach (var resolution in resolutions)
             {
@@ -109,7 +111,8 @@ namespace Microsoft.Quantum.QsCompiler.Transformations
                         var nontrivialResolutionToNative = isResolutionToNative && entry.Key.Item2.Value != resolutionToTypeParam.Item.TypeName.Value;
                         success = success && !nontrivialResolutionToNative;
                         // Check that there is no conflicting resolution already defined.
-                        var conflictingResolutionExists = combinedBuilder.TryGetValue(entry.Key, out var current) && !current.Equals(entry.Value);
+                        var conflictingResolutionExists = combinedBuilder.TryGetValue(entry.Key, out var current) 
+                            && !current.Equals(entry.Value) && !ResolutionToTypeParameter(entry.Key, current);
                         success = success && !conflictingResolutionExists;
                         combinedBuilder[entry.Key] = entry.Value;
                     }

--- a/src/QsCompiler/Transformations/CallGraphWalker.cs
+++ b/src/QsCompiler/Transformations/CallGraphWalker.cs
@@ -60,12 +60,18 @@ namespace Microsoft.Quantum.QsCompiler.Transformations.CallGraphWalker
             }
         }
 
+        /// <summary>
+        /// Adds a dependency to the call graph using the caller's specialization and the called specialization's information.
+        /// </summary>
         public void AddDependency(QsSpecialization callerSpec, QsQualifiedName calledName, QsSpecializationKind calledKind, QsNullable<ImmutableArray<ResolvedType>> calledTypeArgs, CallGraphEdge edge) =>
             AddDependency(
                 callerSpec.Parent, callerSpec.Kind, callerSpec.TypeArguments,
                 calledName, calledKind, calledTypeArgs,
                 edge);
 
+        /// <summary>
+        /// Adds a dependency to the call graph using the relevant information from the caller's specialization and the called specialization.
+        /// </summary>
         public void AddDependency(
             QsQualifiedName callerName, QsSpecializationKind callerKind, QsNullable<ImmutableArray<ResolvedType>> callerTypeArgs,
             QsQualifiedName calledName, QsSpecializationKind calledKind, QsNullable<ImmutableArray<ResolvedType>> calledTypeArgs,
@@ -78,6 +84,13 @@ namespace Microsoft.Quantum.QsCompiler.Transformations.CallGraphWalker
             RecordDependency(callerKey, calledKey, edge);
         }
 
+        /// <summary>
+        /// Returns all specializations that are used directly within the given caller, whether they are
+        /// called, partially applied, or assigned. Each key in the returned dictionary represents a
+        /// specialization that is used by the caller. Each value in the dictionary is an array of edges
+        /// representing all the different ways the given caller specialization took a dependency on the
+        /// specialization represented by the associated key.
+        /// </summary>
         public Dictionary<CallGraphNode, ImmutableArray<CallGraphEdge>> GetDirectDependencies(CallGraphNode callerSpec)
         {
             if (_Dependencies.TryGetValue(callerSpec, out var deps))
@@ -90,12 +103,13 @@ namespace Microsoft.Quantum.QsCompiler.Transformations.CallGraphWalker
             }
         }
 
-        /// Returns all specializations that are used directly within the given caller,
-        /// whether they are called, partially applied, or assigned.
-        /// The returned specializations are identified by the full name of the callable,
-        /// the specialization kind, as well as the resolved type arguments.
-        /// The returned type arguments are the exact type arguments of the expression,
-        /// and may thus be incomplete or correspond to subtypes of a defined specialization bundle.
+        /// <summary>
+        /// Returns all specializations that are used directly within the given caller, whether they are
+        /// called, partially applied, or assigned. Each key in the returned dictionary represents a
+        /// specialization that is used by the caller. Each value in the dictionary is an array of edges
+        /// representing all the different ways the given caller specialization took a dependency on the
+        /// specialization represented by the associated key.
+        /// </summary>
         public Dictionary<CallGraphNode, ImmutableArray<CallGraphEdge>> GetDirectDependencies(QsSpecialization callerSpec) =>
             GetDirectDependencies(new CallGraphNode { CallableName = callerSpec.Parent, Kind = callerSpec.Kind, TypeArgs = RemovePositionFromTypeArgs(callerSpec.TypeArguments) });
 
@@ -127,15 +141,20 @@ namespace Microsoft.Quantum.QsCompiler.Transformations.CallGraphWalker
             //return WalkDependencyTree(callerSpec, new HashSet<(CallGraphNode, DependencyType)>(), DependencyType.NoTypeParameters).ToImmutableArray();
         }
 
-        /// Returns all specializations directly or indirectly used within the given caller,
-        /// whether they are called, partially applied, or assigned.
-        /// The returned specializations are identified by the full name of the callable,
-        /// the specialization kind, as well as the resolved type arguments.
-        /// The returned type arguments are the exact type arguments of the expression,
-        /// and may thus be incomplete or correspond to subtypes of a defined specialization bundle.
+        /// <summary>
+        /// Returns all specializations that are used directly or indirectly within the given caller,
+        /// whether they are called, partially applied, or assigned. Each key in the returned dictionary
+        /// represents a specialization that is used by the caller. Each value in the dictionary is an
+        /// array of edges representing all the different ways the given caller specialization took a
+        /// dependency on the specialization represented by the associated key.
+        /// </summary>
         public Dictionary<CallGraphNode, ImmutableArray<CallGraphEdge>> GetAllDependencies(QsSpecialization callerSpec) =>
             GetAllDependencies(new CallGraphNode { CallableName = callerSpec.Parent, Kind = callerSpec.Kind, TypeArgs = RemovePositionFromTypeArgs(callerSpec.TypeArguments) });
 
+        /// <summary>
+        /// Finds and returns a list of all cycles in the call graph, each one being represented by an array of nodes.
+        /// To get the edges between the nodes of a given cycle, use the GetDirectDependencies method.
+        /// </summary>
         public List<ImmutableArray<CallGraphNode>> GetCallCycles()
         {
             var callStack = new Dictionary<CallGraphNode, CallGraphNode>();
@@ -189,6 +208,10 @@ namespace Microsoft.Quantum.QsCompiler.Transformations.CallGraphWalker
         }
     }
 
+    /// <summary>
+    /// This transformation walks through the compilation without changing it, building up a call graph as it does.
+    /// This call graph is then returned to the user.
+    /// </summary>
     public static class BuildCallGraph
     {
         public static CallGraph Apply(QsCompilation compilation)

--- a/src/QsCompiler/Transformations/CallGraphWalker.cs
+++ b/src/QsCompiler/Transformations/CallGraphWalker.cs
@@ -86,7 +86,10 @@ namespace Microsoft.Quantum.QsCompiler.Transformations
                         entry => AsTypeResolutionKey(entry.Item2.Item),
                         entry => entry.Key);
 
-                foreach (var entry in resolution)
+                // We need to ensure that the mappings for extenal type parameters are processed first, 
+                // to cover an edge case that would otherwise be indicated as a conflicting resolution.
+                var entriesToProcess = resolution.OrderByDescending(entry => mayBeReplaced.Contains(entry.Key));
+                foreach (var entry in entriesToProcess)
                 {
                     var resolutionToTypeParam = entry.Value.Resolution as ResolvedTypeKind.TypeParameter;
                     var isResolutionToNative = resolutionToTypeParam != null && EqualsParent(resolutionToTypeParam.Item.Origin);

--- a/src/QsCompiler/Transformations/CallGraphWalker.cs
+++ b/src/QsCompiler/Transformations/CallGraphWalker.cs
@@ -47,9 +47,8 @@ namespace Microsoft.Quantum.QsCompiler.Transformations
         }
 
         /// <summary>
-        /// Given a sequence of type resolutions specifying e.g. subsequent concretizations as part of a nested expression, 
-        /// or concretizations as part of a cycle in the call graph, constructs a dictionary containing the resolution
-        /// for the type parameters of the specified parent callable. 
+        /// Combines subsequent concretions as part of a nested expression, or concretions as part of a cycle in the call graph,
+        /// into a single dictionary containing the resolution for the type parameters of the specified parent callable. 
         /// The given resolutions are expected to be ordered starting with the dictionary containing the initial mapping for the 
         /// type parameters of the specified parent callable (the "innermost resolutions"). This mapping may potentially be to 
         /// type parameters of other callables, which are then further concretized by subsequent resolutions. 

--- a/src/QsCompiler/Transformations/CallGraphWalker.cs
+++ b/src/QsCompiler/Transformations/CallGraphWalker.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Quantum.QsCompiler.Transformations.CallGraphWalker
         }
 
         /// <summary>
-        /// This is a dictionary mapping source nods to information about target nodes. This information is represented
+        /// This is a dictionary mapping source nodes to information about target nodes. This information is represented
         /// by a dictionary mapping target node to the edges pointing from the source node to the target node.
         /// </summary>
         private Dictionary<CallGraphNode, Dictionary<CallGraphNode, ImmutableArray<CallGraphEdge>>> _Dependencies =

--- a/src/QsCompiler/Transformations/ClassicallyControlled.cs
+++ b/src/QsCompiler/Transformations/ClassicallyControlled.cs
@@ -102,14 +102,14 @@ namespace Microsoft.Quantum.QsCompiler.Transformations.ClassicallyControlled
                             // We are dissolving the application of arguments here, so the call's type argument
                             // resolutions have to be moved to the 'identifier' sub expression.
                             var combined = CallGraph.TryCombineTypeResolutions(global.Item, out var combinedTypeArguments, idTypeArguments, callTypeArguments);
-                            QsCompilerError.Verify(combined, "failed to compine type parameter resolution");
+                            QsCompilerError.Verify(combined, "failed to combine type parameter resolution");
 
                             var globalCallable = SharedState.Compilation.Namespaces
                                 .Where(ns => ns.Name.Equals(global.Item.Namespace))
                                 .Callables()
                                 .FirstOrDefault(c => c.FullName.Name.Equals(global.Item.Name));
 
-                            QsCompilerError.Verify(globalCallable != null, $"Could not find the global reference {global.Item.Namespace.Value + "." + global.Item.Name.Value}");
+                            QsCompilerError.Verify(globalCallable != null, $"Could not find the global reference {global.Item.ToString()}");
 
                             var callableTypeParameters = globalCallable.Signature.TypeParameters
                                 .Select(x => x as QsLocalSymbol.ValidName);
@@ -121,7 +121,7 @@ namespace Microsoft.Quantum.QsCompiler.Transformations.ClassicallyControlled
                                     id.Item1,
                                     QsNullable<ImmutableArray<ResolvedType>>.NewValue(
                                         callableTypeParameters
-                                        .Select(x => combinedTypeArguments.First(y => y.Key.Item2.Equals(x.Item)).Value).ToImmutableArray())), // FIXME: THIS IS WITHOUT ANY CHECK OF THE PARENT...
+                                        .Select(x => combinedTypeArguments[Tuple.Create(global.Item, x.Item)]).ToImmutableArray())), 
                                 TypedExpression.AsTypeArguments(combinedTypeArguments),
                                 call.Item1.ResolvedType,
                                 call.Item1.InferredInformation,

--- a/src/QsCompiler/Transformations/ClassicallyControlled.cs
+++ b/src/QsCompiler/Transformations/ClassicallyControlled.cs
@@ -91,17 +91,17 @@ namespace Microsoft.Quantum.QsCompiler.Transformations.ClassicallyControlled
                     {
                         var newCallIdentifier = call.Item1;
                         var callTypeArguments = expr.Item.TypeParameterResolutions;
-                        var idTypeArguments = call.Item1.TypeParameterResolutions;
 
                         // This relies on anything having type parameters must be a global callable.
-                        if (
-                            newCallIdentifier.Expression is ExpressionKind.Identifier id
+                        if (newCallIdentifier.Expression is ExpressionKind.Identifier id
                             && id.Item1 is Identifier.GlobalCallable global
-                            && (callTypeArguments.Any() || idTypeArguments.Any()))
+                            && (callTypeArguments.Any()))
                         {
                             // We are dissolving the application of arguments here, so the call's type argument
                             // resolutions have to be moved to the 'identifier' sub expression.
-                            var combined = CallGraph.TryCombineTypeResolutions(global.Item, out var combinedTypeArguments, idTypeArguments, callTypeArguments);
+                            var combined = CallGraph.TryCombineTypeResolutions(global.Item, 
+                                out var combinedTypeArguments, 
+                                newCallIdentifier.TypeParameterResolutions, callTypeArguments);
                             QsCompilerError.Verify(combined, "failed to combine type parameter resolution");
 
                             var globalCallable = SharedState.Compilation.Namespaces

--- a/src/QsCompiler/Transformations/ClassicallyControlled.cs
+++ b/src/QsCompiler/Transformations/ClassicallyControlled.cs
@@ -72,28 +72,79 @@ namespace Microsoft.Quantum.QsCompiler.Transformations.ClassicallyControlled
             {
                 public StatementTransformation(SyntaxTreeTransformation<TransformationState> parent) : base(parent) { }
 
+                private static ImmutableDictionary<Tuple<QsQualifiedName, NonNullable<string>>, ResolvedType> TryCompineTypeResolution
+                    (QsQualifiedName parent, params ImmutableDictionary<Tuple<QsQualifiedName, NonNullable<string>>, ResolvedType>[] resolutions)
+                {
+                    var compined = ImmutableDictionary.CreateBuilder<Tuple<QsQualifiedName, NonNullable<string>>, ResolvedType>();
+                    if (resolutions.Length == 0) return compined.ToImmutable();
+
+                    //var parent = resolutions[0].Keys.First().Item1; WRONG...
+                    bool EqualsParent(QsQualifiedName origin) => origin.Namespace.Value == parent.Namespace.Value && origin.Name.Value == parent.Name.Value;
+                    static Tuple<QsQualifiedName, NonNullable<string>> AsTypeResolutionKey(QsTypeParameter tp) => Tuple.Create(tp.Origin, tp.TypeName);
+
+                    foreach (var resolution in resolutions)
+                    {
+                        // Contains a lookup of all the keys in compined whose value needs to be updated 
+                        // if a certain type parameter is resolved by the corrently processed dictionary. 
+                        var mayBeReplaced = compined
+                            .Where(kv => kv.Value.Resolution.IsTypeParameter)
+                            .ToLookup(
+                                kv => AsTypeResolutionKey((kv.Value.Resolution as ResolvedTypeKind.TypeParameter).Item),
+                                kv => kv.Key);
+
+                        foreach (var keyValue in resolution)
+                        {
+                            foreach (var keyInCombined in mayBeReplaced[keyValue.Key])
+                            {
+                                // Give an error if one of the values is a type parameter from the parent callable, 
+                                // but it isn't mapped to itself. 
+                                if (keyValue.Value.Resolution is ResolvedTypeKind.TypeParameter tp
+                                    && EqualsParent(tp.Item.Origin)
+                                    && (keyInCombined.Item2.Value != tp.Item.TypeName.Value || !EqualsParent(keyInCombined.Item1)))
+                                {
+                                    throw new Exception("TOO RESTRICTIVE");
+                                    // FIXME: PROPER DIAGNOSTIC
+                                }
+                                compined[keyInCombined] = keyValue.Value;
+                            }
+
+                            if (EqualsParent(keyValue.Key.Item1))
+                            {
+                                compined[keyValue.Key] = keyValue.Value;
+                            }
+                            else if (!mayBeReplaced.Contains(keyValue.Key))
+                            {
+                                // FIXME: WE MAY NEED TO ALLOW THIS TO AVOID CHECKING EACH NODE IN A CYCLE
+                                throw new Exception("ATTEMPTING TO RESOLVE TYPE PARAMETER THAT DOES NOT BELONG TO THIS CALLABLE");
+                            }
+                        }
+                    }
+
+                    return compined.ToImmutable();
+                }
+
                 /// <summary>
                 /// Get the combined type resolutions for a pair of nested resolutions,
                 /// resolving references in the inner resolutions to the outer resolutions.
                 /// </summary>
-                private TypeArgsResolution GetCombinedTypeResolution(TypeArgsResolution outer, TypeArgsResolution inner)
-                {
-                    var outerDict = outer.ToDictionary(x => (x.Item1, x.Item2), x => x.Item3);
-                    return inner.Select(innerRes =>
-                    {
-                        if (innerRes.Item3.Resolution is ResolvedTypeKind.TypeParameter typeParam &&
-                            outerDict.TryGetValue((typeParam.Item.Origin, typeParam.Item.TypeName), out var outerRes))
-                        {
-                            outerDict.Remove((typeParam.Item.Origin, typeParam.Item.TypeName));
-                            return Tuple.Create(innerRes.Item1, innerRes.Item2, outerRes);
-                        }
-                        else
-                        {
-                            return innerRes;
-                        }
-                    })
-                    .Concat(outerDict.Select(x => Tuple.Create(x.Key.Item1, x.Key.Item2, x.Value))).ToImmutableArray();
-                }
+                //private static TypeArgsResolution GetCombinedTypeResolution(TypeArgsResolution outer, TypeArgsResolution inner)
+                //{
+                //    var outerDict = outer.ToDictionary(x => (x.Item1, x.Item2), x => x.Item3);
+                //    return inner.Select(innerRes =>
+                //    {
+                //        if (innerRes.Item3.Resolution is ResolvedTypeKind.TypeParameter typeParam &&
+                //            outerDict.TryGetValue((typeParam.Item.Origin, typeParam.Item.TypeName), out var outerRes))
+                //        {
+                //            outerDict.Remove((typeParam.Item.Origin, typeParam.Item.TypeName)); // FIXME: THERE IS A BUG HERE: THIS COULD OCCUR SEVERAL TIMES AS VALUE IN THE INNER DICT
+                //            return Tuple.Create(innerRes.Item1, innerRes.Item2, outerRes);
+                //        }
+                //        else
+                //        {
+                //            return innerRes;
+                //        }
+                //    })
+                //    .Concat(outerDict.Select(x => Tuple.Create(x.Key.Item1, x.Key.Item2, x.Value))).ToImmutableArray();
+                //}
 
                 /// <summary>
                 /// Checks if the scope is valid for conversion to an operation call from the conditional control API.
@@ -112,19 +163,20 @@ namespace Microsoft.Quantum.QsCompiler.Transformations.ClassicallyControlled
                         && !TypedExpression.IsPartialApplication(expr.Item.Expression)
                         && call.Item1.Expression is ExpressionKind.Identifier)
                     {
-                        // We are dissolving the application of arguments here, so the call's type argument
-                        // resolutions have to be moved to the 'identifier' sub expression.
-
-                        var callTypeArguments = expr.Item.TypeArguments;
-                        var idTypeArguments = call.Item1.TypeArguments;
-                        var combinedTypeArguments = GetCombinedTypeResolution(callTypeArguments, idTypeArguments);
+                        var newCallIdentifier = call.Item1;
+                        var callTypeArguments = expr.Item.TypeParameterResolutions;
+                        var idTypeArguments = call.Item1.TypeParameterResolutions;
 
                         // This relies on anything having type parameters must be a global callable.
-                        var newCallIdentifier = call.Item1;
-                        if (combinedTypeArguments.Any()
-                            && newCallIdentifier.Expression is ExpressionKind.Identifier id
-                            && id.Item1 is Identifier.GlobalCallable global)
+                        if (
+                            newCallIdentifier.Expression is ExpressionKind.Identifier id
+                            && id.Item1 is Identifier.GlobalCallable global
+                            && (callTypeArguments.Any() || idTypeArguments.Any()))
                         {
+                            // We are dissolving the application of arguments here, so the call's type argument
+                            // resolutions have to be moved to the 'identifier' sub expression.
+                            var combinedTypeArguments = TryCompineTypeResolution(global.Item, idTypeArguments, callTypeArguments);
+
                             var globalCallable = SharedState.Compilation.Namespaces
                                 .Where(ns => ns.Name.Equals(global.Item.Namespace))
                                 .Callables()
@@ -142,8 +194,8 @@ namespace Microsoft.Quantum.QsCompiler.Transformations.ClassicallyControlled
                                     id.Item1,
                                     QsNullable<ImmutableArray<ResolvedType>>.NewValue(
                                         callableTypeParameters
-                                        .Select(x => combinedTypeArguments.First(y => y.Item2.Equals(x.Item)).Item3).ToImmutableArray())),
-                                combinedTypeArguments,
+                                        .Select(x => combinedTypeArguments.First(y => y.Key.Item2.Equals(x.Item)).Value).ToImmutableArray())), // FIXME: THIS IS WITHOUT ANY CHECK OF THE PARENT...
+                                TypedExpression.AsTypeArguments(combinedTypeArguments),
                                 call.Item1.ResolvedType,
                                 call.Item1.InferredInformation,
                                 call.Item1.Range);
@@ -322,7 +374,7 @@ namespace Microsoft.Quantum.QsCompiler.Transformations.ClassicallyControlled
 
                     // Takes a single TypedExpression of type Result and puts in into a
                     // value array expression with the given expression as its only item.
-                    TypedExpression BoxResultInArray(TypedExpression expression) =>
+                    static TypedExpression BoxResultInArray(TypedExpression expression) =>
                         new TypedExpression(
                             ExpressionKind.NewValueArray(ImmutableArray.Create(expression)),
                             TypeArgsResolution.Empty,
@@ -551,7 +603,7 @@ namespace Microsoft.Quantum.QsCompiler.Transformations.ClassicallyControlled
                     }
                     else if (expression.Expression is ExpressionKind.NEQ neq)
                     {
-                        QsResult FlipResult(QsResult result) => result.IsZero ? QsResult.One : QsResult.Zero;
+                        static QsResult FlipResult(QsResult result) => result.IsZero ? QsResult.One : QsResult.Zero;
 
                         if (neq.Item1.Expression is ExpressionKind.ResultLiteral literal1)
                         {


### PR DESCRIPTION
Currently, the implementation requires that for a cycle, the verification is invoked for each node. I'll see if I can find some time to be more clever about it. As a first thing to work with, this should do however, and also gives a good base line to test. 