### PR TITLE
performance:  removed unnecessary zero length array allocations

### DIFF
--- a/src/QsCompiler/CommandLineTool/Commands/Build.cs
+++ b/src/QsCompiler/CommandLineTool/Commands/Build.cs
@@ -94,7 +94,7 @@ namespace Microsoft.Quantum.QsCompiler.CommandLineCompiler
         /// </summary>
         private static IEnumerable<string> SplitCommandLineArguments(string commandLine)
         {
-            var parmChars = commandLine?.ToCharArray() ?? new char[0];
+            var parmChars = commandLine?.ToCharArray() ?? Array.Empty<char>();
             var inQuote = false;
             for (int index = 0; index < parmChars.Length; index++)
             {
@@ -144,14 +144,14 @@ namespace Microsoft.Quantum.QsCompiler.CommandLineCompiler
             if (logger == null) throw new ArgumentNullException(nameof(logger));
             if (!BuildOptions.IncorporateResponseFiles(options, out options))
             {
-                logger.Log(ErrorCode.InvalidCommandLineArgsInResponseFiles, new string[0]);
+                logger.Log(ErrorCode.InvalidCommandLineArgsInResponseFiles, Array.Empty<string>());
                 return ReturnCode.INVALID_ARGUMENTS;
             }
 
             var usesPlugins = options.Plugins != null && options.Plugins.Any();
             if (!options.ParseAssemblyProperties(out var assemblyConstants))
             {
-                logger.Log(WarningCode.InvalidAssemblyProperties, new string[0]);
+                logger.Log(WarningCode.InvalidAssemblyProperties, Array.Empty<string>());
             }
 
             var loadOptions = new CompilationLoader.Configuration

--- a/src/QsCompiler/CommandLineTool/Commands/Diagnose.cs
+++ b/src/QsCompiler/CommandLineTool/Commands/Diagnose.cs
@@ -211,7 +211,7 @@ namespace Microsoft.Quantum.QsCompiler.CommandLineCompiler
 
             if (!options.ParseAssemblyProperties(out var assemblyConstants))
             {
-                logger.Log(WarningCode.InvalidAssemblyProperties, new string[0]);
+                logger.Log(WarningCode.InvalidAssemblyProperties, Array.Empty<string>());
             }
 
             var loadOptions = new CompilationLoader.Configuration

--- a/src/QsCompiler/CommandLineTool/Options.cs
+++ b/src/QsCompiler/CommandLineTool/Options.cs
@@ -66,7 +66,7 @@ namespace Microsoft.Quantum.QsCompiler.CommandLineCompiler
         {
             var success = true;
             parsed = new Dictionary<string, string>();
-            foreach (var keyValue in this.AdditionalAssemblyProperties ?? new string[0])
+            foreach (var keyValue in this.AdditionalAssemblyProperties ?? Array.Empty<string>())
             {
                 var pieces = keyValue?.Split(":");
                 var valid = pieces != null && pieces.Length == 2;
@@ -159,8 +159,8 @@ namespace Microsoft.Quantum.QsCompiler.CommandLineCompiler
         {
             this.Verbosity = overwriteNonDefaultValues || this.Verbosity == DefaultOptions.Verbosity ? updates.Verbosity : this.Verbosity;
             this.OutputFormat = overwriteNonDefaultValues || this.OutputFormat == DefaultOptions.OutputFormat ? updates.OutputFormat : this.OutputFormat;
-            this.NoWarn = (this.NoWarn ?? new int[0]).Concat(updates.NoWarn ?? new int[0]);
-            this.References = (this.References ?? new string[0]).Concat(updates.References ?? new string[0]);
+            this.NoWarn = (this.NoWarn ?? Array.Empty<int>()).Concat(updates.NoWarn ?? Array.Empty<int>());
+            this.References = (this.References ?? Array.Empty<string>()).Concat(updates.References ?? Array.Empty<string>());
         }
 
 

--- a/src/QsCompiler/CompilationManager/CompilationUnit.cs
+++ b/src/QsCompiler/CompilationManager/CompilationUnit.cs
@@ -459,7 +459,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
             this.SyncRoot.EnterWriteLock();
             try
             {
-                foreach (var c in updates ?? new QsCallable[0])
+                foreach (var c in updates ?? Array.Empty<QsCallable>())
                 {
                     if (c?.Specializations == null || c.Specializations.Contains(null))
                     { throw new ArgumentNullException(nameof(updates), "the given compiled callable or specialization is null"); }
@@ -631,7 +631,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         {
             if (callables == null) throw new ArgumentNullException(nameof(callables));
             if (types == null) throw new ArgumentNullException(nameof(types));
-            var emptyLookup = new NonNullable<string>[0].ToLookup(ns => ns, _ => ImmutableArray<string>.Empty);
+            var emptyLookup = Array.Empty<NonNullable<string>>().ToLookup(ns => ns, _ => ImmutableArray<string>.Empty);
 
             static string QualifiedName(QsQualifiedName fullName) => $"{fullName.Namespace.Value}.{fullName.Name.Value}";
             static string ElementName(QsNamespaceElement e) =>

--- a/src/QsCompiler/CompilationManager/CompilationUnitManager.cs
+++ b/src/QsCompiler/CompilationManager/CompilationUnitManager.cs
@@ -131,7 +131,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
                 {
                     // do *not* dispose of the FileContentManagers!
                     this.UnsubscribeFromFileManagerEvents(file);
-                    this.PublishDiagnostics(new PublishDiagnosticParams { Uri = file.Uri, Diagnostics = new Diagnostic[0] });
+                    this.PublishDiagnostics(new PublishDiagnosticParams { Uri = file.Uri, Diagnostics = Array.Empty<Diagnostic>() });
                 }      
                 return null;
             });
@@ -346,7 +346,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
                 this.CompilationUnit.UnregisterDependentLock(file.SyncRoot); // do *not* dispose of the FileContentManager!
                 this.UnsubscribeFromFileManagerEvents(file);                 // ... but unsubscribe from all file events
                 this.CompilationUnit.GlobalSymbols.RemoveSource(docKey);
-                if (publishEmptyDiagnostics) this.PublishDiagnostics(new PublishDiagnosticParams { Uri = uri, Diagnostics = new Diagnostic[0] });
+                if (publishEmptyDiagnostics) this.PublishDiagnostics(new PublishDiagnosticParams { Uri = uri, Diagnostics = Array.Empty<Diagnostic>() });
                 if (this.EnableVerification) this.QueueGlobalTypeCheckingAsync(); // we need to trigger a global type checking for the remaining files...
             });
         }
@@ -375,7 +375,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
                     this.CompilationUnit.UnregisterDependentLock(file.SyncRoot); // do *not* dispose of the FileContentManager!
                     this.UnsubscribeFromFileManagerEvents(file);                 // ... but unsubscribe from all file events
                     this.CompilationUnit.GlobalSymbols.RemoveSource(docKey);
-                    if (publishEmptyDiagnostics) this.PublishDiagnostics(new PublishDiagnosticParams { Uri = uri, Diagnostics = new Diagnostic[0] });
+                    if (publishEmptyDiagnostics) this.PublishDiagnostics(new PublishDiagnosticParams { Uri = uri, Diagnostics = Array.Empty<Diagnostic>() });
                     if (this.EnableVerification) this.QueueGlobalTypeCheckingAsync(); // we need to trigger a global type checking for the remaining files...
                 }
                 if (this.EnableVerification && !suppressVerification) this.QueueGlobalTypeCheckingAsync();

--- a/src/QsCompiler/CompilationManager/EditorSupport/SymbolInformation.cs
+++ b/src/QsCompiler/CompilationManager/EditorSupport/SymbolInformation.cs
@@ -132,7 +132,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
             (declarationLocation, referenceLocations) = (null, null);
             if (compilation == null || fullName == null) return false;
 
-            var emptyDoc = new NonNullable<string>[0].ToLookup(i => i, _ => ImmutableArray<string>.Empty);
+            var emptyDoc = Array.Empty<NonNullable<string>>().ToLookup(i => i, _ => ImmutableArray<string>.Empty);
             var namespaces = compilation.GetCallables()
                 .ToLookup(c => c.Key.Namespace, c => c.Value)
                 .Select(ns => new QsNamespace(ns.Key, ns.Select(QsNamespaceElement.NewQsCallable).ToImmutableArray(), emptyDoc));

--- a/src/QsCompiler/LanguageServer/EditorState.cs
+++ b/src/QsCompiler/LanguageServer/EditorState.cs
@@ -200,7 +200,7 @@ namespace Microsoft.Quantum.QsLanguageServer
                     this.IgnoreEditorUpdatesFor(textDocument.Uri); 
                     this.OpenFiles.TryRemove(textDocument.Uri, out FileContentManager _);
                     if (!associatedWithProject) _ = manager.TryRemoveSourceFileAsync(textDocument.Uri);
-                    this.Publish(new PublishDiagnosticParams { Uri = textDocument.Uri, Diagnostics = new Diagnostic[0] });
+                    this.Publish(new PublishDiagnosticParams { Uri = textDocument.Uri, Diagnostics = Array.Empty<Diagnostic>() });
                     return;
                 }
 
