### PR TITLE
Set a fixed version on Yeoman generator dependency.

### DIFF
--- a/src/VSCodeExtension/package.json.v.template
+++ b/src/VSCodeExtension/package.json.v.template
@@ -124,17 +124,17 @@
         "typescript": "^2.6.1",
         "tslint": "^5.8.0",
         "mocha": "^5.2.0",
-        "@types/yeoman-generator": "^3.1.4",
-        "@types/yosay": "^0.0.29",
         "yeoman-test": "^1.7.0",
         "yeoman-assert": "^3.1.0",
-        "@types/yeoman-environment": "^2.3.3",
         "@types/node": "^9.6.5",
         "@types/mocha": "^5.2.0",
         "@types/which": "1.3.1",
         "@types/tmp": "0.0.33",
         "@types/semver": "^6.0.0",
-        "@types/request": "^2.48.3"
+        "@types/request": "^2.48.3",
+        "@types/yeoman-environment": "2.3.3",
+        "@types/yeoman-generator": "3.1.4",
+        "@types/yosay": "0.0.29"
     },
     "blobs": {
         "win32": {


### PR DESCRIPTION
This change is setting the NPM dependencies on yeoman-generator and yeoman-environment fixed to specific versions.

 - types/yeoman-environment to version 2.3.3
 - types/yeoman-generator to version 3.1.4

This is being done as a way to avoid a breaking change in yeoman-environment version 2.10.0 until we follow up with a way to adapt to it.
