### PR TITLE
Fix to build of faulty Q# program succeeds when calling `dotnet build` twice

### DIFF
--- a/src/QuantumSdk/Sdk/Sdk.targets
+++ b/src/QuantumSdk/Sdk/Sdk.targets
@@ -114,7 +114,10 @@
     <PropertyGroup>
       <QscCommand>$(QscExe) build --format MsBuild $(_VerbosityFlag) --response-files @(QscCommandArgsFile)</QscCommand>
     </PropertyGroup>
-    <Exec Command="$(QscCommand)" IgnoreExitCode="false" /> 
+    <Exec Command="$(QscCommand)" IgnoreExitCode="false" > 
+      <Output TaskParameter="ExitCode" PropertyName="QscExitCode"/>
+    </Exec>
+    <Message Importance="high" Text="Qsc command exit code: $(QscExitCode)"/>
   </Target>
 
   <!-- Configures the dll built by the C# compiler. This target needs to execute during the C# design time build to get accurate intellisense information for (non-generate) C# source files. -->

--- a/src/QuantumSdk/Sdk/Sdk.targets
+++ b/src/QuantumSdk/Sdk/Sdk.targets
@@ -119,7 +119,7 @@
     </Exec>
     <Message Importance="low" Text="Qsc command exit code: $(QscExitCode)"/>
     <Delete Condition="'$(QscExitCode)' != '0'" Files="$(GeneratedFilesOutputPath)$(PathCompatibleAssemblyName).bson" />
-    <Error Text="Qsc command failed with exit code: $(QscExitCode)." Condition="'$(QscExitCode)' != '0'" />
+    <Error Text="Q# compiler failed with exit code: $(QscExitCode)." Condition="'$(QscExitCode)' != '0'" />
   </Target>
 
   <!-- Configures the dll built by the C# compiler. This target needs to execute during the C# design time build to get accurate intellisense information for (non-generate) C# source files. -->
@@ -144,4 +144,3 @@
   </Target>  
 
 </Project>
-

--- a/src/QuantumSdk/Sdk/Sdk.targets
+++ b/src/QuantumSdk/Sdk/Sdk.targets
@@ -117,8 +117,9 @@
     <Exec Command="$(QscCommand)" IgnoreExitCode="false" ContinueOnError="ErrorAndContinue"> 
       <Output TaskParameter="ExitCode" PropertyName="QscExitCode"/>
     </Exec>
-    <Message Importance="high" Text="Qsc command exit code: $(QscExitCode)"/>
+    <Message Importance="low" Text="Qsc command exit code: $(QscExitCode)"/>
     <Delete Condition="'$(QscExitCode)' != '0'" Files="$(GeneratedFilesOutputPath)$(PathCompatibleAssemblyName).bson" />
+    <Error Text="Qsc command failed with exit code: $(QscExitCode)." Condition="'$(QscExitCode)' != '0'" />
   </Target>
 
   <!-- Configures the dll built by the C# compiler. This target needs to execute during the C# design time build to get accurate intellisense information for (non-generate) C# source files. -->

--- a/src/QuantumSdk/Sdk/Sdk.targets
+++ b/src/QuantumSdk/Sdk/Sdk.targets
@@ -114,10 +114,11 @@
     <PropertyGroup>
       <QscCommand>$(QscExe) build --format MsBuild $(_VerbosityFlag) --response-files @(QscCommandArgsFile)</QscCommand>
     </PropertyGroup>
-    <Exec Command="$(QscCommand)" IgnoreExitCode="false" > 
+    <Exec Command="$(QscCommand)" IgnoreExitCode="false" ContinueOnError="ErrorAndContinue"> 
       <Output TaskParameter="ExitCode" PropertyName="QscExitCode"/>
     </Exec>
     <Message Importance="high" Text="Qsc command exit code: $(QscExitCode)"/>
+    <Delete Condition="'$(QscExitCode)' != '0'" Files="$(GeneratedFilesOutputPath)$(PathCompatibleAssemblyName).bson" />
   </Target>
 
   <!-- Configures the dll built by the C# compiler. This target needs to execute during the C# design time build to get accurate intellisense information for (non-generate) C# source files. -->


### PR DESCRIPTION
This change fixes an issue in which building a faulty Q# program succeeds when calling `dotnet build` twice.

This happens because a `bson` file is generated when the program is built the first time, even though compilation failed. When `dotnet build` is invoked for the second time, the `bson` file already exists and it is newer than the original `qs` file, so the incremental build skips invoking the compiler command line tool.

The fix is to delete the `bson` file when Q# compilation fails.