### PR TITLE
Add offsets to diagnostic ranges in Core and SyntaxProcessor instead of CompilationManager

### DIFF
--- a/src/QsCompiler/CompilationManager/TypeChecking.cs
+++ b/src/QsCompiler/CompilationManager/TypeChecking.cs
@@ -425,8 +425,8 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
             var declDiagnostics = symbols.ResolveAll(BuiltIn.NamespacesToAutoOpen);
             var cycleDiagnostics = SyntaxProcessing.SyntaxTree.CheckDefinedTypesForCycles(symbols.DefinedTypes());
 
-            void AddDiagnostics(NonNullable<string> source, IEnumerable<Tuple<Position, QsCompilerDiagnostic>> msgs) =>
-                diagnostics.AddRange(msgs.Select(msg => Diagnostics.Generate(source.Value, msg.Item2, msg.Item1)));
+            void AddDiagnostics(NonNullable<string> source, IEnumerable<QsCompilerDiagnostic> msgs) =>
+                diagnostics.AddRange(msgs.Select(msg => Diagnostics.Generate(source.Value, msg)));
 
             if (fileName != null)
             {

--- a/src/QsCompiler/CompilationManager/TypeChecking.cs
+++ b/src/QsCompiler/CompilationManager/TypeChecking.cs
@@ -1053,12 +1053,8 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
                 var (ifStatement, ifDiagnostics) =
                     Statements.NewIfStatement(context, ifBlock.Item1, ifBlock.Item2, elifBlocks, elseBlock);
                 statement = ifStatement;
-                diagnostics.AddRange(ifDiagnostics.Select(item =>
-                {
-                    var (relativeOffset, diagnostic) = item;
-                    return Diagnostics.Generate(
-                        context.Symbols.SourceFile.Value, diagnostic, rootPosition + relativeOffset);
-                }));
+                diagnostics.AddRange(ifDiagnostics.Select(diagnostic =>
+                    Diagnostics.Generate(context.Symbols.SourceFile.Value, diagnostic, rootPosition)));
                 return true;
             }
             (statement, proceed) = (null, true);

--- a/src/QsCompiler/CompilationManager/TypeChecking.cs
+++ b/src/QsCompiler/CompilationManager/TypeChecking.cs
@@ -1604,8 +1604,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
             // verify that all paths return a value if needed (or fail)
             var (allPathsReturn, messages) = SyntaxProcessing.SyntaxTree.AllPathsReturnValueOrFail(implementation);
             var rootPosition = root.Fragment.Range.Start;
-            diagnostics.AddRange(messages.Select(msg =>
-                Diagnostics.Generate(sourceFile.Value, msg.Item2, rootPosition + msg.Item1)));
+            diagnostics.AddRange(messages.Select(msg => Diagnostics.Generate(sourceFile.Value, msg, rootPosition)));
             if (!(context.ReturnType.Resolution.IsUnitType || context.ReturnType.Resolution.IsInvalidType) && !allPathsReturn)
             {
                 var errRange = Parsing.HeaderDelimiters(root.Fragment.Kind.IsControlledAdjointDeclaration ? 2 : 1).Invoke(root.Fragment.Text);

--- a/src/QsCompiler/CompilationManager/TypeChecking.cs
+++ b/src/QsCompiler/CompilationManager/TypeChecking.cs
@@ -1053,8 +1053,8 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
                 var (ifStatement, ifDiagnostics) =
                     Statements.NewIfStatement(context, ifBlock.Item1, ifBlock.Item2, elifBlocks, elseBlock);
                 statement = ifStatement;
-                diagnostics.AddRange(ifDiagnostics.Select(diagnostic =>
-                    Diagnostics.Generate(context.Symbols.SourceFile.Value, diagnostic, rootPosition)));
+                diagnostics.AddRange(ifDiagnostics.Select(diagnostic => Diagnostics.Generate(
+                    context.Symbols.SourceFile.Value, diagnostic, rootPosition)));
                 return true;
             }
             (statement, proceed) = (null, true);
