### PR TITLE
Fix to reserve symbol in set statement crash

### DIFF
--- a/src/QsCompiler/Tests.Compiler/LocalVerificationTests.fs
+++ b/src/QsCompiler/Tests.Compiler/LocalVerificationTests.fs
@@ -85,6 +85,7 @@ type LocalVerificationTests () =
         this.Expect "ApplyAndReassign8"   [Error ErrorCode.UpdateOfImmutableIdentifier]
         this.Expect "ApplyAndReassign9"   [Error ErrorCode.UpdateOfArrayItemExpr]
         this.Expect "ApplyAndReassign10"  [Error ErrorCode.UpdateOfArrayItemExpr]
+        this.Expect "ApplyAndReassign11"  [Error ErrorCode.InvalidUseOfReservedKeyword]
 
 
     [<Fact>]

--- a/src/QsCompiler/Tests.Compiler/TestCases/LocalVerification.qs
+++ b/src/QsCompiler/Tests.Compiler/TestCases/LocalVerification.qs
@@ -264,6 +264,10 @@ namespace Microsoft.Quantum.Testing.LocalVerification {
         set a[0] += 1;
     }
 
+    function ApplyAndReassign11 () : Unit {
+        set bool = true;
+    }
+
 
     // accessing named items in user defined types
 


### PR DESCRIPTION
This change fixes a crash in the compiler that occurs when a reserved symbol is used in a set statement.