### PR TITLE
Nested Self Resolutions are Disallowed

### DIFF
--- a/src/QsCompiler/Tests.Compiler/TypeParameterTests.fs
+++ b/src/QsCompiler/Tests.Compiler/TypeParameterTests.fs
@@ -263,7 +263,7 @@ type TypeParameterTests () =
         AssertCombinedResolution expected given
 
     [<Fact>]
-    [<Trait("Category","Type resolution")>]
+    [<Trait("Category","Type Resolution")>]
     member this.``Multi-Stage Resolution of Multiple Resolutions to Type Parameter`` () =
 
         let given = [|
@@ -446,7 +446,7 @@ type TypeParameterTests () =
         AssertCombinedResolutionFailure expected given
 
     [<Fact>]
-    [<Trait("Category","Type resolution")>]
+    [<Trait("Category","Type Resolution")>]
     member this.``Inner Cycle Constrains Type Parameter`` () =
 
         let given = [|
@@ -469,7 +469,7 @@ type TypeParameterTests () =
         AssertCombinedResolutionFailure expected given
 
     [<Fact>]
-    [<Trait("Category","Type resolution")>]
+    [<Trait("Category","Type Resolution")>]
     member this.``Nested Type Paramter Resolution`` () =
         let given = [|
             ResolutionFromParam [
@@ -487,7 +487,7 @@ type TypeParameterTests () =
         AssertCombinedResolution expected given
 
     [<Fact>]
-    [<Trait("Category","Type resolution")>]
+    [<Trait("Category","Type Resolution")>]
     member this.``Nested Constricted Resolution`` () =
         let given = [|
             ResolutionFromParam [
@@ -501,25 +501,39 @@ type TypeParameterTests () =
         AssertCombinedResolutionFailure expected given
 
     [<Fact>]
-    [<Trait("Category","Type resolution")>]
-    member this.``Nested Self Resolution`` () =
+    [<Trait("Category","Type Resolution")>]
+    member this.``Constricting Nested Self Resolution`` () =
         let given = [|
             ResolutionFromParam [
-                (FooA, [FooA |> TypeParameter; BarA |> TypeParameter] |> MakeTupleType)
-            ]
-            ResolutionFromParam [
-                (BarA, Int)
+                (FooA, [FooA |> TypeParameter; Int] |> MakeTupleType)
             ]
         |]
         let expected = ResolutionFromParam [
             (FooA, [FooA |> TypeParameter; Int] |> MakeTupleType)
-            (BarA, Int)
         ]
 
-        AssertCombinedResolution expected given
+        AssertCombinedResolutionFailure expected given
 
     [<Fact>]
-    [<Trait("Category","Type resolution")>]
+    [<Trait("Category","Type Resolution")>]
+    member this.``Constricting Indirect Nested Self Resolution`` () =
+        let given = [|
+            ResolutionFromParam [
+                (FooA, BarA |> TypeParameter)
+            ]
+            ResolutionFromParam [
+                (BarA, [Int; FooA |> TypeParameter] |> MakeTupleType)
+            ]
+        |]
+        let expected = ResolutionFromParam [
+            (BarA, [Int; FooA |> TypeParameter] |> MakeTupleType)
+            (FooA, [Int; FooA |> TypeParameter] |> MakeTupleType)
+        ]
+
+        AssertCombinedResolutionFailure expected given
+
+    [<Fact>]
+    [<Trait("Category","Type Resolution")>]
     member this.``Single Dictonary Resolution`` () =
         let given = [|
             ResolutionFromParam [


### PR DESCRIPTION
This Pr updates the TypeParameterCombinations tool so that nested self-resolutions for type parameters are considered constrictive and invalidate the combination.

Addresses #583.