@@ -1115,12 +1115,8 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
                     var innerTransformation = BuildScope(nodes.Current.Children, context, diagnostics);
                     var inner = new QsPositionedBlock(innerTransformation, RelativeLocation(nodes.Current), nodes.Current.Fragment.Comments);
                     var built = Statements.NewConjugation(outer, inner);
-                    diagnostics.AddRange(built.Item2.Select(item =>
-                    {
-                        var (relativeOffset, diagnostic) = item;
-                        return Diagnostics.Generate(
-                            context.Symbols.SourceFile.Value, diagnostic, nodes.Current.RootPosition + relativeOffset);
-                    }));
+                    diagnostics.AddRange(built.Item2.Select(diagnostic => Diagnostics.Generate(
+                        context.Symbols.SourceFile.Value, diagnostic, nodes.Current.RootPosition)));
 
                     statement = built.Item1;
                     proceed = nodes.MoveNext();

--- a/src/QsCompiler/Core/SymbolTable.fs
+++ b/src/QsCompiler/Core/SymbolTable.fs
@@ -1295,7 +1295,10 @@ and NamespaceManager
             let typeDiagnostics = this.CacheTypeResolution()
             let callableDiagnostics = this.CacheCallableResolutions()
             this.ContainsResolutions <- true
-            callableDiagnostics.Concat(typeDiagnostics).ToLookup(fst, snd)
+            callableDiagnostics
+                .Concat(typeDiagnostics)
+                .ToLookup(fst, fun (_, (position, diagnostic)) ->
+                    { diagnostic with QsCompilerDiagnostic.Range = position + diagnostic.Range })
         finally syncRoot.ExitWriteLock()
 
     /// Returns a dictionary that maps each namespace name to a look-up

--- a/src/QsCompiler/SyntaxProcessor/StatementVerification.fs
+++ b/src/QsCompiler/SyntaxProcessor/StatementVerification.fs
@@ -366,7 +366,8 @@ let NewConjugation (outer : QsPositionedBlock, inner : QsPositionedBlock) =
         accumulate.SharedState.ReassignedVariables
     let updateErrs = 
         updatedInInner |> Seq.filter (fun updated -> usedInOuter.Contains updated.Key) |> Seq.collect id
-        |> Seq.map (fun loc -> (loc.Offset, loc.Range |> QsCompilerDiagnostic.Error (ErrorCode.InvalidReassignmentInApplyBlock, []))) |> Seq.toArray
+        |> Seq.map (fun loc -> loc.Offset + loc.Range |> QsCompilerDiagnostic.Error (ErrorCode.InvalidReassignmentInApplyBlock, []))
+        |> Seq.toArray
     QsConjugation.New (outer, inner) |> QsConjugation |> asStatement QsComments.Empty location LocalDeclarations.Empty, updateErrs
 
 /// Given the location of the statement header and the resolution context, 

--- a/src/QsCompiler/SyntaxProcessor/StatementVerification.fs
+++ b/src/QsCompiler/SyntaxProcessor/StatementVerification.fs
@@ -98,14 +98,14 @@ let private verifyResultConditionalBlocks context condBlocks elseBlock =
     let returnError (statement : QsStatement) =
         let error = ErrorCode.ReturnInResultConditionedBlock, [context.ProcessorArchitecture.Value]
         let location = statement.Location.ValueOr { Offset = Position.Zero; Range = Range.Zero }
-        location.Offset, QsCompilerDiagnostic.Error error location.Range
+        location.Offset + location.Range |> QsCompilerDiagnostic.Error error 
     let returnErrors (block : QsPositionedBlock) =
         block.Body.Statements |> Seq.collect returnStatements |> Seq.map returnError
 
     // Diagnostics for variable reassignments.
     let setError (name : NonNullable<string>, location : QsLocation) =
         let error = ErrorCode.SetInResultConditionedBlock, [name.Value; context.ProcessorArchitecture.Value]
