### PR TITLE
Replace LSP ranges with Q# ranges

### DIFF
--- a/src/QsCompiler/CompilationManager/CompilationUnit.cs
+++ b/src/QsCompiler/CompilationManager/CompilationUnit.cs
@@ -923,7 +923,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
             out Position specializationPos)
         {
             (callableName, callablePos, specializationPos) = (null, null, null);
-            if (file == null || pos == null || !Utils.IsValidPosition(pos, file))
+            if (file == null || pos == null || !file.ContainsPosition(pos))
             {
                 return null;
             }

--- a/src/QsCompiler/CompilationManager/ContextBuilder.cs
+++ b/src/QsCompiler/CompilationManager/ContextBuilder.cs
@@ -138,7 +138,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
             bool includeEnd = false)
         {
             tIndex = null;
-            if (file == null || pos == null || !Utils.IsValidPosition(pos, file))
+            if (file == null || pos == null || !file.ContainsPosition(pos))
             {
                 return null;
             }
@@ -168,7 +168,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// </summary>
         public static string TryGetNamespaceAt(this FileContentManager file, Position pos)
         {
-            if (file == null || pos == null || !Utils.IsValidPosition(pos, file))
+            if (file == null || pos == null || !file.ContainsPosition(pos))
             {
                 return null;
             }
@@ -201,7 +201,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
                 return kind;
             }
 
-            if (file == null || pos == null || !Utils.IsValidPosition(pos, file))
+            if (file == null || pos == null || !file.ContainsPosition(pos))
             {
                 return null;
             }
@@ -255,7 +255,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
             {
                 throw new ArgumentNullException(nameof(file));
             }
-            if (!Utils.IsValidRange(range, file))
+            if (!file.ContainsRange(range))
             {
                 throw new ArgumentOutOfRangeException(nameof(range));
             }

--- a/src/QsCompiler/CompilationManager/DataStructures.cs
+++ b/src/QsCompiler/CompilationManager/DataStructures.cs
@@ -384,17 +384,18 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder.DataStructures
     {
         internal struct TreeNode
         {
-            private readonly Position relPosition;
-            private readonly Position rootPosition;
             public readonly CodeFragment Fragment;
             public readonly IReadOnlyList<TreeNode> Children;
 
             /// <summary>
-            /// Returns the position of the root node that all child node positions are relative to.
+            /// The position of the root node that all child node positions are relative to.
             /// </summary>
-            public Position GetRootPosition() => this.rootPosition;
+            public Position RootPosition { get; }
 
-            public Position GetPositionRelativeToRoot() => this.relPosition;
+            /// <summary>
+            /// The position of this node relative to the root node.
+            /// </summary>
+            public Position RelativePosition { get; }
 
             /// <summary>
             /// Builds the TreeNode consisting of the given fragment and children.
@@ -411,8 +412,8 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder.DataStructures
                 {
                     throw new ArgumentException(nameof(parentStart), "parentStart needs to be smaller than or equal to the fragment start");
                 }
-                this.rootPosition = parentStart;
-                this.relPosition = fragment.Range.Start - parentStart;
+                this.RootPosition = parentStart;
+                this.RelativePosition = fragment.Range.Start - parentStart;
             }
         }
 

--- a/src/QsCompiler/CompilationManager/DataStructures.cs
+++ b/src/QsCompiler/CompilationManager/DataStructures.cs
@@ -116,11 +116,10 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder.DataStructures
     public class CodeFragment
     {
         /// <summary>
-        /// Returns the code fragment's range.
+        /// The code fragment's range.
         /// </summary>
-        internal Range GetRange() => this.fragmentRange;
+        internal Range Range { get; }
 
-        private readonly Range fragmentRange;
         internal readonly Range HeaderRange;
         internal readonly int Indentation;
         internal readonly string Text;
@@ -152,7 +151,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder.DataStructures
             this.FollowedBy = next;
             this.Comments = comments ?? QsComments.Empty;
             this.Kind = kind; // nothing here should be modifiable
-            this.fragmentRange = range;
+            this.Range = range;
             this.HeaderRange = GetHeaderRange(this.Text, this.Kind);
             this.IncludeInCompilation = include;
         }
@@ -163,7 +162,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder.DataStructures
         }
 
         internal CodeFragment Copy() =>
-            new CodeFragment(this.Indentation, this.GetRange(), this.Text, this.FollowedBy, this.Comments, this.Kind, this.IncludeInCompilation);
+            new CodeFragment(this.Indentation, this.Range, this.Text, this.FollowedBy, this.Comments, this.Kind, this.IncludeInCompilation);
 
         public bool Equals(CodeFragment other)
         {
@@ -172,7 +171,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder.DataStructures
                 return false;
             }
             return
-                this.GetRange().Equals(other.GetRange()) &&
+                this.Range == other.Range &&
                 this.Indentation == other.Indentation &&
                 this.Text == other.Text &&
                 this.FollowedBy == other.FollowedBy &&
@@ -180,32 +179,32 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder.DataStructures
                 (this.Kind == null ? other.Kind == null : this.Kind.Equals(other.Kind));
         }
 
-        internal CodeFragment TranslateLines(int offset) => this.SetRange(this.GetRange().TranslateLines(offset));
+        internal CodeFragment TranslateLines(int offset) => this.SetRange(this.Range.TranslateLines(offset));
 
         internal CodeFragment SetRange(Range range) =>
             new CodeFragment(this.Indentation, range, this.Text, this.FollowedBy, this.Comments, this.Kind, this.IncludeInCompilation);
 
         internal CodeFragment SetIndentation(int indent) =>
-            new CodeFragment(indent, this.fragmentRange, this.Text, this.FollowedBy, this.Comments, this.Kind, this.IncludeInCompilation);
+            new CodeFragment(indent, this.Range, this.Text, this.FollowedBy, this.Comments, this.Kind, this.IncludeInCompilation);
 
         internal CodeFragment SetCode(string code) =>
-            new CodeFragment(this.Indentation, this.fragmentRange, code, this.FollowedBy, this.Comments, this.Kind, this.IncludeInCompilation);
+            new CodeFragment(this.Indentation, this.Range, code, this.FollowedBy, this.Comments, this.Kind, this.IncludeInCompilation);
 
         internal CodeFragment SetFollowedBy(char delim) =>
-            new CodeFragment(this.Indentation, this.fragmentRange, this.Text, delim, this.Comments, this.Kind, this.IncludeInCompilation);
+            new CodeFragment(this.Indentation, this.Range, this.Text, delim, this.Comments, this.Kind, this.IncludeInCompilation);
 
         internal CodeFragment SetKind(QsFragmentKind kind) =>
-            new CodeFragment(this.Indentation, this.fragmentRange, this.Text, this.FollowedBy, this.Comments, kind, this.IncludeInCompilation);
+            new CodeFragment(this.Indentation, this.Range, this.Text, this.FollowedBy, this.Comments, kind, this.IncludeInCompilation);
 
         internal CodeFragment ClearComments() =>
-            new CodeFragment(this.Indentation, this.fragmentRange, this.Text, this.FollowedBy, null, this.Kind, this.IncludeInCompilation);
+            new CodeFragment(this.Indentation, this.Range, this.Text, this.FollowedBy, null, this.Kind, this.IncludeInCompilation);
 
         internal CodeFragment SetOpeningComments(IEnumerable<string> commentsBefore)
         {
             var relevantComments = commentsBefore.SkipWhile(c => c == null).Reverse();
             relevantComments = relevantComments.SkipWhile(c => c == null).Reverse();
             var comments = new QsComments(relevantComments.Select(c => c ?? string.Empty).ToImmutableArray(), this.Comments.ClosingComments);
-            return new CodeFragment(this.Indentation, this.fragmentRange, this.Text, this.FollowedBy, comments, this.Kind, this.IncludeInCompilation);
+            return new CodeFragment(this.Indentation, this.Range, this.Text, this.FollowedBy, comments, this.Kind, this.IncludeInCompilation);
         }
 
         internal CodeFragment SetClosingComments(IEnumerable<string> commentsAfter)
@@ -213,7 +212,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder.DataStructures
             var relevantComments = commentsAfter.SkipWhile(c => c == null).Reverse();
             relevantComments = relevantComments.SkipWhile(c => c == null).Reverse();
             var comments = new QsComments(this.Comments.OpeningComments, relevantComments.Select(c => c ?? string.Empty).ToImmutableArray());
-            return new CodeFragment(this.Indentation, this.fragmentRange, this.Text, this.FollowedBy, comments, this.Kind, this.IncludeInCompilation);
+            return new CodeFragment(this.Indentation, this.Range, this.Text, this.FollowedBy, comments, this.Kind, this.IncludeInCompilation);
         }
 
         /// <summary>
@@ -408,12 +407,12 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder.DataStructures
                 this.Fragment = fragment ?? throw new ArgumentNullException(nameof(fragment));
                 this.Children = children ?? throw new ArgumentNullException(nameof(children));
 
-                if (fragment.GetRange().Start < parentStart)
+                if (fragment.Range.Start < parentStart)
                 {
                     throw new ArgumentException(nameof(parentStart), "parentStart needs to be smaller than or equal to the fragment start");
                 }
                 this.rootPosition = parentStart;
-                this.relPosition = fragment.GetRange().Start - parentStart;
+                this.relPosition = fragment.Range.Start - parentStart;
             }
         }
 
@@ -513,7 +512,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder.DataStructures
             var symRange = sym.Range.IsNull ? Range.Zero : sym.Range.Item;
             return symName == null
                 ? (HeaderEntry<T>?)null
-                : new HeaderEntry<T>(tIndex, fragment.GetRange().Start, (NonNullable<string>.New(symName), symRange), decl, attributes, doc, fragment.Comments);
+                : new HeaderEntry<T>(tIndex, fragment.Range.Start, (NonNullable<string>.New(symName), symRange), decl, attributes, doc, fragment.Comments);
         }
     }
 

