### PR TITLE
Replace LSP positions with Q# positions

### DIFF
--- a/src/QsCompiler/CompilationManager/CompilationUnit.cs
+++ b/src/QsCompiler/CompilationManager/CompilationUnit.cs
@@ -940,7 +940,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
             }
 
             var ((cName, cPos), (specKind, sPos)) = root.Value;
-            (callablePos, specializationPos) = (cPos.ToQSharp(), sPos.ToQSharp());
+            (callablePos, specializationPos) = (cPos, sPos);
             callableName = new QsQualifiedName(NonNullable<string>.New(nsName), cName);
 
             QsSpecialization GetSpecialization(QsQualifiedName fullName, QsSpecializationKind kind)
@@ -963,8 +963,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
                 return null;
             }
 
-            QsCompilerError.Verify(sPos.ToQSharp() <= pos, "computed closes preceding specialization does not precede the position in question");
-            QsCompilerError.Verify(sPos != null || relevantSpecialization == null, "the position offset should not be null unless the relevant specialization is");
+            QsCompilerError.Verify(sPos <= pos, "computed closes preceding specialization does not precede the position in question");
             return ((SpecializationImplementation.Provided)relevantSpecialization.Implementation).Item2;
         }
 

--- a/src/QsCompiler/CompilationManager/CompilationUnit.cs
+++ b/src/QsCompiler/CompilationManager/CompilationUnit.cs
@@ -917,10 +917,10 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// </summary>
         internal QsScope TryGetSpecializationAt(
             FileContentManager file,
-            Lsp.Position pos,
+            Position pos,
             out QsQualifiedName callableName,
-            out Lsp.Position callablePos,
-            out Lsp.Position specializationPos)
+            out Position callablePos,
+            out Position specializationPos)
         {
             (callableName, callablePos, specializationPos) = (null, null, null);
             if (file == null || pos == null || !Utils.IsValidPosition(pos, file))
@@ -940,7 +940,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
             }
 
             var ((cName, cPos), (specKind, sPos)) = root.Value;
-            (callablePos, specializationPos) = (cPos, sPos);
+            (callablePos, specializationPos) = (cPos.ToQSharp(), sPos.ToQSharp());
             callableName = new QsQualifiedName(NonNullable<string>.New(nsName), cName);
 
             QsSpecialization GetSpecialization(QsQualifiedName fullName, QsSpecializationKind kind)
@@ -963,7 +963,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
                 return null;
             }
 
-            QsCompilerError.Verify(sPos?.IsSmallerThanOrEqualTo(pos) ?? true, "computed closes preceding specialization does not precede the position in question");
+            QsCompilerError.Verify(sPos.ToQSharp() <= pos, "computed closes preceding specialization does not precede the position in question");
             QsCompilerError.Verify(sPos != null || relevantSpecialization == null, "the position offset should not be null unless the relevant specialization is");
             return ((SpecializationImplementation.Provided)relevantSpecialization.Implementation).Item2;
         }
@@ -976,7 +976,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// returns all (valid) symbols defined as part of the declaration of the parent callable with their position information set to the absolute value.
         /// Returns an empty set of declarations if the name of the parent callable is null or no callable with the name is currently compiled.
         /// </summary>
-        internal LocalDeclarations PositionedDeclarations(QsQualifiedName parentCallable, Lsp.Position callablePos, Lsp.Position specPos, LocalDeclarations declarations = null)
+        internal LocalDeclarations PositionedDeclarations(QsQualifiedName parentCallable, Position callablePos, Position specPos, LocalDeclarations declarations = null)
         {
             LocalDeclarations TryGetLocalDeclarations()
             {
@@ -993,10 +993,8 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
                 return LocalDeclarations.Empty;
             }
             declarations ??= TryGetLocalDeclarations();
-            return declarations.WithAbsolutePosition(relOffset =>
-                relOffset.IsNull
-                    ? callablePos.ToQSharp()
-                    : specPos.ToQSharp() + relOffset.Item);
+            return declarations.WithAbsolutePosition(
+                relOffset => relOffset.IsNull ? callablePos : specPos + relOffset.Item);
         }
 
         /// <summary>
@@ -1010,10 +1008,10 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// If the given file or position is null, or if the locally declared symbols could not be determined, returns an empty LocalDeclarations object.
         /// Sets the parent name to null, if no parent could be determind.
         /// </summary>
-        internal LocalDeclarations TryGetLocalDeclarations(FileContentManager file, Lsp.Position pos, out QsQualifiedName parentCallable, bool includeDeclaredAtPosition = false)
+        internal LocalDeclarations TryGetLocalDeclarations(FileContentManager file, Position pos, out QsQualifiedName parentCallable, bool includeDeclaredAtPosition = false)
         {
             var implementation = this.TryGetSpecializationAt(file, pos, out parentCallable, out var callablePos, out var specPos);
-            var declarations = implementation?.LocalDeclarationsAt(pos.Subtract(specPos), includeDeclaredAtPosition);
+            var declarations = implementation?.LocalDeclarationsAt(pos - specPos, includeDeclaredAtPosition);
             return this.PositionedDeclarations(parentCallable, callablePos, specPos, declarations);
         }
 

--- a/src/QsCompiler/CompilationManager/CompilationUnitManager.cs
+++ b/src/QsCompiler/CompilationManager/CompilationUnitManager.cs
@@ -776,7 +776,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
             // FIXME: the correct thing to do here would be to call FlushAndExecute...!
             var success = this.Processing.QueueForExecution(
                 () => this.fileContentManagers.TryGetValue(docKey, out FileContentManager file)
-                    ? file.Rename(this.compilationUnit, param.Position, param.NewName)
+                    ? file.Rename(this.compilationUnit, param.Position.ToQSharp(), param.NewName)
                     : null,
                 out WorkspaceEdit edit);
             return success ? edit : null;

--- a/src/QsCompiler/CompilationManager/ContextBuilder.cs
+++ b/src/QsCompiler/CompilationManager/ContextBuilder.cs
@@ -534,11 +534,10 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
                 var fragment = tokenIndex.GetFragment();
                 var context = tokenIndex.GetContext();
 
-                var fragmentStart = fragment.GetRange().Start;
                 var (include, verifications) = Context.VerifySyntaxTokenContext(context);
                 foreach (var msg in verifications)
                 {
-                    messages.Add(Diagnostics.Generate(file.FileName.Value, msg, fragmentStart));
+                    messages.Add(Diagnostics.Generate(file.FileName.Value, msg, fragment.GetRange().Start.ToQSharp()));
                 }
 
                 if (include)

--- a/src/QsCompiler/CompilationManager/ContextBuilder.cs
+++ b/src/QsCompiler/CompilationManager/ContextBuilder.cs
@@ -100,7 +100,8 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
                 throw new ArgumentException("invalid range");
             }
             var tokenRange = token.GetRange();
-            return tokenRange.Start.IsWithinRange(range) && tokenRange.End.IsWithinRange(range, includeEnd: true);
+            return tokenRange.Start.ToQSharp().IsWithinRange(range)
+                   && tokenRange.End.ToQSharp().IsWithinRange(range, includeEnd: true);
         }
 
         /// <summary>
@@ -352,7 +353,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
 
             var index = -1;
             var tokenRange = token.GetRange();
-            while (++index < list.Count && list[index].GetRange().Start.IsSmallerThan(tokenRange.Start))
+            while (++index < list.Count && list[index].GetRange().Start.ToQSharp() < tokenRange.Start.ToQSharp())
             {
             }
             return index < list.Count && list[index].Equals(token) ? index : -1;

--- a/src/QsCompiler/CompilationManager/DiagnosticTools.cs
+++ b/src/QsCompiler/CompilationManager/DiagnosticTools.cs
@@ -35,36 +35,6 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
                 : new Lsp.Position(position.Line, position.Column);
 
         /// <summary>
-        /// Adds the Q# position to the language server protocol position, returning a new language server protocol
-        /// position.
-        /// </summary>
-        /// <param name="position1">
-        /// The language server protocol position. Null is equivalent to the zero position.
-        /// </param>
-        /// <param name="position2">The Q# position.</param>
-        /// <exception cref="ArgumentException">Thrown if <paramref name="position1"/> is invalid.</exception>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="position2"/> is null.</exception>
-        internal static Lsp.Position GetAbsolutePosition(Lsp.Position position1, Position position2)
-        {
-            // TODO: This should be replaced with `position1 + position2` once both are Q# positions.
-            if (!Utils.IsValidPosition(position1))
-            {
-                throw new ArgumentException(nameof(position1));
-            }
-            if (position2 is null)
-            {
-                throw new ArgumentNullException(nameof(position2));
-            }
-            var absPos = position1?.Copy() ?? new Lsp.Position();
-            absPos.Line += position2.Line;
-            absPos.Character =
-                position2.Line > 0
-                    ? position2.Column
-                    : absPos.Character + position2.Column;
-            return absPos;
-        }
-
-        /// <summary>
         /// Adds the language server protocol position to the Q# compiler range.
         /// </summary>
         /// <param name="position">The language server protocol position.</param>
@@ -80,8 +50,8 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
             }
             return new Lsp.Range
             {
-                Start = GetAbsolutePosition(position, range.Start),
-                End = GetAbsolutePosition(position, range.End)
+                Start = (position.ToQSharp() + range.Start).ToLsp(),
+                End = (position.ToQSharp() + range.End).ToLsp()
             };
         }
 

--- a/src/QsCompiler/CompilationManager/DiagnosticTools.cs
+++ b/src/QsCompiler/CompilationManager/DiagnosticTools.cs
@@ -69,47 +69,15 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         }
 
         /// <summary>
-        /// Returns a new Position with the line number and character of the given Position
-        /// or null in case the given Position is null.
-        /// </summary>
-        public static Lsp.Position Copy(this Lsp.Position pos)
-        {
-            return pos == null
-                ? null
-                : new Lsp.Position(pos.Line, pos.Character);
-        }
-
-        /// <summary>
-        /// Verifies the given Position, and returns a *new* Position with updated line number.
-        /// Throws an ArgumentNullException if the given Position is null.
-        /// Throws an ArgumentException if the given Position is invalid.
-        /// Throws and ArgumentOutOfRangeException if the updated line number is negative.
-        /// </summary>
-        public static Lsp.Position WithUpdatedLineNumber(this Lsp.Position pos, int lineNrChange)
-        {
-            if (!Utils.IsValidPosition(pos))
-            {
-                throw new ArgumentException($"invalid Position in {nameof(WithUpdatedLineNumber)}");
-            }
-            if (pos.Line + lineNrChange < 0)
-            {
-                throw new ArgumentOutOfRangeException(nameof(lineNrChange));
-            }
-            var updated = pos.Copy();
-            updated.Line += lineNrChange;
-            return updated;
-        }
-
-        /// <summary>
         /// For a given Range, returns a new Range with its starting and ending position a copy of the start and end of the given Range
         /// (i.e. does a deep copy) or null in case the given Range is null.
         /// </summary>
-        public static Lsp.Range Copy(this Lsp.Range r)
-        {
-            return r == null
-                ? null
-                : new Lsp.Range { Start = r.Start.Copy(), End = r.End.Copy() };
-        }
+        public static Lsp.Range Copy(this Lsp.Range r) =>
+            r == null ? null : new Lsp.Range
+            {
+                Start = new Lsp.Position(r.Start.Line, r.Start.Character),
+                End = new Lsp.Position(r.End.Line, r.End.Character)
+            };
 
         /// <summary>
         /// Verifies the given Range, and returns a *new* Range with updated line numbers.

--- a/src/QsCompiler/CompilationManager/DiagnosticTools.cs
+++ b/src/QsCompiler/CompilationManager/DiagnosticTools.cs
@@ -249,33 +249,29 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// <summary>
         /// Returns true if the start position of the given diagnostic is larger or equal to lowerBound.
         /// </summary>
