### PR TITLE
Don't execute rewrite steps if the validation fails

### DIFF
--- a/src/QsCompiler/Compiler/CompilationLoader.cs
+++ b/src/QsCompiler/Compiler/CompilationLoader.cs
@@ -694,7 +694,9 @@ namespace Microsoft.Quantum.QsCompiler
         /// </summary>
         private QsCompilation ExecuteAsAtomicTransformation(RewriteSteps.LoadedStep rewriteStep, ref Status status)
         {
-            status = this.ExecuteRewriteStep(rewriteStep, this.CompilationOutput, out var transformed);
+            QsCompilation transformed = null;
+            if (this.CompilationStatus.Validation != Status.Succeeded) status = Status.NotRun;
+            else status = this.ExecuteRewriteStep(rewriteStep, this.CompilationOutput, out transformed);
             return status == Status.Succeeded ? transformed : this.CompilationOutput;
         }
 

--- a/src/QsCompiler/Core/SyntaxTreeTransformation.fs
+++ b/src/QsCompiler/Core/SyntaxTreeTransformation.fs
@@ -51,7 +51,7 @@ type SyntaxTreeTransformation<'T> private (state : 'T, options : TransformationO
         and set value = _Namespaces <- value
 
     /// Invokes the transformation for all namespaces in the given compilation.
-    member this.Apply compilation = 
+    member this.OnCompilation compilation = 
         if options.Rebuild then
             let namespaces = compilation.Namespaces |> Seq.map this.Namespaces.OnNamespace |> ImmutableArray.CreateRange
             QsCompilation.New (namespaces, compilation.EntryPoints)
@@ -310,7 +310,7 @@ type SyntaxTreeTransformation private (options : TransformationOptions, _interna
         and set value = _Namespaces <- value
 
     /// Invokes the transformation for all namespaces in the given compilation.
-    member this.Apply compilation = 
+    member this.OnCompilation compilation = 
         if options.Rebuild then
             let namespaces = compilation.Namespaces |> Seq.map this.Namespaces.OnNamespace |> ImmutableArray.CreateRange
             QsCompilation.New (namespaces, compilation.EntryPoints)

--- a/src/QsCompiler/Tests.Compiler/CommandLineTests.fs
+++ b/src/QsCompiler/Tests.Compiler/CommandLineTests.fs
@@ -8,7 +8,9 @@ open System.IO
 open Microsoft.Quantum.QsCompiler
 open Microsoft.Quantum.QsCompiler.CommandLineCompiler
 open Microsoft.Quantum.QsCompiler.CompilationBuilder
+open Microsoft.Quantum.QsCompiler.ReservedKeywords
 open Xunit
+
 
 let private pathRoot = 
     Path.GetPathRoot(Directory.GetCurrentDirectory())
@@ -177,6 +179,29 @@ let ``options from response files`` () =
 
     let result = Program.Main commandLineArgs
     Assert.Equal(ReturnCode.SUCCESS, result)
+
+
+[<Fact>]
+let ``execute rewrite steps only if validation passes`` () = 
+    let source1 = ("TestCases", "LinkingTests", "Core.qs") |> Path.Combine 
+    let source2 = ("TestCases", "AttributeGeneration.qs") |> Path.Combine 
+    let config = new CompilationLoader.Configuration(GenerateFunctorSupport = true, BuildOutputFolder = null, RuntimeCapabilities = AssemblyConstants.RuntimeCapabilities.QPRGen0)
+    
+    let loadSources (loader : Func<_ seq,_>) = loader.Invoke([source1; source2])
+    let loaded = new CompilationLoader(new CompilationLoader.SourceLoader(loadSources), Seq.empty, new Nullable<_>(config));
+    Assert.Equal(CompilationLoader.Status.Succeeded, loaded.SourceFileLoading)
+    Assert.Equal(CompilationLoader.Status.Succeeded, loaded.ReferenceLoading)
+    Assert.Equal(CompilationLoader.Status.Succeeded, loaded.Validation)
+    Assert.Equal(CompilationLoader.Status.Succeeded, loaded.FunctorSupport)
+    Assert.Equal(CompilationLoader.Status.NotRun, loaded.Monomorphization) // no entry point
+
+    let loadSources (loader : Func<_ seq,_>) = loader.Invoke([source2])
+    let loaded = new CompilationLoader(new CompilationLoader.SourceLoader(loadSources), Seq.empty, new Nullable<_>(config));
+    Assert.Equal(CompilationLoader.Status.Succeeded, loaded.SourceFileLoading)
+    Assert.Equal(CompilationLoader.Status.Succeeded, loaded.ReferenceLoading)
+    Assert.Equal(CompilationLoader.Status.Failed, loaded.Validation)
+    Assert.Equal(CompilationLoader.Status.NotRun, loaded.FunctorSupport)
+    Assert.Equal(CompilationLoader.Status.NotRun, loaded.Monomorphization)
 
 
 [<Fact>]

--- a/src/QsCompiler/Tests.Compiler/LinkingTests.fs
+++ b/src/QsCompiler/Tests.Compiler/LinkingTests.fs
@@ -567,7 +567,7 @@ type LinkingTests (output:ITestOutputHelper) =
                 AssertSource (sDecl.Parent, sDecl.SourceFile, None)
                 sDecl
             let checker = new CheckDeclarations(onTypeDecl, onCallableDecl, onSpecDecl)
-            checker.Apply({EntryPoints = ImmutableArray<QsQualifiedName>.Empty; Namespaces = combined}) |> ignore
+            checker.OnCompilation({EntryPoints = ImmutableArray<QsQualifiedName>.Empty; Namespaces = combined}) |> ignore
 
         let source =  sprintf "Reference%i.dll" >> NonNullable<string>.New
         let chunks = LinkingTests.ReadAndChunkSourceFile "ReferenceLinking.qs"

--- a/src/QsCompiler/Tests.Compiler/LinkingTests.fs
+++ b/src/QsCompiler/Tests.Compiler/LinkingTests.fs
@@ -225,7 +225,7 @@ type LinkingTests (output:ITestOutputHelper) =
             | _ -> ()
 
         let walker = new TypedExpressionWalker<unit>(new Action<_>(onExpr));
-        walker.Transformation.Apply compilation |> ignore
+        walker.Transformation.OnCompilation compilation |> ignore
         Assert.True(gotLength)
         Assert.True(gotIndexRange)
 

--- a/src/QsCompiler/Tests.Compiler/TestCases/AttributeGeneration.qs
+++ b/src/QsCompiler/Tests.Compiler/TestCases/AttributeGeneration.qs
@@ -14,7 +14,7 @@ namespace Microsoft.Quantum.Testing.AttributeGeneration {
     }
 
     operation CallDefaultArray<'A>(size : Int) : 'A[] {
-        return DefaultArray(size);
+        return DefaultArray<'A>(size);
     }
 
 }

