### PR TITLE
Format whole document instead of line-by-line

### DIFF
--- a/src/VSCodeExtension/src/formatter/format-document.ts
+++ b/src/VSCodeExtension/src/formatter/format-document.ts
@@ -16,18 +16,11 @@ const rules: FormatRule[] = [
 export const formatDocument = (
     document: vscode.TextDocument
 ): vscode.TextEdit[] => {
-    const lines: vscode.TextLine[] = Array.from(
-        Array(document.lineCount),
-        (_, lineNo) => document.lineAt(lineNo)
-    );
+    const firstLine = document.lineAt(0);
+    const lastLine = document.lineAt(document.lineCount - 1);
+    const range: vscode.Range = new vscode.Range(firstLine.range.start, lastLine.range.end);
 
-    const formattedLines: vscode.TextEdit[] = lines
-        .map((line) => {
-            const formattedLine: string = formatter(line.text, rules);
-            return formattedLine !== line.text
-                ? vscode.TextEdit.replace(line.range, formattedLine)
-                : null;
-        })
-        .filter((e): e is vscode.TextEdit => e != null);
-    return formattedLines;
+    const formattedDocument: string = formatter(document.getText(), rules);
+
+    return [vscode.TextEdit.replace(range, formattedDocument)];
 };

--- a/src/VSCodeExtension/src/formatter/rules/control-structure.ts
+++ b/src/VSCodeExtension/src/formatter/rules/control-structure.ts
@@ -9,7 +9,7 @@ import { FormatRule } from "../formatter";
  * `if (1 == 1){H(qs[0]);}`
  */
 export const spaceAfterIf: FormatRule = (code: string): string => {
-    return code.replace(/(^| +|;|})if[ \n]*\(/, "$1if (");
+    return code.replace(/(^| +|;|})if[ \n]*\(/gm, "$1if (");
 };
 
 export default [spaceAfterIf];

--- a/src/VSCodeExtension/src/formatter/rules/indent.ts
+++ b/src/VSCodeExtension/src/formatter/rules/indent.ts
@@ -12,9 +12,9 @@ import { FormatRule } from "../formatter";
  * `namespace Foo {}`
  */
 export const namespaceRule: FormatRule = (code: string) => {
-    const namespaceMatcher: RegExp = /^\s*namespace\s+(\w+(?:\.\w+)*)\s*({|{.*})\s*$/g;
+    const namespaceMatcher: RegExp = /^\s*namespace\s+(\w+(?:\.\w+)*)\s*({[\S\s]*}|{)\s*/g;
 
-    return code.replace(namespaceMatcher, (match, namespace, rest) => `namespace ${namespace} ${rest}`);
+    return code.replace(namespaceMatcher, (match, namespace, body) => `namespace ${namespace} ${body}`);
 };
 
 export default [namespaceRule];

--- a/src/VSCodeExtension/src/tests/unit/control-structure.test.ts
+++ b/src/VSCodeExtension/src/tests/unit/control-structure.test.ts
@@ -66,7 +66,7 @@ describe("space after if rule", () => {
     assert.equal(formatter(code, [spaceAfterIf]), expectedCode);
   });
 
-  it("formats space after if it is preceeding with a semicolon", () => {
+  it("formats space after if it is preceding with a semicolon", () => {
     const code = 'mutable bits = new Result[0];if(1==1){Message("1==1");}';
     const expectedCode =
       'mutable bits = new Result[0];if (1==1){Message("1==1");}';
@@ -74,7 +74,7 @@ describe("space after if rule", () => {
     assert.equal(formatter(code, [spaceAfterIf]), expectedCode);
   });
 
-  it("formats space after if it is preceeding with a semicolon with line break", () => {
+  it("formats space after if it is preceding with a semicolon with line break", () => {
     const code = `mutable bits = new Result[0];if 
                    (1==1){Message(\"1==1\");}`;
 
@@ -84,7 +84,7 @@ describe("space after if rule", () => {
     assert.equal(formatter(code, [spaceAfterIf]), expectedCode);
   });
 
-  it("formats space after if it is precceding with a }", () => {
+  it("formats space after if it is preceding with a }", () => {
     const code = `for (idxBit in 1..BitSizeI(max)) {
                       set bits += [SampleQuantumRandomNumberGenerator()];
                     }if(2==2){Message("2==2");}`;

--- a/src/VSCodeExtension/src/tests/unit/control-structure.test.ts
+++ b/src/VSCodeExtension/src/tests/unit/control-structure.test.ts
@@ -120,6 +120,15 @@ describe("space after if rule", () => {
     assert.equal(formatter(code, [spaceAfterIf]), expectedCode);
   });
 
+  it("catches multiple if statements", () => {
+    const code = `if                              (1 == 1){H(qs[0]);}
+if                              (1 == 1){H(qs[0]);}`;
+    const expectedCode = `if (1 == 1){H(qs[0]);}
+if (1 == 1){H(qs[0]);}`;
+
+    assert.equal(formatter(code, [spaceAfterIf]), expectedCode);
+  });
+
   // Activate this test once a strategy for managing comments is implemented
   xit("leaves comments unchanged", () => {
     const code = '// mutable bits = new Result[0];if(1==1){Message("1==1");}';

--- a/src/VSCodeExtension/src/tests/unit/declaration.test.ts
+++ b/src/VSCodeExtension/src/tests/unit/declaration.test.ts
@@ -59,4 +59,13 @@ describe("arguments rule", () => {
 
         assert.equal(formatter(code, [argsRule]), expectedCode);
     });
+
+    it("catches multiple declarations", () => {
+        const code = `  function   Foo   (q  :Qubit,   n :  Int)   :  Unit {}
+operation   Bar   (q  :Qubit,   n :  Int)   :  Unit {}`;
+        const expectedCode = `  function Foo (q : Qubit, n : Int) : Unit {}
+operation Bar (q : Qubit, n : Int) : Unit {}`;
+
+        assert.equal(formatter(code, [argsRule]), expectedCode);
+    });
 });

--- a/src/VSCodeExtension/src/tests/unit/indent.test.ts
+++ b/src/VSCodeExtension/src/tests/unit/indent.test.ts
@@ -67,4 +67,30 @@ describe("namespace rule", () => {
         code = "     namespace   Microsoft.Quantum.Arrays   { // ... }        ";
         assert.equal(formatter(code, [namespaceRule]), expectedCode);
     });
+
+    it("formats multiline", () => {
+        const expectedCode = `namespace Foo {
+    // ... 
+}`;
+
+        let code = `     namespace Foo {
+    // ... 
+}`;
+        assert.equal(formatter(code, [namespaceRule]), expectedCode);
+
+        code = `     namespace Foo {
+    // ... 
+}     `;
+        assert.equal(formatter(code, [namespaceRule]), expectedCode);
+        
+        code = `     namespace Foo     {
+    // ... 
+}`;
+        assert.equal(formatter(code, [namespaceRule]), expectedCode);
+        
+        code = `     namespace Foo     {
+    // ... 
+}    `;
+        assert.equal(formatter(code, [namespaceRule]), expectedCode);
+    });
 });


### PR DESCRIPTION
This PR implements formatting the whole document instead of line-by-line.
Added a test case for namespaces to show that this multi-line implementation is working.