### PR TITLE
Handle multiline declarations

### DIFF
--- a/src/VSCodeExtension/src/formatter/rules/declaration.ts
+++ b/src/VSCodeExtension/src/formatter/rules/declaration.ts
@@ -10,22 +10,14 @@
  * `operation Foo (q : Qubit, n : Int) : Bool`
  */
 export const argsRule = (code: string): string => {
-    const declarationMatcher: RegExp = /(operation|function)\s*(\w+)\s*(\(.*\))\s*:\s*(\w+)/g;
-    const firstArgMatcher: RegExp = /\(((\w*)\s*:\s*([a-zA-Z]+))/g
-    const restArgMatcher: RegExp = /,\s*((\w*)\s*:\s*([a-zA-Z]+))/g;
+    const declarationMatcher: RegExp = /(operation|function)\s*(\w+)\s*(\([^\)]*\))\s*:\s*(\w+)/g;
 
     return code.replace(declarationMatcher, (match, keyword, opName, args, retType) => {
         args = args
-            .replace(
-                firstArgMatcher,
-                (match: string, group: string, variable: string, type: string) =>
-                    `(${variable} : ${type}`
-            )
-            .replace(
-                restArgMatcher,
-                (match: string, group: string, variable: string, type: string) =>
-                    `, ${variable} : ${type}`
-            );
+            // strip whitespace and newlines
+            .replace(/\s+/g, '')
+            .replace(/,/g, ', ')
+            .replace(/:/g, ' : ');
         return `${keyword} ${opName} ${args} : ${retType}`;
     });
 };

--- a/src/VSCodeExtension/src/tests/unit/declaration.test.ts
+++ b/src/VSCodeExtension/src/tests/unit/declaration.test.ts
@@ -68,4 +68,29 @@ operation Bar (q : Qubit, n : Int) : Unit {}`;
 
         assert.equal(formatter(code, [argsRule]), expectedCode);
     });
+
+    it("formats multiline declarations", () => {
+        const code = `operation Foo   (
+    q  :Qubit,
+    n :  Int
+)   :  Bool`;
+        const expectedCode = `operation Foo (q : Qubit, n : Int) : Bool`;
+
+        assert.equal(formatter(code, [argsRule]), expectedCode);
+    });
+
+    it("catches multiple multiline declarations", () => {
+        const code = `operation Foo   (
+    q  :Qubit,
+    n :  Int
+)   :  Bool {}
+function Bar   (
+    q  :Qubit,
+    n :  Int
+)   :  Bool {}`;
+        const expectedCode = `operation Foo (q : Qubit, n : Int) : Bool {}
+function Bar (q : Qubit, n : Int) : Bool {}`;
+
+        assert.equal(formatter(code, [argsRule]), expectedCode);
+    });
 });


### PR DESCRIPTION
Add support for multiline declarations like:
```c#
operation Foo   (
    q  :Qubit,
    n :  Int
)   :  Bool {}
```