-        internal static bool SelectByStart(this Diagnostic m, Lsp.Position lowerBound)
-        {
-            return m?.Range?.Start?.Line == null ? false : lowerBound.IsSmallerThanOrEqualTo(m.Range.Start);
-        }
+        internal static bool SelectByStart(this Diagnostic m, Position lowerBound) =>
+            m?.Range?.Start?.Line != null && lowerBound <= m.Range.Start.ToQSharp();
 
         /// <summary>
         /// Returns true if the start position of the given diagnostic is larger or equal to lowerBound, and smaller than upperBound.
         /// </summary>
-        internal static bool SelectByStart(this Diagnostic m, Lsp.Position lowerBound, Lsp.Position upperBound)
-        {
-            return m?.Range?.Start?.Line == null ? false : lowerBound.IsSmallerThanOrEqualTo(m.Range.Start) && m.Range.Start.IsSmallerThan(upperBound);
-        }
+        internal static bool SelectByStart(this Diagnostic m, Position lowerBound, Position upperBound) =>
+            m?.Range?.Start?.Line != null
+            && lowerBound <= m.Range.Start.ToQSharp()
+            && m.Range.Start.ToQSharp() < upperBound;
 
         /// <summary>
         /// Returns true if the end position of the given diagnostic is larger or equal to lowerBound.
         /// </summary>
-        internal static bool SelectByEnd(this Diagnostic m, Lsp.Position lowerBound)
-        {
-            return m?.Range?.End?.Line == null ? false : lowerBound.IsSmallerThanOrEqualTo(m.Range.End);
-        }
+        internal static bool SelectByEnd(this Diagnostic m, Position lowerBound) =>
+            m?.Range?.End?.Line != null && lowerBound <= m.Range.End.ToQSharp();
 
         /// <summary>
         /// Returns true if the end position of the given diagnostic is larger or equal to lowerBound, and smaller than upperBound.
         /// </summary>
-        internal static bool SelectByEnd(this Diagnostic m, Lsp.Position lowerBound, Lsp.Position upperBound)
-        {
-            return m?.Range?.End?.Line == null ? false : lowerBound.IsSmallerThanOrEqualTo(m.Range.End) && m.Range.End.IsSmallerThan(upperBound);
-        }
+        internal static bool SelectByEnd(this Diagnostic m, Position lowerBound, Position upperBound) =>
+            m?.Range?.End?.Line != null
+            && lowerBound <= m.Range.End.ToQSharp()
+            && m.Range.End.ToQSharp() < upperBound;
     }
 }

--- a/src/QsCompiler/CompilationManager/DiagnosticTools.cs
+++ b/src/QsCompiler/CompilationManager/DiagnosticTools.cs
@@ -253,12 +253,10 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
             m?.Range?.Start?.Line != null && lowerBound <= m.Range.Start.ToQSharp();
 
         /// <summary>
-        /// Returns true if the start position of the given diagnostic is larger or equal to lowerBound, and smaller than upperBound.
+        /// Returns true if the start position of the diagnostic is contained in the range.
         /// </summary>
-        internal static bool SelectByStart(this Diagnostic m, Position lowerBound, Position upperBound) =>
-            m?.Range?.Start?.Line != null
-            && lowerBound <= m.Range.Start.ToQSharp()
-            && m.Range.Start.ToQSharp() < upperBound;
+        internal static bool SelectByStart(this Diagnostic m, Range range) =>
+            !(m?.Range?.Start is null) && range.Contains(m.Range.Start.ToQSharp());
 
         /// <summary>
         /// Returns true if the end position of the given diagnostic is larger or equal to lowerBound.
@@ -267,11 +265,9 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
             m?.Range?.End?.Line != null && lowerBound <= m.Range.End.ToQSharp();
 
         /// <summary>
-        /// Returns true if the end position of the given diagnostic is larger or equal to lowerBound, and smaller than upperBound.
+        /// Returns true if the end position of the diagnostic is contained in the range.
         /// </summary>
-        internal static bool SelectByEnd(this Diagnostic m, Position lowerBound, Position upperBound) =>
-            m?.Range?.End?.Line != null
-            && lowerBound <= m.Range.End.ToQSharp()
-            && m.Range.End.ToQSharp() < upperBound;
+        internal static bool SelectByEnd(this Diagnostic m, Range range) =>
+            !(m?.Range?.End is null) && range.Contains(m.Range.End.ToQSharp());
     }
 }

--- a/src/QsCompiler/CompilationManager/Diagnostics.cs
+++ b/src/QsCompiler/CompilationManager/Diagnostics.cs
@@ -9,6 +9,7 @@ using Microsoft.Quantum.QsCompiler.DataTypes;
 using Microsoft.Quantum.QsCompiler.Diagnostics;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
 using Lsp = Microsoft.VisualStudio.LanguageServer.Protocol;
+using Position = Microsoft.Quantum.QsCompiler.DataTypes.Position;
 
 namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
 {
@@ -81,7 +82,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// Throws an ArgumentNullException if the Range of the given CompilerDiagnostic is null.
         /// Throws an ArgumentOutOfRangeException if the contained range contains zero or negative entries, or if its Start is bigger than its End.
         /// </summary>
-        internal static Diagnostic Generate(string filename, QsCompilerDiagnostic msg, Lsp.Position positionOffset = null)
+        internal static Diagnostic Generate(string filename, QsCompilerDiagnostic msg, Position positionOffset = null)
         {
             if (msg.Range == null)
             {
@@ -93,7 +94,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
                 Code = Code(msg),
                 Source = filename,
                 Message = msg.Message,
-                Range = DiagnosticTools.GetAbsoluteRange(positionOffset, msg.Range)
+                Range = DiagnosticTools.GetAbsoluteRange(positionOffset.ToLsp(), msg.Range)
             };
         }
 
@@ -140,7 +141,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
 
         // warnings 20**
 
-        internal static Diagnostic EmptyStatementWarning(string filename, Lsp.Position pos)
+        internal static Diagnostic EmptyStatementWarning(string filename, Position pos)
         {
             return new Diagnostic
             {
@@ -148,7 +149,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
                 Code = WarningCode.ExcessSemicolon.Code(),
                 Source = filename,
                 Message = DiagnosticItem.Message(WarningCode.ExcessSemicolon, Enumerable.Empty<string>()),
-                Range = pos == null ? null : new Lsp.Range { Start = pos, End = pos }
+                Range = pos == null ? null : new Lsp.Range { Start = pos.ToLsp(), End = pos.ToLsp() }
             };
         }
     }
@@ -175,7 +176,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
 
         // errors 20**
 
-        internal static Diagnostic InvalidFragmentEnding(string filename, ErrorCode code, Lsp.Position pos)
+        internal static Diagnostic InvalidFragmentEnding(string filename, ErrorCode code, Position pos)
         {
             return new Diagnostic
             {
@@ -183,11 +184,11 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
                 Code = Code(code),
                 Source = filename,
                 Message = DiagnosticItem.Message(code, Enumerable.Empty<string>()),
-                Range = pos == null ? null : new Lsp.Range { Start = pos, End = pos }
+                Range = pos == null ? null : new Lsp.Range { Start = pos.ToLsp(), End = pos.ToLsp() }
             };
         }
 
-        internal static Diagnostic MisplacedOpeningBracketError(string filename, Lsp.Position pos)
+        internal static Diagnostic MisplacedOpeningBracketError(string filename, Position pos)
         {
             return new Diagnostic
             {
@@ -195,13 +196,13 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
                 Code = ErrorCode.MisplacedOpeningBracket.Code(),
                 Source = filename,
                 Message = DiagnosticItem.Message(ErrorCode.MisplacedOpeningBracket, Enumerable.Empty<string>()),
-                Range = pos == null ? null : new Lsp.Range { Start = pos, End = pos }
+                Range = pos == null ? null : new Lsp.Range { Start = pos.ToLsp(), End = pos.ToLsp() }
             };
         }
 
         // errors 10**
 
-        internal static Diagnostic ExcessBracketError(string filename, Lsp.Position pos)
+        internal static Diagnostic ExcessBracketError(string filename, Position pos)
         {
             return new Diagnostic
             {
@@ -209,11 +210,11 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
                 Code = ErrorCode.ExcessBracketError.Code(),
                 Source = filename,
                 Message = DiagnosticItem.Message(ErrorCode.ExcessBracketError, Enumerable.Empty<string>()),
-                Range = pos == null ? null : new Lsp.Range { Start = pos, End = pos }
+                Range = pos == null ? null : new Lsp.Range { Start = pos.ToLsp(), End = pos.ToLsp() }
             };
         }
 
-        internal static Diagnostic MissingClosingBracketError(string filename, Lsp.Position pos)
+        internal static Diagnostic MissingClosingBracketError(string filename, Position pos)
         {
             return new Diagnostic
             {
@@ -221,11 +222,11 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
                 Code = ErrorCode.MissingBracketError.Code(),
                 Source = filename,
                 Message = DiagnosticItem.Message(ErrorCode.MissingBracketError, Enumerable.Empty<string>()),
-                Range = pos == null ? null : new Lsp.Range { Start = pos, End = pos }
+                Range = pos == null ? null : new Lsp.Range { Start = pos.ToLsp(), End = pos.ToLsp() }
             };
         }
 
-        internal static Diagnostic MissingStringDelimiterError(string filename, Lsp.Position pos)
+        internal static Diagnostic MissingStringDelimiterError(string filename, Position pos)
         {
             return new Diagnostic
             {
@@ -233,7 +234,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
                 Code = ErrorCode.MissingStringDelimiterError.Code(),
                 Source = filename,
                 Message = DiagnosticItem.Message(ErrorCode.MissingStringDelimiterError, Enumerable.Empty<string>()),
-                Range = pos == null ? null : new Lsp.Range { Start = pos, End = pos }
+                Range = pos == null ? null : new Lsp.Range { Start = pos.ToLsp(), End = pos.ToLsp() }
             };
         }
     }

--- a/src/QsCompiler/CompilationManager/EditorSupport/CodeActions.cs
+++ b/src/QsCompiler/CompilationManager/EditorSupport/CodeActions.cs
@@ -94,7 +94,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
             }
             var (start, end) = (range.Start.Line, range.End.Line);
 
-            var fragAtStart = file.TryGetFragmentAt(range.Start, out var _, includeEnd: true);
+            var fragAtStart = file.TryGetFragmentAt(range.Start.ToQSharp(), out var _, includeEnd: true);
             var inRange = file.GetTokenizedLine(start).Select(t => t.WithUpdatedLineNumber(start)).Where(ContextBuilder.TokensAfter(range.Start)); // does not include fragAtStart
             inRange = start == end
                 ? inRange.Where(ContextBuilder.TokensStartingBefore(range.End))
@@ -271,7 +271,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
             {
                 // TODO: TryGetQsSymbolInfo currently only returns information about the inner most leafs rather than all types etc.
                 // Once it returns indeed all types in the fragment, the following code block should be replaced by the commented out code below.
-                var fragment = file.TryGetFragmentAt(d.Range.Start, out var _);
+                var fragment = file.TryGetFragmentAt(d.Range.Start.ToQSharp(), out var _);
 
                 static IEnumerable<Characteristics> GetCharacteristics(QsTuple<Tuple<QsSymbol, QsType>> argTuple) =>
                     SyntaxGenerator.ExtractItems(argTuple).SelectMany(item => item.Item2.ExtractCharacteristics()).Distinct();
@@ -326,7 +326,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
             }
 
             return updateOfArrayItemExprs
-                .Select(d => file?.TryGetFragmentAt(d.Range.Start, out var _, includeEnd: true))
+                .Select(d => file?.TryGetFragmentAt(d.Range.Start.ToQSharp(), out var _, includeEnd: true))
                 .Where(frag => frag != null)
                 .Select(frag => SuggestedCopyAndUpdateExpr(frag))
                 .Where(s => s.Item2 != null);
@@ -346,7 +346,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
             }
 
             // Ensure that the IndexRange library function exists in this compilation unit.
