### PR TITLE
Fixing invalid return in pack script

### DIFF
--- a/build/pack.ps1
+++ b/build/pack.ps1
@@ -228,7 +228,6 @@ if ($Env:ENABLE_VSIX -ne "false") {
     Pack-VS
 } else {
     Write-Host "##vso[task.logissue type=warning;]VSIX packing skipped due to ENABLE_VSIX variable."
-    return
 }
 
 if (-not $all_ok) {


### PR DESCRIPTION
The `pack.ps1` script fails to report errors if the ENABLE_VSIX flag is set to false. This is due to a an extra `return` in the `else` clause.