### PR TITLE
Classically Controlled Short Circuit Bug Fix

### DIFF
--- a/src/QsCompiler/Tests.Compiler/ClassicalControlTests.fs
+++ b/src/QsCompiler/Tests.Compiler/ClassicalControlTests.fs
@@ -158,9 +158,6 @@ type ClassicalControlTests () =
         |> Seq.find (fun x -> x.Key.Name.Value = name)
         |> (fun x -> x.Value)
 
-    let ApplyIfElseTest2 compilation =
-        ()
-
     let ApplyIfElseTest compilation =
 
         let original = GetCallableWithName compilation Signatures.ClassicalControlNs "Foo" |> GetBodyFromCallable

--- a/src/QsCompiler/Tests.Compiler/TestUtils/Signatures.fs
+++ b/src/QsCompiler/Tests.Compiler/TestUtils/Signatures.fs
@@ -11,7 +11,7 @@ open Microsoft.Quantum.QsCompiler.Transformations.QsCodeOutput
 open Microsoft.Quantum.QsCompiler.SyntaxTokens
 open Microsoft.Quantum.QsCompiler.SyntaxTree
 open Xunit
-    
+
 let private _BaseTypes =
     [|
         "Unit", UnitType
@@ -22,7 +22,7 @@ let private _BaseTypes =
         "Qubit", Qubit
         "Qubit[]", ResolvedType.New Qubit |> ArrayType
     |]