--- a/src/QsCompiler/CompilationManager/DataStructures.cs
+++ b/src/QsCompiler/CompilationManager/DataStructures.cs
@@ -436,9 +436,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder.DataStructures
     /// </summary>
     internal struct HeaderEntry<T>
     {
-        private readonly Position position;
-
-        internal Position GetPosition() => this.position;
+        internal Position Position { get; }
 
         internal readonly NonNullable<string> SymbolName;
         internal readonly Tuple<NonNullable<string>, Range> PositionedSymbol;
@@ -462,7 +460,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder.DataStructures
                 throw new ArgumentNullException(nameof(tIndex));
             }
 
-            this.position = offset;
+            this.Position = offset;
             this.SymbolName = sym.Item1;
             this.PositionedSymbol = new Tuple<NonNullable<string>, Range>(sym.Item1, sym.Item2);
             this.Declaration = decl;

--- a/src/QsCompiler/CompilationManager/DiagnosticTools.cs
+++ b/src/QsCompiler/CompilationManager/DiagnosticTools.cs
@@ -63,7 +63,9 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// Translates the line numbers in the diagnostic by the given offset.
         /// </summary>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="diagnostic"/> is null.</exception>
-        /// <exception cref="ArgumentException">Thrown if the new diagnostic has an invalid range.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">
+        /// Thrown if the new diagnostic has negative line numbers.
+        /// </exception>
         public static Diagnostic TranslateLines(this Diagnostic diagnostic, int offset)
         {
             if (diagnostic is null)
@@ -73,9 +75,10 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
             var copy = diagnostic.Copy();
             copy.Range.Start.Line += offset;
             copy.Range.End.Line += offset;
-            if (!Utils.IsValidRange(copy.Range))
+            if (copy.Range.Start.Line < 0 || copy.Range.End.Line < 0)
             {
-                throw new ArgumentException("Diagnostic range is invalid after translating.");
+                throw new ArgumentOutOfRangeException(
+                    nameof(offset), "Translated diagnostic has negative line numbers.");
             }
             return copy;
         }

--- a/src/QsCompiler/CompilationManager/Diagnostics.cs
+++ b/src/QsCompiler/CompilationManager/Diagnostics.cs
@@ -94,7 +94,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
                 Code = Code(msg),
                 Source = filename,
                 Message = msg.Message,
-                Range = DiagnosticTools.GetAbsoluteRange(positionOffset.ToLsp(), msg.Range)
+                Range = ((positionOffset ?? Position.Zero) + msg.Range).ToLsp()
             };
         }
 

--- a/src/QsCompiler/CompilationManager/EditorSupport/CodeActions.cs
+++ b/src/QsCompiler/CompilationManager/EditorSupport/CodeActions.cs
@@ -130,7 +130,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
             }
 
             // determine what open directives already exist
-            var insertOpenDirAt = firstInNs.GetRange().Start;
+            var insertOpenDirAt = firstInNs.Range.Start;
             var openDirs = nsElements.Select(t => t.GetFragment().Kind?.OpenedNamespace())
                 .TakeWhile(opened => opened?.IsValue ?? false)
                 .Select(opened => (
@@ -290,7 +290,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
                     fragment?.Kind is QsFragmentKind.TypeDefinition type ? GetCharacteristics(type.Item3) :
                     Enumerable.Empty<Characteristics>();
 
-                var fragmentStart = fragment?.GetRange()?.Start;
+                var fragmentStart = fragment?.Range?.Start;
                 return characteristicsInFragment
                     .Where(c => c.Range.IsValue && Range.Overlaps(fragmentStart + c.Range.Item, d.Range.ToQSharp()))
                     .Select(c => ReplaceWith(CharacteristicsAnnotation(c), d.Range));
@@ -329,7 +329,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
                 // Convert set <identifier>[<index>] = <rhs> to set <identifier> w/= <index> <- <rhs>
                 var rhs = $"{exprInfo.Item3} {Keywords.qsCopyAndUpdateOp.cont} {exprInfo.Item4}";
                 var outputStr = $"{Keywords.qsValueUpdate.id} {exprInfo.Item2} {Keywords.qsCopyAndUpdateOp.op}= {rhs}";
-                var edit = new TextEdit { Range = fragment.GetRange().ToLsp(), NewText = outputStr };
+                var edit = new TextEdit { Range = fragment.Range.ToLsp(), NewText = outputStr };
                 return ("Replace with an update-and-reassign statement.", file.GetWorkspaceEdit(edit));
             }
 
@@ -404,7 +404,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
             static IEnumerable<TextEdit> IndexRangeEdits(CodeFragment fragment)
             {
                 if (fragment.Kind is QsFragmentKind.ForLoopIntro forLoopIntro && // todo: in principle we could give these suggestions for any index range
-                    IsIndexRange(forLoopIntro.Item2, fragment.GetRange().Start, out var iterExprRange, out var argTupleRange))
+                    IsIndexRange(forLoopIntro.Item2, fragment.Range.Start, out var iterExprRange, out var argTupleRange))
                 {
                     yield return new TextEdit
                     {
@@ -452,7 +452,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
 
                 // work off of the last reachable fragment, if there is one
                 var lastBeforeErase = lastFragToken.GetFragment();
-                var eraseStart = lastBeforeErase.GetRange().End;
+                var eraseStart = lastBeforeErase.Range.End;
 
                 // find the last fragment in the scope
                 while (currentFragToken != null)
@@ -461,10 +461,10 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
                     currentFragToken = currentFragToken.NextOnScope(true);
                 }
                 var lastInScope = lastFragToken.GetFragment();
-                var eraseEnd = lastInScope.GetRange().End;
+                var eraseEnd = lastInScope.Range.End;
 
                 // determine the whitespace for the replacement string
-                var lastLine = file.GetLine(lastFragToken.Line).Text.Substring(0, lastInScope.GetRange().Start.Column);
+                var lastLine = file.GetLine(lastFragToken.Line).Text.Substring(0, lastInScope.Range.Start.Column);
                 var trimmedLastLine = lastLine.TrimEnd();
                 var whitespace = lastLine[trimmedLastLine.Length..];
 
@@ -503,7 +503,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
             var declSymbol = nsDecl.IsValue ? nsDecl.Item.Item1.Symbol
                 : callableDecl.IsValue ? callableDecl.Item.Item1.Symbol
                 : typeDecl.IsValue ? typeDecl.Item.Item1.Symbol : null;
-            var declStart = fragment.GetRange().Start;
+            var declStart = fragment.Range.Start;
             if (declSymbol == null || file.DocumentingComments(declStart).Any())
             {
                 return Enumerable.Empty<(string, WorkspaceEdit)>();

--- a/src/QsCompiler/CompilationManager/EditorSupport/CodeCompletion.cs
+++ b/src/QsCompiler/CompilationManager/EditorSupport/CodeCompletion.cs
@@ -683,7 +683,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
             var relativeLine = position.Line - fragment.GetRange().Start.Line;
             var lines = Utils.SplitLines(fragment.Text).DefaultIfEmpty("");
             var relativeCharacter =
-                relativeLine == 0 ? position.Column - fragment.GetRange().Start.Character : position.Column;
+                relativeLine == 0 ? position.Column - fragment.GetRange().Start.Column : position.Column;
             if (relativeLine < 0 ||
                 relativeLine >= lines.Count() ||
                 relativeCharacter < 0 ||
@@ -773,7 +773,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
                 throw new ArgumentException("Code fragment has a missing delimiter", nameof(fragment));
             }
 
-            var end = fragment.GetRange().End.ToQSharp();
+            var end = fragment.GetRange().End;
             var position = file.FragmentEnd(ref end);
             return Position.Create(position.Line, position.Column - 1);
         }
@@ -805,7 +805,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
             {
                 return "";
             }
-            return fragment.GetRange().End.ToQSharp() < position
+            return fragment.GetRange().End < position
                 ? fragment.Text + " "
                 : fragment.Text.Substring(0, GetTextIndexFromPosition(fragment, position));
         }

--- a/src/QsCompiler/CompilationManager/EditorSupport/CodeCompletion.cs
+++ b/src/QsCompiler/CompilationManager/EditorSupport/CodeCompletion.cs
@@ -143,7 +143,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
             {
                 throw new ArgumentNullException(nameof(file));
             }
-            if (!Utils.IsValidPosition(position, file))
+            if (!file.ContainsPosition(position))
             {
                 // FileContentManager.IndentationAt will fail if the position is not within the file.
                 fragment = null;

--- a/src/QsCompiler/CompilationManager/EditorSupport/CodeCompletion.cs
+++ b/src/QsCompiler/CompilationManager/EditorSupport/CodeCompletion.cs
@@ -680,10 +680,10 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
                 throw new ArgumentNullException(nameof(position));
             }
 
-            var relativeLine = position.Line - fragment.GetRange().Start.Line;
+            var relativeLine = position.Line - fragment.Range.Start.Line;
             var lines = Utils.SplitLines(fragment.Text).DefaultIfEmpty("");
             var relativeCharacter =
-                relativeLine == 0 ? position.Column - fragment.GetRange().Start.Column : position.Column;
+                relativeLine == 0 ? position.Column - fragment.Range.Start.Column : position.Column;
             if (relativeLine < 0 ||
                 relativeLine >= lines.Count() ||
                 relativeCharacter < 0 ||
@@ -773,7 +773,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
                 throw new ArgumentException("Code fragment has a missing delimiter", nameof(fragment));
             }
 
-            var end = fragment.GetRange().End;
+            var end = fragment.Range.End;
             var position = file.FragmentEnd(ref end);
             return Position.Create(position.Line, position.Column - 1);
         }
@@ -805,7 +805,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
             {
                 return "";
             }