@@ -282,7 +282,7 @@ namespace Microsoft.Quantum.QsLanguageServer
                 if (!removed) onError?.Invoke($"Attempting to close file '{textDocument.Uri.LocalPath}' that is not currently listed as open in the editor.", MessageType.Error);
                 #endif
                 if (!associatedWithProject) _ = manager.TryRemoveSourceFileAsync(textDocument.Uri);
-                this.Publish(new PublishDiagnosticParams { Uri = textDocument.Uri, Diagnostics = new Diagnostic[0] });
+                this.Publish(new PublishDiagnosticParams { Uri = textDocument.Uri, Diagnostics = Array.Empty<Diagnostic>() });
             });
             // When edits are made in a file, but those are discarded by closing the file and hitting "no, don't save",
             // no notification is sent for the now discarded changes;

--- a/src/QsCompiler/LanguageServer/LanguageServer.cs
+++ b/src/QsCompiler/LanguageServer/LanguageServer.cs
@@ -308,10 +308,10 @@ namespace Microsoft.Quantum.QsLanguageServer
             try
             {
                 return QsCompilerError.RaiseOnFailure(() =>
-                this.EditorState.DocumentHighlights(param) ?? new DocumentHighlight[0],
+                this.EditorState.DocumentHighlights(param) ?? Array.Empty<DocumentHighlight>(),
                 "DocumentHighlight threw an exception"); 
             }