-    
+
 let private _MakeTypeMap udts =
     Array.concat
         [
@@ -86,7 +86,7 @@ let public SignatureCheck checkedNamespaces targetSignatures compilation =
     let makeArgsString (args : ResolvedType) =
         match args.Resolution with
         | QsTypeKind.UnitType -> "()"
-        | _ -> args |> SyntaxTreeToQsharp.Default.ToCode 
+        | _ -> args |> SyntaxTreeToQsharp.Default.ToCode
 
     let removeAt i lst =
         Seq.append
@@ -253,12 +253,15 @@ let public ClassicalControlSignatures =
         |])
         (_DefaultTypes, [| // If Elif
             ClassicalControlNs, "Foo", [||], "Unit"
+            ClassicalControlNs, "_Foo", [|"Result"|], "Unit"
         |])
         (_DefaultTypes, [| // And Condition
             ClassicalControlNs, "Foo", [||], "Unit"
+            ClassicalControlNs, "_Foo", [|"Result"|], "Unit"
         |])
         (_DefaultTypes, [| // Or Condition
             ClassicalControlNs, "Foo", [||], "Unit"
+            ClassicalControlNs, "_Foo", [|"Result"|], "Unit"
         |])
         (_DefaultTypes, [| // Don't Lift Functions
             ClassicalControlNs, "Foo", [||], "Unit"

--- a/src/QsCompiler/Transformations/ClassicallyControlled.cs
+++ b/src/QsCompiler/Transformations/ClassicallyControlled.cs
@@ -29,9 +29,177 @@ namespace Microsoft.Quantum.QsCompiler.Transformations.ClassicallyControlled
     {
         public static QsCompilation Apply(QsCompilation compilation)
         {
+            compilation = RestructureConditions.Apply(compilation);
             compilation = LiftConditionBlocks.Apply(compilation);
-
             return ConvertConditions.Apply(compilation);
+        }
+
+        private class RestructureConditions : SyntaxTreeTransformation
+        {
+            public new static QsCompilation Apply(QsCompilation compilation)
+            {
+                var filter = new RestructureConditions();
+
+                return new QsCompilation(compilation.Namespaces.Select(ns => filter.Namespaces.OnNamespace(ns)).ToImmutableArray(), compilation.EntryPoints);
+            }
+
+            private RestructureConditions() : base()
+            {
+                this.Namespaces = new NamespaceTransformation(this);
+                this.Statements = new StatementTransformation(this);
+                this.Expressions = new ExpressionTransformation(this, TransformationOptions.Disabled);
+                this.Types = new TypeTransformation(this, TransformationOptions.Disabled);
+            }
+
+            private class NamespaceTransformation : Core.NamespaceTransformation
+            {
+                public NamespaceTransformation(SyntaxTreeTransformation parent) : base(parent) { }
+
+                public override QsCallable OnFunction(QsCallable c) => c; // Prevent anything in functions from being considered
+            }
+
+            private class StatementTransformation : Core.StatementTransformation
+            {
+                public StatementTransformation(SyntaxTreeTransformation parent) : base(parent) { }
+
+                #region Condition Reshaping Logic
+
+                /// <summary>
+                /// Converts if-elif-else structures to nested if-else structures.
+                /// </summary>
+                private (bool, QsConditionalStatement) ProcessElif(QsConditionalStatement conditionStatment)
+                {
+                    if (conditionStatment.ConditionalBlocks.Length < 2) return (false, conditionStatment);
+
+                    var subCondition = new QsConditionalStatement(conditionStatment.ConditionalBlocks.RemoveAt(0), conditionStatment.Default);
+                    var secondConditionBlock = conditionStatment.ConditionalBlocks[1].Item2;
+                    var subIfStatment = new QsStatement(
+                        QsStatementKind.NewQsConditionalStatement(subCondition),
+                        LocalDeclarations.Empty,
+                        secondConditionBlock.Location,
+                        secondConditionBlock.Comments);
+                    var newDefault = QsNullable<QsPositionedBlock>.NewValue(new QsPositionedBlock(
+                        new QsScope(ImmutableArray.Create(subIfStatment), secondConditionBlock.Body.KnownSymbols),
+                        secondConditionBlock.Location,
+                        QsComments.Empty));
+
+                    return (true, new QsConditionalStatement(ImmutableArray.Create(conditionStatment.ConditionalBlocks[0]), newDefault));
+                }
+
+                /// <summary>
+                /// Converts conditional statements whose top-most condition is an OR.
+                /// Creates a nested structure without the top-most OR.
+                /// </summary>
+                private (bool, QsConditionalStatement) ProcessOR(QsConditionalStatement conditionStatment)
+                {
+                    // This method expects elif blocks to have been abstracted out
+                    if (conditionStatment.ConditionalBlocks.Length != 1) return (false, conditionStatment);
+
+                    var (condition, block) = conditionStatment.ConditionalBlocks[0];
+
+                    if (condition.Expression is ExpressionKind.OR orCondition)
+                    {
+                        var subCondition = new QsConditionalStatement(ImmutableArray.Create(Tuple.Create(orCondition.Item2, block)), conditionStatment.Default);
+                        var subIfStatment = new QsStatement(
+                            QsStatementKind.NewQsConditionalStatement(subCondition),
+                            LocalDeclarations.Empty,
+                            block.Location,
+                            QsComments.Empty);
+                        var newDefault = QsNullable<QsPositionedBlock>.NewValue(new QsPositionedBlock(
+                            new QsScope(ImmutableArray.Create(subIfStatment), block.Body.KnownSymbols),
+                            block.Location,
+                            QsComments.Empty));
+
+                        return (true, new QsConditionalStatement(ImmutableArray.Create(Tuple.Create(orCondition.Item1, block)), newDefault));
+                    }
+                    else
+                    {
+                        return (false, conditionStatment);
+                    }
+                }
+
+                /// <summary>
+                /// Converts conditional statements whose top-most condition is an AND.
+                /// Creates a nested structure without the top-most AND.
+                /// </summary>
+                private (bool, QsConditionalStatement) ProcessAND(QsConditionalStatement conditionStatment)
+                {
+                    // This method expects elif blocks to have been abstracted out
+                    if (conditionStatment.ConditionalBlocks.Length != 1) return (false, conditionStatment);
+
+                    var (condition, block) = conditionStatment.ConditionalBlocks[0];
+
+                    if (condition.Expression is ExpressionKind.AND andCondition)
+                    {
+                        var subCondition = new QsConditionalStatement(ImmutableArray.Create(Tuple.Create(andCondition.Item2, block)), conditionStatment.Default);
+                        var subIfStatment = new QsStatement(
+                            QsStatementKind.NewQsConditionalStatement(subCondition),
+                            LocalDeclarations.Empty,
+                            block.Location,
+                            QsComments.Empty);
+                        var newBlock = new QsPositionedBlock(
+                            new QsScope(ImmutableArray.Create(subIfStatment), block.Body.KnownSymbols),
+                            block.Location,
+                            QsComments.Empty);
+
+                        return (true, new QsConditionalStatement(ImmutableArray.Create(Tuple.Create(andCondition.Item1, newBlock)), conditionStatment.Default));
+                    }
+                    else
+                    {
+                        return (false, conditionStatment);
+                    }
+                }
+
+                /// <summary>
+                /// Converts conditional statements to nested structures so they do not
+                /// have elif blocks or top-most OR or AND conditions.
+                /// </summary>
+                private QsStatement ReshapeConditional(QsStatement statement)
+                {
+                    if (statement.Statement is QsStatementKind.QsConditionalStatement condition)
+                    {
+                        var stm = condition.Item;
+                        (_, stm) = ProcessElif(stm);
+                        bool wasOrProcessed, wasAndProcessed;
+                        do
+                        {
+                            (wasOrProcessed, stm) = ProcessOR(stm);
+                            (wasAndProcessed, stm) = ProcessAND(stm);
+                        } while (wasOrProcessed || wasAndProcessed);
+
+                        return new QsStatement(
+                            QsStatementKind.NewQsConditionalStatement(stm),
+                            statement.SymbolDeclarations,
+                            statement.Location,
+                            statement.Comments);
+                    }
+                    return statement;
+                }
+
+                #endregion
+
+                public override QsScope OnScope(QsScope scope)
+                {
+                    var parentSymbols = this.OnLocalDeclarations(scope.KnownSymbols);
+                    var statements = new List<QsStatement>();
+
+                    foreach (var statement in scope.Statements)
+                    {
+                        if (statement.Statement is QsStatementKind.QsConditionalStatement)
+                        {
+                            var stm = ReshapeConditional(statement);
+                            stm = this.OnStatement(stm);
+                            statements.Add(stm);
+                        }
+                        else
+                        {
+                            statements.Add(this.OnStatement(statement));
+                        }
+                    }
+
+                    return new QsScope(statements.ToImmutableArray(), parentSymbols);
+                }
+            }
         }
 
         private class ConvertConditions : SyntaxTreeTransformation<ConvertConditions.TransformationState>
@@ -614,122 +782,6 @@ namespace Microsoft.Quantum.QsCompiler.Transformations.ClassicallyControlled
 
                 #endregion
 
-                #region Condition Reshaping Logic
-
-                /// <summary>
-                /// Converts if-elif-else structures to nested if-else structures.
-                /// </summary>
-                private (bool, QsConditionalStatement) ProcessElif(QsConditionalStatement conditionStatment)
-                {
-                    if (conditionStatment.ConditionalBlocks.Length < 2) return (false, conditionStatment);
-
-                    var subCondition = new QsConditionalStatement(conditionStatment.ConditionalBlocks.RemoveAt(0), conditionStatment.Default);
-                    var secondConditionBlock = conditionStatment.ConditionalBlocks[1].Item2;
-                    var subIfStatment = new QsStatement(
-                        QsStatementKind.NewQsConditionalStatement(subCondition),
-                        LocalDeclarations.Empty,
-                        secondConditionBlock.Location,
-                        secondConditionBlock.Comments);
-                    var newDefault = QsNullable<QsPositionedBlock>.NewValue(new QsPositionedBlock(
-                        new QsScope(ImmutableArray.Create(subIfStatment), secondConditionBlock.Body.KnownSymbols),
-                        secondConditionBlock.Location,
-                        QsComments.Empty));
-
-                    return (true, new QsConditionalStatement(ImmutableArray.Create(conditionStatment.ConditionalBlocks[0]), newDefault));
-                }
-
-                /// <summary>
-                /// Converts conditional statements whose top-most condition is an OR.
-                /// Creates a nested structure without the top-most OR.
-                /// </summary>
-                private (bool, QsConditionalStatement) ProcessOR(QsConditionalStatement conditionStatment)
-                {
-                    // This method expects elif blocks to have been abstracted out
-                    if (conditionStatment.ConditionalBlocks.Length != 1) return (false, conditionStatment);
-
-                    var (condition, block) = conditionStatment.ConditionalBlocks[0];
-
-                    if (condition.Expression is ExpressionKind.OR orCondition)
-                    {
-                        var subCondition = new QsConditionalStatement(ImmutableArray.Create(Tuple.Create(orCondition.Item2, block)), conditionStatment.Default);
-                        var subIfStatment = new QsStatement(
-                            QsStatementKind.NewQsConditionalStatement(subCondition),
-                            LocalDeclarations.Empty,
-                            block.Location,
-                            QsComments.Empty);
-                        var newDefault = QsNullable<QsPositionedBlock>.NewValue(new QsPositionedBlock(
-                            new QsScope(ImmutableArray.Create(subIfStatment), block.Body.KnownSymbols),
-                            block.Location,
-                            QsComments.Empty));
-
-                        return (true, new QsConditionalStatement(ImmutableArray.Create(Tuple.Create(orCondition.Item1, block)), newDefault));
-                    }
-                    else
-                    {
-                        return (false, conditionStatment);
-                    }
-                }
-
-                /// <summary>
-                /// Converts conditional statements whose top-most condition is an AND.
-                /// Creates a nested structure without the top-most AND.
-                /// </summary>
-                private (bool, QsConditionalStatement) ProcessAND(QsConditionalStatement conditionStatment)
-                {
-                    // This method expects elif blocks to have been abstracted out
-                    if (conditionStatment.ConditionalBlocks.Length != 1) return (false, conditionStatment);
-
-                    var (condition, block) = conditionStatment.ConditionalBlocks[0];
-
-                    if (condition.Expression is ExpressionKind.AND andCondition)
-                    {
-                        var subCondition = new QsConditionalStatement(ImmutableArray.Create(Tuple.Create(andCondition.Item2, block)), conditionStatment.Default);
-                        var subIfStatment = new QsStatement(
-                            QsStatementKind.NewQsConditionalStatement(subCondition),
-                            LocalDeclarations.Empty,
-                            block.Location,
-                            QsComments.Empty);
-                        var newBlock = new QsPositionedBlock(
-                            new QsScope(ImmutableArray.Create(subIfStatment), block.Body.KnownSymbols),
-                            block.Location,
-                            QsComments.Empty);
-
-                        return (true, new QsConditionalStatement(ImmutableArray.Create(Tuple.Create(andCondition.Item1, newBlock)), conditionStatment.Default));
-                    }
-                    else
-                    {
-                        return (false, conditionStatment);
-                    }
-                }
-
-                /// <summary>
-                /// Converts conditional statements to nested structures so they do not
-                /// have elif blocks or top-most OR or AND conditions.
-                /// </summary>
-                private QsStatement ReshapeConditional(QsStatement statement)
-                {
-                    if (statement.Statement is QsStatementKind.QsConditionalStatement condition)
-                    {
-                        var stm = condition.Item;
-                        (_, stm) = ProcessElif(stm);
-                        bool wasOrProcessed, wasAndProcessed;
-                        do
-                        {
-                            (wasOrProcessed, stm) = ProcessOR(stm);
-                            (wasAndProcessed, stm) = ProcessAND(stm);
-                        } while (wasOrProcessed || wasAndProcessed);
-
-                        return new QsStatement(
-                            QsStatementKind.NewQsConditionalStatement(stm),
-                            statement.SymbolDeclarations,
-                            statement.Location,
-                            statement.Comments);
-                    }
-                    return statement;
-                }
-
-                #endregion
-
                 public override QsScope OnScope(QsScope scope)
                 {
                     var parentSymbols = this.OnLocalDeclarations(scope.KnownSymbols);
@@ -739,10 +791,8 @@ namespace Microsoft.Quantum.QsCompiler.Transformations.ClassicallyControlled
                     {
                         if (statement.Statement is QsStatementKind.QsConditionalStatement)
                         {
-                            var stm = ReshapeConditional(statement);
-                            stm = this.OnStatement(stm);
+                            var stm = this.OnStatement(statement);
                             stm = ConvertConditionalToControlCall(stm);
-
                             statements.Add(stm);
                         }
                         else

--- a/src/QsCompiler/Transformations/ClassicallyControlled.cs
+++ b/src/QsCompiler/Transformations/ClassicallyControlled.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Quantum.QsCompiler.Transformations.ClassicallyControlled
     /// with equivalent nested if-else statements.
     /// 2st Pass: Lift the contents of conditional statements into separate operations, where possible.
     /// 3nd Pass: Convert conditional statements into interface calls, where possible.
-    /// This relies on global callables being the only things that having type parameters.
+    /// This relies on global callables being the only things that have type parameters.
     /// </summary>
     public static class ReplaceClassicalControl
     {
@@ -287,7 +287,7 @@ namespace Microsoft.Quantum.QsCompiler.Transformations.ClassicallyControlled
                         var idTypeArguments = call.Item1.TypeArguments;
                         var combinedTypeArguments = GetCombinedTypeResolution(callTypeArguments, idTypeArguments);
 
-                        // This relies on anything having type parameters must be a global callable.
+                        // This relies on global callables being the only things that have type parameters.
                         var newCallIdentifier = call.Item1;
                         if (combinedTypeArguments.Any()
                             && newCallIdentifier.Expression is ExpressionKind.Identifier id

--- a/src/QsCompiler/Transformations/ClassicallyControlled.cs
+++ b/src/QsCompiler/Transformations/ClassicallyControlled.cs
@@ -18,12 +18,12 @@ namespace Microsoft.Quantum.QsCompiler.Transformations.ClassicallyControlled
     using TypeArgsResolution = ImmutableArray<Tuple<QsQualifiedName, NonNullable<string>, ResolvedType>>;
 
     /// <summary>
-    /// This transformation works in two passes.
-    /// 1st Pass: Lift the contents of conditional statements into separate operations, where possible.
-    /// 2nd Pass: On the way down the tree, reshape conditional statements to replace Elif's and
-    /// top level OR and AND conditions with equivalent nested if-else statements. One the way back up
-    /// the tree, convert conditional statements into interface calls, where possible.
-    /// This relies on anything having type parameters must be a global callable.
+    /// This transformation works in three passes.
+    /// 1st Pass: Reshape conditional statements to replace Elif's and top level OR and AND conditions
+    /// with equivalent nested if-else statements.
+    /// 2st Pass: Lift the contents of conditional statements into separate operations, where possible.
+    /// 3nd Pass: Convert conditional statements into interface calls, where possible.
+    /// This relies on global callables being the only things that having type parameters.
     /// </summary>
     public static class ReplaceClassicalControl
     {


### PR DESCRIPTION
Rearranged the order of steps in the Classically Controlled transformation so that the restructuring of if-statements is performed first. This addresses an issue where all conditional expressions were always evaluated even when they should have been short-circuited (#475)  