### PR TITLE
Use OnCompilation in Transformations

### DIFF
--- a/src/QsCompiler/Transformations/ClassicallyControlled.cs
+++ b/src/QsCompiler/Transformations/ClassicallyControlled.cs
@@ -36,12 +36,8 @@ namespace Microsoft.Quantum.QsCompiler.Transformations.ClassicallyControlled
 
         private class RestructureConditions : SyntaxTreeTransformation
         {
-            public new static QsCompilation Apply(QsCompilation compilation)
-            {
-                var filter = new RestructureConditions();
-
-                return new QsCompilation(compilation.Namespaces.Select(ns => filter.Namespaces.OnNamespace(ns)).ToImmutableArray(), compilation.EntryPoints);
-            }
+            public static QsCompilation Apply(QsCompilation compilation) =>
+                new RestructureConditions().OnCompilation(compilation);
 
             private RestructureConditions() : base()
             {
@@ -204,12 +200,8 @@ namespace Microsoft.Quantum.QsCompiler.Transformations.ClassicallyControlled
 
         private class ConvertConditions : SyntaxTreeTransformation<ConvertConditions.TransformationState>
         {
-            public new static QsCompilation Apply(QsCompilation compilation)
-            {
-                var filter = new ConvertConditions(compilation);
-
-                return new QsCompilation(compilation.Namespaces.Select(ns => filter.Namespaces.OnNamespace(ns)).ToImmutableArray(), compilation.EntryPoints);
-            }
+            public static QsCompilation Apply(QsCompilation compilation) =>
+                new ConvertConditions(compilation).OnCompilation(compilation);
 
             public class TransformationState
             {
@@ -809,12 +801,8 @@ namespace Microsoft.Quantum.QsCompiler.Transformations.ClassicallyControlled
 
     internal static class LiftConditionBlocks
     {
-        public static QsCompilation Apply(QsCompilation compilation)
-        {
-            var filter = new LiftContent();
-
-            return new QsCompilation(compilation.Namespaces.Select(ns => filter.Namespaces.OnNamespace(ns)).ToImmutableArray(), compilation.EntryPoints);
-        }
+        public static QsCompilation Apply(QsCompilation compilation) =>
+            new LiftContent().OnCompilation(compilation);
 
         private class LiftContent : ContentLifting.LiftContent<LiftContent.TransformationState>
         {

--- a/src/QsCompiler/Transformations/Monomorphization.cs
+++ b/src/QsCompiler/Transformations/Monomorphization.cs
@@ -176,7 +176,7 @@ namespace Microsoft.Quantum.QsCompiler.Transformations.Monomorphization
             {
                 var filter = new ResolveGenerics(responses.ToLookup(res => res.concreteCallable.FullName.Namespace, res => res.concreteCallable), intrinsicCallableSet);
 
-                return new QsCompilation(compilation.Namespaces.Select(ns => filter.Namespaces.OnNamespace(ns)).ToImmutableArray(), compilation.EntryPoints);
+                return filter.OnCompilation(compilation);
             }
 
             public class TransformationState
@@ -368,7 +368,7 @@ namespace Microsoft.Quantum.QsCompiler.Transformations.Monomorphization
                 public override ImmutableConcretion OnTypeParamResolutions(ImmutableConcretion typeParams)
                 {
                     // Merge the type params into the current dictionary
-                   
+
                     foreach (var kvp in typeParams.Where(kv => !SharedState.IntrinsicCallableSet.Contains(kv.Key.Item1)))
                     {
                         SharedState.CurrentParamTypes.Add(kvp.Key, kvp.Value);


### PR DESCRIPTION
Updates some transformations to use the new OnCompilation method instead of looping through namespaces manually.