### PR TITLE
Do not include dependencies with PrivateAssets="All" in the compiler package

### DIFF
--- a/src/QsCompiler/Compiler/FindNuspecReferences.ps1
+++ b/src/QsCompiler/Compiler/FindNuspecReferences.ps1
@@ -37,7 +37,7 @@ function Add-NuGetDependencyFromCsprojToNuspec($PathToCsproj)
 
         # Check if package already added as dependency, only add if new:
         $added = $dep.dependency | Where { $_.id -eq $id }
-        if (!$added) {
+        if (!$added -and ($_.PrivateAssets -ne "All")) {
             Write-Host "Adding $id"
             $onedependency = $dep.AppendChild($nuspec.CreateElement('dependency', $nuspec.package.metadata.NamespaceURI))
             $onedependency.SetAttribute('id', $id)
@@ -58,4 +58,3 @@ Add-NuGetDependencyFromCsprojToNuspec "Compiler.csproj" $dep
 # Save into .nuspec file:
 $nuspec.package.metadata.AppendChild($dep)
 $nuspec.Save("$PSScriptRoot\Compiler.nuspec")
-

--- a/src/QsCompiler/Compiler/FindNuspecReferences.ps1
+++ b/src/QsCompiler/Compiler/FindNuspecReferences.ps1
@@ -37,7 +37,7 @@ function Add-NuGetDependencyFromCsprojToNuspec($PathToCsproj)
 
         # Check if package already added as dependency, only add if new:
         $added = $dep.dependency | Where { $_.id -eq $id }
-        if (!$added -and ($_.PrivateAssets -ne "All")) {
+        if (!$added -and $_.PrivateAssets -ne "All") {
             Write-Host "Adding $id"
             $onedependency = $dep.AppendChild($nuspec.CreateElement('dependency', $nuspec.package.metadata.NamespaceURI))
             $onedependency.SetAttribute('id', $id)


### PR DESCRIPTION
`FindNuspecReferences.ps1` adds all dependencies to `Compiler.nuspec`, even ones marked with `PrivateAssets="All"`. That meant that the StyleCop analyzers for the Q# compiler source code were propagating to projects that have a reference to the Q# compiler package, which is a bit unwelcome for downstream projects.