--- a/src/QsCompiler/Tests.Compiler/TransformationTests.fs
+++ b/src/QsCompiler/Tests.Compiler/TransformationTests.fs
@@ -168,23 +168,23 @@ let ``attaching attributes to callables`` () =
 
     let transformed = AttributeUtils.AddToCallables(compilation, testAttribute, predicate)
     let checker = new CheckDeclarations(checkType, checkCallable attGenNs 1, checkSpec)
-    checker.Apply transformed |> ignore
+    checker.OnCompilation transformed |> ignore
 
     let transformed = AttributeUtils.AddToCallables(compilation, testAttribute, null)
     let checker = new CheckDeclarations(checkType, checkCallable null 1, checkSpec)
-    checker.Apply transformed |> ignore
+    checker.OnCompilation transformed |> ignore
 
     let transformed = AttributeUtils.AddToCallables(compilation, testAttribute)
     let checker = new CheckDeclarations(checkType, checkCallable null 1, checkSpec)
-    checker.Apply transformed |> ignore
+    checker.OnCompilation transformed |> ignore
 
     let transformed = AttributeUtils.AddToCallables(compilation, struct (testAttribute, new Func<_,_>(predicate)), struct(testAttribute, new Func<_,_>(predicate)))
     let checker = new CheckDeclarations(checkType, checkCallable attGenNs 2, checkSpec)
-    checker.Apply transformed |> ignore
+    checker.OnCompilation transformed |> ignore
     
     let transformed = AttributeUtils.AddToCallables(compilation, testAttribute, testAttribute)
     let checker = new CheckDeclarations(checkType, checkCallable null 2, checkSpec)
-    checker.Apply transformed |> ignore
+    checker.OnCompilation transformed |> ignore
     
 
 [<Fact>]

--- a/src/QsCompiler/Transformations/Attributes.cs
+++ b/src/QsCompiler/Transformations/Attributes.cs
@@ -56,7 +56,7 @@ namespace Microsoft.Quantum.QsCompiler.Transformations
         /// Throws an ArgumentNullException if the given attribute or compilation is null.
         /// </summary>
         public static QsCompilation AddToCallables(QsCompilation compilation, QsDeclarationAttribute attribute, CallablePredicate predicate = null) =>
-            new AddAttributes(new[] { (attribute, predicate) }).Apply(compilation);
+            new AddAttributes(new[] { (attribute, predicate) }).OnCompilation(compilation);
 
         /// <summary>
         /// Adds the given attribute(s) to all callables in the given compilation that satisfy the given predicate 
@@ -64,14 +64,14 @@ namespace Microsoft.Quantum.QsCompiler.Transformations
         /// Throws an ArgumentNullException if one of the given attributes or the compilation is null.
         /// </summary>
         public static QsCompilation AddToCallables(QsCompilation compilation, params (QsDeclarationAttribute, CallablePredicate)[] attributes) =>
-            new AddAttributes(attributes).Apply(compilation);
+            new AddAttributes(attributes).OnCompilation(compilation);
 
         /// <summary>
         /// Adds the given attribute(s) to all callables in the given compilation.
         /// Throws an ArgumentNullException if one of the given attributes or the compilation is null.
         /// </summary>
         public static QsCompilation AddToCallables(QsCompilation compilation, params QsDeclarationAttribute[] attributes) =>
-            new AddAttributes(attributes.Select(att => (att, (CallablePredicate)null))).Apply(compilation);
+            new AddAttributes(attributes.Select(att => (att, (CallablePredicate)null))).OnCompilation(compilation);
 
         /// <summary>
         /// Adds the given attribute to all callables in the given namespace that satisfy the given predicate 

--- a/src/QuantumSdk/README.md
+++ b/src/QuantumSdk/README.md
@@ -92,6 +92,7 @@ The content of the file should be similar to the following, with `Package_Name` 
 
 </Project>
 ```
+This [example](https://github.com/microsoft/qsharp-compiler/tree/master/examples/CompilerExtensions/ExtensionPackage) provides a template for packaging a Q# compiler extension. 
 
 If you develop a NuGet package to extend the Q# compilation process, we recommend to distribute it as a self-contained package to avoid issues due to references that could not be resolved. Each qsc reference is loaded into its own context to avoid issues when several references depend on different versions of the same package. 
 


### PR DESCRIPTION
To avoid that rewrite steps have to have handling for invalid code, rewrite steps are supposed to be able to rely on that they obtain a valid syntax tree. We hence won't invoke any steps if the initial validation of the compilation fails. 
This fixes the issue https://github.com/microsoft/qsharp-runtime/issues/242.