-            catch { return new DocumentHighlight[0]; }
+            catch { return Array.Empty<DocumentHighlight>(); }
         }
 
         [JsonRpcMethod(Methods.TextDocumentReferencesName)]
@@ -322,10 +322,10 @@ namespace Microsoft.Quantum.QsLanguageServer
             try
             {
                 return QsCompilerError.RaiseOnFailure(() =>
-                this.EditorState.SymbolReferences(param) ?? new Location[0],
+                this.EditorState.SymbolReferences(param) ?? Array.Empty<Location>(),
                 "FindReferences threw an exception");
             }
-            catch { return new Location[0]; }
+            catch { return Array.Empty<Location>(); }
         }
 
         [JsonRpcMethod(Methods.TextDocumentHoverName)]
@@ -376,10 +376,10 @@ namespace Microsoft.Quantum.QsLanguageServer
             try
             {
                 return QsCompilerError.RaiseOnFailure(() =>
-                this.EditorState.DocumentSymbols(param) ?? new SymbolInformation[0], 
+                this.EditorState.DocumentSymbols(param) ?? Array.Empty<SymbolInformation>(), 
                 "DocumentSymbols threw an exception");
             }
-            catch { return new SymbolInformation[0]; } 
+            catch { return Array.Empty<SymbolInformation>(); } 
         }
 
         [JsonRpcMethod(Methods.TextDocumentCompletionName)]
@@ -441,7 +441,7 @@ namespace Microsoft.Quantum.QsLanguageServer
                 "CodeAction threw an exception")
                 .ToArray();
             }
-            catch { return new Command[0]; }
+            catch { return Array.Empty<Command>(); }
         }
 
         [JsonRpcMethod(Methods.WorkspaceExecuteCommandName)]

--- a/src/QsCompiler/Tests.DocGenerator/DocParsingTests.cs
+++ b/src/QsCompiler/Tests.DocGenerator/DocParsingTests.cs
@@ -319,7 +319,7 @@ output:
             var phaseEstArgTuple = ResolvedType.New(QsType.NewTupleType(phaseEstArgs));
             var phaseEstOp = ResolvedType.New(QsType.NewOperation(new SigTypeTuple(phaseEstArgTuple, doubleType), noInfo));
 
-            var typeParams = new QsLocalSymbol[] { }.ToImmutableArray();
+            var typeParams = Array.Empty<QsLocalSymbol>().ToImmutableArray();
             var argTypes = new ResolvedType[] { qubitToUnitOp, qubitToUnitOp, qubitToUnitOpAC, phaseEstOp, qubitArrayType }.ToImmutableArray();
             var argTupleType = ResolvedType.New(QsType.NewTupleType(argTypes));
             var signature = new ResolvedSignature(typeParams, argTupleType, doubleType, noInfo);
@@ -332,7 +332,7 @@ output:
                             .ConvertAll(arg => QsTuple<ArgDeclType>.NewQsTupleItem(arg))
                             .ToImmutableArray();
             var argTuple = QsTuple<ArgDeclType>.NewQsTuple(args);
-            var specs = new QsSpecialization[] { }.ToImmutableArray();
+            var specs = Array.Empty<QsSpecialization>().ToImmutableArray();
 
             var qsCallable = new QsCallable(QsCallableKind.Operation,
                                             MakeFullName("AdiabaticStateEnergyUnitary"),

--- a/src/QsCompiler/Transformations/IntrinsicResolution.cs
+++ b/src/QsCompiler/Transformations/IntrinsicResolution.cs
@@ -90,7 +90,7 @@ namespace Microsoft.Quantum.QsCompiler.Transformations.IntrinsicResolution
             var tempNs = StripPositionInfo.Apply(
                 new QsNamespace(NonNullable<string>.New("tempNs"),
                     ImmutableArray.Create<QsNamespaceElement>(first, second),
-                    new NonNullable<string>[0].ToLookup(ns => ns, _ => ImmutableArray<string>.Empty)));
+                    Array.Empty<NonNullable<string>>().ToLookup(ns => ns, _ => ImmutableArray<string>.Empty)));
             var firstUDT = ((QsNamespaceElement.QsCustomType)tempNs.Elements[0]).Item;
             var secondUDT = ((QsNamespaceElement.QsCustomType)tempNs.Elements[1]).Item;            
             return firstUDT.TypeItems.Equals(secondUDT.TypeItems);


### PR DESCRIPTION
Replaced unneeded array allocations with `Array.Empty<T>()`