### PR TITLE
Remove Classical Control NoOp Precondition Dependency

### DIFF
--- a/src/QsCompiler/Compiler/RewriteSteps/ClassicallyControlled.cs
+++ b/src/QsCompiler/Compiler/RewriteSteps/ClassicallyControlled.cs
@@ -44,8 +44,6 @@ namespace Microsoft.Quantum.QsCompiler.BuiltInRewriteSteps
                 .ToHashSet();
             var requiredBuiltIns = new HashSet<QsQualifiedName>()
             {
-                BuiltIn.NoOp.FullName,
-                
                 BuiltIn.ApplyIfZero.FullName,
                 BuiltIn.ApplyIfZeroA.FullName,
                 BuiltIn.ApplyIfZeroC.FullName,

--- a/src/QsCompiler/Compiler/RewriteSteps/ClassicallyControlled.cs
+++ b/src/QsCompiler/Compiler/RewriteSteps/ClassicallyControlled.cs
@@ -44,6 +44,8 @@ namespace Microsoft.Quantum.QsCompiler.BuiltInRewriteSteps
                 .ToHashSet();
             var requiredBuiltIns = new HashSet<QsQualifiedName>()
             {
+                BuiltIn.NoOp.FullName,
+                
                 BuiltIn.ApplyIfZero.FullName,
                 BuiltIn.ApplyIfZeroA.FullName,
                 BuiltIn.ApplyIfZeroC.FullName,


### PR DESCRIPTION
Reverses #459, as that is causing issues in the Simulation unit tests.