### PR TITLE
Add tests for equality comparisons

### DIFF
--- a/src/QsCompiler/Tests.Compiler/TestCases/TypeChecking.qs
+++ b/src/QsCompiler/Tests.Compiler/TestCases/TypeChecking.qs
@@ -282,6 +282,46 @@ namespace Microsoft.Quantum.Testing.TypeChecking {
     }
 
 
+    // Equality comparison
+
+    function UnitEquality(x : Unit, y : Unit) : Bool { return x == y; }
+    function UnitInequality(x : Unit, y : Unit) : Bool { return x != y; }
+    function IntEquality(x : Int, y : Int) : Bool { return x == y; }
+    function IntInequality(x : Int, y : Int) : Bool { return x != y; }
+    function BigIntEquality(x : BigInt, y : BigInt) : Bool { return x == y; }
+    function BigIntInequality(x : BigInt, y : BigInt) : Bool { return x != y; }
+    function DoubleEquality(x : Double, y : Double) : Bool { return x == y; }
+    function DoubleInequality(x : Double, y : Double) : Bool { return x != y; }
+    function BoolEquality(x : Bool, y : Bool) : Bool { return x == y; }
+    function BoolInequality(x : Bool, y : Bool) : Bool { return true != true; }
+    function StringEquality(x : String, y : String) : Bool { return x == y; }
+    function StringInequality(x : String, y : String) : Bool { return x != y; }
+    function QubitEquality(x : Qubit, y : Qubit) : Bool { return x == y; }
+    function QubitInequality(x : Qubit, y : Qubit) : Bool { return x != y; }
+    function ResultEquality(x : Result, y : Result) : Bool { return x == y; }
+    function ResultInequality(x : Result, y : Result) : Bool { return x != y; }
+    function PauliEquality(x : Pauli, y : Pauli) : Bool { return x == y; }
+    function PauliInequality(x : Pauli, y : Pauli) : Bool { return x != y; }
+    function RangeEquality(x : Range, y : Range) : Bool { return x == y; }
+    function RangeInequality(x : Range, y : Range) : Bool { return x != y; }
+    function ArrayEquality(x : Int[], y : Int[]) : Bool { return x == y; }
+    function ArrayInequality(x : Int[], y : Int[]) : Bool { return x != y; }
+    function TupleEquality(x : (Int, Int), y : (Int, Int)) : Bool { return x == y; }
+    function TupleInequality(x : (Int, Int), y : (Int, Int)) : Bool { return x != y; }
+    function UDTEquality(x : NamedItems1, y : NamedItems1) : Bool { return x == y; }
+    function UDTInequality(x : NamedItems1, y : NamedItems1) : Bool { return x != y; }
+    function GenericEquality<'A>(x : 'A, y : 'A) : Bool { return x == y; }
+    function GenericInequality<'A>(x : 'A, y : 'A) : Bool { return x != y; }
+    function OperationEquality(x : (Unit => Unit), y : (Unit => Unit)) : Bool { return x == y; }
+    function OperationInequality(x : (Unit => Unit), y : (Unit => Unit)) : Bool { return x != y; }
+    function FunctionEquality(x : (Unit -> Unit), y : (Unit -> Unit)) : Bool { return x == y; }
+    function FunctionInequality(x : (Unit -> Unit), y : (Unit -> Unit)) : Bool { return x != y; }
+    function InvalidTypeEquality(x : __Invalid__, y : __Invalid__) : Bool { return x == y; }
+    function InvalidTypeInequality(x : __Invalid__, y : __Invalid__) : Bool { return x != y; }
+    function NoCommonBaseEquality(x : Int, y : String) : Bool { return x == y; }
+    function NoCommonBaseInequality(x : Int, y : String) : Bool { return x != y; }
+
+
     // utils for testing type matching of arguments
 
     function GenSimple<'A> (arg : 'A) : 'A {

--- a/src/QsCompiler/Tests.Compiler/TypeCheckingTests.fs
+++ b/src/QsCompiler/Tests.Compiler/TypeCheckingTests.fs
@@ -69,6 +69,50 @@ type TypeCheckingTests (output:ITestOutputHelper) =
 
 
     [<Fact>]
