### PR TITLE
Fixing use of ASSEMBLY_CONSTANTS

### DIFF
--- a/build/build.ps1
+++ b/build/build.ps1
@@ -17,10 +17,15 @@ function Build-One {
     );
 
     Write-Host "##[info]Building $project ..."
+    if ("" -ne "$Env:ASSEMBLY_CONSTANTS") {
+        $args = @("/property:DefineConstants=$Env:ASSEMBLY_CONSTANTS");
+    }  else {
+        $args = @();
+    }
     dotnet build (Join-Path $PSScriptRoot $project) `
         -c $Env:BUILD_CONFIGURATION `
         -v $Env:BUILD_VERBOSITY `
-        /property:DefineConstants=$Env:ASSEMBLY_CONSTANTS `
+        @args `
         /property:Version=$Env:ASSEMBLY_VERSION
 
     if  ($LastExitCode -ne 0) {
@@ -70,9 +75,14 @@ function Build-VS() {
             
             if (Get-Command msbuild -ErrorAction SilentlyContinue) {
                 Try {
+                    if ("" -ne "$Env:ASSEMBLY_CONSTANTS") {
+                        $args = @("/property:DefineConstants=$Env:ASSEMBLY_CONSTANTS");
+                    }  else {
+                        $args = @();
+                    }
                     msbuild VisualStudioExtension.sln `
                         /property:Configuration=$Env:BUILD_CONFIGURATION `
-                        /property:DefineConstants=$Env:ASSEMBLY_CONSTANTS `
+                        @args `
                         /property:AssemblyVersion=$Env:ASSEMBLY_VERSION
     
                     if ($LastExitCode -ne 0) {

--- a/build/pack.ps1
+++ b/build/pack.ps1
@@ -17,10 +17,15 @@ function Publish-One {
     );
 
     Write-Host "##[info]Publishing $project ..."
+    if ("" -ne "$Env:ASSEMBLY_CONSTANTS") {
+        $args = @("/property:DefineConstants=$Env:ASSEMBLY_CONSTANTS");
+    }  else {
+        $args = @();
+    }
     dotnet publish (Join-Path $PSScriptRoot $project) `
         -c $Env:BUILD_CONFIGURATION `
         -v $Env:BUILD_VERBOSITY `
-        /property:DefineConstants=$Env:ASSEMBLY_CONSTANTS `
+        @args `
         /property:Version=$Env:ASSEMBLY_VERSION
 
     if  ($LastExitCode -ne 0) {
@@ -112,6 +117,11 @@ function Pack-SelfContained() {
         New-Item -ItemType Directory -Path $ArchiveDir -Force -ErrorAction SilentlyContinue;
 
         try {
+            if ("" -ne "$Env:ASSEMBLY_CONSTANTS") {
+                $args = @("/property:DefineConstants=$Env:ASSEMBLY_CONSTANTS");
+            }  else {
+                $args = @();
+            }
             $ArchivePath = Join-Path $ArchiveDir "$BaseName-$DotNetRuntimeID-$Env:ASSEMBLY_VERSION.zip";
             dotnet publish (Join-Path $PSScriptRoot $Project) `
                 -c $Env:BUILD_CONFIGURATION `
@@ -119,7 +129,7 @@ function Pack-SelfContained() {
                 --self-contained `
                 --runtime $DotNetRuntimeID `
                 --output $TargetDir `
-                /property:DefineConstants=$Env:ASSEMBLY_CONSTANTS `
+                @args `
                 /property:Version=$Env:ASSEMBLY_VERSION
             Write-Host "##[info]Writing self-contained deployment to $ArchivePath..."
             Compress-Archive `

--- a/build/test.ps1
+++ b/build/test.ps1
@@ -19,11 +19,16 @@ function Test-One {
 
     Write-Host "##[info]Testing $project..."
 
+    if ("" -ne "$Env:ASSEMBLY_CONSTANTS") {
+        $args = @("/property:DefineConstants=$Env:ASSEMBLY_CONSTANTS");
+    }  else {
+        $args = @();
+    }
     dotnet test (Join-Path $PSScriptRoot $project) `
         -c $Env:BUILD_CONFIGURATION `
         -v $Env:BUILD_VERBOSITY `
         --logger trx `
-        /property:DefineConstants=$Env:ASSEMBLY_CONSTANTS `
+        @args `
         /property:Version=$Env:ASSEMBLY_VERSION
 
     if  ($LastExitCode -ne 0) {


### PR DESCRIPTION
Fixes Scripts use of `DefineConstants` overrides all build constants, possibly hiding test failures #446