### PR TITLE
Prevent entry point driver from being loaded as a QSC reference

### DIFF
--- a/src/QuantumSdk/Tools/BuildConfiguration/Generate.cs
+++ b/src/QuantumSdk/Tools/BuildConfiguration/Generate.cs
@@ -17,9 +17,10 @@ namespace Microsoft.Quantum.Sdk.Tools
         private static readonly IReadOnlyCollection<string> IncompatibleQscReferences = new[]
         {
             // TODO: This is to work around an assembly that is included with the C# generation package, but which
-            // shouldn't be loaded as a compiler reference. If the Quantum SDK allows packages to explicitly specify
-            // which assemblies should be loaded for rewrite steps, instead of loading all of the assemblies in the
-            // package, then this can be removed.
+            // can't be loaded as a compiler reference. If the SDK gains support for packages containing a combination
+            // of assemblies that can be loaded as rewrite steps and those that can't, this should be removed.
+            //
+            // See: https://github.com/microsoft/qsharp-compiler/issues/435
             "Microsoft.Quantum.CsharpGeneration.EntryPointDriver.dll"
         };
         

--- a/src/QuantumSdk/Tools/BuildConfiguration/Generate.cs
+++ b/src/QuantumSdk/Tools/BuildConfiguration/Generate.cs
@@ -36,21 +36,12 @@ namespace Microsoft.Quantum.Sdk.Tools
                 "diagnostic".Equals(options.Verbosity, StringComparison.InvariantCultureIgnoreCase) ||
                 "diag".Equals(options.Verbosity, StringComparison.InvariantCultureIgnoreCase);
 
-            static (string, int) ParseQscReference(string qscRef)
-            {
-                var pieces = qscRef.Trim().TrimStart('(').TrimEnd(')').Split(',');
-                var path = pieces.First().Trim();
-                return (path, Int32.TryParse(pieces.Skip(1).SingleOrDefault(), out var priority) ? priority : 0);
-            }
-
-            ILookup<bool, string> qscReferences;
+            IEnumerable<string> compatibleQscReferences;
+            IEnumerable<string> incompatibleQscReferences;
             try
             {
-                qscReferences = (options.QscReferences ?? Array.Empty<string>())
-                    .Select(ParseQscReference)
-                    .OrderByDescending(qscRef => qscRef.Item2)
-                    .Select(qscRef => qscRef.Item1)
-                    .ToLookup(qscRef => IncompatibleQscReferences.Contains(Path.GetFileName(qscRef)));
+                (compatibleQscReferences, incompatibleQscReferences) = 
+                    ParseQscReferences(options.QscReferences ?? Array.Empty<string>());
             }
             catch (Exception ex)
             {
@@ -61,16 +52,38 @@ namespace Microsoft.Quantum.Sdk.Tools
                 return ReturnCode.INVALID_ARGUMENTS;
             }
 
-            var incompatible = qscReferences[true];
-            foreach (var reference in incompatible)
+            if (verbose)
             {
-                Console.Error.WriteLine($"Ignored incompatible reference {reference}.");
+                foreach (var reference in incompatibleQscReferences)
+                {
+                    Console.Error.WriteLine($"Skipped incompatible QSC reference: {reference}");
+                }
             }
-            
-            var compatible = qscReferences[false];
-            return WriteConfigFile(options.OutputFile, compatible, verbose)
+            return WriteConfigFile(options.OutputFile, compatibleQscReferences, verbose)
                 ? ReturnCode.SUCCESS
                 : ReturnCode.IO_EXCEPTION;
+        }
+
+        /// <summary>
+        /// Parses the QSC reference strings in the format "(path, priority)" and partitions them into compatible and
+        /// incompatible references.
+        /// </summary>
+        /// <param name="qscReferences">The QSC reference strings to parse.</param>
+        /// <returns>A tuple of compatible and incompatible QSC references.</returns>
+        private static (IEnumerable<string>, IEnumerable<string>) ParseQscReferences(IEnumerable<string> qscReferences)
+        {
+            static (string, int) ParseQscReference(string qscRef)
+            {
+                var pieces = qscRef.Trim().TrimStart('(').TrimEnd(')').Split(',');
+                var path = pieces.First().Trim();
+                return (path, int.TryParse(pieces.Skip(1).SingleOrDefault(), out var priority) ? priority : 0);
+            }
+            var compatible = qscReferences
+                .Select(ParseQscReference)
+                .OrderByDescending(qscRef => qscRef.Item2)
+                .Select(qscRef => qscRef.Item1)
+                .ToLookup(qscRef => !IncompatibleQscReferences.Contains(Path.GetFileName(qscRef)));
+            return (compatible[true], compatible[false]);
         }
 
         /// <summary>


### PR DESCRIPTION
This works around a problem caused by including the entry point driver assembly in the C# generation package. The SDK tries to load all of the assemblies, but this one has dependencies that are not included in the package, so loading fails.

Note: This is to feature/azure-quantum-preview instead of features/azure-quantum-preview to match the branch name on qsharp-runtime.