### PR TITLE
Order built-in rewrite steps according to their priority

### DIFF
--- a/src/QsCompiler/Compiler/CompilationLoader.cs
+++ b/src/QsCompiler/Compiler/CompilationLoader.cs
@@ -80,7 +80,8 @@ namespace Microsoft.Quantum.QsCompiler
         public static Func<string, Assembly> LoadAssembly { get; set; }
         /// <summary>
         /// Sorts the given list of step according to their relative priority give by getPriority. 
-        /// Throws the corresponding exception if getPriority is null. 
+        /// Throws the corresponding exception if <paramref name="getPriority" /> is <c>null</c>. 
+
         /// </summary>
         internal static void SortRewriteSteps<T>(List<T> steps, Func<T, int> getPriority) =>
             steps?.Sort((fst, snd) => getPriority(snd) - getPriority(fst));

--- a/src/QsCompiler/Compiler/CompilationLoader.cs
+++ b/src/QsCompiler/Compiler/CompilationLoader.cs
@@ -502,10 +502,12 @@ namespace Microsoft.Quantum.QsCompiler
                 steps.Add((rewriteStep.Priority, () => ExecuteAsAtomicTransformation(rewriteStep, ref this.CompilationStatus.PreEvaluation)));
             }
 
-            for (int i = 0; i < this.ExternalRewriteSteps.Length; i++)
+            for (int j = 0; j < this.ExternalRewriteSteps.Length; j++)
             {
-                var priority = this.ExternalRewriteSteps[i].Priority;
-                steps.Add((priority, () => ExecuteAsAtomicTransformation(this.ExternalRewriteSteps[i], ref this.CompilationStatus.LoadedRewriteSteps[i])));
+                var priority = this.ExternalRewriteSteps[j].Priority;
+                Func<QsCompilation> Execute(int index) => () => 
+                    ExecuteAsAtomicTransformation(this.ExternalRewriteSteps[index], ref this.CompilationStatus.LoadedRewriteSteps[index]);
+                steps.Add((priority, Execute(j)));
             }
 
             RaiseCompilationTaskStart("OverallCompilation", "RewriteSteps");

--- a/src/QsCompiler/Compiler/ExternalRewriteSteps.cs
+++ b/src/QsCompiler/Compiler/ExternalRewriteSteps.cs
@@ -291,7 +291,7 @@ namespace Microsoft.Quantum.QsCompiler
                     assemblyConstants.TryAdd(AssemblyConstants.AssemblyName, config.ProjectNameWithoutExtension);
                 }
 
-                loadedSteps.Sort((fst, snd) => snd.Priority - fst.Priority);
+                CompilationLoader.SortRewriteSteps(loadedSteps, step => step.Priority);
                 rewriteSteps.AddRange(loadedSteps);
             }
             return rewriteSteps.ToImmutableArray();

--- a/src/QsCompiler/Compiler/PluginInterface.cs
+++ b/src/QsCompiler/Compiler/PluginInterface.cs
@@ -14,10 +14,20 @@ namespace Microsoft.Quantum.QsCompiler
     /// </summary>
     public static class RewriteStepPriorities
     {
+        /// Priority of the built-in transformation that replaces 
+        /// if-statements with the corresponding calls to built-in quantum operations if possible. 
         public const int ControlFlowSubstitutions = 1100;
+        /// Priority of the built-in transformation that replaces 
+        /// all type parametrized callables with concrete instantiations and drops any unused callables. 
         public const int TypeParameterElimination = 1000;
+        /// Priority of the built-in transformation that replaces 
+        /// all functor generation directives with the corresponding implementation.  
         public const int GenerationOfFunctorSupport = 600;
+        /// Priority of the built-in transformation that inlines all conjugations 
+        /// and thus eliminates that construct from the syntax tree.
         public const int InliningOfConjugations = 500;
+        /// Priority of the built-in transformation that 
+        /// evaluates classical computations as much as possible. 
         public const int EvaluationOfClassicalComputations = 100;
     }
 