-            var nsName = file.TryGetNamespaceAt(range.Start);
+            var nsName = file.TryGetNamespaceAt(range.Start.ToQSharp());
             if (nsName == null)
             {
                 return Enumerable.Empty<(string, WorkspaceEdit)>();
@@ -435,7 +435,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
 
             WorkspaceEdit SuggestedRemoval(Lsp.Position pos)
             {
-                var fragment = file.TryGetFragmentAt(pos, out var currentFragToken);
+                var fragment = file.TryGetFragmentAt(pos.ToQSharp(), out var currentFragToken);
                 var lastFragToken = new CodeFragment.TokenIndex(currentFragToken);
                 if (fragment == null || --lastFragToken == null)
                 {
@@ -496,7 +496,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
                 : callableDecl.IsValue ? callableDecl.Item.Item1.Symbol
                 : typeDecl.IsValue ? typeDecl.Item.Item1.Symbol : null;
             var declStart = fragment.GetRange().Start;
-            if (declSymbol == null || file.DocumentingComments(declStart).Any())
+            if (declSymbol == null || file.DocumentingComments(declStart.ToQSharp()).Any())
             {
                 return Enumerable.Empty<(string, WorkspaceEdit)>();
             }

--- a/src/QsCompiler/CompilationManager/EditorSupport/CodeCompletion.cs
+++ b/src/QsCompiler/CompilationManager/EditorSupport/CodeCompletion.cs
@@ -784,7 +784,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
                 tokens = file.GetTokenizedLine(--line);
             }
 
-            var index = tokens.TakeWhile(ContextBuilder.TokensUpTo(position)).Count() - 1;
+            var index = tokens.TakeWhile(ContextBuilder.TokensUpTo(position.ToQSharp())).Count() - 1;
             if (index == -1)
             {
                 return null;

--- a/src/QsCompiler/CompilationManager/EditorSupport/CodeCompletion.cs
+++ b/src/QsCompiler/CompilationManager/EditorSupport/CodeCompletion.cs
@@ -812,7 +812,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
                 throw new ArgumentException("Code fragment has a missing delimiter", nameof(fragment));
             }
 
-            var end = fragment.GetRange().End;
+            var end = fragment.GetRange().End.ToQSharp();
             var position = file.FragmentEnd(ref end);
             return new Lsp.Position(position.Line, position.Column - 1);
         }

--- a/src/QsCompiler/CompilationManager/EditorSupport/CodeCompletion.cs
+++ b/src/QsCompiler/CompilationManager/EditorSupport/CodeCompletion.cs
@@ -16,6 +16,7 @@ using Microsoft.VisualStudio.LanguageServer.Protocol;
 using static Microsoft.Quantum.QsCompiler.SyntaxGenerator;
 using static Microsoft.Quantum.QsCompiler.TextProcessing.CodeCompletion.FragmentParsing;
 using Lsp = Microsoft.VisualStudio.LanguageServer.Protocol;
+using Position = Microsoft.Quantum.QsCompiler.DataTypes.Position;
 
 namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
 {
@@ -75,13 +76,13 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// Returns an empty completion list if the given position is within a comment.
         /// </summary>
         public static CompletionList Completions(
-            this FileContentManager file, CompilationUnit compilation, Lsp.Position position)
+            this FileContentManager file, CompilationUnit compilation, Position position)
         {
-            if (file == null || compilation == null || position == null || !Utils.IsValidPosition(position))
+            if (file == null || compilation == null || position == null)
             {
                 return null;
             }
-            if (file.GetLine(position.Line).WithoutEnding.Length < position.Character)
+            if (file.GetLine(position.Line).WithoutEnding.Length < position.Column)
             {
                 return Enumerable.Empty<CompletionItem>().ToCompletionList(false);
             }
@@ -135,19 +136,14 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// determined. Stores the code fragment found at or before the given position into an out parameter.
         /// </summary>
         /// <exception cref="ArgumentNullException">Thrown when any argument is null.</exception>
-        /// <exception cref="ArgumentException">Thrown when the position is invalid.</exception>
         private static (CompletionScope, QsFragmentKind) GetCompletionEnvironment(
-            FileContentManager file, Lsp.Position position, out CodeFragment fragment)
+            FileContentManager file, Position position, out CodeFragment fragment)
         {
             if (file == null)
             {
                 throw new ArgumentNullException(nameof(file));
             }
-            if (!Utils.IsValidPosition(position))
-            {
-                throw new ArgumentException(nameof(position));
-            }
-            if (!Utils.IsValidPosition(position.ToQSharp(), file))
+            if (!Utils.IsValidPosition(position, file))
             {
                 // FileContentManager.IndentationAt will fail if the position is not within the file.
                 fragment = null;
@@ -162,7 +158,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
             }
 
             fragment = token.GetFragment();
-            var relativeIndentation = fragment.Indentation - file.IndentationAt(position.ToQSharp());
+            var relativeIndentation = fragment.Indentation - file.IndentationAt(position);
             QsCompilerError.Verify(Math.Abs(relativeIndentation) <= 1);
             var parents =
                 new[] { token }.Concat(token.GetNonEmptyParents())
@@ -212,11 +208,10 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// Returns completion items that match the given kind.
         /// </summary>
         /// <exception cref="ArgumentNullException">Thrown when any argument is null.</exception>
-        /// <exception cref="ArgumentException">Thrown when the position is invalid.</exception>
         private static IEnumerable<CompletionItem> GetCompletionsForKind(
             FileContentManager file,
             CompilationUnit compilation,
-            Lsp.Position position,
+            Position position,
             CompletionKind kind,
             string namespacePrefix = "")
         {
@@ -227,10 +222,6 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
             if (compilation == null)
             {
                 throw new ArgumentNullException(nameof(compilation));
-            }
-            if (!Utils.IsValidPosition(position))
-            {
-                throw new ArgumentException(nameof(position));
             }
             if (kind == null)
             {
@@ -253,7 +244,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
                 case CompletionKind.Keyword keyword:
                     return new[] { new CompletionItem { Label = keyword.Item, Kind = CompletionItemKind.Keyword } };
             }
-            var currentNamespace = file.TryGetNamespaceAt(position.ToQSharp());
+            var currentNamespace = file.TryGetNamespaceAt(position);
             var openNamespaces =
                 namespacePrefix == "" ? GetOpenNamespaces(file, compilation, position) : new[] { namespacePrefix };
             switch (kind.Tag)
@@ -290,7 +281,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// </summary>
         /// <exception cref="ArgumentNullException">Thrown when any argument is null.</exception>
         private static IEnumerable<CompletionItem> GetFallbackCompletions(
-            FileContentManager file, CompilationUnit compilation, Lsp.Position position)
+            FileContentManager file, CompilationUnit compilation, Position position)
         {
             if (file == null)
             {
@@ -309,14 +300,14 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
             // decimal number), then no completions are valid here.
             var nsPath = GetSymbolNamespacePath(file, position);
             if (nsPath == null &&
-                position.Character > 0 &&
-                position.Character <= file.GetLine(position.Line).Text.Length &&
-                file.GetLine(position.Line).Text[position.Character - 1] == '.')
+                position.Column > 0 &&
+                position.Column <= file.GetLine(position.Line).Text.Length &&
+                file.GetLine(position.Line).Text[position.Column - 1] == '.')
             {
                 return Array.Empty<CompletionItem>();
             }
 
-            var currentNamespace = file.TryGetNamespaceAt(position.ToQSharp());
+            var currentNamespace = file.TryGetNamespaceAt(position);
             if (nsPath != null)
             {
                 var resolvedNsPath = ResolveNamespaceAlias(file, compilation, position, nsPath);
@@ -342,9 +333,8 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// shows only completions for mutable local variables. Returns an empty enumerator if the position is invalid.
         /// </summary>
         /// <exception cref="ArgumentNullException">Thrown when any argument is null.</exception>
-        /// <exception cref="ArgumentException">Thrown when the position is invalid.</exception>
         private static IEnumerable<CompletionItem> GetLocalCompletions(
-            FileContentManager file, CompilationUnit compilation, Lsp.Position position, bool mutableOnly = false)
+            FileContentManager file, CompilationUnit compilation, Position position, bool mutableOnly = false)
         {
             if (file == null)
             {
@@ -354,13 +344,9 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
             {
                 throw new ArgumentNullException(nameof(compilation));
             }
-            if (!Utils.IsValidPosition(position))
-            {
-                throw new ArgumentException(nameof(position));
-            }
             return
                 compilation
-                .TryGetLocalDeclarations(file, position.ToQSharp(), out _, includeDeclaredAtPosition: false)
+                .TryGetLocalDeclarations(file, position, out _, includeDeclaredAtPosition: false)
                 .Variables
                 .Where(variable => !mutableOnly || variable.InferredInformation.IsMutable)
                 .Select(variable => new CompletionItem()
@@ -533,9 +519,8 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// a dot.
         /// </summary>
         /// <exception cref="ArgumentNullException">Thrown when any argument is null.</exception>
-        /// <exception cref="ArgumentException">Thrown when the position is invalid.</exception>
         private static IEnumerable<CompletionItem> GetNamespaceAliasCompletions(
-            FileContentManager file, CompilationUnit compilation, Lsp.Position position, string prefix = "")
+            FileContentManager file, CompilationUnit compilation, Position position, string prefix = "")
         {
             if (file == null)
             {
@@ -544,10 +529,6 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
             if (compilation == null)
             {
                 throw new ArgumentNullException(nameof(compilation));
-            }
-            if (!Utils.IsValidPosition(position))
-            {
-                throw new ArgumentException(nameof(position));
             }
             if (prefix == null)
             {
@@ -558,7 +539,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
             {
                 prefix += ".";
             }
-            var @namespace = file.TryGetNamespaceAt(position.ToQSharp());
+            var @namespace = file.TryGetNamespaceAt(position);
             if (@namespace == null || !compilation.GlobalSymbols.NamespaceExists(NonNullable<string>.New(@namespace)))
             {
                 return Array.Empty<CompletionItem>();
@@ -630,9 +611,8 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// position in the file. Returns an empty enumerator if the position is invalid.
         /// </summary>
         /// <exception cref="ArgumentNullException">Thrown when any argument is null.</exception>
-        /// <exception cref="ArgumentException">Thrown when the position is invalid.</exception>
         private static IEnumerable<string> GetOpenNamespaces(
-            FileContentManager file, CompilationUnit compilation, Lsp.Position position)
+            FileContentManager file, CompilationUnit compilation, Position position)
         {
             if (file == null)
             {
@@ -642,12 +622,8 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
             {
                 throw new ArgumentNullException(nameof(compilation));
             }
-            if (!Utils.IsValidPosition(position))
-            {
-                throw new ArgumentException(nameof(position));
-            }
 
-            var @namespace = file.TryGetNamespaceAt(position.ToQSharp());
+            var @namespace = file.TryGetNamespaceAt(position);
             if (@namespace == null || !compilation.GlobalSymbols.NamespaceExists(NonNullable<string>.New(@namespace)))
             {
                 return Array.Empty<string>();
@@ -664,19 +640,14 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// symbol.
         /// </summary>
         /// <exception cref="ArgumentNullException">Thrown when any argument is null.</exception>
-        /// <exception cref="ArgumentException">Thrown when the position is invalid.</exception>
-        private static string GetSymbolNamespacePath(FileContentManager file, Lsp.Position position)
+        private static string GetSymbolNamespacePath(FileContentManager file, Position position)
         {
             if (file == null)
             {
                 throw new ArgumentNullException(nameof(file));
             }
-            if (!Utils.IsValidPosition(position))
-            {
-                throw new ArgumentException(nameof(position));
-            }
 
-            var fragment = file.TryGetFragmentAt(position.ToQSharp(), out _, includeEnd: true);
+            var fragment = file.TryGetFragmentAt(position, out _, includeEnd: true);
             if (fragment == null)
             {
                 return null;
@@ -698,7 +669,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// </summary>
         /// <exception cref="ArgumentException">Thrown when the position is outside the fragment range.</exception>
         /// <exception cref="ArgumentNullException">Thrown when any argument is null.</exception>
-        private static int GetTextIndexFromPosition(CodeFragment fragment, Lsp.Position position)
+        private static int GetTextIndexFromPosition(CodeFragment fragment, Position position)
         {
             if (fragment == null)
             {
@@ -712,7 +683,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
             var relativeLine = position.Line - fragment.GetRange().Start.Line;
             var lines = Utils.SplitLines(fragment.Text).DefaultIfEmpty("");
             var relativeCharacter =
-                relativeLine == 0 ? position.Character - fragment.GetRange().Start.Character : position.Character;
+                relativeLine == 0 ? position.Column - fragment.GetRange().Start.Character : position.Column;
             if (relativeLine < 0 ||
                 relativeLine >= lines.Count() ||
                 relativeCharacter < 0 ||
@@ -728,9 +699,8 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// the alias unchanged.
         /// </summary>
         /// <exception cref="ArgumentNullException">Thrown when any argument is null.</exception>
-        /// <exception cref="ArgumentException">Thrown when the position is invalid.</exception>
         private static string ResolveNamespaceAlias(
-            FileContentManager file, CompilationUnit compilation, Lsp.Position position, string alias)
+            FileContentManager file, CompilationUnit compilation, Position position, string alias)
         {
             if (file == null)
             {
@@ -740,16 +710,12 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
             {
                 throw new ArgumentNullException(nameof(compilation));
             }
-            if (!Utils.IsValidPosition(position))
-            {
-                throw new ArgumentException(nameof(position));
-            }
             if (alias == null)
             {
                 throw new ArgumentNullException(nameof(alias));
             }
 
-            var nsName = file.TryGetNamespaceAt(position.ToQSharp());
+            var nsName = file.TryGetNamespaceAt(position);
             if (nsName == null || !compilation.GlobalSymbols.NamespaceExists(NonNullable<string>.New(nsName)))
             {
                 return alias;
@@ -763,16 +729,11 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// no token at or before the given position.
         /// </summary>
         /// <exception cref="ArgumentNullException">Thrown when any argument is null.</exception>
-        /// <exception cref="ArgumentException">Thrown when the position is invalid.</exception>
-        private static CodeFragment.TokenIndex GetTokenAtOrBefore(FileContentManager file, Lsp.Position position)
+        private static CodeFragment.TokenIndex GetTokenAtOrBefore(FileContentManager file, Position position)
         {
             if (file == null)
             {
                 throw new ArgumentNullException(nameof(file));
-            }
-            if (!Utils.IsValidPosition(position))
-            {
-                throw new ArgumentException(nameof(position));
             }
 
             var line = position.Line;
@@ -784,7 +745,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
                 tokens = file.GetTokenizedLine(--line);
             }
 
-            var index = tokens.TakeWhile(ContextBuilder.TokensUpTo(position.ToQSharp())).Count() - 1;
+            var index = tokens.TakeWhile(ContextBuilder.TokensUpTo(position)).Count() - 1;
             if (index == -1)
             {
                 return null;
@@ -797,7 +758,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// </summary>
         /// <exception cref="ArgumentException">Thrown when the code fragment has a missing delimiter.</exception>
         /// <exception cref="ArgumentNullException">Thrown when any argument is null.</exception>
-        private static Lsp.Position GetDelimiterPosition(FileContentManager file, CodeFragment fragment)
+        private static Position GetDelimiterPosition(FileContentManager file, CodeFragment fragment)
         {
             if (file == null)
             {
@@ -814,18 +775,16 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
 
             var end = fragment.GetRange().End.ToQSharp();
             var position = file.FragmentEnd(ref end);
-            return new Lsp.Position(position.Line, position.Column - 1);
+            return Position.Create(position.Line, position.Column - 1);
         }
 
         /// <summary>
         /// Returns true if the fragment has a delimiting character and the given position occurs after it.
         /// </summary>
         private static bool IsPositionAfterDelimiter(
-                FileContentManager file,
-                CodeFragment fragment,
-                Lsp.Position position) =>
+                FileContentManager file, CodeFragment fragment, Position position) =>
             fragment.FollowedBy != CodeFragment.MissingDelimiter
-            && GetDelimiterPosition(file, fragment).IsSmallerThan(position);
+            && GetDelimiterPosition(file, fragment) < position;
 
         /// <summary>
         /// Returns a substring of the fragment text before the given position.
@@ -835,24 +794,18 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// space character appended to it.
         /// </summary>
         /// <exception cref="ArgumentNullException">Thrown when file or position is null.</exception>
-        /// <exception cref="ArgumentException">Thrown when the position is invalid.</exception>
         private static string GetFragmentTextBeforePosition(
-            FileContentManager file, CodeFragment fragment, Lsp.Position position)
+            FileContentManager file, CodeFragment fragment, Position position)
         {
             if (file == null)
             {
                 throw new ArgumentNullException(nameof(file));
             }
-            if (!Utils.IsValidPosition(position))
-            {
-                throw new ArgumentException(nameof(position));
-            }
-
             if (fragment == null || IsPositionAfterDelimiter(file, fragment, position))
             {
                 return "";
             }
-            return fragment.GetRange().End.IsSmallerThan(position)
+            return fragment.GetRange().End.ToQSharp() < position
                 ? fragment.Text + " "
                 : fragment.Text.Substring(0, GetTextIndexFromPosition(fragment, position));
         }

--- a/src/QsCompiler/CompilationManager/EditorSupport/CodeCompletion.cs
+++ b/src/QsCompiler/CompilationManager/EditorSupport/CodeCompletion.cs
@@ -147,7 +147,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
             {
                 throw new ArgumentException(nameof(position));
             }
-            if (!Utils.IsValidPosition(position, file))
+            if (!Utils.IsValidPosition(position.ToQSharp(), file))
             {
                 // FileContentManager.IndentationAt will fail if the position is not within the file.
                 fragment = null;
@@ -162,7 +162,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
             }
 
             fragment = token.GetFragment();
-            var relativeIndentation = fragment.Indentation - file.IndentationAt(position);
+            var relativeIndentation = fragment.Indentation - file.IndentationAt(position.ToQSharp());
             QsCompilerError.Verify(Math.Abs(relativeIndentation) <= 1);
             var parents =
                 new[] { token }.Concat(token.GetNonEmptyParents())
@@ -253,7 +253,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
                 case CompletionKind.Keyword keyword:
                     return new[] { new CompletionItem { Label = keyword.Item, Kind = CompletionItemKind.Keyword } };
             }
-            var currentNamespace = file.TryGetNamespaceAt(position);
+            var currentNamespace = file.TryGetNamespaceAt(position.ToQSharp());
             var openNamespaces =
                 namespacePrefix == "" ? GetOpenNamespaces(file, compilation, position) : new[] { namespacePrefix };
             switch (kind.Tag)
@@ -316,7 +316,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
                 return Array.Empty<CompletionItem>();
             }
 
-            var currentNamespace = file.TryGetNamespaceAt(position);
+            var currentNamespace = file.TryGetNamespaceAt(position.ToQSharp());
             if (nsPath != null)
             {
                 var resolvedNsPath = ResolveNamespaceAlias(file, compilation, position, nsPath);
@@ -360,7 +360,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
             }
             return
                 compilation
-                .TryGetLocalDeclarations(file, position, out _, includeDeclaredAtPosition: false)
+                .TryGetLocalDeclarations(file, position.ToQSharp(), out _, includeDeclaredAtPosition: false)
                 .Variables
                 .Where(variable => !mutableOnly || variable.InferredInformation.IsMutable)
                 .Select(variable => new CompletionItem()
@@ -558,7 +558,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
             {
                 prefix += ".";
             }
-            var @namespace = file.TryGetNamespaceAt(position);
+            var @namespace = file.TryGetNamespaceAt(position.ToQSharp());
             if (@namespace == null || !compilation.GlobalSymbols.NamespaceExists(NonNullable<string>.New(@namespace)))
             {
                 return Array.Empty<CompletionItem>();
@@ -647,7 +647,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
                 throw new ArgumentException(nameof(position));
             }
 
-            var @namespace = file.TryGetNamespaceAt(position);
+            var @namespace = file.TryGetNamespaceAt(position.ToQSharp());
             if (@namespace == null || !compilation.GlobalSymbols.NamespaceExists(NonNullable<string>.New(@namespace)))
             {
                 return Array.Empty<string>();
@@ -676,7 +676,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
                 throw new ArgumentException(nameof(position));
             }
 
-            var fragment = file.TryGetFragmentAt(position, out _, includeEnd: true);
+            var fragment = file.TryGetFragmentAt(position.ToQSharp(), out _, includeEnd: true);
             if (fragment == null)
             {
                 return null;
@@ -749,7 +749,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
                 throw new ArgumentNullException(nameof(alias));
             }
 
-            var nsName = file.TryGetNamespaceAt(position);
+            var nsName = file.TryGetNamespaceAt(position.ToQSharp());
             if (nsName == null || !compilation.GlobalSymbols.NamespaceExists(NonNullable<string>.New(nsName)))
             {
                 return alias;
@@ -814,7 +814,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
 
             var end = fragment.GetRange().End;
             var position = file.FragmentEnd(ref end);
-            return new Lsp.Position(position.Line, position.Character - 1);
+            return new Lsp.Position(position.Line, position.Column - 1);
         }
 
         /// <summary>

--- a/src/QsCompiler/CompilationManager/EditorSupport/EditorCommands.cs
+++ b/src/QsCompiler/CompilationManager/EditorSupport/EditorCommands.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// Returns the source file and position where the item at the given position is declared at,
         /// if such a declaration exists, and returns null otherwise.
         /// </summary>
-        public static Location DefinitionLocation(this FileContentManager file, CompilationUnit compilation, Lsp.Position position)
+        public static Location DefinitionLocation(this FileContentManager file, CompilationUnit compilation, Position position)
         {
             var symbolInfo = file?.TryGetQsSymbolInfo(position, true, out CodeFragment _); // includes the end position
             if (symbolInfo == null || compilation == null)
@@ -48,7 +48,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
                 return null;
             }
 
-            var locals = compilation.TryGetLocalDeclarations(file, position.ToQSharp(), out var cName, includeDeclaredAtPosition: true);
+            var locals = compilation.TryGetLocalDeclarations(file, position, out var cName, includeDeclaredAtPosition: true);
             if (cName == null)
             {
                 return null;
@@ -80,7 +80,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
             {
                 return null;
             }
-            if (!file.TryGetReferences(compilation, position, out var declLocation, out var locations))
+            if (!file.TryGetReferences(compilation, position.ToQSharp(), out var declLocation, out var locations))
             {
                 return null;
             }
@@ -101,7 +101,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
             {
                 return null;
             }
-            var found = file.TryGetReferences(compilation, position, out var declLocation, out var locations);
+            var found = file.TryGetReferences(compilation, position.ToQSharp(), out var declLocation, out var locations);
             if (!found)
             {
                 return null;
@@ -173,7 +173,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
             }
             var found = file.TryGetReferences(
                 compilation,
-                position,
+                position.ToQSharp(),
                 out var declLocation,
                 out var locations,
                 limitToSourceFiles: ImmutableHashSet.Create(file.FileName));
@@ -203,13 +203,13 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         public static Hover HoverInformation(
             this FileContentManager file,
             CompilationUnit compilation,
-            Lsp.Position position,
+            Position position,
             MarkupKind format = MarkupKind.PlainText)
         {
             Hover GetHover(string info) => info == null ? null : new Hover
             {
                 Contents = new MarkupContent { Kind = format, Value = info },
-                Range = new Lsp.Range { Start = position, End = position }
+                Range = new Lsp.Range { Start = position.ToLsp(), End = position.ToLsp() }
             };
 
             var markdown = format == MarkupKind.Markdown;
@@ -223,8 +223,8 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
             {
                 return GetHover(symbolInfo.UsedLiterals.Single().LiteralInfo(markdown).Value);
             }
-            var locals = compilation.TryGetLocalDeclarations(file, position.ToQSharp(), out var cName, includeDeclaredAtPosition: true);
-            var nsName = cName?.Namespace.Value ?? file.TryGetNamespaceAt(position.ToQSharp());
+            var locals = compilation.TryGetLocalDeclarations(file, position, out var cName, includeDeclaredAtPosition: true);
+            var nsName = cName?.Namespace.Value ?? file.TryGetNamespaceAt(position);
             if (nsName == null)
             {
                 return null;

--- a/src/QsCompiler/CompilationManager/EditorSupport/EditorCommands.cs
+++ b/src/QsCompiler/CompilationManager/EditorSupport/EditorCommands.cs
@@ -48,7 +48,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
                 return null;
             }
 
-            var locals = compilation.TryGetLocalDeclarations(file, position, out var cName, includeDeclaredAtPosition: true);
+            var locals = compilation.TryGetLocalDeclarations(file, position.ToQSharp(), out var cName, includeDeclaredAtPosition: true);
             if (cName == null)
             {
                 return null;
@@ -223,8 +223,8 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
             {
                 return GetHover(symbolInfo.UsedLiterals.Single().LiteralInfo(markdown).Value);
             }
-            var locals = compilation.TryGetLocalDeclarations(file, position, out var cName, includeDeclaredAtPosition: true);
-            var nsName = cName?.Namespace.Value ?? file.TryGetNamespaceAt(position);
+            var locals = compilation.TryGetLocalDeclarations(file, position.ToQSharp(), out var cName, includeDeclaredAtPosition: true);
+            var nsName = cName?.Namespace.Value ?? file.TryGetNamespaceAt(position.ToQSharp());
             if (nsName == null)
             {
                 return null;
@@ -258,7 +258,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         {
             // getting the relevant token (if any)
 
-            var fragment = file?.TryGetFragmentAt(position, out var _, includeEnd: true);
+            var fragment = file?.TryGetFragmentAt(position.ToQSharp(), out var _, includeEnd: true);
             if (fragment?.Kind == null || compilation == null)
             {
                 return null;
@@ -282,7 +282,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
                 return result == 0 ? x.End.CompareTo(y.End) : result;
             });
 
-            var nsName = file.TryGetNamespaceAt(position);
+            var nsName = file.TryGetNamespaceAt(position.ToQSharp());
             var (method, args) = overlappingEx.Last().Expression is QsExpressionKind<QsExpression, QsSymbol, QsType>.CallLikeExpression c ? (c.Item1, c.Item2) : (null, null);
             if (nsName == null || method == null || args == null)
             {

--- a/src/QsCompiler/CompilationManager/EditorSupport/EditorCommands.cs
+++ b/src/QsCompiler/CompilationManager/EditorSupport/EditorCommands.cs
@@ -350,8 +350,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
 
             // now that we now what callable is called we need to check which argument should come next
 
-            bool BeforePosition(Range symRange) =>
-                DiagnosticTools.GetAbsolutePosition(fragmentStart, symRange.End).ToQSharp() < position;
+            bool BeforePosition(Range symRange) => fragmentStart.ToQSharp() + symRange.End < position;
 
             IEnumerable<(Range, string)> ExtractParameterRanges(
                 QsExpression ex, QsTuple<LocalVariableDeclaration<QsLocalSymbol>> decl)

--- a/src/QsCompiler/CompilationManager/EditorSupport/EditorCommands.cs
+++ b/src/QsCompiler/CompilationManager/EditorSupport/EditorCommands.cs
@@ -268,7 +268,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
             // getting the overlapping call expressions (if any), and determine the header of the called callable
 
             bool OverlapsWithPosition(Range symRange) =>
-                position.ToLsp().IsWithinRange(DiagnosticTools.GetAbsoluteRange(fragmentStart, symRange), true);
+                position.IsWithinRange(DiagnosticTools.GetAbsoluteRange(fragmentStart, symRange), true);
 
             var overlappingEx = fragment.Kind.CallExpressions().Where(ex => ex.Range.IsValue && OverlapsWithPosition(ex.Range.Item)).ToList();
             if (!overlappingEx.Any())

--- a/src/QsCompiler/CompilationManager/EditorSupport/SymbolInformation.cs
+++ b/src/QsCompiler/CompilationManager/EditorSupport/SymbolInformation.cs
@@ -103,7 +103,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
             // getting the symbol information (if any), and return the overlapping items only
 
             bool OverlapsWithPosition(Range symRange) =>
-                position.ToLsp().IsWithinRange(DiagnosticTools.GetAbsoluteRange(fragmentStart, symRange), includeEnd);
+                position.IsWithinRange(DiagnosticTools.GetAbsoluteRange(fragmentStart, symRange), includeEnd);
 
             var symbolInfo = fragment.Kind.SymbolInformation();
 

--- a/src/QsCompiler/CompilationManager/EditorSupport/SymbolInformation.cs
+++ b/src/QsCompiler/CompilationManager/EditorSupport/SymbolInformation.cs
@@ -259,8 +259,8 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
             else
             {
                 // the given position corresponds to a variable declared as part of a specialization declaration or implementation
-                var defStart = DiagnosticTools.GetAbsolutePosition(defOffset, defRange.Start);
-                var statements = implementation.StatementsAfterDeclaration(defStart.ToQSharp() - specPos);
+                var defStart = defOffset.ToQSharp() + defRange.Start;
+                var statements = implementation.StatementsAfterDeclaration(defStart - specPos);
                 var scope = new QsScope(statements.ToImmutableArray(), locals);
                 referenceLocations = IdentifierReferences.Find(definition.Item.Item1, scope, file.FileName, specPos).Select(AsLocation);
             }

--- a/src/QsCompiler/CompilationManager/FileContentManager.cs
+++ b/src/QsCompiler/CompilationManager/FileContentManager.cs
@@ -542,7 +542,9 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
                 var syntaxCheckInOriginal = new Lsp.Range
                 {
                     Start = syntaxCheckInUpdated.Start,
-                    End = syntaxCheckInUpdated.End == this.End() ? origFileEnd : syntaxCheckInUpdated.End.WithUpdatedLineNumber(-lineNrChange)
+                    End = syntaxCheckInUpdated.End.ToQSharp() == this.End()
+                        ? origFileEnd.ToLsp()
+                        : syntaxCheckInUpdated.End.WithUpdatedLineNumber(-lineNrChange)
                 };
 
                 // update the tokens and make sure the necessary connections get marked as edited
@@ -751,7 +753,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
                     FilterAndMarkEdited(end, ContextBuilder.TokensAfter(new Lsp.Position(0, range.End.Character)));
                 }
 
-                var enveloppingFragment = this.TryGetFragmentAt(range.Start, out var _);
+                var enveloppingFragment = this.TryGetFragmentAt(range.Start.ToQSharp(), out var _);
                 if (enveloppingFragment != null)
                 {
                     start = enveloppingFragment.GetRange().Start.Line;
@@ -1105,7 +1107,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
                 }
                 var change = new TextDocumentContentChangeEvent
                 {
-                    Range = new Lsp.Range { Start = new Lsp.Position(), End = this.End() },
+                    Range = new Lsp.Range { Start = new Lsp.Position(), End = this.End().ToLsp() },
                     // fixme: range length is not accurate, but also not used...
                     RangeLength = 0,
                     Text = text

--- a/src/QsCompiler/CompilationManager/FileContentManager.cs
+++ b/src/QsCompiler/CompilationManager/FileContentManager.cs
@@ -545,7 +545,9 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
                     Start = syntaxCheckInUpdated.Start,
                     End = syntaxCheckInUpdated.End.ToQSharp() == this.End()
                         ? origFileEnd.ToLsp()
-                        : syntaxCheckInUpdated.End.WithUpdatedLineNumber(-lineNrChange)
+                        : new Lsp.Position(
+                            syntaxCheckInUpdated.End.Line - lineNrChange,
+                            syntaxCheckInUpdated.End.Character)
                 };
 
                 // update the tokens and make sure the necessary connections get marked as edited

--- a/src/QsCompiler/CompilationManager/FileContentManager.cs
+++ b/src/QsCompiler/CompilationManager/FileContentManager.cs
@@ -15,6 +15,7 @@ using Microsoft.Quantum.QsCompiler.SyntaxProcessing;
 using Microsoft.Quantum.QsCompiler.SyntaxTree;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
 using Lsp = Microsoft.VisualStudio.LanguageServer.Protocol;
+using Position = Microsoft.Quantum.QsCompiler.DataTypes.Position;
 
 namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
 {
@@ -750,7 +751,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
                 }
                 if (start != end)
                 {
-                    FilterAndMarkEdited(end, ContextBuilder.TokensAfter(new Lsp.Position(0, range.End.Character)));
+                    FilterAndMarkEdited(end, ContextBuilder.TokensAfter(Position.Create(0, range.End.Character)));
                 }
 
                 var enveloppingFragment = this.TryGetFragmentAt(range.Start.ToQSharp(), out var _);

--- a/src/QsCompiler/CompilationManager/FileContentManager.cs
+++ b/src/QsCompiler/CompilationManager/FileContentManager.cs
@@ -200,14 +200,15 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
             {
                 throw new ArgumentException(nameof(syntaxCheckDelimiters));
             }
-            var (syntaxCheckStart, syntaxCheckEnd) = (syntaxCheckDelimiters.Start, syntaxCheckDelimiters.End);
+            var (syntaxCheckStart, syntaxCheckEnd) =
+                (syntaxCheckDelimiters.Start.ToQSharp(), syntaxCheckDelimiters.End.ToQSharp());
 
             Diagnostic UpdateLineNrs(Diagnostic m) => m.SelectByStart(syntaxCheckEnd) ? m.WithUpdatedLineNumber(lineNrChange) : m;
             diagnostics.SyncRoot.EnterWriteLock();
             try
             {
                 diagnostics.RemoveAll(m => m.SelectByStart(syntaxCheckStart, syntaxCheckEnd) || m.SelectByEnd(syntaxCheckStart, syntaxCheckEnd));  // remove any Diagnostic overlapping with the updated interval
-                diagnostics.RemoveAll(m => m.SelectByStart(new Lsp.Position(), syntaxCheckStart) && m.SelectByEnd(syntaxCheckEnd)); // these are also no longer valid
+                diagnostics.RemoveAll(m => m.SelectByStart(Position.Zero, syntaxCheckStart) && m.SelectByEnd(syntaxCheckEnd)); // these are also no longer valid
                 if (lineNrChange != 0)
                 {
                     diagnostics.Transform(UpdateLineNrs);
@@ -241,7 +242,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
             }
 
             InvalidateOrUpdateBySyntaxCheckDelimeters(updated, syntaxCheckDelimiters, lineNrChange);
-            Diagnostic UpdateLineNrs(Diagnostic m) => m.SelectByStart(syntaxCheckDelimiters.End) ? m.WithUpdatedLineNumber(lineNrChange) : m;
+            Diagnostic UpdateLineNrs(Diagnostic m) => m.SelectByStart(syntaxCheckDelimiters.End.ToQSharp()) ? m.WithUpdatedLineNumber(lineNrChange) : m;
             if (lineNrChange != 0)
             {
                 diagnostics.Transform(UpdateLineNrs);
@@ -760,7 +761,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
                 if (enveloppingFragment != null)
                 {
                     start = enveloppingFragment.GetRange().Start.Line;
-                    FilterAndMarkEdited(start, token => !range.Start.IsWithinRange(token.GetRange().WithUpdatedLineNumber(start)));
+                    FilterAndMarkEdited(start, token => !range.Start.ToQSharp().IsWithinRange(token.GetRange().WithUpdatedLineNumber(start)));
                 }
 
                 // which lines get marked as edited depends on the tokens prior to transformation,

--- a/src/QsCompiler/CompilationManager/ProjectManager.cs
+++ b/src/QsCompiler/CompilationManager/ProjectManager.cs
@@ -1121,7 +1121,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// </summary>
         public SignatureHelp SignatureHelp(TextDocumentPositionParams param, MarkupKind format = MarkupKind.PlainText) =>
             this.Manager(param?.TextDocument?.Uri)?.FileQuery(
-                param?.TextDocument, (file, c) => file.SignatureHelp(c, param?.Position, format), suppressExceptionLogging: true);
+                param?.TextDocument, (file, c) => file.SignatureHelp(c, param?.Position.ToQSharp(), format), suppressExceptionLogging: true);
 
         /// <summary>
         /// Returns information about the item at the specified position as Hover information.
@@ -1147,7 +1147,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// </summary>
         public DocumentHighlight[] DocumentHighlights(TextDocumentPositionParams param) =>
             this.Manager(param?.TextDocument?.Uri)?.FileQuery(
-                param?.TextDocument, (file, c) => file.DocumentHighlights(c, param?.Position), suppressExceptionLogging: true);
+                param?.TextDocument, (file, c) => file.DocumentHighlights(c, param?.Position.ToQSharp()), suppressExceptionLogging: true);
 
         /// <summary>
         /// Returns an array with all locations where the symbol at the given position - if any - is referenced.
@@ -1160,7 +1160,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// </summary>
         public Location[] SymbolReferences(ReferenceParams param) =>
             this.Manager(param?.TextDocument?.Uri)?.FileQuery(
-                param?.TextDocument, (file, c) => file.SymbolReferences(c, param?.Position, param.Context), suppressExceptionLogging: true);
+                param?.TextDocument, (file, c) => file.SymbolReferences(c, param?.Position.ToQSharp(), param.Context), suppressExceptionLogging: true);
 
         /// <summary>
         /// Returns the SymbolInformation for each namespace declaration,

--- a/src/QsCompiler/CompilationManager/ProjectManager.cs
+++ b/src/QsCompiler/CompilationManager/ProjectManager.cs
@@ -1107,7 +1107,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// </summary>
         public Location DefinitionLocation(TextDocumentPositionParams param) =>
             this.Manager(param?.TextDocument?.Uri)?.FileQuery(
-                param?.TextDocument, (file, c) => file.DefinitionLocation(c, param?.Position), suppressExceptionLogging: true);
+                param?.TextDocument, (file, c) => file.DefinitionLocation(c, param?.Position.ToQSharp()), suppressExceptionLogging: true);
 
         /// <summary>
         /// Returns the signature help information for a call expression if there is such an expression at the specified position.
@@ -1134,7 +1134,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// </summary>
         public Hover HoverInformation(TextDocumentPositionParams param, MarkupKind format = MarkupKind.PlainText) =>
             this.Manager(param?.TextDocument?.Uri)?.FileQuery(
-                param?.TextDocument, (file, c) => file.HoverInformation(c, param?.Position, format), suppressExceptionLogging: true);
+                param?.TextDocument, (file, c) => file.HoverInformation(c, param?.Position.ToQSharp(), format), suppressExceptionLogging: true);
 
         /// <summary>
         /// Returns an array with all usages of the identifier at the given position (if any) as DocumentHighlights.

--- a/src/QsCompiler/CompilationManager/ProjectManager.cs
+++ b/src/QsCompiler/CompilationManager/ProjectManager.cs
@@ -1194,7 +1194,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         public CompletionList Completions(TextDocumentPositionParams param) =>
             this.Manager(param?.TextDocument?.Uri)?.FileQuery(
                 param?.TextDocument,
-                (file, compilation) => file.Completions(compilation, param?.Position),
+                (file, compilation) => file.Completions(compilation, param?.Position.ToQSharp()),
                 suppressExceptionLogging: true);
 
         /// <summary>

--- a/src/QsCompiler/CompilationManager/ScopeTracking.cs
+++ b/src/QsCompiler/CompilationManager/ScopeTracking.cs
@@ -708,11 +708,11 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
             var lastLine = file.GetLine(file.NrLines() - 1);
             if (lastLine.FinalIndentation() > 0)
             {
-                yield return Errors.MissingClosingBracketError(file.FileName.Value, new Lsp.Position(file.NrLines() - 1, lastLine.Text.Length));
+                yield return Errors.MissingClosingBracketError(file.FileName.Value, Position.Create(file.NrLines() - 1, lastLine.Text.Length));
             }
             if (ContinueString(lastLine))
             {
-                yield return Errors.MissingStringDelimiterError(file.FileName.Value, new Lsp.Position(file.NrLines() - 1, lastLine.Text.Length));
+                yield return Errors.MissingStringDelimiterError(file.FileName.Value, Position.Create(file.NrLines() - 1, lastLine.Text.Length));
             }
         }
 
@@ -731,7 +731,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
             {
                 foreach (var pos in line.ExcessBracketPositions)
                 {
-                    yield return Errors.ExcessBracketError(file.FileName.Value, new Lsp.Position(start, pos));
+                    yield return Errors.ExcessBracketError(file.FileName.Value, Position.Create(start, pos));
                 }
                 ++start;
             }

--- a/src/QsCompiler/CompilationManager/TextProcessor.cs
+++ b/src/QsCompiler/CompilationManager/TextProcessor.cs
@@ -96,8 +96,8 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
                         var generated = Diagnostics.Generate(filename, fragmentDiagnostic, fragmentRange.Start.ToQSharp());
                         diagnostics.Add(generated);
 
-                        var fragmentEnd = fragment.GetRange().End;
-                        var diagnosticGoesUpToFragmentEnd = fragmentEnd.IsWithinRange(generated.Range) || fragmentEnd.Equals(generated.Range.End);
+                        var fragmentEnd = fragment.GetRange().End.ToQSharp();
+                        var diagnosticGoesUpToFragmentEnd = fragmentEnd.IsWithinRange(generated.Range) || fragmentEnd == generated.Range.End.ToQSharp();
                         if (fragmentDiagnostic.Diagnostic.IsError && diagnosticGoesUpToFragmentEnd)
                         {
                             checkEnding = false;

--- a/src/QsCompiler/CompilationManager/TextProcessor.cs
+++ b/src/QsCompiler/CompilationManager/TextProcessor.cs
@@ -33,9 +33,9 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
             }
             // opting to not complain about semicolons not following code anywhere in the file (i.e. on any scope)
             var diagnostics = fragments.Where(snippet => snippet.Text.Length == 0 && snippet.FollowedBy == ';')
-                .Select(snippet => Warnings.EmptyStatementWarning(filename, snippet.GetRange().End))
+                .Select(snippet => Warnings.EmptyStatementWarning(filename, snippet.GetRange().End.ToQSharp()))
                 .Concat(fragments.Where(snippet => snippet.Text.Length == 0 && snippet.FollowedBy == '{')
-                .Select(snippet => Errors.MisplacedOpeningBracketError(filename, snippet.GetRange().End)));
+                .Select(snippet => Errors.MisplacedOpeningBracketError(filename, snippet.GetRange().End.ToQSharp())));
             return diagnostics.ToList(); // in case fragments change
         }
 
@@ -54,7 +54,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
             var code = fragment.Kind.InvalidEnding;
             if (Diagnostics.ExpectedEnding(code) != fragment.FollowedBy)
             {
-                yield return Errors.InvalidFragmentEnding(filename, code, fragment.GetRange().End);
+                yield return Errors.InvalidFragmentEnding(filename, code, fragment.GetRange().End.ToQSharp());
             }
         }
 
@@ -93,7 +93,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
                     var checkEnding = true; // if there is already a diagnostic overlapping with the ending, then don't bother checking the ending
                     foreach (var fragmentDiagnostic in output.Diagnostics)
                     {
-                        var generated = Diagnostics.Generate(filename, fragmentDiagnostic, fragmentRange.Start);
+                        var generated = Diagnostics.Generate(filename, fragmentDiagnostic, fragmentRange.Start.ToQSharp());
                         diagnostics.Add(generated);
 
                         var fragmentEnd = fragment.GetRange().End;

--- a/src/QsCompiler/CompilationManager/TypeChecking.cs
+++ b/src/QsCompiler/CompilationManager/TypeChecking.cs
@@ -613,7 +613,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// </summary>
         private static QsScope BuildScope(
             IReadOnlyList<FragmentTree.TreeNode> nodeContent,
-            ScopeContext<Lsp.Position> context,
+            ScopeContext<Position> context,
             List<Diagnostic> diagnostics,
             ImmutableHashSet<QsFunctor> requiredFunctorSupport = null)
         {
@@ -647,8 +647,8 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// </exception>
         private static T BuildStatement<T>(
             FragmentTree.TreeNode node,
-            Func<QsLocation, ScopeContext<Lsp.Position>, Tuple<T, QsCompilerDiagnostic[]>> build,
-            ScopeContext<Lsp.Position> context,
+            Func<QsLocation, ScopeContext<Position>, Tuple<T, QsCompilerDiagnostic[]>> build,
+            ScopeContext<Position> context,
             List<Diagnostic> diagnostics)
         {
             if (build == null)
@@ -687,7 +687,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// </summary>
         private static bool TryBuildUsingStatement(
             IEnumerator<FragmentTree.TreeNode> nodes,
-            ScopeContext<Lsp.Position> context,
+            ScopeContext<Position> context,
             List<Diagnostic> diagnostics,
             out bool proceed,
             out QsStatement statement)
@@ -743,7 +743,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// </summary>
         private static bool TryBuildBorrowStatement(
             IEnumerator<FragmentTree.TreeNode> nodes,
-            ScopeContext<Lsp.Position> context,
+            ScopeContext<Position> context,
             List<Diagnostic> diagnostics,
             out bool proceed,
             out QsStatement statement)
@@ -800,7 +800,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// </summary>
         private static bool TryBuildRepeatStatement(
             IEnumerator<FragmentTree.TreeNode> nodes,
-            ScopeContext<Lsp.Position> context,
+            ScopeContext<Position> context,
             List<Diagnostic> diagnostics,
             out bool proceed,
             out QsStatement statement)
@@ -880,7 +880,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// </summary>
         private static bool TryBuildForStatement(
             IEnumerator<FragmentTree.TreeNode> nodes,
-            ScopeContext<Lsp.Position> context,
+            ScopeContext<Position> context,
             List<Diagnostic> diagnostics,
             out bool proceed,
             out QsStatement statement)
@@ -936,7 +936,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// </summary>
         private static bool TryBuildWhileStatement(
             IEnumerator<FragmentTree.TreeNode> nodes,
-            ScopeContext<Lsp.Position> context,
+            ScopeContext<Position> context,
             List<Diagnostic> diagnostics,
             out bool proceed,
             out QsStatement statement)
@@ -992,7 +992,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// </summary>
         private static bool TryBuildIfStatement(
             IEnumerator<FragmentTree.TreeNode> nodes,
-            ScopeContext<Lsp.Position> context,
+            ScopeContext<Position> context,
             List<Diagnostic> diagnostics,
             out bool proceed,
             out QsStatement statement)
@@ -1082,7 +1082,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// </summary>
         private static bool TryBuildConjugationStatement(
             IEnumerator<FragmentTree.TreeNode> nodes,
-            ScopeContext<Lsp.Position> context,
+            ScopeContext<Position> context,
             List<Diagnostic> diagnostics,
             out bool proceed,
             out QsStatement statement)
@@ -1156,7 +1156,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// </summary>
         private static bool TryBuildLetStatement(
             IEnumerator<FragmentTree.TreeNode> nodes,
-            ScopeContext<Lsp.Position> context,
+            ScopeContext<Position> context,
             List<Diagnostic> diagnostics,
             out bool proceed,
             out QsStatement statement)
@@ -1208,7 +1208,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// </summary>
         private static bool TryBuildMutableStatement(
             IEnumerator<FragmentTree.TreeNode> nodes,
-            ScopeContext<Lsp.Position> context,
+            ScopeContext<Position> context,
             List<Diagnostic> diagnostics,
             out bool proceed,
             out QsStatement statement)
@@ -1260,7 +1260,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// </summary>
         private static bool TryBuildSetStatement(
             IEnumerator<FragmentTree.TreeNode> nodes,
-            ScopeContext<Lsp.Position> context,
+            ScopeContext<Position> context,
             List<Diagnostic> diagnostics,
             out bool proceed,
             out QsStatement statement)
@@ -1312,7 +1312,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// </summary>
         private static bool TryBuildFailStatement(
             IEnumerator<FragmentTree.TreeNode> nodes,
-            ScopeContext<Lsp.Position> context,
+            ScopeContext<Position> context,
             List<Diagnostic> diagnostics,
             out bool proceed,
             out QsStatement statement)
@@ -1364,7 +1364,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// </summary>
         private static bool TryBuildReturnStatement(
             IEnumerator<FragmentTree.TreeNode> nodes,
-            ScopeContext<Lsp.Position> context,
+            ScopeContext<Position> context,
             List<Diagnostic> diagnostics,
             out bool proceed,
             out QsStatement statement)
@@ -1416,7 +1416,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// </summary>
         private static bool TryBuildExpressionStatement(
             IEnumerator<FragmentTree.TreeNode> nodes,
-            ScopeContext<Lsp.Position> context,
+            ScopeContext<Position> context,
             List<Diagnostic> diagnostics,
             out bool proceed,
             out QsStatement statement)
@@ -1462,7 +1462,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// or if any of the fragments contained in the given nodes is null.
         /// </summary>
         private static ImmutableArray<QsStatement> BuildStatements(
-            IEnumerator<FragmentTree.TreeNode> nodes, ScopeContext<Lsp.Position> context, List<Diagnostic> diagnostics)
+            IEnumerator<FragmentTree.TreeNode> nodes, ScopeContext<Position> context, List<Diagnostic> diagnostics)
         {
             if (nodes == null)
             {
@@ -1568,7 +1568,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
             NonNullable<string> sourceFile,
             QsTuple<LocalVariableDeclaration<QsLocalSymbol>> argTuple,
             ImmutableHashSet<QsFunctor> requiredFunctorSupport,
-            ScopeContext<Lsp.Position> context,
+            ScopeContext<Position> context,
             List<Diagnostic> diagnostics)
         {
             if (argTuple == null)
@@ -1612,9 +1612,9 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
 
             // verify that all paths return a value if needed (or fail)
             var (allPathsReturn, messages) = SyntaxProcessing.SyntaxTree.AllPathsReturnValueOrFail(implementation);
-            var rootPosition = root.Fragment.GetRange().Start;
-            Lsp.Position AsAbsolutePosition(Position statementPos) => rootPosition.Add(statementPos.ToLsp());
-            diagnostics.AddRange(messages.Select(msg => Diagnostics.Generate(sourceFile.Value, msg.Item2, AsAbsolutePosition(msg.Item1))));
+            var rootPosition = root.Fragment.GetRange().Start.ToQSharp();
+            diagnostics.AddRange(messages.Select(msg =>
+                Diagnostics.Generate(sourceFile.Value, msg.Item2, (rootPosition + msg.Item1).ToLsp())));
             if (!(context.ReturnType.Resolution.IsUnitType || context.ReturnType.Resolution.IsInvalidType) && !allPathsReturn)
             {
                 var errRange = Parsing.HeaderDelimiters(root.Fragment.Kind.IsControlledAdjointDeclaration ? 2 : 1).Invoke(root.Fragment.Text);
@@ -1785,7 +1785,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
 
                     QsGeneratorDirective GetDirective(QsSpecializationKind k) => definedSpecs.TryGetValue(k, out defined) && defined.Item1.IsValue ? defined.Item1.Item : null;
                     var requiredFunctorSupport = RequiredFunctorSupport(kind, GetDirective).ToImmutableHashSet();
-                    var context = ScopeContext<Lsp.Position>.Create(
+                    var context = ScopeContext<Position>.Create(
                         compilation.GlobalSymbols,
                         compilation.RuntimeCapabilities,
                         compilation.ProcessorArchitecture,
@@ -1980,7 +1980,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
                     var declaredVariables = SyntaxGenerator.ExtractItems(info.ArgumentTuple);
 
                     // verify the variable declarations in the callable declaration
-                    var symbolTracker = new SymbolTracker<Lsp.Position>(compilation.GlobalSymbols, info.SourceFile, parent); // only ever used to verify declaration args
+                    var symbolTracker = new SymbolTracker<Position>(compilation.GlobalSymbols, info.SourceFile, parent); // only ever used to verify declaration args
                     symbolTracker.BeginScope();
                     foreach (var decl in declaredVariables)
                     {

--- a/src/QsCompiler/CompilationManager/TypeChecking.cs
+++ b/src/QsCompiler/CompilationManager/TypeChecking.cs
@@ -77,7 +77,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
             bool IsDocCommentLine(string text) => text.StartsWith("///") || text == string.Empty;
 
             var lastPreceding = file.GetTokenizedLine(pos.Line)
-                .TakeWhile(ContextBuilder.TokensUpTo(new Lsp.Position(0, pos.Column)))
+                .TakeWhile(ContextBuilder.TokensUpTo(Position.Create(0, pos.Column)))
                 .LastOrDefault(RelevantToken)?.WithUpdatedLineNumber(pos.Line);
             for (var lineNr = pos.Line; lastPreceding == null && lineNr-- > 0;)
             {

--- a/src/QsCompiler/CompilationManager/TypeChecking.cs
+++ b/src/QsCompiler/CompilationManager/TypeChecking.cs
@@ -613,7 +613,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// </summary>
         private static QsScope BuildScope(
             IReadOnlyList<FragmentTree.TreeNode> nodeContent,
-            ScopeContext<Position> context,
+            ScopeContext context,
             List<Diagnostic> diagnostics,
             ImmutableHashSet<QsFunctor> requiredFunctorSupport = null)
         {
@@ -647,8 +647,8 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// </exception>
         private static T BuildStatement<T>(
             FragmentTree.TreeNode node,
-            Func<QsLocation, ScopeContext<Position>, Tuple<T, QsCompilerDiagnostic[]>> build,
-            ScopeContext<Position> context,
+            Func<QsLocation, ScopeContext, Tuple<T, QsCompilerDiagnostic[]>> build,
+            ScopeContext context,
             List<Diagnostic> diagnostics)
         {
             if (build == null)
@@ -687,7 +687,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// </summary>
         private static bool TryBuildUsingStatement(
             IEnumerator<FragmentTree.TreeNode> nodes,
-            ScopeContext<Position> context,
+            ScopeContext context,
             List<Diagnostic> diagnostics,
             out bool proceed,
             out QsStatement statement)
@@ -743,7 +743,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// </summary>
         private static bool TryBuildBorrowStatement(
             IEnumerator<FragmentTree.TreeNode> nodes,
-            ScopeContext<Position> context,
+            ScopeContext context,
             List<Diagnostic> diagnostics,
             out bool proceed,
             out QsStatement statement)
@@ -800,7 +800,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// </summary>
         private static bool TryBuildRepeatStatement(
             IEnumerator<FragmentTree.TreeNode> nodes,
-            ScopeContext<Position> context,
+            ScopeContext context,
             List<Diagnostic> diagnostics,
             out bool proceed,
             out QsStatement statement)
@@ -880,7 +880,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// </summary>
         private static bool TryBuildForStatement(
             IEnumerator<FragmentTree.TreeNode> nodes,
-            ScopeContext<Position> context,
+            ScopeContext context,
             List<Diagnostic> diagnostics,
             out bool proceed,
             out QsStatement statement)
@@ -936,7 +936,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// </summary>
         private static bool TryBuildWhileStatement(
             IEnumerator<FragmentTree.TreeNode> nodes,
-            ScopeContext<Position> context,
+            ScopeContext context,
             List<Diagnostic> diagnostics,
             out bool proceed,
             out QsStatement statement)
@@ -992,7 +992,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// </summary>
         private static bool TryBuildIfStatement(
             IEnumerator<FragmentTree.TreeNode> nodes,
-            ScopeContext<Position> context,
+            ScopeContext context,
             List<Diagnostic> diagnostics,
             out bool proceed,
             out QsStatement statement)
@@ -1082,7 +1082,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// </summary>
         private static bool TryBuildConjugationStatement(
             IEnumerator<FragmentTree.TreeNode> nodes,
-            ScopeContext<Position> context,
+            ScopeContext context,
             List<Diagnostic> diagnostics,
             out bool proceed,
             out QsStatement statement)
@@ -1156,7 +1156,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// </summary>
         private static bool TryBuildLetStatement(
             IEnumerator<FragmentTree.TreeNode> nodes,
-            ScopeContext<Position> context,
+            ScopeContext context,
             List<Diagnostic> diagnostics,
             out bool proceed,
             out QsStatement statement)
@@ -1208,7 +1208,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// </summary>
         private static bool TryBuildMutableStatement(
             IEnumerator<FragmentTree.TreeNode> nodes,
-            ScopeContext<Position> context,
+            ScopeContext context,
             List<Diagnostic> diagnostics,
             out bool proceed,
             out QsStatement statement)
@@ -1260,7 +1260,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// </summary>
         private static bool TryBuildSetStatement(
             IEnumerator<FragmentTree.TreeNode> nodes,
-            ScopeContext<Position> context,
+            ScopeContext context,
             List<Diagnostic> diagnostics,
             out bool proceed,
             out QsStatement statement)
@@ -1312,7 +1312,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// </summary>
         private static bool TryBuildFailStatement(
             IEnumerator<FragmentTree.TreeNode> nodes,
-            ScopeContext<Position> context,
+            ScopeContext context,
             List<Diagnostic> diagnostics,
             out bool proceed,
             out QsStatement statement)
@@ -1364,7 +1364,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// </summary>
         private static bool TryBuildReturnStatement(
             IEnumerator<FragmentTree.TreeNode> nodes,
-            ScopeContext<Position> context,
+            ScopeContext context,
             List<Diagnostic> diagnostics,
             out bool proceed,
             out QsStatement statement)
@@ -1416,7 +1416,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// </summary>
         private static bool TryBuildExpressionStatement(
             IEnumerator<FragmentTree.TreeNode> nodes,
-            ScopeContext<Position> context,
+            ScopeContext context,
             List<Diagnostic> diagnostics,
             out bool proceed,
             out QsStatement statement)
@@ -1462,7 +1462,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// or if any of the fragments contained in the given nodes is null.
         /// </summary>
         private static ImmutableArray<QsStatement> BuildStatements(
-            IEnumerator<FragmentTree.TreeNode> nodes, ScopeContext<Position> context, List<Diagnostic> diagnostics)
+            IEnumerator<FragmentTree.TreeNode> nodes, ScopeContext context, List<Diagnostic> diagnostics)
         {
             if (nodes == null)
             {
@@ -1568,7 +1568,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
             NonNullable<string> sourceFile,
             QsTuple<LocalVariableDeclaration<QsLocalSymbol>> argTuple,
             ImmutableHashSet<QsFunctor> requiredFunctorSupport,
-            ScopeContext<Position> context,
+            ScopeContext context,
             List<Diagnostic> diagnostics)
         {
             if (argTuple == null)
@@ -1785,7 +1785,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
 
                     QsGeneratorDirective GetDirective(QsSpecializationKind k) => definedSpecs.TryGetValue(k, out defined) && defined.Item1.IsValue ? defined.Item1.Item : null;
                     var requiredFunctorSupport = RequiredFunctorSupport(kind, GetDirective).ToImmutableHashSet();
-                    var context = ScopeContext<Position>.Create(
+                    var context = ScopeContext.Create(
                         compilation.GlobalSymbols,
                         compilation.RuntimeCapabilities,
                         compilation.ProcessorArchitecture,
@@ -1980,7 +1980,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
                     var declaredVariables = SyntaxGenerator.ExtractItems(info.ArgumentTuple);
 
                     // verify the variable declarations in the callable declaration
-                    var symbolTracker = new SymbolTracker<Position>(compilation.GlobalSymbols, info.SourceFile, parent); // only ever used to verify declaration args
+                    var symbolTracker = new SymbolTracker(compilation.GlobalSymbols, info.SourceFile, parent); // only ever used to verify declaration args
                     symbolTracker.BeginScope();
                     foreach (var decl in declaredVariables)
                     {

--- a/src/QsCompiler/CompilationManager/Utils.cs
+++ b/src/QsCompiler/CompilationManager/Utils.cs
@@ -272,68 +272,9 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         internal static bool IsValidRange(Lsp.Range range, FileContentManager file) =>
             IsValidPosition(range?.Start.ToQSharp(), file) && IsValidPosition(range.End.ToQSharp(), file) && range.Start.IsSmallerThanOrEqualTo(range.End);
 
-        /// <summary>
-        /// Returns the absolute position under the assumption that snd is relative to fst and both positions are zero-based.
-        /// Throws an ArgumentNullException if a given position is null.
-        /// Throws an ArgumentException if a given position is not valid.
-        /// </summary>
-        internal static Lsp.Position Add(this Lsp.Position fst, Lsp.Position snd)
-        {
-            if (!IsValidPosition(fst))
-            {
-                throw new ArgumentException(nameof(fst));
-            }
-            if (!IsValidPosition(snd))
-            {
-                throw new ArgumentException(nameof(snd));
-            }
-            return new Lsp.Position(fst.Line + snd.Line, snd.Line == 0 ? fst.Character + snd.Character : snd.Character);
-        }
-
-        /// <summary>
-        /// Returns the position of fst relative to snd under the assumption that both positions are zero-based.
-        /// Throws an ArgumentNullException if a given position is null.
-        /// Throws an ArgumentException if a given position is not valid, or if fst is smaller than snd.
-        /// </summary>
-        internal static Lsp.Position Subtract(this Lsp.Position fst, Lsp.Position snd)
-        {
-            if (!IsValidPosition(fst))
-            {
-                throw new ArgumentException(nameof(fst));
-            }
-            if (!IsValidPosition(snd))
-            {
-                throw new ArgumentException(nameof(snd));
-            }
-            if (fst.IsSmallerThan(snd))
-            {
-                throw new ArgumentException(nameof(snd), "the position to subtract from needs to be larger than the position to subract");
-            }
-            var relPos = new Lsp.Position(fst.Line - snd.Line, fst.Line == snd.Line ? fst.Character - snd.Character : fst.Character);
-            QsCompilerError.Verify(snd.Add(relPos).Equals(fst), "adding the relative position to snd does not equal fst");
-            return relPos;
-        }
-
         // tools for debugging
 
         public static string DiagnosticString(this Lsp.Range r) =>
             $"({r?.Start?.Line},{r?.Start?.Character}) - ({r?.End?.Line},{r?.End?.Character})";
-
-        internal static string DiagnosticString(FileContentManager file)
-        {
-            if (file == null)
-            {
-                throw new ArgumentNullException(nameof(file));
-            }
-            var annotatedContent = new string[file.NrLines()];
-            for (var lineNr = 0; lineNr < file.NrLines(); ++lineNr)
-            {
-                var line = file.GetLine(lineNr);
-                var delimString = "[" + string.Join(",", line.StringDelimiters) + "] ";
-                var prefix = delimString + string.Concat<string>(Enumerable.Repeat("*", line.ExcessBracketPositions.Count()));
-                annotatedContent[lineNr] = $"{prefix}i{line.Indentation}: {line.WithoutEnding}";
-            }
-            return JoinLines(annotatedContent);
-        }
     }
 }

--- a/src/QsCompiler/DataStructures/DataTypes.fs
+++ b/src/QsCompiler/DataStructures/DataTypes.fs
@@ -76,11 +76,19 @@ type Position = private Position of int * int with
     /// The column number, where column zero is the first column in the line.
     member this.Column = match this with Position (_, column) -> column
 
+    /// <summary>
     /// Translates the first position by the amount of the second position. If the resulting position is on the same
     /// line, the column numbers are added; otherwise, the second position's column number is used.
-    static member (+) (a : Position, b : Position) =
-        let line = a.Line + b.Line
-        let column = if b.Line = 0 then a.Column + b.Column else b.Column
+    /// </summary>
+    /// <remarks>
+    /// Addition is an associative but not commutative operation.
+    /// </remarks>
+    static member (+) (offset : Position, relative : Position) =
+        let line = offset.Line + relative.Line
+        let column =
+            if relative.Line = 0
+            then offset.Column + relative.Column
+            else relative.Column
         Position (line, column)
 
     /// <summary>
@@ -90,9 +98,12 @@ type Position = private Position of int * int with
     /// <exception cref="ArgumentOutOfRangeException">
     /// Thrown if the resulting position has a negative line or column number.
     /// </exception>
-    static member (-) (a : Position, b : Position) =
-        let line = a.Line - b.Line
-        let column = if a.Line = b.Line then a.Column - b.Column else a.Column
+    static member (-) (position : Position, offset : Position) =
+        let line = position.Line - offset.Line
+        let column =
+            if position.Line = offset.Line
+            then position.Column - offset.Column
+            else position.Column
         Position (line, column)
 
     /// Returns true if the positions have the same line and column numbers.

--- a/src/QsCompiler/DataStructures/DataTypes.fs
+++ b/src/QsCompiler/DataStructures/DataTypes.fs
@@ -101,13 +101,13 @@ type Position = private Position of int * int with
     /// Returns true if the second position occurs before the first position.
     static member op_LessThan (a : Position, b) = (a :> Position IComparable).CompareTo b < 0
 
-    /// Returns true if the second position occurs at or before the first position.
+    /// Returns true if the second position occurs on or before the first position.
     static member op_LessThanOrEqual (a : Position, b) = (a :> Position IComparable).CompareTo b <= 0
 
     /// Returns true if the second position occurs after the first position. 
     static member op_GreaterThan (a : Position, b) = (a :> Position IComparable).CompareTo b > 0
 
-    /// Returns true if the second position occurs at or after the first position.
+    /// Returns true if the second position occurs on or after the first position.
     static member op_GreaterThanOrEqual (a : Position, b) = (a :> Position IComparable).CompareTo b >= 0
 
     /// <summary>
@@ -130,6 +130,9 @@ type Range = private Range of Position * Position with
 
     /// The end of the range.
     member this.End = match this with Range (_, end') -> end'
+
+    /// Returns true if the position occurs on or after the starting position, and before the ending position.
+    member this.Contains position = this.Start <= position && position < this.End
 
     /// Adds the range's start and end positions to the given position.
     static member (+) (position : Position, range : Range) =

--- a/src/QsCompiler/DataStructures/DataTypes.fs
+++ b/src/QsCompiler/DataStructures/DataTypes.fs
@@ -83,11 +83,32 @@ type Position = private Position of int * int with
         let column = if b.Line = 0 then a.Column + b.Column else b.Column
         Position (line, column)
 
+    /// <summary>
+    /// Translates the first position backwards by the amount of the second position. If the resulting position is on
+    /// the same line, the column numbers are subtracted; otherwise, the first position's column number is used.
+    /// </summary>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown if the resulting position has a negative line or column number.
+    /// </exception>
+    static member (-) (a : Position, b : Position) =
+        let line = a.Line - b.Line
+        let column = if a.Line = b.Line then a.Column - b.Column else a.Column
+        Position (line, column)
+
     /// Returns true if the positions have the same line and column numbers.
     static member op_Equality (a : Position, b : Position) = a = b
 
+    /// Returns true if the second position occurs before the first position.
+    static member op_LessThan (a : Position, b) = (a :> Position IComparable).CompareTo b < 0
+
+    /// Returns true if the second position occurs at or before the first position.
+    static member op_LessThanOrEqual (a : Position, b) = (a :> Position IComparable).CompareTo b <= 0
+
     /// Returns true if the second position occurs after the first position. 
     static member op_GreaterThan (a : Position, b) = (a :> Position IComparable).CompareTo b > 0
+
+    /// Returns true if the second position occurs at or after the first position.
+    static member op_GreaterThanOrEqual (a : Position, b) = (a :> Position IComparable).CompareTo b >= 0
 
     /// <summary>
     /// Creates a position.

--- a/src/QsCompiler/SyntaxProcessor/ExpressionVerification.fs
+++ b/src/QsCompiler/SyntaxProcessor/ExpressionVerification.fs
@@ -362,7 +362,7 @@ let private VerifyControlledApplication addError (ex : ResolvedType, range) =
 /// If the Identifier could potentially be type parameterized (even if the number of type parameters is null), 
 /// but the number of type arguments does not match the number of type parameters, adds a WrongNumberOfTypeArguments error via addDiagnostic.
 /// Returns the resolved Identifer after type parameter resolution as typed expression. 
-let private VerifyIdentifier addDiagnostic (symbols : SymbolTracker<_>) (sym, tArgs) = 
+let private VerifyIdentifier addDiagnostic (symbols : SymbolTracker) (sym, tArgs) = 
     let resolvedTargs = tArgs |> QsNullable<_>.Map (fun (args : ImmutableArray<QsType>) -> 
         args.Select (fun tArg -> tArg.Type |> function 
             | MissingType -> ResolvedType.New MissingType 

--- a/src/QsCompiler/SyntaxProcessor/ScopeTools.fs
+++ b/src/QsCompiler/SyntaxProcessor/ScopeTools.fs
@@ -46,7 +46,7 @@ type private TrackedScope = private {
 /// (i.e. if the version number of the NamespaceManager has changed). 
 /// The constructor throws an ArgumentException if the given NamespaceManager does not contain all resolutions, 
 /// or if a callable with the given parent name does not exist in the given NamespaceManager.
-type SymbolTracker<'P>(globals : NamespaceManager, sourceFile, parent : QsQualifiedName) =  
+type SymbolTracker(globals : NamespaceManager, sourceFile, parent : QsQualifiedName) =  
 // TODO: once we support type specialiations, the parent needs to be the specialization name rather than the callable name
 
     do  if not globals.ContainsResolutions then ArgumentException "the content of the given namespace manager needs to be resolved" |> raise
@@ -281,9 +281,9 @@ type SymbolTracker<'P>(globals : NamespaceManager, sourceFile, parent : QsQualif
                 | _ -> addError (ErrorCode.UnknownItemName, [udt.Name.Value; name.Value]); InvalidType |> ResolvedType.New
 
 /// The context used for symbol resolution and type checking within the scope of a callable.
-type ScopeContext<'a> =
+type ScopeContext =
     { /// The symbol tracker for the parent callable.
-      Symbols : SymbolTracker<'a>
+      Symbols : SymbolTracker
       /// True if the parent callable for the current scope is an operation.
       IsInOperation : bool
       /// True if the current expression is contained within the condition of an if- or elif-statement.
@@ -313,7 +313,7 @@ type ScopeContext<'a> =
                          (spec : SpecializationDeclarationHeader) =
         match nsManager.TryGetCallable spec.Parent (spec.Parent.Namespace, spec.SourceFile) with
         | Found declaration ->
-            { Symbols = SymbolTracker<'a> (nsManager, spec.SourceFile, spec.Parent)
+            { Symbols = SymbolTracker (nsManager, spec.SourceFile, spec.Parent)
               IsInOperation = declaration.Kind = Operation
               IsInIfCondition = false
               ReturnType = StripPositionInfo.Apply declaration.Signature.ReturnType

--- a/src/QsCompiler/Tests.Compiler/TestUtils/SetupVerificationTests.fs
+++ b/src/QsCompiler/Tests.Compiler/TestUtils/SetupVerificationTests.fs
@@ -43,8 +43,7 @@ type CompilerTests (compilation : CompilationUnitManager.Compilation) =
             for i = 1 to locations.Length do
                 let key = fst locations.[i-1]
                 if i < locations.Length then 
-                    let withinCurrentDeclaration (d : Diagnostic) = 
-                        Utils.IsSmallerThan(d.Range.Start, (snd locations.[i]).ToLsp ())
+                    let withinCurrentDeclaration (d : Diagnostic) = d.Range.Start.ToQSharp() < snd locations.[i]
                     yield key, containedDiagnostics.TakeWhile(withinCurrentDeclaration).ToImmutableArray()
                     containedDiagnostics <- containedDiagnostics.SkipWhile(withinCurrentDeclaration)
                 else yield key, containedDiagnostics.ToImmutableArray()


### PR DESCRIPTION
Replaces LSP position types with Q# position types in the compilation manager. Removed several functions that operated on LSP positions that are no longer necessary because the functionality is built into the Q# position type.

Because LSP ranges haven't been replaced yet, a lot of conversions like `range.Start.ToQSharp()` and `range.End.ToQSharp()` needed to be added temporarily. Those should go away when LSP ranges are replaced with Q# ranges that use Q# positions for their start and end points. (Probably in the next PR.)

Part of #506.