### PR TITLE
Remove IndexRange From Monomorphization Exemption List

### DIFF
--- a/src/QsCompiler/CompilationManager/EditorSupport/CodeActions.cs
+++ b/src/QsCompiler/CompilationManager/EditorSupport/CodeActions.cs
@@ -315,7 +315,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
                 return Enumerable.Empty<(string, WorkspaceEdit)>();
             }
             var indexRange = compilation.GlobalSymbols.TryGetCallable(
-                new QsQualifiedName(BuiltIn.IndexRange.FullName.Namespace, BuiltIn.IndexRange.FullName.Name),
+                BuiltIn.IndexRange.FullName,
                 NonNullable<string>.New(nsName),
                 file.FileName);
             if (!indexRange.IsFound)
@@ -368,8 +368,8 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
             var fragments = file.FragmentsOverlappingWithRange(range);
             var edits = fragments.SelectMany(IndexRangeEdits);
             var suggestedOpenDir = file.OpenDirectiveSuggestions(range.Start.Line, BuiltIn.IndexRange.FullName.Namespace);
-            return edits.Any() 
-                ? new[] { ("Use IndexRange to iterate over indices.", file.GetWorkspaceEdit(suggestedOpenDir.Concat(edits).ToArray())) } 
+            return edits.Any()
+                ? new[] { ("Use IndexRange to iterate over indices.", file.GetWorkspaceEdit(suggestedOpenDir.Concat(edits).ToArray())) }
                 : Enumerable.Empty<(string, WorkspaceEdit)>();
         }
 

--- a/src/QsCompiler/Compiler/RewriteSteps/Monomorphization.cs
+++ b/src/QsCompiler/Compiler/RewriteSteps/Monomorphization.cs
@@ -11,12 +11,12 @@ using Microsoft.Quantum.QsCompiler.Transformations.Monomorphization.Validation;
 namespace Microsoft.Quantum.QsCompiler.BuiltInRewriteSteps
 {
     /// <summary>
-    /// Replaces all type parametrized callables with concrete instantiations, dropping any unused callables. 
+    /// Replaces all type parametrized callables with concrete instantiations, dropping any unused callables.
     /// </summary>
     internal class Monomorphization : IRewriteStep
     {
         public string Name => "Monomorphization";
-        public int Priority => RewriteStepPriorities.TypeParameterElimination; 
+        public int Priority => RewriteStepPriorities.TypeParameterElimination;
         public IDictionary<string, string> AssemblyConstants { get; }
         public IEnumerable<IRewriteStep.Diagnostic> GeneratedDiagnostics => null;
 

--- a/src/QsCompiler/Core/Dependencies.fs
+++ b/src/QsCompiler/Core/Dependencies.fs
@@ -36,8 +36,7 @@ type BuiltIn = {
     /// These should be non-Generic callables only.
     static member RewriteStepDependencies =
         ImmutableHashSet.Create (
-            BuiltIn.RangeReverse.FullName,
-            BuiltIn.IndexRange.FullName
+            BuiltIn.RangeReverse.FullName
     )
 
     /// Returns true if the given attribute marks the corresponding declaration as entry point.
@@ -209,5 +208,5 @@ type BuiltIn = {
 
     static member IndexRange = {
         FullName = {Name = "IndexRange" |> NonNullable<string>.New; Namespace = BuiltIn.StandardArrayNamespace}
-        Kind = Function (TypeParameters = ImmutableArray.Empty)
+        Kind = Function (TypeParameters = ImmutableArray.Create("TElement" |> NonNullable<string>.New))
     }


### PR DESCRIPTION
Removed IndexRange from the monomorphization exemption list.
Added the appropriate type parameter to the BuiltIn member for IndexRange.