--- a/src/QsCompiler/Compiler/PluginInterface.cs
+++ b/src/QsCompiler/Compiler/PluginInterface.cs
@@ -9,6 +9,18 @@ using Microsoft.Quantum.QsCompiler.SyntaxTree;
 
 namespace Microsoft.Quantum.QsCompiler
 {
+    /// <summary>
+    /// Lists the priorities for built-in rewrite steps. 
+    /// </summary>
+    public static class RewriteStepPriorities
+    {
+        public const int ControlFlowSubstitutions = 1100;
+        public const int TypeParameterElimination = 1000;
+        public const int GenerationOfFunctorSupport = 600;
+        public const int InliningOfConjugations = 500;
+        public const int EvaluationOfClassicalComputations = 100;
+    }
+
     public interface IRewriteStep
     {
         public enum Stage 

--- a/src/QsCompiler/Compiler/PluginInterface.cs
+++ b/src/QsCompiler/Compiler/PluginInterface.cs
@@ -14,20 +14,30 @@ namespace Microsoft.Quantum.QsCompiler
     /// </summary>
     public static class RewriteStepPriorities
     {
+        /// <summary>
         /// Priority of the built-in transformation that replaces 
         /// if-statements with the corresponding calls to built-in quantum operations if possible. 
+        /// </summary>
         public const int ControlFlowSubstitutions = 1100;
+        /// <summary>
         /// Priority of the built-in transformation that replaces 
         /// all type parametrized callables with concrete instantiations and drops any unused callables. 
+        /// </summary>
         public const int TypeParameterElimination = 1000;
+        /// <summary>
         /// Priority of the built-in transformation that replaces 
         /// all functor generation directives with the corresponding implementation.  
+        /// </summary>
         public const int GenerationOfFunctorSupport = 600;
+        /// <summary>
         /// Priority of the built-in transformation that inlines all conjugations 
         /// and thus eliminates that construct from the syntax tree.
+        /// </summary>
         public const int InliningOfConjugations = 500;
+        /// <summary>
         /// Priority of the built-in transformation that 
         /// evaluates classical computations as much as possible. 
+        /// </summary>
         public const int EvaluationOfClassicalComputations = 100;
     }
 

--- a/src/QsCompiler/Compiler/RewriteSteps/ClassicallyControlled.cs
+++ b/src/QsCompiler/Compiler/RewriteSteps/ClassicallyControlled.cs
@@ -9,10 +9,14 @@ using Microsoft.Quantum.QsCompiler.Transformations.ClassicallyControlled;
 
 namespace Microsoft.Quantum.QsCompiler.BuiltInRewriteSteps
 {
+    /// <summary>
+    /// Replaces if-statements with the corresponding calls to built-in quantum operations if possible. 
+    /// Rewrite step with priority 1100.
+    /// </summary>
     internal class ClassicallyControlled : IRewriteStep
     {
         public string Name => "Classically Controlled";
-        public int Priority => 10; // Not used for built-in transformations like this
+        public int Priority => RewriteStepPriorities.ControlFlowSubstitutions; 
         public IDictionary<string, string> AssemblyConstants { get; }
         public IEnumerable<IRewriteStep.Diagnostic> GeneratedDiagnostics => null;
 

--- a/src/QsCompiler/Compiler/RewriteSteps/ClassicallyControlled.cs
+++ b/src/QsCompiler/Compiler/RewriteSteps/ClassicallyControlled.cs
@@ -11,7 +11,6 @@ namespace Microsoft.Quantum.QsCompiler.BuiltInRewriteSteps
 {
     /// <summary>
     /// Replaces if-statements with the corresponding calls to built-in quantum operations if possible. 
-    /// Rewrite step with priority 1100.
     /// </summary>
     internal class ClassicallyControlled : IRewriteStep
     {

--- a/src/QsCompiler/Compiler/RewriteSteps/ConjugationInlining.cs
+++ b/src/QsCompiler/Compiler/RewriteSteps/ConjugationInlining.cs
@@ -9,7 +9,6 @@ namespace Microsoft.Quantum.QsCompiler.BuiltInRewriteSteps
 {
     /// <summary>
     /// Inlines all conjugations, eliminating that construct from the syntax tree.  
-    /// Rewrite step with priority 500.
     /// </summary>
     internal class ConjugationInlining : IRewriteStep
     {

--- a/src/QsCompiler/Compiler/RewriteSteps/ConjugationInlining.cs
+++ b/src/QsCompiler/Compiler/RewriteSteps/ConjugationInlining.cs
@@ -7,10 +7,14 @@ using Microsoft.Quantum.QsCompiler.SyntaxTree;
 
 namespace Microsoft.Quantum.QsCompiler.BuiltInRewriteSteps
 {
+    /// <summary>
+    /// Inlines all conjugations, eliminating that construct from the syntax tree.  
+    /// Rewrite step with priority 500.
+    /// </summary>
     internal class ConjugationInlining : IRewriteStep
     {
         public string Name => "Conjugation Inlining";
-        public int Priority => 10; // Not used for built-in transformations like this
+        public int Priority => RewriteStepPriorities.InliningOfConjugations;
         public IDictionary<string, string> AssemblyConstants { get; }
         public IEnumerable<IRewriteStep.Diagnostic> GeneratedDiagnostics => null;
 

--- a/src/QsCompiler/Compiler/RewriteSteps/FullPreEvaluation.cs
+++ b/src/QsCompiler/Compiler/RewriteSteps/FullPreEvaluation.cs
@@ -9,7 +9,6 @@ namespace Microsoft.Quantum.QsCompiler.BuiltInRewriteSteps
 {
     /// <summary>
     /// Evaluates classical computations as much as possible.   
-    /// Rewrite step with priority 100.
     /// </summary>
     internal class FullPreEvaluation : IRewriteStep
     {

--- a/src/QsCompiler/Compiler/RewriteSteps/FullPreEvaluation.cs
+++ b/src/QsCompiler/Compiler/RewriteSteps/FullPreEvaluation.cs
@@ -7,10 +7,14 @@ using Microsoft.Quantum.QsCompiler.SyntaxTree;
 
 namespace Microsoft.Quantum.QsCompiler.BuiltInRewriteSteps
 {
+    /// <summary>
+    /// Evaluates classical computations as much as possible.   
+    /// Rewrite step with priority 100.
+    /// </summary>
     internal class FullPreEvaluation : IRewriteStep
     {
         public string Name => "Full Pre-Evaluation";
-        public int Priority => 10; // Not used for built-in transformations like this
+        public int Priority => RewriteStepPriorities.EvaluationOfClassicalComputations;
         public IDictionary<string, string> AssemblyConstants { get; }
         public IEnumerable<IRewriteStep.Diagnostic> GeneratedDiagnostics => null;
 

--- a/src/QsCompiler/Compiler/RewriteSteps/FunctorGeneration.cs
+++ b/src/QsCompiler/Compiler/RewriteSteps/FunctorGeneration.cs
@@ -8,10 +8,14 @@ using Microsoft.Quantum.QsCompiler.SyntaxTree;
 
 namespace Microsoft.Quantum.QsCompiler.BuiltInRewriteSteps
 {
+    /// <summary>
+    /// Replaces all functor generation directives with the corresponding implementation.  
+    /// Rewrite step with priority 600.
+    /// </summary>
     internal class FunctorGeneration : IRewriteStep
     {
         public string Name => "Functor Generation";
-        public int Priority => 10; // Not used for built-in transformations like this
+        public int Priority => RewriteStepPriorities.GenerationOfFunctorSupport;
         public IDictionary<string, string> AssemblyConstants { get; }
         public IEnumerable<IRewriteStep.Diagnostic> GeneratedDiagnostics => null;
 

--- a/src/QsCompiler/Compiler/RewriteSteps/FunctorGeneration.cs
+++ b/src/QsCompiler/Compiler/RewriteSteps/FunctorGeneration.cs
@@ -10,7 +10,6 @@ namespace Microsoft.Quantum.QsCompiler.BuiltInRewriteSteps
 {
     /// <summary>
     /// Replaces all functor generation directives with the corresponding implementation.  
-    /// Rewrite step with priority 600.
     /// </summary>
     internal class FunctorGeneration : IRewriteStep
     {

--- a/src/QsCompiler/Compiler/RewriteSteps/IntrinsicResolution.cs
+++ b/src/QsCompiler/Compiler/RewriteSteps/IntrinsicResolution.cs
@@ -8,6 +8,9 @@ using Microsoft.Quantum.QsCompiler.Transformations.IntrinsicResolution;
 
 namespace Microsoft.Quantum.QsCompiler.BuiltInRewriteSteps
 {
+    /// <summary>
+    /// Replaces any syntax tree element in the compilation with the one in the environment tree given upon construction. 
+    /// </summary>
     internal class IntrinsicResolution : IRewriteStep
     {
         public string Name => "Intrinsic Resolution";

--- a/src/QsCompiler/Compiler/RewriteSteps/Monomorphization.cs
+++ b/src/QsCompiler/Compiler/RewriteSteps/Monomorphization.cs
@@ -10,10 +10,14 @@ using Microsoft.Quantum.QsCompiler.Transformations.Monomorphization.Validation;
 
 namespace Microsoft.Quantum.QsCompiler.BuiltInRewriteSteps
 {
+    /// <summary>
+    /// Replaces all type parametrized callables with concrete instantiations, dropping any unused callables. 
+    /// Rewrite step with priority 1000.
+    /// </summary>
     internal class Monomorphization : IRewriteStep
     {
         public string Name => "Monomorphization";
-        public int Priority => 10; // Not used for built-in transformations like this
+        public int Priority => RewriteStepPriorities.TypeParameterElimination; 
         public IDictionary<string, string> AssemblyConstants { get; }
         public IEnumerable<IRewriteStep.Diagnostic> GeneratedDiagnostics => null;
 

--- a/src/QsCompiler/Compiler/RewriteSteps/Monomorphization.cs
+++ b/src/QsCompiler/Compiler/RewriteSteps/Monomorphization.cs
@@ -12,7 +12,6 @@ namespace Microsoft.Quantum.QsCompiler.BuiltInRewriteSteps
 {
     /// <summary>
     /// Replaces all type parametrized callables with concrete instantiations, dropping any unused callables. 
-    /// Rewrite step with priority 1000.
     /// </summary>
     internal class Monomorphization : IRewriteStep
     {

--- a/src/QsCompiler/Core/Dependencies.fs
+++ b/src/QsCompiler/Core/Dependencies.fs
@@ -32,6 +32,14 @@ type BuiltIn = {
     /// Returns the set of namespaces that is automatically opened for each compilation.
     static member NamespacesToAutoOpen = ImmutableHashSet.Create (BuiltIn.CoreNamespace)
 
+    /// Returns the set of callables that rewrite steps take dependencies on.
+    /// These should be non-Generic callables only.
+    static member RewriteStepDependencies =
+        ImmutableHashSet.Create (
+            BuiltIn.RangeReverse.FullName,
+            BuiltIn.IndexRange.FullName
+    )
+
     /// Returns true if the given attribute marks the corresponding declaration as entry point.
     static member MarksEntryPoint (att : QsDeclarationAttribute) = att.TypeId |> function
         | Value tId -> tId.Namespace.Value = BuiltIn.EntryPoint.FullName.Namespace.Value && tId.Name.Value = BuiltIn.EntryPoint.FullName.Name.Value

--- a/src/QsCompiler/Transformations/Monomorphization.cs
+++ b/src/QsCompiler/Transformations/Monomorphization.cs
@@ -19,6 +19,16 @@ namespace Microsoft.Quantum.QsCompiler.Transformations.Monomorphization
     using GetConcreteIdentifierFunc = Func<Identifier.GlobalCallable, /*ImmutableConcretion*/ ImmutableDictionary<Tuple<QsQualifiedName, NonNullable<string>>, ResolvedType>, Identifier>;
     using ImmutableConcretion = ImmutableDictionary<Tuple<QsQualifiedName, NonNullable<string>>, ResolvedType>;
 
+    /// <summary>
+    /// This transformation replaces callables with type parameters with concrete
+    /// instances of the same callables. The concrete values for the type parameters
+    /// are found from uses of the callables.
+    /// This transformation also removes all callables that are not used directly or
+    /// indirectly from any of the marked entry point.
+    /// Intrinsic callables are not monomorphized or removed from the compilation.
+    /// There are also some built-in callables that are also exempt from
+    /// being removed from non-use, as they are needed for later rewrite steps.
+    /// </summary>
     public static class Monomorphize
     {
         private struct Request
@@ -41,6 +51,11 @@ namespace Microsoft.Quantum.QsCompiler.Transformations.Monomorphization
 
             var globals = compilation.Namespaces.GlobalCallableResolutions();
 
+            var exemptCallableSet = globals
+                .Where(kvp => BuiltIn.RewriteStepDependencies.Contains(kvp.Key) || kvp.Value.Specializations.Any(spec => spec.Implementation.IsIntrinsic))
+                .Select(kvp => kvp.Key)
+                .ToImmutableHashSet();
+
             var entryPoints = compilation.EntryPoints
                 .Select(call => new Request
                 {
@@ -58,7 +73,7 @@ namespace Microsoft.Quantum.QsCompiler.Transformations.Monomorphization
 
                 // If there is a call to an unknown callable, throw exception
                 if (!globals.TryGetValue(currentRequest.originalName, out QsCallable originalGlobal))
-                    throw new ArgumentException($"Couldn't find definition for callable: {currentRequest.originalName.ToString()}");
+                    throw new ArgumentException($"Couldn't find definition for callable: {currentRequest.originalName}");
 
                 var currentResponse = new Response
                 {
@@ -74,12 +89,12 @@ namespace Microsoft.Quantum.QsCompiler.Transformations.Monomorphization
                 currentResponse = ReplaceTypeParamImplementations.Apply(currentResponse);
 
                 // Rewrite calls
-                currentResponse = ReplaceTypeParamCalls.Apply(currentResponse, getConcreteIdentifier);
+                currentResponse = ReplaceTypeParamCalls.Apply(currentResponse, getConcreteIdentifier, exemptCallableSet);
 
                 responses.Add(currentResponse);
             }
 
-            return ResolveGenerics.Apply(compilation, responses);
+            return ResolveGenerics.Apply(compilation, responses, exemptCallableSet);
         }
 
         private static Identifier GetConcreteIdentifier(
@@ -157,22 +172,22 @@ namespace Microsoft.Quantum.QsCompiler.Transformations.Monomorphization
 
         private class ResolveGenerics : SyntaxTreeTransformation<ResolveGenerics.TransformationState>
         {
-            public static QsCompilation Apply(QsCompilation compilation, List<Response> responses)
+            public static QsCompilation Apply(QsCompilation compilation, List<Response> responses, ImmutableHashSet<QsQualifiedName> exemptCallableSet)
             {
-                var filter = new ResolveGenerics(responses
-                    .GroupBy(res => res.concreteCallable.FullName.Namespace)
-                    .ToImmutableDictionary(group => group.Key, group => group.Select(res => res.concreteCallable)));
+                var filter = new ResolveGenerics(responses.ToLookup(res => res.concreteCallable.FullName.Namespace, res => res.concreteCallable), exemptCallableSet);
 
                 return new QsCompilation(compilation.Namespaces.Select(ns => filter.Namespaces.OnNamespace(ns)).ToImmutableArray(), compilation.EntryPoints);
             }
 
             public class TransformationState
             {
-                public readonly ImmutableDictionary<NonNullable<string>, IEnumerable<QsCallable>> NamespaceCallables;
+                public readonly ILookup<NonNullable<string>, QsCallable> NamespaceCallables;
+                public readonly ImmutableHashSet<QsQualifiedName> ExemptCallableSet;
 
-                public TransformationState(ImmutableDictionary<NonNullable<string>, IEnumerable<QsCallable>> namespaceCallables)
+                public TransformationState(ILookup<NonNullable<string>, QsCallable> namespaceCallables, ImmutableHashSet<QsQualifiedName> exemptCallableSet)
                 {
                     this.NamespaceCallables = namespaceCallables;
+                    this.ExemptCallableSet = exemptCallableSet;
                 }
             }
 
@@ -180,8 +195,9 @@ namespace Microsoft.Quantum.QsCompiler.Transformations.Monomorphization
             /// Constructor for the ResolveGenericsSyntax class. Its transform function replaces global callables in the namespace.
             /// </summary>
             /// <param name="namespaceCallables">Maps namespace names to an enumerable of all global callables in that namespace.</param>
-            private ResolveGenerics(ImmutableDictionary<NonNullable<string>, IEnumerable<QsCallable>> namespaceCallables) : base(new TransformationState(namespaceCallables)) 
-            { 
+            private ResolveGenerics(ILookup<NonNullable<string>, QsCallable> namespaceCallables, ImmutableHashSet<QsQualifiedName> exemptCallableSet)
+                : base(new TransformationState(namespaceCallables, exemptCallableSet))
+            {
                 this.Namespaces = new NamespaceTransformation(this);
                 this.Statements = new StatementTransformation<TransformationState>(this, TransformationOptions.Disabled);
                 this.Expressions = new ExpressionTransformation<TransformationState>(this, TransformationOptions.Disabled);
@@ -192,15 +208,25 @@ namespace Microsoft.Quantum.QsCompiler.Transformations.Monomorphization
             {
                 public NamespaceTransformation(SyntaxTreeTransformation<TransformationState> parent) : base(parent) { }
 
+                private bool NamespaceElementFilter(QsNamespaceElement elem)
+                {
+                    if (elem is QsNamespaceElement.QsCallable call)
+                    {
+                        return SharedState.ExemptCallableSet.Contains(call.Item.FullName);
+                    }
+                    else
+                    {
+                        return true;
+                    }
+                }
+
                 public override QsNamespace OnNamespace(QsNamespace ns)
                 {
-                    SharedState.NamespaceCallables.TryGetValue(ns.Name, out IEnumerable<QsCallable> concretesInNs);
-
                     // Removes unused or generic callables from the namespace
                     // Adds in the used concrete callables
                     return ns.WithElements(elems => elems
-                        .Where(elem => !(elem is QsNamespaceElement.QsCallable))
-                        .Concat(concretesInNs?.Select(call => QsNamespaceElement.NewQsCallable(call)) ?? Enumerable.Empty<QsNamespaceElement>())
+                        .Where(NamespaceElementFilter)
+                        .Concat(SharedState.NamespaceCallables[ns.Name].Select(QsNamespaceElement.NewQsCallable))
                         .ToImmutableArray());
                 }
             }
@@ -239,8 +265,8 @@ namespace Microsoft.Quantum.QsCompiler.Transformations.Monomorphization
                 }
             }
 
-            private ReplaceTypeParamImplementations(ImmutableConcretion typeParams) : base(new TransformationState(typeParams)) 
-            { 
+            private ReplaceTypeParamImplementations(ImmutableConcretion typeParams) : base(new TransformationState(typeParams))
+            {
                 this.Namespaces = new NamespaceTransformation(this);
                 this.Types = new TypeTransformation(this);
             }
@@ -284,9 +310,9 @@ namespace Microsoft.Quantum.QsCompiler.Transformations.Monomorphization
         private class ReplaceTypeParamCalls :
             SyntaxTreeTransformation<ReplaceTypeParamCalls.TransformationState>
         {
-            public static Response Apply(Response current, GetConcreteIdentifierFunc getConcreteIdentifier)
+            public static Response Apply(Response current, GetConcreteIdentifierFunc getConcreteIdentifier, ImmutableHashSet<QsQualifiedName> exemptCallableSet)
             {
-                var filter = new ReplaceTypeParamCalls(getConcreteIdentifier);
+                var filter = new ReplaceTypeParamCalls(getConcreteIdentifier, exemptCallableSet);
 
                 // Create a new response with the transformed callable
                 return new Response
@@ -301,15 +327,18 @@ namespace Microsoft.Quantum.QsCompiler.Transformations.Monomorphization
             {
                 public readonly Concretion CurrentParamTypes = new Concretion();
                 public readonly GetConcreteIdentifierFunc GetConcreteIdentifier;
+                public readonly ImmutableHashSet<QsQualifiedName> ExemptCallableSet;
 
-                public TransformationState(GetConcreteIdentifierFunc getConcreteIdentifier)
+                public TransformationState(GetConcreteIdentifierFunc getConcreteIdentifier, ImmutableHashSet<QsQualifiedName> exemptCallableSet)
                 {
                     this.GetConcreteIdentifier = getConcreteIdentifier;
+                    this.ExemptCallableSet = exemptCallableSet;
                 }
             }
 
-            private ReplaceTypeParamCalls(GetConcreteIdentifierFunc getConcreteIdentifier) : base(new TransformationState(getConcreteIdentifier)) 
-            { 
+            private ReplaceTypeParamCalls(GetConcreteIdentifierFunc getConcreteIdentifier, ImmutableHashSet<QsQualifiedName> exemptCallableSet)
+                : base(new TransformationState(getConcreteIdentifier, exemptCallableSet))
+            {
                 this.Expressions = new ExpressionTransformation(this);
                 this.ExpressionKinds = new ExpressionKindTransformation(this);
                 this.Types = new TypeTransformation(this);
@@ -359,9 +388,13 @@ namespace Microsoft.Quantum.QsCompiler.Transformations.Monomorphization
                             .Where(kvp => kvp.Key.Item1.Equals(global.Item))
                             .ToImmutableDictionary(kvp => kvp.Key, kvp => kvp.Value);
 
-                        // Create a new identifier
-                        sym = SharedState.GetConcreteIdentifier(global, applicableParams);
-                        tArgs = QsNullable<ImmutableArray<ResolvedType>>.Null;
+                        // We want to skip over intrinsic callables. They will not be monomorphized.
+                        if (!SharedState.ExemptCallableSet.Contains(global.Item))
+                        {
+                            // Create a new identifier
+                            sym = SharedState.GetConcreteIdentifier(global, applicableParams);
+                            tArgs = QsNullable<ImmutableArray<ResolvedType>>.Null;
+                        }
 
                         // Remove Type Params used from the CurrentParamTypes
                         foreach (var key in applicableParams.Keys)

--- a/src/QsCompiler/Transformations/MonomorphizationValidation.cs
+++ b/src/QsCompiler/Transformations/MonomorphizationValidation.cs
@@ -16,7 +16,12 @@ namespace Microsoft.Quantum.QsCompiler.Transformations.Monomorphization.Validati
     {
         public static void Apply(QsCompilation compilation)
         {
-            var filter = new ValidateMonomorphization();
+            var intrinsicCallableSet = compilation.Namespaces.GlobalCallableResolutions()
+                .Where(kvp => kvp.Value.Specializations.Any(spec => spec.Implementation.IsIntrinsic))
+                .Select(kvp => kvp.Key)
+                .ToImmutableHashSet();
+
+            var filter = new ValidateMonomorphization(intrinsicCallableSet);
 
             foreach (var ns in compilation.Namespaces)
             {
@@ -24,10 +29,18 @@ namespace Microsoft.Quantum.QsCompiler.Transformations.Monomorphization.Validati
             }
         }
 
-        public class TransformationState { }
+        public class TransformationState
+        {
+            public readonly ImmutableHashSet<QsQualifiedName> IntrinsicCallableSet;
 
-        internal ValidateMonomorphization() : base(new TransformationState()) 
-        { 
+            public TransformationState(ImmutableHashSet<QsQualifiedName> intrinsicCallableSet)
+            {
+                this.IntrinsicCallableSet = intrinsicCallableSet;
+            }
+        }
+
+        internal ValidateMonomorphization(ImmutableHashSet<QsQualifiedName> intrinsicCallableSet) : base(new TransformationState(intrinsicCallableSet))
+        {
             this.Namespaces = new NamespaceTransformation(this);
             this.Expressions = new ExpressionTransformation(this);
             this.Types = new TypeTransformation(this);
@@ -35,7 +48,20 @@ namespace Microsoft.Quantum.QsCompiler.Transformations.Monomorphization.Validati
 
         private class NamespaceTransformation : NamespaceTransformation<TransformationState>
         {
-            public NamespaceTransformation(SyntaxTreeTransformation<TransformationState> parent) : base(parent) { }
+            public NamespaceTransformation(SyntaxTreeTransformation<TransformationState> parent) : base(parent, TransformationOptions.NoRebuild) { }
+
+            public override QsCallable OnCallableDeclaration(QsCallable c)
+            {
+                // Don't validate intrinsics
+                if (!SharedState.IntrinsicCallableSet.Contains(c.FullName))
+                {
+                    return base.OnCallableDeclaration(c);
+                }
+                else
+                {
+                    return c;
+                }
+            }
 
             public override ResolvedSignature OnSignature(ResolvedSignature s)
             {
@@ -50,11 +76,12 @@ namespace Microsoft.Quantum.QsCompiler.Transformations.Monomorphization.Validati
 
         private class ExpressionTransformation : ExpressionTransformation<TransformationState>
         {
-            public ExpressionTransformation(SyntaxTreeTransformation<TransformationState> parent) : base(parent) { }
+            public ExpressionTransformation(SyntaxTreeTransformation<TransformationState> parent) : base(parent, TransformationOptions.NoRebuild) { }
 
             public override ImmutableDictionary<Tuple<QsQualifiedName, NonNullable<string>>, ResolvedType> OnTypeParamResolutions(ImmutableDictionary<Tuple<QsQualifiedName, NonNullable<string>>, ResolvedType> typeParams)
             {
-                if (typeParams.Any())
+                // Type resolutions for intrinsics are allowed
+                if (typeParams.Any(kvp => !SharedState.IntrinsicCallableSet.Contains(kvp.Key.Item1)))
                 {
                     throw new Exception("Type Parameter Resolutions must be empty");
                 }
@@ -65,7 +92,7 @@ namespace Microsoft.Quantum.QsCompiler.Transformations.Monomorphization.Validati
 
         private class TypeTransformation : TypeTransformation<TransformationState>
         {
-            public TypeTransformation(SyntaxTreeTransformation<TransformationState> parent) : base(parent) { }
+            public TypeTransformation(SyntaxTreeTransformation<TransformationState> parent) : base(parent, TransformationOptions.NoRebuild) { }
 
             public override QsTypeKind<ResolvedType, UserDefinedType, QsTypeParameter, CallableInformation> OnTypeParameter(QsTypeParameter tp)
             {


### PR DESCRIPTION
This change allows compiler extensions to plug in at (almost) any stage during the compilation. 