-            return fragment.GetRange().End < position
+            return fragment.Range.End < position
                 ? fragment.Text + " "
                 : fragment.Text.Substring(0, GetTextIndexFromPosition(fragment, position));
         }

--- a/src/QsCompiler/CompilationManager/EditorSupport/EditorCommands.cs
+++ b/src/QsCompiler/CompilationManager/EditorSupport/EditorCommands.cs
@@ -133,7 +133,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// The key of the look-up is a suitable title for the corresponding edits that can be presented to the user.
         /// Returns null if any of the given arguments is null or if suitable edits cannot be determined.
         /// </summary>
-        public static ILookup<string, WorkspaceEdit> CodeActions(this FileContentManager file, CompilationUnit compilation, Lsp.Range range, CodeActionContext context)
+        public static ILookup<string, WorkspaceEdit> CodeActions(this FileContentManager file, CompilationUnit compilation, Range range, CodeActionContext context)
         {
             if (range?.Start == null || range.End == null || file == null || !Utils.IsValidRange(range, file))
             {
@@ -143,9 +143,9 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
             var suggestionsForAmbiguousIds = file.SuggestionsForAmbiguousIdentifiers(compilation, context?.Diagnostics);
             var suggestionsForDeprecatedSyntax = file.SuggestionsForDeprecatedSyntax(context?.Diagnostics);
             var suggestionsForUpdateAndReassign = file.SuggestionsForUpdateAndReassignStatements(context?.Diagnostics);
-            var suggestionsForIndexRange = file.SuggestionsForIndexRange(compilation, range);
+            var suggestionsForIndexRange = file.SuggestionsForIndexRange(compilation, range.ToLsp());
             var suggestionsForUnreachableCode = file.SuggestionsForUnreachableCode(context?.Diagnostics);
-            var suggestionsForDocComments = file.DocCommentSuggestions(range);
+            var suggestionsForDocComments = file.DocCommentSuggestions(range.ToLsp());
             return suggestionsForUnknownIds
                 .Concat(suggestionsForAmbiguousIds)
                 .Concat(suggestionsForDeprecatedSyntax)
@@ -267,8 +267,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
 
             // getting the overlapping call expressions (if any), and determine the header of the called callable
 
-            bool OverlapsWithPosition(Range symRange) =>
-                position.IsWithinRange(DiagnosticTools.GetAbsoluteRange(fragmentStart, symRange), true);
+            bool OverlapsWithPosition(Range symRange) => (fragmentStart + symRange).ContainsEnd(position);
 
             var overlappingEx = fragment.Kind.CallExpressions().Where(ex => ex.Range.IsValue && OverlapsWithPosition(ex.Range.Item)).ToList();
             if (!overlappingEx.Any())
@@ -350,7 +349,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
 
             // now that we now what callable is called we need to check which argument should come next
 
-            bool BeforePosition(Range symRange) => fragmentStart.ToQSharp() + symRange.End < position;
+            bool BeforePosition(Range symRange) => fragmentStart + symRange.End < position;
 
             IEnumerable<(Range, string)> ExtractParameterRanges(
                 QsExpression ex, QsTuple<LocalVariableDeclaration<QsLocalSymbol>> decl)

--- a/src/QsCompiler/CompilationManager/EditorSupport/EditorCommands.cs
+++ b/src/QsCompiler/CompilationManager/EditorSupport/EditorCommands.cs
@@ -263,7 +263,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
             {
                 return null;
             }
-            var fragmentStart = fragment.GetRange().Start;
+            var fragmentStart = fragment.Range.Start;
 
             // getting the overlapping call expressions (if any), and determine the header of the called callable
 

--- a/src/QsCompiler/CompilationManager/EditorSupport/EditorCommands.cs
+++ b/src/QsCompiler/CompilationManager/EditorSupport/EditorCommands.cs
@@ -143,9 +143,9 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
             var suggestionsForAmbiguousIds = file.SuggestionsForAmbiguousIdentifiers(compilation, context?.Diagnostics);
             var suggestionsForDeprecatedSyntax = file.SuggestionsForDeprecatedSyntax(context?.Diagnostics);
             var suggestionsForUpdateAndReassign = file.SuggestionsForUpdateAndReassignStatements(context?.Diagnostics);
-            var suggestionsForIndexRange = file.SuggestionsForIndexRange(compilation, range.ToLsp());
+            var suggestionsForIndexRange = file.SuggestionsForIndexRange(compilation, range);
             var suggestionsForUnreachableCode = file.SuggestionsForUnreachableCode(context?.Diagnostics);
-            var suggestionsForDocComments = file.DocCommentSuggestions(range.ToLsp());
+            var suggestionsForDocComments = file.DocCommentSuggestions(range);
             return suggestionsForUnknownIds
                 .Concat(suggestionsForAmbiguousIds)
                 .Concat(suggestionsForDeprecatedSyntax)

--- a/src/QsCompiler/CompilationManager/EditorSupport/EditorCommands.cs
+++ b/src/QsCompiler/CompilationManager/EditorSupport/EditorCommands.cs
@@ -135,7 +135,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// </summary>
         public static ILookup<string, WorkspaceEdit> CodeActions(this FileContentManager file, CompilationUnit compilation, Range range, CodeActionContext context)
         {
-            if (range?.Start == null || range.End == null || file == null || !Utils.IsValidRange(range, file))
+            if (range?.Start == null || range.End == null || file == null || !file.ContainsRange(range))
             {
                 return null;
             }

--- a/src/QsCompiler/CompilationManager/EditorSupport/SymbolInformation.cs
+++ b/src/QsCompiler/CompilationManager/EditorSupport/SymbolInformation.cs
@@ -241,9 +241,9 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
             {
                 return true;
             }
-            var (defOffset, defRange) = (definition.Item.Item2.ToLsp(), definition.Item.Item3);
+            var (defOffset, defRange) = (definition.Item.Item2, definition.Item.Item3);
 
-            if (defOffset.Equals(callablePos))
+            if (defOffset == callablePos)
             {
                 // the given position corresponds to a variable declared as part of a callable declaration
                 if (!compilation.GetCallables().TryGetValue(parentName, out var parent))
@@ -261,7 +261,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
             else
             {
                 // the given position corresponds to a variable declared as part of a specialization declaration or implementation
-                var defStart = defOffset.ToQSharp() + defRange.Start;
+                var defStart = defOffset + defRange.Start;
                 var statements = implementation.StatementsAfterDeclaration(defStart - specPos);
                 var scope = new QsScope(statements.ToImmutableArray(), locals);
                 referenceLocations = IdentifierReferences.Find(definition.Item.Item1, scope, file.FileName, specPos).Select(AsLocation);

--- a/src/QsCompiler/CompilationManager/EditorSupport/SymbolInformation.cs
+++ b/src/QsCompiler/CompilationManager/EditorSupport/SymbolInformation.cs
@@ -98,7 +98,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
             {
                 return null;
             }
-            var fragmentStart = fragment.GetRange().Start;
+            var fragmentStart = fragment.Range.Start;
 
             // getting the symbol information (if any), and return the overlapping items only
 

--- a/src/QsCompiler/CompilationManager/FileContentManager.cs
+++ b/src/QsCompiler/CompilationManager/FileContentManager.cs
@@ -537,12 +537,12 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
                 var lineNrChange = replacements.Count - count;
                 var syntaxCheckInUpdated = this.GetSyntaxCheckDelimiters(start, replacements.Count);
                 var syntaxCheckInOriginal = Range.Create(
-                    syntaxCheckInUpdated.Start.ToQSharp(),
-                    syntaxCheckInUpdated.End.ToQSharp() == this.End()
+                    syntaxCheckInUpdated.Start,
+                    syntaxCheckInUpdated.End == this.End()
                         ? origFileEnd
                         : Position.Create(
                             syntaxCheckInUpdated.End.Line - lineNrChange,
-                            syntaxCheckInUpdated.End.Character));
+                            syntaxCheckInUpdated.End.Column));
 
                 // update the tokens and make sure the necessary connections get marked as edited
                 // -> needs to be done *before* updating the tracked line numbers!

--- a/src/QsCompiler/CompilationManager/FileContentManager.cs
+++ b/src/QsCompiler/CompilationManager/FileContentManager.cs
@@ -189,30 +189,21 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// removes all diagnostics that are no longer valid due to that change, and
         /// updates the line numbers of the remaining diagnostics if needed.
         /// Throws an ArgumentNullException if the given diagnostics to update or if the syntax check delimiters are null.
-        /// Throws an ArgumentException if the given start and end position do not denote a valid range.
         /// </summary>
-        private static void InvalidateOrUpdateBySyntaxCheckDelimeters(ManagedList<Diagnostic> diagnostics, Lsp.Range syntaxCheckDelimiters, int lineNrChange)
+        private static void InvalidateOrUpdateBySyntaxCheckDelimeters(ManagedList<Diagnostic> diagnostics, Range syntaxCheckDelimiters, int lineNrChange)
         {
             if (diagnostics == null)
             {
                 throw new ArgumentNullException(nameof(diagnostics));
             }
-            if (!Utils.IsValidRange(syntaxCheckDelimiters))
-            {
-                throw new ArgumentException(nameof(syntaxCheckDelimiters));
-            }
-            var syntaxCheck = Range.Create(
-                syntaxCheckDelimiters.Start.ToQSharp(),
-                syntaxCheckDelimiters.End.ToQSharp());
-
-            Diagnostic UpdateLineNrs(Diagnostic m) => m.SelectByStart(syntaxCheck.End) ? m.WithUpdatedLineNumber(lineNrChange) : m;
+            Diagnostic UpdateLineNrs(Diagnostic m) => m.SelectByStart(syntaxCheckDelimiters.End) ? m.TranslateLines(lineNrChange) : m;
             diagnostics.SyncRoot.EnterWriteLock();
             try
             {
                 // remove any Diagnostic overlapping with the updated interval
-                diagnostics.RemoveAll(m => m.SelectByStart(syntaxCheck) || m.SelectByEnd(syntaxCheck));
+                diagnostics.RemoveAll(m => m.SelectByStart(syntaxCheckDelimiters) || m.SelectByEnd(syntaxCheckDelimiters));
                 // these are also no longer valid
-                diagnostics.RemoveAll(m => m.SelectByStart(Range.Create(Position.Zero, syntaxCheck.Start)) && m.SelectByEnd(syntaxCheck.End));
+                diagnostics.RemoveAll(m => m.SelectByStart(Range.Create(Position.Zero, syntaxCheckDelimiters.Start)) && m.SelectByEnd(syntaxCheckDelimiters.End));
                 if (lineNrChange != 0)
                 {
                     diagnostics.Transform(UpdateLineNrs);
@@ -233,7 +224,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         private static void DelayInvalidateOrUpdate(
             ManagedList<Diagnostic> diagnostics,
             ManagedList<Diagnostic> updated,
-            Lsp.Range syntaxCheckDelimiters,
+            Range syntaxCheckDelimiters,
             int lineNrChange)
         {
             if (diagnostics == null)
@@ -246,7 +237,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
             }
 
             InvalidateOrUpdateBySyntaxCheckDelimeters(updated, syntaxCheckDelimiters, lineNrChange);
-            Diagnostic UpdateLineNrs(Diagnostic m) => m.SelectByStart(syntaxCheckDelimiters.End.ToQSharp()) ? m.WithUpdatedLineNumber(lineNrChange) : m;
+            Diagnostic UpdateLineNrs(Diagnostic m) => m.SelectByStart(syntaxCheckDelimiters.End) ? m.TranslateLines(lineNrChange) : m;
             if (lineNrChange != 0)
             {
                 diagnostics.Transform(UpdateLineNrs);
@@ -284,7 +275,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
             }
 
             var end = start + count;
-            Diagnostic UpdateLineNrs(Diagnostic m) => m.SelectByStartLine(end) ? m.WithUpdatedLineNumber(lineNrChange) : m;
+            Diagnostic UpdateLineNrs(Diagnostic m) => m.SelectByStartLine(end) ? m.TranslateLines(lineNrChange) : m;
 
             this.scopeDiagnostics.SyncRoot.EnterWriteLock();
             try
@@ -315,7 +306,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// Throws an ArgumentNullException if the given diagnostics to update or the syntax check delimiters are null.
         /// Throws an ArgumentException if the given start and end position do not denote a valid range.
         /// </summary>
-        private void InvalidateOrUpdateSyntaxDiagnostics(Lsp.Range syntaxCheckDelimiters, int lineNrChange) =>
+        private void InvalidateOrUpdateSyntaxDiagnostics(Range syntaxCheckDelimiters, int lineNrChange) =>
             InvalidateOrUpdateBySyntaxCheckDelimeters(this.syntaxDiagnostics, syntaxCheckDelimiters, lineNrChange);
 
         /// <summary>
@@ -372,7 +363,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
             }
 
             var end = start + count;
-            Diagnostic UpdateLineNrs(Diagnostic m) => m.SelectByStartLine(end) ? m.WithUpdatedLineNumber(lineNrChange) : m;
+            Diagnostic UpdateLineNrs(Diagnostic m) => m.SelectByStartLine(end) ? m.TranslateLines(lineNrChange) : m;
 
             this.contextDiagnostics.SyncRoot.EnterWriteLock();
             try
@@ -405,7 +396,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// Throws an ArgumentNullException if the given diagnostics to update or the syntax check delimiters are null.
         /// Throws an ArgumentException if the given start and end position do not denote a valid range.
         /// </summary>
-        private void InvalidateOrUpdateHeaderDiagnostics(Lsp.Range syntaxCheckDelimiters, int lineNrChange) =>
+        private void InvalidateOrUpdateHeaderDiagnostics(Range syntaxCheckDelimiters, int lineNrChange) =>
             DelayInvalidateOrUpdate(this.headerDiagnostics, this.updatedHeaderDiagnostics, syntaxCheckDelimiters, lineNrChange);
 
         /// <summary>
@@ -433,7 +424,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// Throws an ArgumentNullException if the given diagnostics to update or the syntax check delimiters are null.
         /// Throws an ArgumentException if the given start and end position do not denote a valid range.
         /// </summary>
-        private void InvalidateOrUpdateSemanticDiagnostics(Lsp.Range syntaxCheckDelimiters, int lineNrChange) =>
+        private void InvalidateOrUpdateSemanticDiagnostics(Range syntaxCheckDelimiters, int lineNrChange) =>
             DelayInvalidateOrUpdate(this.semanticDiagnostics, this.updatedSemanticDiagnostics, syntaxCheckDelimiters, lineNrChange);
 
         /// <summary>
@@ -545,15 +536,13 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
                 this.content.Replace(start, count, replacements);
                 var lineNrChange = replacements.Count - count;
                 var syntaxCheckInUpdated = this.GetSyntaxCheckDelimiters(start, replacements.Count);
-                var syntaxCheckInOriginal = new Lsp.Range
-                {
-                    Start = syntaxCheckInUpdated.Start,
-                    End = syntaxCheckInUpdated.End.ToQSharp() == this.End()
-                        ? origFileEnd.ToLsp()
-                        : new Lsp.Position(
+                var syntaxCheckInOriginal = Range.Create(
+                    syntaxCheckInUpdated.Start.ToQSharp(),
+                    syntaxCheckInUpdated.End.ToQSharp() == this.End()
+                        ? origFileEnd
+                        : Position.Create(
                             syntaxCheckInUpdated.End.Line - lineNrChange,
-                            syntaxCheckInUpdated.End.Character)
-                };
+                            syntaxCheckInUpdated.End.Character));
 
                 // update the tokens and make sure the necessary connections get marked as edited
                 // -> needs to be done *before* updating the tracked line numbers!
@@ -630,7 +619,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
                 var fragmentRanges = fragments.Select(t => t.GetRange());
                 var (min, max) = (fragmentRanges.Min(frag => frag.Start.Line), fragmentRanges.Max(frag => frag.End.Line));
                 var existing = Enumerable.Range(min, max - min + 1)
-                    .SelectMany(lineNr => this.GetTokenizedLine(lineNr).Select(t => t.WithUpdatedLineNumber(lineNr).GetRange().DiagnosticString() + $": {t.Text}"));
+                    .SelectMany(lineNr => this.GetTokenizedLine(lineNr).Select(t => t.TranslateLines(lineNr).GetRange().DiagnosticString() + $": {t.Text}"));
                 throw new ArgumentException("the given fragments to update overlap with existing tokens - \n" +
                     $"Ranges for updates were: \n{string.Join("\n", fragments.Select(t => t.GetRange().DiagnosticString() + $": {t.Text}"))} \n" +
                     $"Ranges for existing are: \n{string.Join("\n", existing)}");
@@ -719,18 +708,13 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// Tokens starting at range.End or ending at range.Start are *not* considered to be overlapping.
         /// Futs a write-lock on the Tokens during the entire routine.
         /// Throws an ArgumentNullException if the given range or it start or end position is null.
-        /// Throws an ArgumentException if the given range is not a valid range.
         /// Throws an ArgumentOutOfRangeException if the line number of the range end is larger than the number of currently saved tokens.
         /// </summary>
-        private void RemoveTokensInRange(Lsp.Range range)
+        private void RemoveTokensInRange(Range range)
         {
             this.tokens.SyncRoot.EnterWriteLock();
             try
             {
-                if (!Utils.IsValidRange(range))
-                {
-                    throw new ArgumentException("invalid range"); // *don't* verify against the current file content
-                }
                 if (range.End.Line >= this.tokens.Count())
                 {
                     throw new ArgumentOutOfRangeException(nameof(range));
@@ -751,21 +735,22 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
                 }
 
                 var (start, end) = (range.Start.Line, range.End.Line);
-                FilterAndMarkEdited(start, ContextBuilder.NotOverlappingWith(range.WithUpdatedLineNumber(-start)));
+                FilterAndMarkEdited(start, ContextBuilder.NotOverlappingWith(range.TranslateLines(-start)));
                 for (var i = start + 1; i < end; ++i)
                 {
                     FilterAndMarkEdited(i, _ => false); // remove all
                 }
                 if (start != end)
                 {
-                    FilterAndMarkEdited(end, ContextBuilder.TokensAfter(Position.Create(0, range.End.Character)));
+                    FilterAndMarkEdited(end, ContextBuilder.TokensAfter(Position.Create(0, range.End.Column)));
                 }
 
-                var enveloppingFragment = this.TryGetFragmentAt(range.Start.ToQSharp(), out var _);
-                if (enveloppingFragment != null)
+                var envelopingFragment = this.TryGetFragmentAt(range.Start, out _);
+                if (envelopingFragment != null)
                 {
-                    start = enveloppingFragment.GetRange().Start.Line;
-                    FilterAndMarkEdited(start, token => !range.Start.ToQSharp().IsWithinRange(token.GetRange().WithUpdatedLineNumber(start)));
+                    var envelopeStart = envelopingFragment.GetRange().Start.Line;
+                    FilterAndMarkEdited(envelopeStart, token =>
+                        !token.GetRange().TranslateLines(envelopeStart).Contains(range.Start));
                 }
 
                 // which lines get marked as edited depends on the tokens prior to transformation,
@@ -835,7 +820,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
                     var startLine = fragments.First().GetRange().Start.Line;
                     var tokens =
                         fragments.TakeWhile(fragment => fragment.GetRange().Start.Line == startLine)
-                        .Select(token => token.WithUpdatedLineNumber(-startLine)) // token ranges are relative to their start line! (to simplify updating...)
+                        .Select(token => token.TranslateLines(-startLine)) // token ranges are relative to their start line! (to simplify updating...)
                         .ToImmutableArray();
 
                     ImmutableArray<CodeFragment> MergeAndAttachComments(ImmutableArray<CodeFragment> current)
@@ -938,7 +923,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// whose content has been edited since the last call to this routine.
         /// Invalidates all semantic diagnostics withing the corresponding Ranges.
         /// </summary>
-        internal void MarkCallableAsContentEdited(IEnumerable<(Lsp.Range, QsQualifiedName)> edited)
+        internal void MarkCallableAsContentEdited(IEnumerable<(Range, QsQualifiedName)> edited)
         {
             foreach (var (range, callableName) in edited)
             {
@@ -1219,7 +1204,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// <summary>
         /// Returns all namespace declarations in the file sorted by the line number they are declared on.
         /// </summary>
-        public IEnumerable<(NonNullable<string>, Lsp.Range)> GetNamespaceDeclarations()
+        public IEnumerable<(NonNullable<string>, Range)> GetNamespaceDeclarations()
         {
             var decl = this.FilterFragments(this.header.GetNamespaceDeclarations, FileHeader.IsNamespaceDeclaration);
             return decl.Select(fragment => (fragment.Kind.DeclaredNamespaceName(InternalUse.UnknownNamespace), fragment.GetRange()))
@@ -1230,7 +1215,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// <summary>
         /// Returns all type declarations in the file sorted by the line number they are declared on.
         /// </summary>
-        public IEnumerable<(NonNullable<string>, Lsp.Range)> GetTypeDeclarations()
+        public IEnumerable<(NonNullable<string>, Range)> GetTypeDeclarations()
         {
             var decl = this.FilterFragments(this.header.GetTypeDeclarations, FileHeader.IsTypeDeclaration);
             return decl.Select(fragment => (fragment.Kind.DeclaredTypeName(null), fragment.GetRange()))
@@ -1241,7 +1226,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// <summary>
         /// Returns all callable declarations in the file sorted by the line number they are declared on.
         /// </summary>
-        public IEnumerable<(NonNullable<string>, Lsp.Range)> GetCallableDeclarations()
+        public IEnumerable<(NonNullable<string>, Range)> GetCallableDeclarations()
         {
             var decl = this.FilterFragments(this.header.GetCallableDeclarations, FileHeader.IsCallableDeclaration);
             return decl.Select(fragment => (fragment.Kind.DeclaredCallableName(null), fragment.GetRange()))

--- a/src/QsCompiler/CompilationManager/FileContentManager.cs
+++ b/src/QsCompiler/CompilationManager/FileContentManager.cs
@@ -1037,23 +1037,19 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         {
             // NOTE: since there may be still unprocessed changes aggregated in UnprocessedChanges we cannot verify the range of the change against the current file content,
             // however, let's at least check that nothing is null, all entries are positive, and the range start is smaller than or equal to the range end
-
             if (change == null)
             {
                 throw new ArgumentNullException(nameof(change));
             }
-            if (!Utils.IsValidRange(change.Range))
-            {
-                throw new ArgumentException("range of the given change is invalid");
-            }
+
             this.timer.Stop(); // will be restarted if needed
-
-            var start = change.Range.Start.Line;
-            var count = change.Range.End.Line - start + 1;
-            var line = this.unprocessedUpdates.Any() ? this.unprocessedUpdates.Peek().Range.Start.Line : start;
-
+            var range = change.Range.ToQSharp();
+            var count = range.End.Line - range.Start.Line + 1;
+            var line = this.unprocessedUpdates.Any()
+                ? this.unprocessedUpdates.Peek().Range.Start.Line
+                : range.Start.Line;
             publishDiagnostics = true;
-            if (count == 1 && line == start)
+            if (count == 1 && line == range.Start.Line)
             {
                 this.unprocessedUpdates.Enqueue(change);
 

--- a/src/QsCompiler/CompilationManager/FileContentManager.cs
+++ b/src/QsCompiler/CompilationManager/FileContentManager.cs
@@ -607,7 +607,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// </summary>
         private void VerifyTokenUpdate(IReadOnlyList<CodeFragment> fragments)
         {
-            if (fragments.Any(fragment => !Utils.IsValidRange(fragment.GetRange(), this)))
+            if (fragments.Any(fragment => !this.ContainsRange(fragment.GetRange())))
             {
                 throw new ArgumentException("the range of the given token to update is not a valid range within the current file content");
             }

--- a/src/QsCompiler/CompilationManager/ProjectManager.cs
+++ b/src/QsCompiler/CompilationManager/ProjectManager.cs
@@ -1182,7 +1182,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// </summary>
         public ILookup<string, WorkspaceEdit> CodeActions(CodeActionParams param) =>
             this.Manager(param?.TextDocument?.Uri)?.FileQuery(
-                param?.TextDocument, (file, c) => file.CodeActions(c, param?.Range, param.Context), suppressExceptionLogging: true);
+                param?.TextDocument, (file, c) => file.CodeActions(c, param?.Range.ToQSharp(), param.Context), suppressExceptionLogging: true);
 
         /// <summary>
         /// Returns a list of suggested completion items for the given location.

--- a/src/QsCompiler/CompilationManager/ScopeTracking.cs
+++ b/src/QsCompiler/CompilationManager/ScopeTracking.cs
@@ -443,7 +443,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// </summary>
         internal static int IndentationAt(this FileContentManager file, Position pos)
         {
-            if (!Utils.IsValidPosition(pos, file))
+            if (!file.ContainsPosition(pos))
             {
                 throw new ArgumentException("given position is not within file");
             }

--- a/src/QsCompiler/CompilationManager/TextProcessor.cs
+++ b/src/QsCompiler/CompilationManager/TextProcessor.cs
@@ -34,9 +34,9 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
             }
             // opting to not complain about semicolons not following code anywhere in the file (i.e. on any scope)
             var diagnostics = fragments.Where(snippet => snippet.Text.Length == 0 && snippet.FollowedBy == ';')
-                .Select(snippet => Warnings.EmptyStatementWarning(filename, snippet.GetRange().End))
+                .Select(snippet => Warnings.EmptyStatementWarning(filename, snippet.Range.End))
                 .Concat(fragments.Where(snippet => snippet.Text.Length == 0 && snippet.FollowedBy == '{')
-                .Select(snippet => Errors.MisplacedOpeningBracketError(filename, snippet.GetRange().End)));
+                .Select(snippet => Errors.MisplacedOpeningBracketError(filename, snippet.Range.End)));
             return diagnostics.ToList(); // in case fragments change
         }
 
@@ -55,7 +55,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
             var code = fragment.Kind.InvalidEnding;
             if (Diagnostics.ExpectedEnding(code) != fragment.FollowedBy)
             {
-                yield return Errors.InvalidFragmentEnding(filename, code, fragment.GetRange().End);
+                yield return Errors.InvalidFragmentEnding(filename, code, fragment.Range.End);
             }
         }
 
@@ -77,7 +77,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
 
             foreach (var snippet in fragments)
             {
-                var snippetStart = snippet.GetRange().Start;
+                var snippetStart = snippet.Range.Start;
                 var outputs = Parsing.ProcessCodeFragment(snippet.Text);
                 for (var outputIndex = 0; outputIndex < outputs.Length; ++outputIndex)
                 {
@@ -97,7 +97,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
                         var generated = Diagnostics.Generate(filename, fragmentDiagnostic, fragmentRange.Start);
                         diagnostics.Add(generated);
 
-                        var fragmentEnd = fragment.GetRange().End;
+                        var fragmentEnd = fragment.Range.End;
                         var generatedRange = generated.Range.ToQSharp();
                         var diagnosticGoesUpToFragmentEnd =
                             generatedRange.Contains(fragmentEnd) || fragmentEnd == generatedRange.End;

--- a/src/QsCompiler/CompilationManager/TextProcessor.cs
+++ b/src/QsCompiler/CompilationManager/TextProcessor.cs
@@ -385,7 +385,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// Throws an ArgumentNullException if file is null.
         /// Throws an ArgumentOutOfRangeException if the range [start, start + count) is not a valid range within the current file content.
         /// </summary>
-        internal static Lsp.Range GetSyntaxCheckDelimiters(this FileContentManager file, int start, int count)
+        internal static Range GetSyntaxCheckDelimiters(this FileContentManager file, int start, int count)
         {
             if (file == null)
             {
@@ -408,11 +408,9 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
             var syntaxCheckEnd = firstAfterModified < lastInFile
                 ? file.FragmentEnd(ref firstAfterModified)
                 : file.End();
-            return new Lsp.Range
-            {
-                Start = syntaxCheckStart.ToLsp(),
-                End = lastInFile <= syntaxCheckEnd ? file.End().ToLsp() : syntaxCheckEnd.ToLsp()
-            };
+            return Range.Create(
+                syntaxCheckStart,
+                lastInFile <= syntaxCheckEnd ? file.End() : syntaxCheckEnd);
         }
 
         /// <summary>

--- a/src/QsCompiler/CompilationManager/TextProcessor.cs
+++ b/src/QsCompiler/CompilationManager/TextProcessor.cs
@@ -130,7 +130,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// </summary>
         private static string GetCodeSnippet(this FileContentManager file, Range range)
         {
-            if (!Utils.IsValidRange(range, file))
+            if (!file.ContainsRange(range))
             {
                 throw new ArgumentException($"cannot extract code snippet for the given range \n range: {range.DiagnosticString()}");
             }
@@ -247,7 +247,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// </summary>
         internal static Position FragmentEnd(this FileContentManager file, ref Position current)
         {
-            if (!Utils.IsValidPosition(current, file))
+            if (!file.ContainsPosition(current))
             {
                 throw new ArgumentException("given position is not within file");
             }
@@ -302,7 +302,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// </summary>
         private static Position PositionAfterPrevious(this FileContentManager file, Position current)
         {
-            if (!Utils.IsValidPosition(current, file))
+            if (!file.ContainsPosition(current))
             {
                 throw new ArgumentException("given position is not within file");
             }

--- a/src/QsCompiler/CompilationManager/TypeChecking.cs
+++ b/src/QsCompiler/CompilationManager/TypeChecking.cs
@@ -69,7 +69,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// </summary>
         internal static ImmutableArray<string> DocumentingComments(this FileContentManager file, Position pos, bool ignorePrecedingAttributes = true)
         {
-            if (!Utils.IsValidPosition(pos, file))
+            if (!file.ContainsPosition(pos))
             {
                 throw new ArgumentException(nameof(pos));
             }

--- a/src/QsCompiler/CompilationManager/TypeChecking.cs
+++ b/src/QsCompiler/CompilationManager/TypeChecking.cs
@@ -45,7 +45,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
                     precedingFragment = preceding.GetFragment();
                     if (precedingFragment.IncludeInCompilation && precedingFragment.Kind is QsFragmentKind.DeclarationAttribute att)
                     {
-                        var offset = precedingFragment.GetRange().Start;
+                        var offset = precedingFragment.Range.Start;
                         attributes.Add(new AttributeAnnotation(att.Item1, att.Item2, offset, precedingFragment.Comments));
                     }
                     else
@@ -53,7 +53,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
                         break;
                     }
                 }
-                var docComments = file.DocumentingComments(tIndex.GetFragment().GetRange().Start);
+                var docComments = file.DocumentingComments(tIndex.GetFragment().Range.Start);
                 return (tIndex, HeaderEntry<T>.From(getDeclaration, tIndex, attributes.ToImmutableArray(), docComments, keepInvalid));
             })
             ?.Where(tuple => tuple.Item2 != null).Select(tuple => (tuple.Item1, tuple.Item2.Value));
@@ -84,7 +84,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
                 lastPreceding = file.GetTokenizedLine(lineNr).LastOrDefault(RelevantToken)?.TranslateLines(lineNr);
             }
 
-            var firstRelevant = lastPreceding == null ? 0 : lastPreceding.GetRange().End.Line + 1;
+            var firstRelevant = lastPreceding == null ? 0 : lastPreceding.Range.End.Line + 1;
             return file.GetLines(firstRelevant, pos.Line > firstRelevant ? pos.Line - firstRelevant : 0)
                 .Select(line => line.Text.Trim()).Where(IsDocCommentLine).Select(line => line.TrimStart('/'))
                 .SkipWhile(text => string.IsNullOrWhiteSpace(text)).Reverse()
@@ -378,7 +378,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
                 {
                     var msgRange = Parsing.HeaderDelimiters(1).Invoke(statement.Text);
                     var msg = QsCompilerDiagnostic.Error(ErrorCode.NotWithinSpecialization, Enumerable.Empty<string>(), msgRange);
-                    diagnostics.Add(Diagnostics.Generate(file.FileName.Value, msg, statement.GetRange().Start));
+                    diagnostics.Add(Diagnostics.Generate(file.FileName.Value, msg, statement.Range.Start));
                 }
             }
 
@@ -526,7 +526,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
                 tokens?.Select(token =>
                 {
                     var fragment = token.GetFragmentWithClosingComments();
-                    var parentPos = rootPos ?? fragment.GetRange().Start;
+                    var parentPos = rootPos ?? fragment.Range.Start;
                     return new FragmentTree.TreeNode(fragment, BuildNodes(ChildrenToCompile(token), parentPos), parentPos);
                 })
                 ?.ToList()?.AsReadOnly();
@@ -664,7 +664,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
                 throw new ArgumentNullException(nameof(diagnostics));
             }
 
-            var statementPos = node.Fragment.GetRange().Start;
+            var statementPos = node.Fragment.Range.Start;
             var location = new QsLocation(node.GetPositionRelativeToRoot(), node.Fragment.HeaderRange);
             var (statement, messages) = build(location, context);
             diagnostics.AddRange(messages.Select(msg => Diagnostics.Generate(context.Symbols.SourceFile.Value, msg, statementPos)));
@@ -1601,7 +1601,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
                 context.Symbols.TryAddVariableDeclartion(decl);
             }
 
-            var specPos = root.Fragment.GetRange().Start;
+            var specPos = root.Fragment.Range.Start;
             foreach (var decl in variablesOnSpecialization)
             {
                 var msgs = context.Symbols.TryAddVariableDeclartion(decl).Item2;
@@ -1614,7 +1614,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
 
             // verify that all paths return a value if needed (or fail)
             var (allPathsReturn, messages) = SyntaxProcessing.SyntaxTree.AllPathsReturnValueOrFail(implementation);
-            var rootPosition = root.Fragment.GetRange().Start;
+            var rootPosition = root.Fragment.Range.Start;
             diagnostics.AddRange(messages.Select(msg =>
                 Diagnostics.Generate(sourceFile.Value, msg.Item2, rootPosition + msg.Item1)));
             if (!(context.ReturnType.Resolution.IsUnitType || context.ReturnType.Resolution.IsInvalidType) && !allPathsReturn)
@@ -1778,7 +1778,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
                 // a user defined implementation is ignored if it is invalid to specify such (e.g. for self-adjoint or intrinsic operations)
                 if (implementation == null && gen is QsSpecializationGeneratorKind<QsSymbol>.UserDefinedImplementation userDefined)
                 {
-                    var specPos = root.Fragment.GetRange().Start;
+                    var specPos = root.Fragment.Range.Start;
                     var (arg, messages) = buildArg(userDefined.Item);
                     foreach (var msg in messages)
                     {
@@ -1813,7 +1813,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
                 }
                 bool InvalidCharacteristicsOrSupportedFunctors(params QsFunctor[] functors) =>
                     parentCharacteristics.AreInvalid || !functors.Any(f => !supportedFunctors.Contains(f));
-                if (!definedSpecs.Values.Any(d => d.Item2.Position is DeclarationHeader.Offset.Defined pos && pos.Item == root.Fragment.GetRange().Start))
+                if (!definedSpecs.Values.Any(d => d.Item2.Position is DeclarationHeader.Offset.Defined pos && pos.Item == root.Fragment.Range.Start))
                 {
                     return null; // only process specializations that are valid
                 }

--- a/src/QsCompiler/CompilationManager/TypeChecking.cs
+++ b/src/QsCompiler/CompilationManager/TypeChecking.cs
@@ -665,7 +665,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
             }
 
             var statementPos = node.Fragment.Range.Start;
-            var location = new QsLocation(node.GetPositionRelativeToRoot(), node.Fragment.HeaderRange);
+            var location = new QsLocation(node.RelativePosition, node.Fragment.HeaderRange);
             var (statement, messages) = build(location, context);
             diagnostics.AddRange(messages.Select(msg => Diagnostics.Generate(context.Symbols.SourceFile.Value, msg, statementPos)));
             return statement;
@@ -1016,7 +1016,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
 
             if (nodes.Current.Fragment.Kind is QsFragmentKind.IfClause ifCond)
             {
-                var rootPosition = nodes.Current.GetRootPosition();
+                var rootPosition = nodes.Current.RootPosition;
 
                 // if block
                 var buildClause = BuildStatement(
@@ -1045,7 +1045,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
                 if (proceed && nodes.Current.Fragment.Kind.IsElseClause)
                 {
                     var scope = BuildScope(nodes.Current.Children, context, diagnostics);
-                    var elseLocation = new QsLocation(nodes.Current.GetPositionRelativeToRoot(), nodes.Current.Fragment.HeaderRange);
+                    var elseLocation = new QsLocation(nodes.Current.RelativePosition, nodes.Current.Fragment.HeaderRange);
                     elseBlock = QsNullable<QsPositionedBlock>.NewValue(
                         new QsPositionedBlock(scope, QsNullable<QsLocation>.NewValue(elseLocation), nodes.Current.Fragment.Comments));
                     proceed = nodes.MoveNext();
@@ -1105,7 +1105,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
             }
 
             QsNullable<QsLocation> RelativeLocation(FragmentTree.TreeNode node) =>
-                QsNullable<QsLocation>.NewValue(new QsLocation(node.GetPositionRelativeToRoot(), node.Fragment.HeaderRange));
+                QsNullable<QsLocation>.NewValue(new QsLocation(node.RelativePosition, node.Fragment.HeaderRange));
 
             if (nodes.Current.Fragment.Kind.IsWithinBlockIntro)
             {
@@ -1124,9 +1124,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
                     {
                         var (relativeOffset, diagnostic) = item;
                         return Diagnostics.Generate(
-                            context.Symbols.SourceFile.Value,
-                            diagnostic,
-                            nodes.Current.GetRootPosition() + relativeOffset);
+                            context.Symbols.SourceFile.Value, diagnostic, nodes.Current.RootPosition + relativeOffset);
                     }));
 
                     statement = built.Item1;

--- a/src/QsCompiler/CompilationManager/Utils.cs
+++ b/src/QsCompiler/CompilationManager/Utils.cs
@@ -9,6 +9,7 @@ using System.Threading;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
 using Lsp = Microsoft.VisualStudio.LanguageServer.Protocol;
 using Position = Microsoft.Quantum.QsCompiler.DataTypes.Position;
+using Range = Microsoft.Quantum.QsCompiler.DataTypes.Range;
 
 namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
 {
@@ -130,7 +131,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// </summary>
         internal static string GetTextChangedLines(FileContentManager file, TextDocumentContentChangeEvent change)
         {
-            if (!IsValidRange(change.Range, file))
+            if (!IsValidRange(change.Range.ToQSharp(), file))
             {
                 throw new ArgumentOutOfRangeException(nameof(change)); // range can be empty
             }
@@ -178,17 +179,60 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         // utils for dealing with positions and ranges
 
         /// <summary>
+        /// Converts the language server protocol position into a Q# compiler position.
+        /// </summary>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="position"/> is null.</exception>
+        /// <exception cref="ArgumentException">Thrown if <paramref name="position"/> is invalid.</exception>
+        public static Position ToQSharp(this Lsp.Position position) =>
+            position is null
+                ? throw new ArgumentNullException(nameof(position))
+                : Position.Create(position.Line, position.Character);
+
+        /// <summary>
+        /// Converts the Q# compiler position into a language server protocol position.
+        /// </summary>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="position"/> is null.</exception>
+        public static Lsp.Position ToLsp(this Position position) =>
+            position is null
+                ? throw new ArgumentNullException(nameof(position))
+                : new Lsp.Position(position.Line, position.Column);
+
+        /// <summary>
+        /// Converts the language server protocol range into a Q# compiler range.
+        /// </summary>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="range"/> is null.</exception>
+        /// <exception cref="ArgumentException">Thrown if <paramref name="range"/> is invalid.</exception>
+        internal static Range ToQSharp(this Lsp.Range range) =>
+            range is null
+                ? throw new ArgumentNullException(nameof(range))
+                : Range.Create(range.Start.ToQSharp(), range.End.ToQSharp());
+
+        /// <summary>
+        /// Converts the Q# compiler range into a language server protocol range.
+        /// </summary>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="range"/> is null.</exception>
+        internal static Lsp.Range ToLsp(this Range range) =>
+            range is null
+                ? throw new ArgumentNullException(nameof(range))
+                : new Lsp.Range { Start = range.Start.ToLsp(), End = range.End.ToLsp() };
+
+        /// <summary>
         /// Returns true if the given position is valid, i.e. if both the line and character are positive.
         /// Throws an ArgumentNullException is an argument is null.
         /// </summary>
-        public static bool IsValidPosition(Lsp.Position pos)
-        {
-            if (pos == null)
-            {
-                throw new ArgumentNullException(nameof(pos));
-            }
-            return pos.Line >= 0 && pos.Character >= 0;
-        }
+        internal static bool IsValidPosition(Lsp.Position pos) =>
+            pos is null
+                ? throw new ArgumentNullException(nameof(pos))
+                : pos.Line >= 0 && pos.Character >= 0;
+
+        /// <summary>
+        /// Returns true if the given range is valid, i.e. if both start and end are valid positions, and start is smaller than or equal to end.
+        /// Throws an ArgumentNullException if an argument is null.
+        /// </summary>
+        public static bool IsValidRange(Lsp.Range range) =>
+            IsValidPosition(range?.Start)
+            && IsValidPosition(range.End)
+            && range.Start.ToQSharp() <= range.End.ToQSharp();
 
         /// <summary>
         /// Returns true if the given position is valid, i.e. if the line is within the given file,
@@ -205,59 +249,19 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         }
 
         /// <summary>
-        /// Returns true if the given ranges overlap.
-        /// Throws an ArgumentNullException if any of the given ranges is null.
-        /// Throws an ArgumentException if any of the given ranges is not valid.
-        /// </summary>
-        internal static bool Overlaps(this Lsp.Range range1, Lsp.Range range2)
-        {
-            if (!IsValidRange(range1) || !IsValidRange(range2))
-            {
-                throw new ArgumentException("invalid range given for comparison");
-            }
-            var (first, second) = range1.Start.ToQSharp() < range2.Start.ToQSharp() ? (range1, range2) : (range2, range1);
-            return second.Start.ToQSharp() < first.End.ToQSharp();
-        }
-
-        /// <summary>
-        /// Verifies the given position and range, and returns true if the given position lays within the given range.
-        /// If includeEnd is true then the end point of the range is considered to be part of the range,
-        /// otherwise the range is considered to include the start but excludes the end point.
-        /// Throws an ArgumentNullException if the given position or range is null.
-        /// Throws an ArgumentException if the given range is not valid.
-        /// </summary>
-        internal static bool IsWithinRange(this Position pos, Lsp.Range range, bool includeEnd = false)
-        {
-            if (!IsValidRange(range))
-            {
-                throw new ArgumentException("invalid range given for comparison");
-            }
-            return range.Start.ToQSharp() <= pos
-                   && (includeEnd ? pos <= range.End.ToQSharp() : pos < range.End.ToQSharp());
-        }
-
-        /// <summary>
-        /// Returns true if the given range is valid, i.e. if both start and end are valid positions, and start is smaller than or equal to end.
-        /// Throws an ArgumentNullException if an argument is null.
-        /// </summary>
-        public static bool IsValidRange(Lsp.Range range) =>
-            IsValidPosition(range?.Start)
-            && IsValidPosition(range.End)
-            && range.Start.ToQSharp() <= range.End.ToQSharp();
-
-        /// <summary>
         /// Returns true if the given range is valid,
         /// i.e. if both start and end are valid positions within the given file, and start is smaller than or equal to end.
         /// Throws an ArgumentNullException if an argument is null.
         /// </summary>
-        internal static bool IsValidRange(Lsp.Range range, FileContentManager file) =>
-            IsValidPosition(range?.Start.ToQSharp(), file)
-            && IsValidPosition(range.End.ToQSharp(), file)
-            && range.Start.ToQSharp() <= range.End.ToQSharp();
+        internal static bool IsValidRange(Range range, FileContentManager file) =>
+            !(range is null)
+            && IsValidPosition(range.Start, file)
+            && IsValidPosition(range.End, file)
+            && range.Start <= range.End;
 
         // tools for debugging
 
-        public static string DiagnosticString(this Lsp.Range r) =>
-            $"({r?.Start?.Line},{r?.Start?.Character}) - ({r?.End?.Line},{r?.End?.Character})";
+        public static string DiagnosticString(this Range r) =>
+            $"({r?.Start?.Line},{r?.Start?.Column}) - ({r?.End?.Line},{r?.End?.Column})";
     }
 }

--- a/src/QsCompiler/CompilationManager/Utils.cs
+++ b/src/QsCompiler/CompilationManager/Utils.cs
@@ -131,7 +131,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// </summary>
         internal static string GetTextChangedLines(FileContentManager file, TextDocumentContentChangeEvent change)
         {
-            if (!IsValidRange(change.Range.ToQSharp(), file))
+            if (!file.ContainsRange(change.Range.ToQSharp()))
             {
                 throw new ArgumentOutOfRangeException(nameof(change)); // range can be empty
             }
@@ -235,29 +235,42 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
             && range.Start.ToQSharp() <= range.End.ToQSharp();
 
         /// <summary>
-        /// Returns true if the given position is valid, i.e. if the line is within the given file,
-        /// and the character is within the text on that line (including text.Length).
-        /// Throws an ArgumentNullException is an argument is null.
+        /// Returns true if the position is within the bounds of the file contents.
         /// </summary>
-        internal static bool IsValidPosition(Position pos, FileContentManager file)
+        /// <exception cref="ArgumentNullException">
+        /// Thrown if <paramref name="file"/> or <paramref name="position"/> is null.
+        /// </exception>
+        internal static bool ContainsPosition(this FileContentManager file, Position position)
         {
-            if (file == null)
+            if (file is null)
             {
                 throw new ArgumentNullException(nameof(file));
             }
-            return pos.Line < file.NrLines() && pos.Column <= file.GetLine(pos.Line).Text.Length;
+            if (position is null)
+            {
+                throw new ArgumentNullException(nameof(position));
+            }
+            return position.Line < file.NrLines() && position.Column <= file.GetLine(position.Line).Text.Length;
         }
 
         /// <summary>
-        /// Returns true if the given range is valid,
-        /// i.e. if both start and end are valid positions within the given file, and start is smaller than or equal to end.
-        /// Throws an ArgumentNullException if an argument is null.
+        /// Returns true if the range is within the bounds of the file contents.
         /// </summary>
-        internal static bool IsValidRange(Range range, FileContentManager file) =>
-            !(range is null)
-            && IsValidPosition(range.Start, file)
-            && IsValidPosition(range.End, file)
-            && range.Start <= range.End;
+        /// <exception cref="ArgumentNullException">
+        /// Thrown if <paramref name="file"/> or <paramref name="range"/> is null.
+        /// </exception>
+        internal static bool ContainsRange(this FileContentManager file, Range range)
+        {
+            if (file is null)
+            {
+                throw new ArgumentNullException(nameof(file));
+            }
+            if (range is null)
+            {
+                throw new ArgumentNullException(nameof(range));
+            }
+            return file.ContainsPosition(range.Start) && file.ContainsPosition(range.End) && range.Start <= range.End;
+        }
 
         // tools for debugging
 

--- a/src/QsCompiler/CompilationManager/Utils.cs
+++ b/src/QsCompiler/CompilationManager/Utils.cs
@@ -202,7 +202,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// </summary>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="range"/> is null.</exception>
         /// <exception cref="ArgumentException">Thrown if <paramref name="range"/> is invalid.</exception>
-        internal static Range ToQSharp(this Lsp.Range range) =>
+        public static Range ToQSharp(this Lsp.Range range) =>
             range is null
                 ? throw new ArgumentNullException(nameof(range))
                 : Range.Create(range.Start.ToQSharp(), range.End.ToQSharp());
@@ -211,28 +211,10 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// Converts the Q# compiler range into a language server protocol range.
         /// </summary>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="range"/> is null.</exception>
-        internal static Lsp.Range ToLsp(this Range range) =>
+        public static Lsp.Range ToLsp(this Range range) =>
             range is null
                 ? throw new ArgumentNullException(nameof(range))
                 : new Lsp.Range { Start = range.Start.ToLsp(), End = range.End.ToLsp() };
-
-        /// <summary>
-        /// Returns true if the given position is valid, i.e. if both the line and character are positive.
-        /// Throws an ArgumentNullException is an argument is null.
-        /// </summary>
-        internal static bool IsValidPosition(Lsp.Position pos) =>
-            pos is null
-                ? throw new ArgumentNullException(nameof(pos))
-                : pos.Line >= 0 && pos.Character >= 0;
-
-        /// <summary>
-        /// Returns true if the given range is valid, i.e. if both start and end are valid positions, and start is smaller than or equal to end.
-        /// Throws an ArgumentNullException if an argument is null.
-        /// </summary>
-        public static bool IsValidRange(Lsp.Range range) =>
-            IsValidPosition(range?.Start)
-            && IsValidPosition(range.End)
-            && range.Start.ToQSharp() <= range.End.ToQSharp();
 
         /// <summary>
         /// Returns true if the position is within the bounds of the file contents.

--- a/src/QsCompiler/Compiler/ExternalRewriteSteps.cs
+++ b/src/QsCompiler/Compiler/ExternalRewriteSteps.cs
@@ -14,7 +14,7 @@ using Microsoft.Quantum.QsCompiler.ReservedKeywords;
 using Microsoft.Quantum.QsCompiler.SyntaxTree;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
 using Lsp = Microsoft.VisualStudio.LanguageServer.Protocol;
-using Position = Microsoft.Quantum.QsCompiler.DataTypes.Position;
+using Range = Microsoft.Quantum.QsCompiler.DataTypes.Range;
 
 namespace Microsoft.Quantum.QsCompiler
 {
@@ -91,14 +91,6 @@ namespace Microsoft.Quantum.QsCompiler
                     diagnostic.Severity == CodeAnalysis.DiagnosticSeverity.Info ? DiagnosticSeverity.Information :
                     DiagnosticSeverity.Hint;
 
-                var startPosition = diagnostic.Start == null ? null : new Lsp.Position(diagnostic.Start.Line, diagnostic.Start.Column);
-                var endPosition = diagnostic.End == null ? startPosition : new Lsp.Position(diagnostic.End.Line, diagnostic.End.Column);
-                var range = startPosition == null || diagnostic.Source == null ? null : new Lsp.Range { Start = startPosition, End = endPosition };
-                if (range != null && !Utils.IsValidRange(range))
-                {
-                    range = null;
-                }
-
                 var stageAnnotation =
                     diagnostic.Stage == IRewriteStep.Stage.PreconditionVerification ? $"[{diagnostic.Stage}] " :
                     diagnostic.Stage == IRewriteStep.Stage.PostconditionVerification ? $"[{diagnostic.Stage}] " :
@@ -112,7 +104,7 @@ namespace Microsoft.Quantum.QsCompiler
                     Severity = severity,
                     Message = $"{stageAnnotation}{diagnostic.Message}",
                     Source = diagnostic.Source,
-                    Range = range
+                    Range = diagnostic.Source is null ? null : diagnostic.Range?.ToLsp()
                 };
             }
 
@@ -150,8 +142,7 @@ namespace Microsoft.Quantum.QsCompiler
                             Severity = (CodeAnalysis.DiagnosticSeverity)itemType.GetProperty(nameof(IRewriteStep.Diagnostic.Severity)).GetValue(obj, null),
                             Message = itemType.GetProperty(nameof(IRewriteStep.Diagnostic.Message)).GetValue(obj, null) as string,
                             Source = itemType.GetProperty(nameof(IRewriteStep.Diagnostic.Source)).GetValue(obj, null) as string,
-                            Start = itemType.GetProperty(nameof(IRewriteStep.Diagnostic.Start)).GetValue(obj, null) as Position,
-                            End = itemType.GetProperty(nameof(IRewriteStep.Diagnostic.End)).GetValue(obj, null) as Position
+                            Range = itemType.GetProperty(nameof(IRewriteStep.Diagnostic.Range)).GetValue(obj, null) as Range
                         });
                     }
                     return diagnostics.ToImmutable();

--- a/src/QsCompiler/Compiler/Logging.cs
+++ b/src/QsCompiler/Compiler/Logging.cs
@@ -177,7 +177,7 @@ namespace Microsoft.Quantum.QsCompiler.Diagnostics
                 ++this.NrWarningsLogged;
             }
 
-            var msg = m.Range == null ? m : m.WithUpdatedLineNumber(this.lineNrOffset);
+            var msg = m.Range == null ? m : m.TranslateLines(this.lineNrOffset);
             this.Output(msg);
         }
 

--- a/src/QsCompiler/Compiler/PluginInterface.cs
+++ b/src/QsCompiler/Compiler/PluginInterface.cs
@@ -82,16 +82,10 @@ namespace Microsoft.Quantum.QsCompiler
             public Stage Stage { get; set; }
 
             /// <summary>
-            /// Zero-based position in the source file where the code that caused the generation of the diagnostic starts.
-            /// The position is null if the diagnostic is not caused by a piece of source code.
+            /// Zero-based range in the source file of the code that caused the generation of the diagnostic.
+            /// The range is null if the diagnostic is not caused by a piece of source code.
             /// </summary>
-            public Position Start { get; set; }
-
-            /// <summary>
-            /// Zero-based position in the source file where the code that caused the generation of the diagnostic ends.
-            /// The position is null if the diagnostic is not caused by a piece of source code.
-            /// </summary>
-            public Position End { get; set; }
+            public Range Range { get; set; }
 
             /// <summary>
             /// Initializes a new diagnostic.
@@ -110,8 +104,7 @@ namespace Microsoft.Quantum.QsCompiler
                     Message = d.Message,
                     Source = d.Source,
                     Stage = stage,
-                    Start = d.Range?.Start?.ToQSharp(),
-                    End = d.Range?.End?.ToQSharp()
+                    Range = d.Range?.ToQSharp()
                 };
         }
 

--- a/src/QsCompiler/DataStructures/DataTypes.fs
+++ b/src/QsCompiler/DataStructures/DataTypes.fs
@@ -142,8 +142,16 @@ type Range = private Range of Position * Position with
     /// The end of the range.
     member this.End = match this with Range (_, end') -> end'
 
-    /// Returns true if the position occurs on or after the starting position, and before the ending position.
+    /// Returns true if the range contains the given position, excluding the end position.
     member this.Contains position = this.Start <= position && position < this.End
+
+    /// Returns true if the range contains the given position, including the end position.
+    member this.ContainsEnd position = this.Start <= position && position <= this.End
+
+    /// Translates the line numbers of the start and end positions by the given offset.
+    member this.TranslateLines offset =
+        Range (Position (this.Start.Line + offset, this.Start.Column),
+               Position (this.End.Line + offset, this.End.Column))
 
     /// Adds the range's start and end positions to the given position.
     static member (+) (position : Position, range : Range) =
@@ -170,6 +178,9 @@ type Range = private Range of Position * Position with
     /// either range.
     static member Span (a : Range) (b : Range) =
         Range (min a.Start b.Start, max a.End b.End)
+
+    /// Returns true if the ranges overlap.
+    static member Overlaps (a : Range) (b : Range) = min a.Start b.Start < max a.End b.End
 
 [<Struct>]
 type QsCompilerDiagnostic =

--- a/src/QsCompiler/Tests.LanguageServer/TestInput.cs
+++ b/src/QsCompiler/Tests.LanguageServer/TestInput.cs
@@ -103,7 +103,7 @@ namespace Microsoft.Quantum.QsLanguageServer.Testing
                 Start = new Position(startLine, startChar),
                 End = new Position(endLine, endChar)
             };
-            Assert.IsTrue(Builder.IsValidRange(range));
+            Assert.IsTrue(TestUtils.IsValidRange(range));
             return range;
         }
 

--- a/src/QsCompiler/Tests.LanguageServer/TestUtils.cs
+++ b/src/QsCompiler/Tests.LanguageServer/TestUtils.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Builder = Microsoft.Quantum.QsCompiler.CompilationBuilder.Utils;
+using Range = Microsoft.VisualStudio.LanguageServer.Protocol.Range;
 
 namespace Microsoft.Quantum.QsLanguageServer.Testing
 {
@@ -90,7 +91,7 @@ namespace Microsoft.Quantum.QsLanguageServer.Testing
         // does not modify range
         internal static int GetRangeLength(VisualStudio.LanguageServer.Protocol.Range range, IReadOnlyList<string> content)
         {
-            Assert.IsTrue(Builder.IsValidRange(range));
+            Assert.IsTrue(IsValidRange(range));
             if (range.Start.Line == range.End.Line)
             {
                 return range.End.Character - range.Start.Character;
@@ -115,7 +116,7 @@ namespace Microsoft.Quantum.QsLanguageServer.Testing
                 throw new ArgumentException("the given content has to have at least on line");
             }
 
-            Assert.IsTrue(Builder.IsValidRange(change?.Range) && change.Text != null);
+            Assert.IsTrue(IsValidRange(change?.Range) && change.Text != null);
             Assert.IsTrue(change.Range.End.Line < content.Count());
             Assert.IsTrue(change.Range.Start.Character <= content[change.Range.Start.Line].Length);
             Assert.IsTrue(change.Range.End.Character <= content[change.Range.End.Line].Length);
@@ -140,6 +141,20 @@ namespace Microsoft.Quantum.QsLanguageServer.Testing
 
             content.RemoveRange(startLine, endLine - startLine + 1);
             content.InsertRange(startLine, lineChanges);
+        }
+
+        internal static bool IsValidRange(Range range)
+        {
+            static bool IsValidPosition(Position position) => position.Line >= 0 && position.Character >= 0;
+
+            static bool IsBeforeOrEqual(Position a, Position b) =>
+                a.Line < b.Line || (a.Line == b.Line && a.Character <= b.Character);
+
+            return !(range?.Start is null) &&
+                   !(range.End is null) &&
+                   IsValidPosition(range.Start) &&
+                   IsValidPosition(range.End) &&
+                   IsBeforeOrEqual(range.Start, range.End);
         }
     }
 }


### PR DESCRIPTION
Replaces the LSP range type with the Q# compiler range type everywhere, except where an LSP message is being created that actually needs an LSP range.

Part of #506.