+    member this.``Equality comparison`` () =
+        this.Expect "UnitEquality" [Error ErrorCode.InvalidTypeInEqualityComparison]
+        this.Expect "UnitInequality" [Error ErrorCode.InvalidTypeInEqualityComparison]
+        this.Expect "IntEquality" []
+        this.Expect "IntInequality" []
+        this.Expect "BigIntEquality" []
+        this.Expect "BigIntInequality" []
+        this.Expect "DoubleEquality" []
+        this.Expect "DoubleInequality" []
+        this.Expect "BoolEquality" []
+        this.Expect "BoolInequality" []
+        this.Expect "StringEquality" []
+        this.Expect "StringInequality" []
+        this.Expect "QubitEquality" []
+        this.Expect "QubitInequality" []
+        this.Expect "ResultEquality" []
+        this.Expect "ResultInequality" []
+        this.Expect "PauliEquality" []
+        this.Expect "PauliInequality" []
+        this.Expect "RangeEquality" [Error ErrorCode.InvalidTypeInEqualityComparison]
+        this.Expect "RangeInequality" [Error ErrorCode.InvalidTypeInEqualityComparison]
+        this.Expect "ArrayEquality" [Error ErrorCode.InvalidTypeInEqualityComparison]
+        this.Expect "ArrayInequality" [Error ErrorCode.InvalidTypeInEqualityComparison]
+        this.Expect "TupleEquality" [Error ErrorCode.InvalidTypeInEqualityComparison]
+        this.Expect "TupleInequality" [Error ErrorCode.InvalidTypeInEqualityComparison]
+        this.Expect "UDTEquality" [Error ErrorCode.InvalidTypeInEqualityComparison]
+        this.Expect "UDTInequality" [Error ErrorCode.InvalidTypeInEqualityComparison]
+        this.Expect "GenericEquality" [Error ErrorCode.InvalidTypeInEqualityComparison]
+        this.Expect "GenericInequality" [Error ErrorCode.InvalidTypeInEqualityComparison]
+        this.Expect "OperationEquality" [Error ErrorCode.InvalidTypeInEqualityComparison]
+        this.Expect "OperationInequality" [Error ErrorCode.InvalidTypeInEqualityComparison]
+        this.Expect "FunctionEquality" [Error ErrorCode.InvalidTypeInEqualityComparison]
+        this.Expect "FunctionInequality" [Error ErrorCode.InvalidTypeInEqualityComparison]
+        this.Expect "InvalidTypeEquality" [ Error ErrorCode.InvalidUseOfReservedKeyword
+                                            Error ErrorCode.InvalidUseOfReservedKeyword ]
+        this.Expect "InvalidTypeInequality" [ Error ErrorCode.InvalidUseOfReservedKeyword
+                                              Error ErrorCode.InvalidUseOfReservedKeyword ]
+        this.Expect "NoCommonBaseEquality" [ Error ErrorCode.ArgumentMismatchInBinaryOp
+                                             Error ErrorCode.ArgumentMismatchInBinaryOp ]
+        this.Expect "NoCommonBaseInequality" [ Error ErrorCode.ArgumentMismatchInBinaryOp
+                                               Error ErrorCode.ArgumentMismatchInBinaryOp ]
+
+
+    [<Fact>]
     member this.``Argument matching`` () = 
         this.Expect "MatchArgument1"  []
         this.Expect "MatchArgument2"  []
@@ -194,7 +238,3 @@ type TypeCheckingTests (output:ITestOutputHelper) =
         this.Expect "ArrayType18" []
         this.Expect "ArrayType19" []
         this.Expect "ArrayType20" []
-
-
-
-


### PR DESCRIPTION
I couldn't find any existing tests for checking which types support equality comparisons, so I added them to the type checking tests. These tests catch [the mistake I made in PR #449](https://github.com/microsoft/qsharp-compiler/pull/449#discussion_r436390162) that @bettinaheim found.