-        location.Offset, QsCompilerDiagnostic.Error error location.Range
+        location.Offset + location.Range |> QsCompilerDiagnostic.Error error 
     let setErrors (block : QsPositionedBlock) = nonLocalUpdates context.Symbols block.Body |> Seq.map setError
 
     let blocks =

--- a/src/QsCompiler/SyntaxProcessor/TreeVerification.fs
+++ b/src/QsCompiler/SyntaxProcessor/TreeVerification.fs
@@ -191,5 +191,5 @@ let CheckDefinedTypesForCycles (definitions : ImmutableArray<TypeDeclarationHead
             let udt = definitions.[udtIndex]
             let loc = getLocation udt
             ((loc.Offset, udt.SourceFile), loc.Range |> QsCompilerDiagnostic.Error (ErrorCode.TypeIsPartOfCyclicDeclaration, [])) |> diagnostics.Add        
-    let positionAndDiagnostic ((pos, _), msg) = pos, msg 
-    diagnostics.ToLookup(fst >> snd, positionAndDiagnostic)
+    let updateDiagnosticRange ((pos, _), msg) = { msg with QsCompilerDiagnostic.Range = pos + msg.Range } 
+    diagnostics.ToLookup(fst >> snd, updateDiagnosticRange)

--- a/src/QsCompiler/SyntaxProcessor/TreeVerification.fs
+++ b/src/QsCompiler/SyntaxProcessor/TreeVerification.fs
@@ -191,5 +191,5 @@ let CheckDefinedTypesForCycles (definitions : ImmutableArray<TypeDeclarationHead
             let udt = definitions.[udtIndex]
             let loc = getLocation udt
             ((loc.Offset, udt.SourceFile), loc.Range |> QsCompilerDiagnostic.Error (ErrorCode.TypeIsPartOfCyclicDeclaration, [])) |> diagnostics.Add        
-    let updateDiagnosticRange ((pos, _), msg) = { msg with QsCompilerDiagnostic.Range = pos + msg.Range } 
-    diagnostics.ToLookup(fst >> snd, updateDiagnosticRange)
+    diagnostics.ToLookup (fst >> snd, fun ((position, _), diagnostic) ->
+        { diagnostic with QsCompilerDiagnostic.Range = position + diagnostic.Range })

--- a/src/QsCompiler/SyntaxProcessor/TreeVerification.fs
+++ b/src/QsCompiler/SyntaxProcessor/TreeVerification.fs
@@ -22,10 +22,10 @@ open Microsoft.Quantum.QsCompiler.SyntaxTree
 /// Such diagnostics include in particular warnings for all statement that will never be executed, and errors for misplaced returns statements
 /// Throws an ArgumentException if the statements contain no location information. 
 let AllPathsReturnValueOrFail body = 
-    let diagnostics = new List<Position * QsCompilerDiagnostic>()
+    let diagnostics = ResizeArray<_> ()
     let addDiagnostic diag (stm : QsStatement) = stm.Location |> function
         | Null -> ArgumentException "no location set for the given statement" |> raise
-        | Value loc -> (loc.Offset, loc.Range |> diag) |> diagnostics.Add
+        | Value loc -> loc.Offset + loc.Range |> diag |> diagnostics.Add
 
     // generate an error for every return within a using or borrowing block that is not executed as the last statement of a particular path
     let returnsWithinQubitScope = new List<QsStatement>() 


### PR DESCRIPTION
This is the original problem that drove me to refactor the position and ranges types: I wanted to add the offset to the range directly in SyntaxProcessor, instead of returning a tuple to the CompilationManager. Now it's possible.

This simplifies the return types of several functions from `Position * QsCompilerDiagnostic[]` to `QsCompilerDiagnostic[]`, and eliminates the risk that CompilationManager will forget to add the offsets to the range (which happened before: #491).

Part of #531.