### PR TITLE
Using NuGet.ProjectModel from the install path to avoid version conflicts

### DIFF
--- a/src/QsCompiler/LanguageServer/LanguageServer.csproj
+++ b/src/QsCompiler/LanguageServer/LanguageServer.csproj
@@ -25,7 +25,6 @@
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="16.3.0" ExcludeAssets="runtime" />
     <PackageReference Include="Microsoft.VisualStudio.LanguageServer.Protocol" Version="16.3.57" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
-    <PackageReference Include="NuGet.ProjectModel" Version="5.6.0" />
     <PackageReference Include="StreamJsonRpc" Version="2.2.34" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.164" PrivateAssets="All" />
     <PackageReference Include="System.Reactive" Version="4.2.0" />

--- a/src/QsCompiler/LanguageServer/Program.cs
+++ b/src/QsCompiler/LanguageServer/Program.cs
@@ -111,7 +111,6 @@ namespace Microsoft.Quantum.QsLanguageServer
                     {
                         return assemblyLoadContext.LoadFromAssemblyPath(path);
                     }
-
                     return null;
                 };
             }

--- a/src/QsCompiler/LanguageServer/Program.cs
+++ b/src/QsCompiler/LanguageServer/Program.cs
@@ -104,6 +104,10 @@ namespace Microsoft.Quantum.QsLanguageServer
             try
             {
                 VisualStudioInstance vsi = MSBuildLocator.RegisterDefaults();
+
+                // We're using the installed version of the binaries to avoid a dependency between
+                // the .NET Core SDK version and NuGet. This is a workaround due to the issue below:
+                // https://github.com/microsoft/MSBuildLocator/issues/86
                 AssemblyLoadContext.Default.Resolving += (assemblyLoadContext, assemblyName) =>
                 {
                     string path = Path.Combine(vsi.MSBuildPath, assemblyName.Name + ".dll");

--- a/src/QsCompiler/Tests.LanguageServer/ProjectLoaderTests.cs
+++ b/src/QsCompiler/Tests.LanguageServer/ProjectLoaderTests.cs
@@ -18,6 +18,8 @@ namespace Microsoft.Quantum.QsLanguageServer.Testing
         static ProjectLoaderTests()
         {
             VisualStudioInstance vsi = MSBuildLocator.RegisterDefaults();
+
+            // This is replicating the approach followed in Microsoft.Quantum.QsLanguageServer.Server.Run()
             AssemblyLoadContext.Default.Resolving += (assemblyLoadContext, assemblyName) =>
             {
                 string path = Path.Combine(vsi.MSBuildPath, assemblyName.Name + ".dll");


### PR DESCRIPTION
This change removes the dependency on NuGet.ProjectModel from the LanguageServer project and instead relies on the installed version of the binary. This change intends to avoid the dependency between the .Net Core SDK version and NuGet in MSBuildLocator. See issue [#86](https://github.com/microsoft/MSBuildLocator/issues/86) for additional reference.