### PR TITLE
Language Server to use SEMVER_VERSION

### DIFF
--- a/build/pack.ps1
+++ b/build/pack.ps1
@@ -122,7 +122,7 @@ function Pack-SelfContained() {
             }  else {
                 $args = @();
             }
-            $ArchivePath = Join-Path $ArchiveDir "$BaseName-$DotNetRuntimeID-$Env:ASSEMBLY_VERSION.zip";
+            $ArchivePath = Join-Path $ArchiveDir "$BaseName-$DotNetRuntimeID-$Env:SEMVER_VERSION.zip";
             dotnet publish (Join-Path $PSScriptRoot $Project) `
                 -c $Env:BUILD_CONFIGURATION `
                 -v $Env:BUILD_VERBOSITY `

--- a/src/VSCodeExtension/package.json.v.template
+++ b/src/VSCodeExtension/package.json.v.template
@@ -130,15 +130,15 @@
     },
     "blobs": {
         "win32": {
-            "url": "https://msquantumpublic.blob.core.windows.net/qsharp-compiler/LanguageServer-win10-x64-#ASSEMBLY_VERSION#.zip",
+            "url": "https://msquantumpublic.blob.core.windows.net/qsharp-compiler/LanguageServer-win10-x64-#SEMVER_VERSION#.zip",
             "sha256": "<DISABLED>"
         },
         "darwin": {
-            "url": "https://msquantumpublic.blob.core.windows.net/qsharp-compiler/LanguageServer-osx-x64-#ASSEMBLY_VERSION#.zip",
+            "url": "https://msquantumpublic.blob.core.windows.net/qsharp-compiler/LanguageServer-osx-x64-#SEMVER_VERSION#.zip",
             "sha256": "<DISABLED>"
         },
         "linux": {
-            "url": "https://msquantumpublic.blob.core.windows.net/qsharp-compiler/LanguageServer-linux-x64-#ASSEMBLY_VERSION#.zip",
+            "url": "https://msquantumpublic.blob.core.windows.net/qsharp-compiler/LanguageServer-linux-x64-#SEMVER_VERSION#.zip",
             "sha256": "<DISABLED>"
         }
     },

--- a/src/VSCodeExtension/src/languageServer.ts
+++ b/src/VSCodeExtension/src/languageServer.ts
@@ -213,8 +213,8 @@ export class LanguageServer {
         if (info === undefined || info === null) {
             throw new Error("Package info was undefined.");
         }
-        if (versionCheck && info.assemblyVersion !== version) {
-            console.log(`[qsharp-lsp] Found version ${version}, expected version ${info.assemblyVersion}. Clearing cached version.`);
+        if (versionCheck && info.version !== version) {
+            console.log(`[qsharp-lsp] Found version ${version}, expected version ${info.version}. Clearing cached version.`);
             await this.clearCache();
             return false;
         }


### PR DESCRIPTION
Now that we chagned assembly_version to be constant, the extension should be using its own version to match the corresponding Language Server file to download, otherwise it can't differentiate among different versions of the same minor.