### PR TITLE
Populating type argument handles when building the call graph for executables

### DIFF
--- a/src/QsCompiler/Tests.Compiler/CallGraphTests.fs
+++ b/src/QsCompiler/Tests.Compiler/CallGraphTests.fs
@@ -755,8 +755,8 @@ type CallGraphTests (output:ITestOutputHelper) =
             let dependencies = givenGraph.GetDirectDependencies (strToNode nameFrom)
             for nameTo in nameToList do
                 let expectedNode = strToNode nameTo
-                Assert.True(dependencies.Contains(expectedNode) && dependencies.[expectedNode].Any(),
-                    sprintf "Expected %s to take dependency on %s." nameFrom nameTo)
+                Assert.False(dependencies.Contains(expectedNode) && dependencies.[expectedNode].Any(),
+                    sprintf "Expected %s not to depend on %s." nameFrom nameTo)
 
         // The generalized methods of asserting dependencies assumes Body nodes, but
         // this relationship is between a Body and an Adjoint specializations, so we

--- a/src/QsCompiler/Transformations/CallGraph.cs
+++ b/src/QsCompiler/Transformations/CallGraph.cs
@@ -547,8 +547,20 @@ namespace Microsoft.Quantum.QsCompiler.DependencyAnalysis
         /// </summary>
         public int Count => _Dependencies.Count;
 
-        private void RecordDependency(CallGraphNode callerKey, CallGraphNode calledKey, CallGraphEdge edge)
+        /// <summary>
+        /// Adds a dependency to the call graph.
+        /// The given information about the type arguments for the called callable 
+        /// needs to be consistent with the given type parameter resolutions and the type arguments of the caller.
+        /// Throws ArgumentNullException if any of the arguments are null.
+        /// </summary>
+        internal void AddDependency( // Kept internal due to the consistency requirement for the arguments!
+            CallGraphNode callerKey, CallGraphNode calledKey,
+            TypeParameterResolutions typeParamRes)
         {
+            if (callerKey == null) throw new ArgumentNullException(nameof(callerKey));
+            if (calledKey == null) throw new ArgumentNullException(nameof(calledKey));
+            var edge = new CallGraphEdge(typeParamRes);
+
             if (_Dependencies.TryGetValue(callerKey, out var deps))
             {
                 if (!deps.TryGetValue(calledKey, out var edges))
@@ -572,27 +584,6 @@ namespace Microsoft.Quantum.QsCompiler.DependencyAnalysis
             {
                 _Dependencies[calledKey] = new Dictionary<CallGraphNode, ImmutableArray<CallGraphEdge>>();
             }
-        }
-
-        /// <summary>
-        /// Adds a dependency to the call graph using the relevant information from the
-        /// caller's specialization and the called specialization. All parameters are
-        /// expected to be non-null; the QsNullable parameters may take on their
-        /// associated null value.
-        /// The given information about the type arguments for the called callable 
-        /// needs to be consistent with the given type parameter resolutions and the type arguments of the caller.
-        /// Throws ArgumentNullException if any of the non-nullable arguments are null.
-        /// </summary>
-        internal void AddDependency( // Kept internal due to the consistency requirement for the arguments!
-            QsQualifiedName callerName, QsSpecializationKind callerKind, QsNullable<ImmutableArray<ResolvedType>> callerTypeArgs,
-            QsQualifiedName calledName, QsSpecializationKind calledKind, QsNullable<ImmutableArray<ResolvedType>> calledTypeArgs,
-            TypeParameterResolutions typeParamRes)
-        {
-            var callerKey = new CallGraphNode(callerName, callerKind, callerTypeArgs);
-            var calledKey = new CallGraphNode(calledName, calledKind, calledTypeArgs);
-
-            var edge = new CallGraphEdge(typeParamRes);
-            RecordDependency(callerKey, calledKey, edge);
         }
 
         /// <summary>

--- a/src/QsCompiler/Transformations/CallGraph.cs
+++ b/src/QsCompiler/Transformations/CallGraph.cs
@@ -152,18 +152,6 @@ namespace Microsoft.Quantum.QsCompiler.DependencyAnalysis
         }
 
         /// <summary>
-        /// Copy constructor for CallGraphEdge objects.
-        /// Throws ArgumentNullException if edge is null or its ParamResolutions field is null
-        /// </summary>
-        public CallGraphEdge(CallGraphEdge edge)
-        {
-            if (edge == null || edge.ParamResolutions == null) throw new ArgumentNullException(nameof(edge));
-
-            // Remove position info from type parameter resolutions
-            ParamResolutions = edge.ParamResolutions;
-        }
-
-        /// <summary>
         /// Determines if the object is the same as the given edge, ignoring the
         /// ordering of key-value pairs in the type parameter dictionaries.
         /// </summary>

--- a/src/QsCompiler/Transformations/CallGraphWalker.cs
+++ b/src/QsCompiler/Transformations/CallGraphWalker.cs
@@ -69,7 +69,7 @@ namespace Microsoft.Quantum.QsCompiler.Transformations.CallGraphWalker
                             return (matches, spec);
                         });
 
-                        var matches = specArgMatches.OrderBy(match => match.Item1).Append((-1, null));
+                        var matches = specArgMatches.OrderByDescending(match => match.Item1).Append((-1, null));
                         if (matches.First().Item1 < 0)
                             throw new ArgumentException($"Could not find a suitable {currentRequest.Kind} specialization for {currentRequest.CallableName}");
 


### PR DESCRIPTION
This PR properly populates all type argument handles when building the call graph for an executable. All existing tests (which check the call graph for libraries) pass, but I haven't had the chance yet to add tests to check that the information including type arguments is indeed accurate - I'm happy to add those, but I wanted to put this up before the branches diverge to give a change to pull this in before continuing the work. 