### PR TITLE
Add callable-local runtime capability inference

### DIFF
--- a/src/QsCompiler/Compiler/CompilationLoader.cs
+++ b/src/QsCompiler/Compiler/CompilationLoader.cs
@@ -260,6 +260,7 @@ namespace Microsoft.Quantum.QsCompiler
             internal Status Serialization = Status.NotRun;
             internal Status BinaryFormat = Status.NotRun;
             internal Status DllGeneration = Status.NotRun;
+            internal Status CapabilityInference = Status.NotRun;
             internal Status[] LoadedRewriteSteps;
 
             internal ExecutionStatus(IEnumerable<IRewriteStep> externalRewriteSteps) =>
@@ -283,6 +284,7 @@ namespace Microsoft.Quantum.QsCompiler
                 this.WasSuccessful(options.SerializeSyntaxTree, this.Serialization) &&
                 this.WasSuccessful(options.BuildOutputFolder != null, this.BinaryFormat) &&
                 this.WasSuccessful(options.DllOutputPath != null, this.DllGeneration) &&
+                this.WasSuccessful(!options.IsExecutable, this.CapabilityInference) &&
                 this.LoadedRewriteSteps.All(status => this.WasSuccessful(true, status));
         }
 
@@ -566,6 +568,12 @@ namespace Microsoft.Quantum.QsCompiler
             {
                 var rewriteStep = new RewriteSteps.LoadedStep(new FullPreEvaluation(), typeof(IRewriteStep), thisDllUri);
                 steps.Add((rewriteStep.Priority, () => this.ExecuteAsAtomicTransformation(rewriteStep, ref this.compilationStatus.PreEvaluation)));
+            }
+
+            if (!this.config.IsExecutable)
+            {
+                var capabilityInference = new RewriteSteps.LoadedStep(new CapabilityInference(), typeof(IRewriteStep), thisDllUri);
+                steps.Add((capabilityInference.Priority, () => this.ExecuteAsAtomicTransformation(capabilityInference, ref this.compilationStatus.CapabilityInference)));
             }
 
             for (int j = 0; j < this.externalRewriteSteps.Length; j++)

--- a/src/QsCompiler/Compiler/Compiler.csproj
+++ b/src/QsCompiler/Compiler/Compiler.csproj
@@ -5,6 +5,7 @@
     <TargetFramework>netstandard2.1</TargetFramework>
     <PackageId>Microsoft.Quantum.Compiler</PackageId>
     <AssemblyName>Microsoft.Quantum.QsCompiler</AssemblyName>
+    <RootNamespace>Microsoft.Quantum.QsCompiler</RootNamespace>
     <AssemblyTitle>Microsoft Q# compiler library.</AssemblyTitle>
   </PropertyGroup>
 

--- a/src/QsCompiler/Compiler/PluginInterface.cs
+++ b/src/QsCompiler/Compiler/PluginInterface.cs
@@ -44,6 +44,12 @@ namespace Microsoft.Quantum.QsCompiler
         /// evaluates classical computations as much as possible.
         /// </summary>
         public const int EvaluationOfClassicalComputations = 100;
+
+        /// <summary>
+        /// Priority of the built-in transformation that infers the minimum runtime capabilities required by each
+        /// callable.
+        /// </summary>
+        public const int CapabilityInference = 90;
     }
 
     public interface IRewriteStep

--- a/src/QsCompiler/Compiler/PluginInterface.cs
+++ b/src/QsCompiler/Compiler/PluginInterface.cs
@@ -11,7 +11,8 @@ using VS = Microsoft.VisualStudio.LanguageServer.Protocol;
 namespace Microsoft.Quantum.QsCompiler
 {
     /// <summary>
-    /// Lists the priorities for built-in rewrite steps.
+    /// Lists the priorities for built-in rewrite steps. Steps with a larger priority number have higher priority and
+    /// will be executed first.
     /// </summary>
     public static class RewriteStepPriorities
     {
@@ -121,7 +122,7 @@ namespace Microsoft.Quantum.QsCompiler
 
         /// <summary>
         /// The priority of the transformation relative to other transformations within the same dll or package.
-        /// Steps with higher priority will be executed first.
+        /// Steps with a larger priority number have higher priority and will be executed first.
         /// </summary>
         public int Priority { get; }
 

--- a/src/QsCompiler/Compiler/RewriteSteps/CapabilityInference.cs
+++ b/src/QsCompiler/Compiler/RewriteSteps/CapabilityInference.cs
@@ -38,10 +38,11 @@ namespace Microsoft.Quantum.QsCompiler.BuiltInRewriteSteps
                 if (element is QsNamespaceElement.QsCallable callable)
                 {
                     Console.WriteLine(callable.Item.FullName);
-                    foreach (var inference in callable.Item.Specializations.SelectMany(SpecializationInferences))
+                    foreach (var pattern in callable.Item.Specializations.SelectMany(SpecializationPatterns))
                     {
-                        Console.WriteLine(inference);
+                        Console.WriteLine(pattern);
                     }
+                    Console.WriteLine();
                 }
             }
             transformed = compilation;

--- a/src/QsCompiler/Compiler/RewriteSteps/CapabilityInference.cs
+++ b/src/QsCompiler/Compiler/RewriteSteps/CapabilityInference.cs
@@ -32,7 +32,10 @@ namespace Microsoft.Quantum.QsCompiler.BuiltInRewriteSteps
 
         public bool Transformation(QsCompilation compilation, out QsCompilation transformed)
         {
-            // TODO
+            foreach (var inference in SyntaxProcessing.CapabilityInference.Inferences(compilation))
+            {
+                Console.WriteLine(inference);
+            }
             transformed = compilation;
             return true;
         }

--- a/src/QsCompiler/Compiler/RewriteSteps/CapabilityInference.cs
+++ b/src/QsCompiler/Compiler/RewriteSteps/CapabilityInference.cs
@@ -33,16 +33,7 @@ namespace Microsoft.Quantum.QsCompiler.BuiltInRewriteSteps
 
         public bool Transformation(QsCompilation compilation, out QsCompilation transformed)
         {
-            foreach (var element in compilation.Namespaces.SelectMany(ns => ns.Elements))
-            {
-                if (element is QsNamespaceElement.QsCallable callable)
-                {
-                    Console.WriteLine(callable.Item.FullName);
-                    Console.WriteLine(CallableCapability(callable.Item));
-                    Console.WriteLine();
-                }
-            }
-            transformed = compilation;
+            transformed = InferCapabilities(compilation);
             return true;
         }
 

--- a/src/QsCompiler/Compiler/RewriteSteps/CapabilityInference.cs
+++ b/src/QsCompiler/Compiler/RewriteSteps/CapabilityInference.cs
@@ -38,10 +38,7 @@ namespace Microsoft.Quantum.QsCompiler.BuiltInRewriteSteps
                 if (element is QsNamespaceElement.QsCallable callable)
                 {
                     Console.WriteLine(callable.Item.FullName);
-                    foreach (var pattern in callable.Item.Specializations.SelectMany(SpecializationPatterns))
-                    {
-                        Console.WriteLine(pattern);
-                    }
+                    Console.WriteLine(CallableCapability(callable.Item));
                     Console.WriteLine();
                 }
             }

--- a/src/QsCompiler/Compiler/RewriteSteps/CapabilityInference.cs
+++ b/src/QsCompiler/Compiler/RewriteSteps/CapabilityInference.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Quantum.QsCompiler.SyntaxTree;
+using static Microsoft.Quantum.QsCompiler.SyntaxProcessing.CapabilityInference;
 
 namespace Microsoft.Quantum.QsCompiler.BuiltInRewriteSteps
 {
@@ -32,9 +33,16 @@ namespace Microsoft.Quantum.QsCompiler.BuiltInRewriteSteps
 
         public bool Transformation(QsCompilation compilation, out QsCompilation transformed)
         {
-            foreach (var inference in SyntaxProcessing.CapabilityInference.Inferences(compilation))
+            foreach (var element in compilation.Namespaces.SelectMany(ns => ns.Elements))
             {
-                Console.WriteLine(inference);
+                if (element is QsNamespaceElement.QsCallable callable)
+                {
+                    Console.WriteLine(callable.Item.FullName);
+                    foreach (var inference in callable.Item.Specializations.SelectMany(SpecializationInferences))
+                    {
+                        Console.WriteLine(inference);
+                    }
+                }
             }
             transformed = compilation;
             return true;

--- a/src/QsCompiler/Compiler/RewriteSteps/CapabilityInference.cs
+++ b/src/QsCompiler/Compiler/RewriteSteps/CapabilityInference.cs
@@ -1,0 +1,42 @@
+﻿#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Quantum.QsCompiler.SyntaxTree;
+
+namespace Microsoft.Quantum.QsCompiler.BuiltInRewriteSteps
+{
+    /// <summary>
+    /// Infers the minimum runtime capabilities required by each callable.
+    /// </summary>
+    internal class CapabilityInference : IRewriteStep
+    {
+        public string Name { get; } = "Capability Inference";
+
+        public int Priority { get; } = RewriteStepPriorities.CapabilityInference;
+
+        public IDictionary<string, string> AssemblyConstants { get; } =
+            new Dictionary<string, string>();
+
+        public IEnumerable<IRewriteStep.Diagnostic> GeneratedDiagnostics { get; } =
+            Enumerable.Empty<IRewriteStep.Diagnostic>();
+
+        public bool ImplementsPreconditionVerification { get; } = false;
+
+        public bool ImplementsTransformation { get; } = true;
+
+        public bool ImplementsPostconditionVerification { get; } = false;
+
+        public bool PreconditionVerification(QsCompilation compilation) => throw new NotSupportedException();
+
+        public bool Transformation(QsCompilation compilation, out QsCompilation transformed)
+        {
+            // TODO
+            transformed = compilation;
+            return true;
+        }
+
+        public bool PostconditionVerification(QsCompilation compilation) => throw new NotSupportedException();
+    }
+}

--- a/src/QsCompiler/Core/Dependencies.fs
+++ b/src/QsCompiler/Core/Dependencies.fs
@@ -94,6 +94,11 @@ type BuiltIn = {
         Kind = Attribute
     }
 
+    static member Capability = {
+        FullName = {Name = "Capability" |> NonNullable<string>.New; Namespace = BuiltIn.CoreNamespace}
+        Kind = Attribute
+    }
+
     // dependencies in Microsoft.Quantum.Diagnostics
 
     static member Test = {

--- a/src/QsCompiler/Core/Dependencies.fs
+++ b/src/QsCompiler/Core/Dependencies.fs
@@ -3,9 +3,13 @@
 
 namespace Microsoft.Quantum.QsCompiler
 
+open System
 open System.Collections.Immutable
+
 open Microsoft.Quantum.QsCompiler.DataTypes
 open Microsoft.Quantum.QsCompiler.ReservedKeywords
+open Microsoft.Quantum.QsCompiler.ReservedKeywords.AssemblyConstants
+open Microsoft.Quantum.QsCompiler.SyntaxTokens
 open Microsoft.Quantum.QsCompiler.SyntaxTree
 
 
@@ -65,6 +69,18 @@ type BuiltIn = {
     static member internal DefinesLoadedViaTestNameInsteadOf (att : QsDeclarationAttribute) = att.TypeId |> function
         | Value tId -> tId.Namespace.Value = GeneratedAttributes.Namespace && tId.Name.Value = GeneratedAttributes.LoadedViaTestNameInsteadOf
         | Null -> false
+
+    /// Returns the runtime capabilities if the attribute is a valid capability attribute, or Null otherwise.
+    static member GetCapability attribute =
+        let isCapability udt =
+            { Namespace = udt.Namespace; Name = udt.Name } = BuiltIn.Capability.FullName
+
+        match attribute.TypeId, attribute.Argument.Expression with
+        | Value udt, StringLiteral (string, _) when isCapability udt ->
+            match Enum.TryParse<RuntimeCapabilities> string.Value with
+            | true, capability -> Value capability
+            | false, _ -> Null
+        | _ -> Null
 
 
     // dependencies in Microsoft.Quantum.Core

--- a/src/QsCompiler/DataStructures/ReservedKeywords.fs
+++ b/src/QsCompiler/DataStructures/ReservedKeywords.fs
@@ -258,9 +258,9 @@ module AssemblyConstants =
         /// Measurement results cannot be compared for equality.
         | QPRGen0 = 1
 
-        /// Measurement results can be compared for equality only in if-statement conditional expressions. The block of
-        /// an if-statement that depends on a result cannot contain set statements for mutable variables declared
-        /// outside the block, or return statements.
+        /// Measurement results can be compared for equality only in if-statement conditional expressions in operations.
+        /// The block of an if-statement that depends on a result cannot contain set statements for mutable variables
+        /// declared outside the block, or return statements.
         | QPRGen1 = 2
 
 

--- a/src/QsCompiler/DataStructures/ReservedKeywords.fs
+++ b/src/QsCompiler/DataStructures/ReservedKeywords.fs
@@ -248,11 +248,20 @@ module AssemblyConstants =
     let ResourcesEstimator = "ResourcesEstimator"
     let ExposeReferencesViaTestNames = "ExposeReferencesViaTestNames"
 
-    // Note: The names of the capabilities here need to match the ones defined by the Sdk.
+    /// The runtime capabilities supported by an execution target.
     type RuntimeCapabilities = 
-    | Unknown = 0 
-    | QPRGen0 = 1
-    | QPRGen1 = 2
+        // Note: The names of the capabilities here need to match the ones defined by the Sdk.
+
+        /// No known runtime restrictions. Any Q# program can be executed.
+        | Unknown = 0
+
+        /// Measurement results cannot be compared for equality.
+        | QPRGen0 = 1
+
+        /// Measurement results can be compared for equality only in if-statement conditional expressions. The block of
+        /// an if-statement that depends on a result cannot contain set statements for mutable variables declared
+        /// outside the block, or return statements.
+        | QPRGen1 = 2
 
 
 /// contains reserved names for command line arguments of Q# projects

--- a/src/QsCompiler/SyntaxProcessor/CapabilityInference.fs
+++ b/src/QsCompiler/SyntaxProcessor/CapabilityInference.fs
@@ -8,6 +8,7 @@ open Microsoft.Quantum.QsCompiler.ReservedKeywords.AssemblyConstants
 open Microsoft.Quantum.QsCompiler.SyntaxTokens
 open Microsoft.Quantum.QsCompiler.SyntaxTree
 open Microsoft.Quantum.QsCompiler.Transformations
+open Microsoft.Quantum.QsCompiler.Transformations
 open Microsoft.Quantum.QsCompiler.Transformations.Core
 open Microsoft.Quantum.QsCompiler.Transformations.SearchAndReplace
 
@@ -228,8 +229,7 @@ let InferCapabilities compilation =
         new NamespaceTransformation (transformation) with
             override this.OnCallableDeclaration callable =
                 let capability = callableCapability callable
-                let arg =
-                    SyntaxGenerator.StringLiteral (capability.ToString () |> NonNullable<_>.New, ImmutableArray.Empty)
+                let arg = capability.ToString () |> AttributeUtils.StringArgument
                 let attribute = AttributeUtils.BuildAttribute (BuiltIn.Capability.FullName, arg)
                 { callable with Attributes = callable.Attributes.Add attribute }
     }

--- a/src/QsCompiler/SyntaxProcessor/CapabilityInference.fs
+++ b/src/QsCompiler/SyntaxProcessor/CapabilityInference.fs
@@ -116,23 +116,23 @@ let private conditionalStatementPatterns { ConditionalBlocks = condBlocks; Defau
         match s.Statement with
         | QsReturnStatement _ -> [ s ]
         | _ -> []
-    let returnInferences (block : QsPositionedBlock) =
+    let returnPatterns (block : QsPositionedBlock) =
         block.Body.Statements
         |> Seq.collect returnStatements
         |> Seq.map (fun statement ->
                let range = statement.Location |> QsNullable<_>.Map (fun location -> location.Offset + location.Range)
                ReturnInResultConditionedBlock range)
-    let setInferences (block : QsPositionedBlock) =
+    let setPatterns (block : QsPositionedBlock) =
         nonLocalUpdates block.Body
         |> Seq.map (fun (name, location) ->
                SetInResultConditionedBlock (name.Value, location.Offset + location.Range |> Value))
-    let foldInferences (dependsOnResult, diagnostics) (condition : TypedExpression, block : QsPositionedBlock) =
+    let foldPatterns (dependsOnResult, diagnostics) (condition : TypedExpression, block : QsPositionedBlock) =
         if dependsOnResult || condition.Exists isResultEquality
-        then true, Seq.concat [ diagnostics; returnInferences block; setInferences block ]
+        then true, Seq.concat [ diagnostics; returnPatterns block; setPatterns block ]
         else false, diagnostics
 
     conditionBlocks condBlocks elseBlock
-    |> Seq.fold foldInferences (false, Seq.empty)
+    |> Seq.fold foldPatterns (false, Seq.empty)
     |> snd
 
 let private statementPatterns statement =

--- a/src/QsCompiler/SyntaxProcessor/CapabilityInference.fs
+++ b/src/QsCompiler/SyntaxProcessor/CapabilityInference.fs
@@ -1,0 +1,124 @@
+﻿module Microsoft.Quantum.QsCompiler.SyntaxProcessing.CapabilityInference
+
+open Microsoft.Quantum.QsCompiler
+open Microsoft.Quantum.QsCompiler.DataTypes
+open Microsoft.Quantum.QsCompiler.ReservedKeywords.AssemblyConstants
+open Microsoft.Quantum.QsCompiler.SyntaxTokens
+open Microsoft.Quantum.QsCompiler.SyntaxTree
+open Microsoft.Quantum.QsCompiler.Transformations.Core
+open Microsoft.Quantum.QsCompiler.Transformations.SearchAndReplace
+
+type Inference =
+    | ReturnInResultConditionedBlock of Range QsNullable
+    | SetInResultConditionedBlock of string * Range QsNullable
+    | ResultEqualityInCondition of Range QsNullable
+    | ResultEqualityNotInCondition of Range QsNullable
+
+let private capability = function
+    | ResultEqualityInCondition _ -> RuntimeCapabilities.QPRGen1
+    | ResultEqualityNotInCondition _ -> RuntimeCapabilities.Unknown
+    | ReturnInResultConditionedBlock _ -> RuntimeCapabilities.Unknown
+    | SetInResultConditionedBlock _ -> RuntimeCapabilities.Unknown
+
+/// Returns true if the expression is an equality or inequality comparison between two expressions of type Result.
+let private isResultEquality { TypedExpression.Expression = expression } =
+    let validType = function
+        | InvalidType -> None
+        | kind -> Some kind
+    let binaryType lhs rhs =
+        validType lhs.ResolvedType.Resolution
+        |> Option.defaultValue rhs.ResolvedType.Resolution
+
+    // This assumes that:
+    // - Result has no derived types that support equality comparisons.
+    // - Compound types containing Result (e.g., tuples or arrays of results) do not support equality comparison.
+    match expression with
+    | EQ (lhs, rhs)
+    | NEQ (lhs, rhs) -> binaryType lhs rhs = Result
+    | _ -> false
+
+let private expressionInferences inCondition offset (expression : TypedExpression) =
+    expression.ExtractAll <| fun expression' ->
+        if isResultEquality expression'
+        then
+            expression'.Range
+            |> QsNullable.Map2 (+) offset
+            |> if inCondition then ResultEqualityInCondition else ResultEqualityNotInCondition
+            |> Seq.singleton
+        else Seq.empty
+
+/// Finds the locations where a mutable variable, which was not declared locally in the given scope, is reassigned.
+/// Returns the name of the variable and the location of the reassignment.
+let private nonLocalUpdates scope =
+    let isKnownSymbol name =
+        scope.KnownSymbols.Variables
+        |> Seq.exists (fun variable -> variable.VariableName = name)
+
+    let accumulator = AccumulateIdentifiers ()
+    accumulator.Statements.OnScope scope |> ignore
+    accumulator.SharedState.ReassignedVariables
+    |> Seq.collect (fun grouping -> grouping |> Seq.map (fun location -> grouping.Key, location))
+    |> Seq.filter (fst >> isKnownSymbol)
+
+let private conditionBlocks condBlocks elseBlock =
+    elseBlock
+    |> QsNullable<_>.Map (fun block -> SyntaxGenerator.BoolLiteral true, block)
+    |> QsNullable<_>.Fold (fun acc x -> x :: acc) []
+    |> Seq.append condBlocks
+
+/// Verifies that any conditional blocks which depend on a measurement result do not use any language constructs that
+/// are not supported by the runtime capabilities. Returns the diagnostics for the blocks.
+let private conditionalStatementInferences { ConditionalBlocks = condBlocks; Default = elseBlock } =
+    let returnStatements (statement : QsStatement) = statement.ExtractAll <| fun s ->
+        match s.Statement with
+        | QsReturnStatement _ -> [ s ]
+        | _ -> []
+    let returnInferences (block : QsPositionedBlock) =
+        block.Body.Statements
+        |> Seq.collect returnStatements
+        |> Seq.map (fun statement ->
+               let range = statement.Location |> QsNullable<_>.Map (fun location -> location.Offset + location.Range)
+               ReturnInResultConditionedBlock range)
+    let setInferences (block : QsPositionedBlock) =
+        nonLocalUpdates block.Body
+        |> Seq.map (fun (name, location) ->
+               SetInResultConditionedBlock (name.Value, location.Offset + location.Range |> Value))
+    let foldInferences (dependsOnResult, diagnostics) (condition : TypedExpression, block : QsPositionedBlock) =
+        let offset = block.Location |> QsNullable<_>.Map (fun location -> location.Offset)
+        let conditionInferences = expressionInferences true offset condition
+        if dependsOnResult || condition.Exists isResultEquality
+        then true, Seq.concat [ diagnostics; conditionInferences; returnInferences block; setInferences block ]
+        else false, Seq.append diagnostics conditionInferences
+
+    conditionBlocks condBlocks elseBlock
+    |> Seq.fold foldInferences (false, Seq.empty)
+    |> snd
+
+let Inferences compilation =
+    let inferences = ResizeArray ()
+    let mutable offset = Null
+    let transformation = SyntaxTreeTransformation TransformationOptions.NoRebuild
+
+    transformation.Statements <- {
+        new StatementTransformation (transformation, TransformationOptions.NoRebuild) with
+            member this.OnLocation location =
+                offset <- location |> QsNullable<_>.Map (fun location' -> location'.Offset)
+                location
+    }
+    transformation.StatementKinds <- {
+        new StatementKindTransformation (transformation, TransformationOptions.NoRebuild) with
+            member this.OnConditionalStatement statement =
+                conditionalStatementInferences statement |> inferences.AddRange
+                for _, block in conditionBlocks statement.ConditionalBlocks statement.Default do
+                    this.Transformation.Statements.OnScope block.Body |> ignore
+                QsConditionalStatement statement
+    }
+    transformation.Expressions <- {
+        new ExpressionTransformation (transformation, TransformationOptions.NoRebuild) with
+            member this.OnTypedExpression expression =
+                expressionInferences false offset expression |> inferences.AddRange
+                expression
+    }
+
+    transformation.OnCompilation compilation |> ignore
+    inferences

--- a/src/QsCompiler/SyntaxProcessor/CapabilityInference.fs
+++ b/src/QsCompiler/SyntaxProcessor/CapabilityInference.fs
@@ -132,8 +132,8 @@ let private conditionBlocks condBlocks elseBlock =
     |> QsNullable<_>.Fold (fun acc x -> x :: acc) []
     |> Seq.append condBlocks
 
-/// Verifies that any conditional blocks which depend on a measurement result do not use any language constructs that
-/// are not supported by the runtime capabilities. Returns the diagnostics for the blocks.
+/// Returns all patterns in the conditional statement that are relevant to its conditions. It does not return patterns
+/// for the conditions themselves, or the patterns of nested conditional statements.
 let private conditionalStatementPatterns { ConditionalBlocks = condBlocks; Default = elseBlock } =
     let returnStatements (statement : QsStatement) = statement.ExtractAll <| fun s ->
         match s.Statement with

--- a/src/QsCompiler/SyntaxProcessor/CapabilityInference.fs
+++ b/src/QsCompiler/SyntaxProcessor/CapabilityInference.fs
@@ -195,12 +195,9 @@ let InferCapabilities compilation =
         new NamespaceTransformation (transformation) with
             override this.OnCallableDeclaration callable =
                 let capability = callableCapability callable
-                let attributeName =
-                    { Namespace = NonNullable<_>.New "Microsoft.Quantum.Core"
-                      Name = NonNullable<_>.New "Capability" }
-                let attributeValue =
+                let arg =
                     SyntaxGenerator.StringLiteral (capability.ToString () |> NonNullable<_>.New, ImmutableArray.Empty)
-                let attribute = AttributeUtils.BuildAttribute (attributeName, attributeValue)
+                let attribute = AttributeUtils.BuildAttribute (BuiltIn.Capability.FullName, arg)
                 { callable with Attributes = callable.Attributes.Add attribute }
     }
     transformation.OnCompilation compilation

--- a/src/QsCompiler/SyntaxProcessor/ExpressionVerification.fs
+++ b/src/QsCompiler/SyntaxProcessor/ExpressionVerification.fs
@@ -251,19 +251,8 @@ let private VerifyEqualityComparison context addError (lhsType, lhsRange) (rhsTy
     // comparison for any derived type).
     let argumentError = ErrorCode.ArgumentMismatchInBinaryOp, [toString lhsType; toString rhsType]
     let baseType = CommonBaseType addError argumentError context.Symbols.Parent (lhsType, lhsRange) (rhsType, rhsRange)
-
-    // This assumes that:
-    // - Result has no derived types that support equality comparisons.
-    // - Compound types containing Result (e.g., tuples or arrays of results) do not support equality comparison.
-    match baseType.Resolution with
-    | Result when context.Capabilities = RuntimeCapabilities.QPRGen0 ->
-        addError (ErrorCode.UnsupportedResultComparison, [context.ProcessorArchitecture.Value]) rhsRange
-    | Result when context.Capabilities = RuntimeCapabilities.QPRGen1 &&
-                  not (context.IsInOperation && context.IsInIfCondition) ->
-        addError (ErrorCode.ResultComparisonNotInOperationIf, [context.ProcessorArchitecture.Value]) rhsRange
-    | _ ->
-        let unsupportedError = ErrorCode.InvalidTypeInEqualityComparison, [toString baseType]
-        VerifyIsOneOf (fun t -> t.supportsEqualityComparison) unsupportedError addError (baseType, rhsRange) |> ignore
+    let unsupportedError = ErrorCode.InvalidTypeInEqualityComparison, [toString baseType]
+    VerifyIsOneOf (fun t -> t.supportsEqualityComparison) unsupportedError addError (baseType, rhsRange) |> ignore
 
 /// Given a list of all item types and there corresponding ranges, verifies that a value array literal can be built from them. 
 /// Adds a MissingExprInArray error with the corresponding range using addError if one of the given types is missing. 

--- a/src/QsCompiler/SyntaxProcessor/ScopeTools.fs
+++ b/src/QsCompiler/SyntaxProcessor/ScopeTools.fs
@@ -289,8 +289,6 @@ type ScopeContext =
       Symbols : SymbolTracker
       /// True if the parent callable for the current scope is an operation.
       IsInOperation : bool
-      /// True if the current expression is contained within the condition of an if- or elif-statement.
-      IsInIfCondition : bool
       /// The return type of the parent callable for the current scope.
       ReturnType : ResolvedType
       /// The runtime capabilities for the compilation unit.
@@ -318,12 +316,7 @@ type ScopeContext =
         | Found declaration ->
             { Symbols = SymbolTracker (nsManager, spec.SourceFile, spec.Parent)
               IsInOperation = declaration.Kind = Operation
-              IsInIfCondition = false
               ReturnType = StripPositionInfo.Apply declaration.Signature.ReturnType
               Capabilities = capabilities
               ProcessorArchitecture = processorArchitecture }
         | _ -> raise <| ArgumentException "The specialization's parent callable does not exist."
-
-    /// Returns a new scope context for an expression that is contained within the condition of an if- or
-    /// elif-statement.
-    member this.WithinIfCondition = { this with IsInIfCondition = true }

--- a/src/QsCompiler/SyntaxProcessor/StatementVerification.fs
+++ b/src/QsCompiler/SyntaxProcessor/StatementVerification.fs
@@ -9,7 +9,6 @@ open System.Collections.Immutable
 open Microsoft.Quantum.QsCompiler
 open Microsoft.Quantum.QsCompiler.DataTypes
 open Microsoft.Quantum.QsCompiler.Diagnostics
-open Microsoft.Quantum.QsCompiler.ReservedKeywords.AssemblyConstants
 open Microsoft.Quantum.QsCompiler.SyntaxExtensions
 open Microsoft.Quantum.QsCompiler.SyntaxProcessing
 open Microsoft.Quantum.QsCompiler.SyntaxProcessing.Expressions
@@ -65,75 +64,6 @@ let private onAutoInvertCheckQuantumDependency (symbols : SymbolTracker) (ex : T
 let private onAutoInvertGenerateError (errCode, range) (symbols : SymbolTracker) = 
     if not (symbols.RequiredFunctorSupport.Contains QsFunctor.Adjoint) then [||]
     else [| range |> QsCompilerDiagnostic.Error errCode |] 
-
-/// <summary>
-/// Returns true if the expression is an equality or inequality comparison between two expressions of type Result.
-/// </summary>
-/// <param name="parent">The name of the callable in which the expression occurs.</param>
-/// <param name="expression">The expression.</param>
-let private isResultComparison ({ Expression = expression } : TypedExpression) =
-    let validType = function
-        | InvalidType -> None
-        | kind -> Some kind
-    let binaryType lhs rhs = validType lhs.ResolvedType.Resolution |> Option.defaultValue rhs.ResolvedType.Resolution
-
-    // This assumes that:
-    // - Result has no derived types that support equality comparisons.
-    // - Compound types containing Result (e.g., tuples or arrays of results) do not support equality comparison.
-    match expression with
-    | EQ (lhs, rhs) -> binaryType lhs rhs = Result
-    | NEQ (lhs, rhs) -> binaryType lhs rhs = Result
-    | _ -> false
-
-/// Finds the locations where a mutable variable, which was not declared locally in the given scope, is reassigned. The
-/// symbol tracker is not modified. Returns the name of the variable and the location of the reassignment.
-let private nonLocalUpdates (symbols : SymbolTracker) (scope : QsScope) =
-    // This assumes that a variable with the same name cannot be re-declared in an inner scope (i.e., shadowing is not
-    // allowed).
-    let identifierExists (name, location : QsLocation) =
-        let symbol = { Symbol = Symbol name; Range = Value location.Range }
-        match (symbols.ResolveIdentifier ignore symbol |> fst).VariableName with
-        | InvalidIdentifier -> false
-        | _ -> true
-    let accumulator = AccumulateIdentifiers()
-    accumulator.Statements.OnScope scope |> ignore
-    accumulator.SharedState.ReassignedVariables
-    |> Seq.collect (fun grouping -> Seq.map (fun location -> grouping.Key, location) grouping)
-    |> Seq.filter identifierExists
-
-/// Verifies that any conditional blocks which depend on a measurement result do not use any language constructs that
-/// are not supported by the runtime capabilities. Returns the diagnostics for the blocks.
-let private verifyResultConditionalBlocks context condBlocks elseBlock =
-    // Diagnostics for return statements.
-    let returnStatements (statement : QsStatement) = statement.ExtractAll <| fun s ->
-        match s.Statement with
-        | QsReturnStatement _ -> [s]
-        | _ -> []
-    let returnError (statement : QsStatement) =
-        let error = ErrorCode.ReturnInResultConditionedBlock, [context.ProcessorArchitecture.Value]
-        let location = statement.Location.ValueOr { Offset = Position.Zero; Range = Range.Zero }
-        location.Offset + location.Range |> QsCompilerDiagnostic.Error error 
-    let returnErrors (block : QsPositionedBlock) =
-        block.Body.Statements |> Seq.collect returnStatements |> Seq.map returnError
-
-    // Diagnostics for variable reassignments.
-    let setError (name : NonNullable<string>, location : QsLocation) =
-        let error = ErrorCode.SetInResultConditionedBlock, [name.Value; context.ProcessorArchitecture.Value]
-        location.Offset + location.Range |> QsCompilerDiagnostic.Error error 
-    let setErrors (block : QsPositionedBlock) = nonLocalUpdates context.Symbols block.Body |> Seq.map setError
-
-    let blocks =
-        elseBlock
-        |> QsNullable<_>.Map (fun block -> SyntaxGenerator.BoolLiteral true, block)
-        |> QsNullable<_>.Fold (fun acc x -> x :: acc) []
-        |> Seq.append condBlocks
-    let foldErrors (dependsOnResult, diagnostics) (condition : TypedExpression, block) =
-        if dependsOnResult || condition.Exists isResultComparison
-        then true, Seq.concat [returnErrors block; setErrors block; diagnostics]
-        else false, diagnostics
-    if context.Capabilities = RuntimeCapabilities.QPRGen1
-    then Seq.fold foldErrors (false, Seq.empty) blocks |> snd
-    else Seq.empty
 
 
 // utils for building QsStatements from QsFragmentKinds
@@ -342,18 +272,15 @@ let NewConditionalBlock comments location context (qsExpr : QsExpression) =
 /// Given a conditional block for the if-clause of a Q# if-statement, a sequence of conditional blocks for the elif-clauses,
 /// as well as optionally a positioned block of Q# statements and its location for the else-clause, builds and returns the complete if-statement.
 /// Throws an ArgumentException if the given if-block contains no location information.
-let NewIfStatement context (ifBlock : TypedExpression * QsPositionedBlock) elifBlocks elseBlock =
+let NewIfStatement (ifBlock : TypedExpression * QsPositionedBlock) elifBlocks elseBlock =
     let location =
         match (snd ifBlock).Location with
         | Null -> ArgumentException "No location is set for the given if-block." |> raise
         | Value location -> location
     let condBlocks = Seq.append (Seq.singleton ifBlock) elifBlocks
-    let statement =
-        QsConditionalStatement.New (condBlocks, elseBlock)
-        |> QsConditionalStatement
-        |> asStatement QsComments.Empty location LocalDeclarations.Empty
-    let diagnostics = verifyResultConditionalBlocks context condBlocks elseBlock
-    statement, diagnostics
+    QsConditionalStatement.New (condBlocks, elseBlock)
+    |> QsConditionalStatement
+    |> asStatement QsComments.Empty location LocalDeclarations.Empty
 
 /// Given a positioned block of Q# statements for the repeat-block of a Q# RUS-statement, a typed expression containing the success condition, 
 /// as well as a positioned block of Q# statements for the fixup-block, builds the complete RUS-statement at the given location and returns it.

--- a/src/QsCompiler/SyntaxProcessor/SyntaxProcessor.fsproj
+++ b/src/QsCompiler/SyntaxProcessor/SyntaxProcessor.fsproj
@@ -14,11 +14,11 @@
     </Compile>
     <Compile Include="VerificationTools.fs" />
     <Compile Include="ScopeTools.fs" />
+    <Compile Include="CapabilityInference.fs" />
     <Compile Include="ContextVerification.fs" />
     <Compile Include="ExpressionVerification.fs" />
     <Compile Include="StatementVerification.fs" />
     <Compile Include="TreeVerification.fs" />
-    <Compile Include="CapabilityInference.fs" />
     <Compile Include="DeclarationVerification.fs" />
     <Compile Include="SyntaxExtensions.fs" />
   </ItemGroup>

--- a/src/QsCompiler/SyntaxProcessor/SyntaxProcessor.fsproj
+++ b/src/QsCompiler/SyntaxProcessor/SyntaxProcessor.fsproj
@@ -18,6 +18,7 @@
     <Compile Include="ExpressionVerification.fs" />
     <Compile Include="StatementVerification.fs" />
     <Compile Include="TreeVerification.fs" />
+    <Compile Include="CapabilityInference.fs" />
     <Compile Include="DeclarationVerification.fs" />
     <Compile Include="SyntaxExtensions.fs" />
   </ItemGroup>

--- a/src/QsCompiler/Tests.Compiler/CapabilityInferenceTests.fs
+++ b/src/QsCompiler/Tests.Compiler/CapabilityInferenceTests.fs
@@ -1,0 +1,67 @@
+﻿module Microsoft.Quantum.QsCompiler.Testing.CapabilityInferenceTests
+
+open Microsoft.Quantum.QsCompiler.DataTypes
+open Microsoft.Quantum.QsCompiler.SyntaxExtensions
+open Microsoft.Quantum.QsCompiler.SyntaxProcessing
+open Microsoft.Quantum.QsCompiler.SyntaxTokens
+open Microsoft.Quantum.QsCompiler.SyntaxTree
+open Xunit
+
+let private callables =
+    CompilerTests.Compile ("TestCases", [ "CapabilityVerification.qs" ])
+    |> fun compilation -> compilation.BuiltCompilation
+    |> CapabilityInference.InferCapabilities
+    |> fun compilation -> compilation.Namespaces
+    |> GlobalCallableResolutions
+
+let private attributes (callable : QsCallable) =
+    let extractString = function
+        | StringLiteral (value, _) -> value.Value
+        | _ -> failwith "Expression is not a string."
+
+    callable.Attributes
+    |> QsNullable<_>.Choose (fun attribute ->
+           attribute.TypeId |> QsNullable<_>.Map (fun name -> name, attribute.Argument))
+    |> Seq.filter (fun (name, _) -> name.Namespace.Value = "Microsoft.Quantum.Core" && name.Name.Value = "Capability")
+    |> Seq.map (fun (_, value) -> extractString value.Expression)
+
+let private expect capabilities name =
+    let actual = attributes callables.[CapabilityVerificationTests.testName name]
+    Assert.Equal<string> (capabilities, actual)
+
+[<Fact>]
+let ``Infers QPRGen0`` () =
+    [ "NoOp"
+      "ResultTuple"
+      "ResultArray" ]
+    |> List.iter (expect [ "QPRGen0" ])
+
+[<Fact>]
+let ``Infers QPRGen1`` () =
+    [ "SetLocal"
+      "EmptyIfOp"
+      "EmptyIfNeqOp"
+      "Reset"
+      "ResetNeq" ]
+    |> List.iter (expect [ "QPRGen1" ])
+
+[<Fact>]
+let ``Infers Unknown`` () =
+    [ "ResultAsBool"
+      "ResultAsBoolNeq"
+      "ResultAsBoolOp"
+      "ResultAsBoolNeqOp"
+      "ResultAsBoolOpReturnIf"
+      "ResultAsBoolNeqOpReturnIf"
+      "ResultAsBoolOpReturnIfNested"
+      "ResultAsBoolOpSetIf"
+      "ResultAsBoolNeqOpSetIf"
+      "ResultAsBoolOpElseSet"
+      "ElifSet"
+      "ElifElifSet"
+      "ElifElseSet"
+      "SetReusedName"
+      "SetTuple"
+      "EmptyIf"
+      "EmptyIfNeq" ]
+    |> List.iter (expect [ "Unknown" ])

--- a/src/QsCompiler/Tests.Compiler/CapabilityInferenceTests.fs
+++ b/src/QsCompiler/Tests.Compiler/CapabilityInferenceTests.fs
@@ -25,9 +25,12 @@ let private expect capability name =
 [<Fact>]
 let ``Infers QPRGen0`` () =
     [ "NoOp"
+      "ResetOverrideLow"
+
+      // Tuples and arrays don't support equality, so they are inferred as QPRGen0 for now. If tuple and array equality
+      // is supported, ResultTuple and ResultArray should be inferred as Unknown instead.
       "ResultTuple"
-      "ResultArray"
-      "ResetOverrideLow" ]
+      "ResultArray" ]
     |> List.iter (expect RuntimeCapabilities.QPRGen0)
 
 [<Fact>]

--- a/src/QsCompiler/Tests.Compiler/CapabilityInferenceTests.fs
+++ b/src/QsCompiler/Tests.Compiler/CapabilityInferenceTests.fs
@@ -60,6 +60,7 @@ let ``Infers Unknown`` () =
       "ResultAsBoolOpSetIf"
       "ResultAsBoolNeqOpSetIf"
       "ResultAsBoolOpElseSet"
+      "NestedResultIfReturn"
       "ElifSet"
       "ElifElifSet"
       "ElifElseSet"

--- a/src/QsCompiler/Tests.Compiler/CapabilityInferenceTests.fs
+++ b/src/QsCompiler/Tests.Compiler/CapabilityInferenceTests.fs
@@ -25,7 +25,7 @@ let private expect capability name =
 [<Fact>]
 let ``Infers QPRGen0`` () =
     [ "NoOp"
-      "ResetOverrideLow"
+      "OverrideGen1ToGen0"
 
       // Tuples and arrays don't support equality, so they are inferred as QPRGen0 for now. If tuple and array equality
       // is supported, ResultTuple and ResultArray should be inferred as Unknown instead.
@@ -39,7 +39,9 @@ let ``Infers QPRGen1`` () =
       "EmptyIfOp"
       "EmptyIfNeqOp"
       "Reset"
-      "ResetNeq" ]
+      "ResetNeq"
+      "OverrideGen0ToGen1"
+      "ExplicitGen1" ]
     |> List.iter (expect RuntimeCapabilities.QPRGen1)
 
 [<Fact>]
@@ -62,5 +64,5 @@ let ``Infers Unknown`` () =
       "SetTuple"
       "EmptyIf"
       "EmptyIfNeq"
-      "ResetOverrideHigh" ]
+      "OverrideGen1ToUnknown" ]
     |> List.iter (expect RuntimeCapabilities.Unknown)

--- a/src/QsCompiler/Tests.Compiler/CapabilityInferenceTests.fs
+++ b/src/QsCompiler/Tests.Compiler/CapabilityInferenceTests.fs
@@ -1,7 +1,7 @@
 ﻿module Microsoft.Quantum.QsCompiler.Testing.CapabilityInferenceTests
 
+open Microsoft.Quantum.QsCompiler
 open Microsoft.Quantum.QsCompiler.DataTypes
-open Microsoft.Quantum.QsCompiler.SyntaxExtensions
 open Microsoft.Quantum.QsCompiler.SyntaxProcessing
 open Microsoft.Quantum.QsCompiler.SyntaxTokens
 open Microsoft.Quantum.QsCompiler.SyntaxTree
@@ -22,7 +22,7 @@ let private attributes (callable : QsCallable) =
     callable.Attributes
     |> QsNullable<_>.Choose (fun attribute ->
            attribute.TypeId |> QsNullable<_>.Map (fun name -> name, attribute.Argument))
-    |> Seq.filter (fun (name, _) -> name.Namespace.Value = "Microsoft.Quantum.Core" && name.Name.Value = "Capability")
+    |> Seq.filter (fun (udt, _) -> { Namespace = udt.Namespace; Name = udt.Name } = BuiltIn.Capability.FullName)
     |> Seq.map (fun (_, value) -> extractString value.Expression)
 
 let private expect capabilities name =

--- a/src/QsCompiler/Tests.Compiler/CapabilityInferenceTests.fs
+++ b/src/QsCompiler/Tests.Compiler/CapabilityInferenceTests.fs
@@ -41,6 +41,7 @@ let ``Infers QPRGen1`` () =
       "Reset"
       "ResetNeq"
       "OverrideGen0ToGen1"
+      "OverrideUnknownToGen1"
       "ExplicitGen1" ]
     |> List.iter (expect RuntimeCapabilities.QPRGen1)
 

--- a/src/QsCompiler/Tests.Compiler/CapabilityInferenceTests.fs
+++ b/src/QsCompiler/Tests.Compiler/CapabilityInferenceTests.fs
@@ -7,6 +7,7 @@ open Microsoft.Quantum.QsCompiler.SyntaxTokens
 open Microsoft.Quantum.QsCompiler.SyntaxTree
 open Xunit
 
+/// A mapping of all callables in the capability verification tests, after inferring capabilities.
 let private callables =
     CompilerTests.Compile ("TestCases", [ "CapabilityVerification.qs" ])
     |> fun compilation -> compilation.BuiltCompilation
@@ -14,6 +15,7 @@ let private callables =
     |> fun compilation -> compilation.Namespaces
     |> GlobalCallableResolutions
 
+/// Returns the inferred capabilities of the callable based on its attributes.
 let private attributes (callable : QsCallable) =
     let extractString = function
         | StringLiteral (value, _) -> value.Value
@@ -25,16 +27,17 @@ let private attributes (callable : QsCallable) =
     |> Seq.filter (fun (udt, _) -> { Namespace = udt.Namespace; Name = udt.Name } = BuiltIn.Capability.FullName)
     |> Seq.map (fun (_, value) -> extractString value.Expression)
 
-let private expect capabilities name =
+/// Asserts that the inferred capability of the callable with the given name matches the expected capability.
+let private expect capability name =
     let actual = attributes callables.[CapabilityVerificationTests.testName name]
-    Assert.Equal<string> (capabilities, actual)
+    Assert.Equal<string> ([ capability ], actual)
 
 [<Fact>]
 let ``Infers QPRGen0`` () =
     [ "NoOp"
       "ResultTuple"
       "ResultArray" ]
-    |> List.iter (expect [ "QPRGen0" ])
+    |> List.iter (expect "QPRGen0")
 
 [<Fact>]
 let ``Infers QPRGen1`` () =
@@ -43,7 +46,7 @@ let ``Infers QPRGen1`` () =
       "EmptyIfNeqOp"
       "Reset"
       "ResetNeq" ]
-    |> List.iter (expect [ "QPRGen1" ])
+    |> List.iter (expect "QPRGen1")
 
 [<Fact>]
 let ``Infers Unknown`` () =
@@ -64,4 +67,4 @@ let ``Infers Unknown`` () =
       "SetTuple"
       "EmptyIf"
       "EmptyIfNeq" ]
-    |> List.iter (expect [ "Unknown" ])
+    |> List.iter (expect "Unknown")

--- a/src/QsCompiler/Tests.Compiler/CapabilityVerificationTests.fs
+++ b/src/QsCompiler/Tests.Compiler/CapabilityVerificationTests.fs
@@ -57,8 +57,9 @@ let private simpleTests =
       "EmptyIfNeqOp"
       "Reset"
       "ResetNeq"
-      "ResetOverrideHigh"
-      "ResetOverrideLow" ]
+      "OverrideGen1ToUnknown"
+      "OverrideGen1ToGen0"
+      "ExplicitGen1" ]
 
 [<Fact>]
 let ``Unknown allows all Result comparison`` () =
@@ -67,6 +68,11 @@ let ``Unknown allows all Result comparison`` () =
     [ "ResultTuple"
       "ResultArray" ]
     |> List.iter (expect unknown [ErrorCode.InvalidTypeInEqualityComparison])
+
+let ``QPRGen0 allows callables without Result comparison`` () =
+    [ "NoOp"
+      "OverrideGen0ToGen1" ]
+    |> List.iter (expect gen0 [])
 
 [<Fact>]
 let ``QPRGen0 restricts all Result comparison`` () =
@@ -139,6 +145,7 @@ let ``QPRGen1 allows empty Result if operation`` () =
 let ``QPRGen1 allows operation call from Result if`` () =
     [ "Reset"
       "ResetNeq"
-      "ResetOverrideHigh"
-      "ResetOverrideLow" ]
+      "OverrideGen1ToUnknown"
+      "OverrideGen1ToGen0"
+      "ExplicitGen1" ]
     |> List.iter (expect gen1 [])

--- a/src/QsCompiler/Tests.Compiler/CapabilityVerificationTests.fs
+++ b/src/QsCompiler/Tests.Compiler/CapabilityVerificationTests.fs
@@ -45,6 +45,7 @@ let private simpleTests =
       "ResultAsBoolOpSetIf"
       "ResultAsBoolNeqOpSetIf"
       "ResultAsBoolOpElseSet"
+      "NestedResultIfReturn"
       "ElifSet"
       "ElifElifSet"
       "ElifElseSet"
@@ -92,7 +93,8 @@ let ``QPRGen1 restricts non-if Result comparison in operations`` () =
 let ``QPRGen1 restricts return from Result if`` () =
     [ "ResultAsBoolOpReturnIf"
       "ResultAsBoolOpReturnIfNested"
-      "ResultAsBoolNeqOpReturnIf" ]
+      "ResultAsBoolNeqOpReturnIf"
+      "NestedResultIfReturn" ]
     |> List.iter (expect gen1 <| Seq.replicate 2 ErrorCode.ReturnInResultConditionedBlock)
 
 [<Fact>]

--- a/src/QsCompiler/Tests.Compiler/CapabilityVerificationTests.fs
+++ b/src/QsCompiler/Tests.Compiler/CapabilityVerificationTests.fs
@@ -15,21 +15,22 @@ let private compile capabilities =
     CompilerTests.Compile ("TestCases", ["CapabilityVerification.qs"], capabilities = capabilities)
 
 /// The unknown capability tester.
-let private unknown = CompilerTests (compile RuntimeCapabilities.Unknown)
+let private unknown = compile RuntimeCapabilities.Unknown |> CompilerTests
 
 /// The QPRGen0 capability tester.
-let private gen0 = CompilerTests (compile RuntimeCapabilities.QPRGen0)
+let private gen0 = compile RuntimeCapabilities.QPRGen0 |> CompilerTests
 
 /// The QPRGen1 capability tester.
-let private gen1 = CompilerTests (compile RuntimeCapabilities.QPRGen1)
+let private gen1 = compile RuntimeCapabilities.QPRGen1 |> CompilerTests
 
 /// The qualified name for the test case name.
-let private testName name =
+let internal testName name =
     QsQualifiedName.New (NonNullable<_>.New "Microsoft.Quantum.Testing.CapabilityVerification",
                          NonNullable<_>.New name)
 
 /// Asserts that the tester produces the expected error codes for the test case with the given name.
-let private expect (tester : CompilerTests) errorCodes name = tester.VerifyDiagnostics (testName name, Seq.map Error errorCodes)
+let private expect (tester : CompilerTests) errorCodes name =
+    tester.VerifyDiagnostics (testName name, Seq.map Error errorCodes)
 
 /// The names of all "simple" test cases: test cases that have exactly one unsupported result comparison error in
 /// QPRGen0, and no errors in Unknown.

--- a/src/QsCompiler/Tests.Compiler/CapabilityVerificationTests.fs
+++ b/src/QsCompiler/Tests.Compiler/CapabilityVerificationTests.fs
@@ -59,6 +59,7 @@ let private simpleTests =
       "ResetNeq"
       "OverrideGen1ToUnknown"
       "OverrideGen1ToGen0"
+      "OverrideUnknownToGen1"
       "ExplicitGen1" ]
 
 [<Fact>]

--- a/src/QsCompiler/Tests.Compiler/CapabilityVerificationTests.fs
+++ b/src/QsCompiler/Tests.Compiler/CapabilityVerificationTests.fs
@@ -56,7 +56,9 @@ let private simpleTests =
       "EmptyIfOp"
       "EmptyIfNeqOp"
       "Reset"
-      "ResetNeq" ]
+      "ResetNeq"
+      "ResetOverrideHigh"
+      "ResetOverrideLow" ]
 
 [<Fact>]
 let ``Unknown allows all Result comparison`` () =
@@ -136,5 +138,7 @@ let ``QPRGen1 allows empty Result if operation`` () =
 [<Fact>]
 let ``QPRGen1 allows operation call from Result if`` () =
     [ "Reset"
-      "ResetNeq" ]
+      "ResetNeq"
+      "ResetOverrideHigh"
+      "ResetOverrideLow" ]
     |> List.iter (expect gen1 [])

--- a/src/QsCompiler/Tests.Compiler/TestCases/CapabilityVerification.qs
+++ b/src/QsCompiler/Tests.Compiler/TestCases/CapabilityVerification.qs
@@ -198,17 +198,29 @@ namespace Microsoft.Quantum.Testing.CapabilityVerification {
         return rs == [One] ? true | false;
     }
     
-    // Inferred capabilities can be overridden.
+    // Inferred capabilities can be overridden or given explicitly.
+
+    @Capability("QPRGen1")
+    operation OverrideGen0ToGen1(q : Qubit) : Unit {
+        X(q);
+    }
 
     @Capability("Unknown")
-    operation ResetOverrideHigh(q : Qubit) : Unit {
+    operation OverrideGen1ToUnknown(q : Qubit) : Unit {
         if (M(q) == One) {
             X(q);
         }
     }
 
     @Capability("QPRGen0")
-    operation ResetOverrideLow(q : Qubit) : Unit {
+    operation OverrideGen1ToGen0(q : Qubit) : Unit {
+        if (M(q) == One) {
+            X(q);
+        }
+    }
+
+    @Capability("QPRGen1")
+    operation ExplicitGen1(q : Qubit) : Unit {
         if (M(q) == One) {
             X(q);
         }

--- a/src/QsCompiler/Tests.Compiler/TestCases/CapabilityVerification.qs
+++ b/src/QsCompiler/Tests.Compiler/TestCases/CapabilityVerification.qs
@@ -3,15 +3,9 @@
 
 /// Test cases for verification of execution target runtime capabilities.
 namespace Microsoft.Quantum.Testing.CapabilityVerification {
-    internal operation X(q : Qubit) : Unit {
-        body intrinsic;
-    }
+    open Microsoft.Quantum.Intrinsic;
 
-    internal operation M(q : Qubit) : Result {
-        body intrinsic;
-    }
-
-    internal operation NoOp() : Unit { }
+    operation NoOp() : Unit { }
 
     function ResultAsBool(result : Result) : Bool {
         return result == Zero ? false | true;
@@ -202,5 +196,39 @@ namespace Microsoft.Quantum.Testing.CapabilityVerification {
 
     function ResultArray(rs : Result[]) : Bool {
         return rs == [One] ? true | false;
+    }
+    
+    // Inferred capabilities can be overridden.
+
+    @Capability("Unknown")
+    operation ResetOverrideHigh(q : Qubit) : Unit {
+        if (M(q) == One) {
+            X(q);
+        }
+    }
+
+    @Capability("QPRGen0")
+    operation ResetOverrideLow(q : Qubit) : Unit {
+        if (M(q) == One) {
+            X(q);
+        }
+    }
+}
+
+namespace Microsoft.Quantum.Core {
+    @Attribute()
+    newtype Attribute = Unit;
+
+    @Attribute()
+    newtype Capability = String;
+}
+
+namespace Microsoft.Quantum.Intrinsic {
+    operation X(q : Qubit) : Unit {
+        body intrinsic;
+    }
+
+    operation M(q : Qubit) : Result {
+        body intrinsic;
     }
 }

--- a/src/QsCompiler/Tests.Compiler/TestCases/CapabilityVerification.qs
+++ b/src/QsCompiler/Tests.Compiler/TestCases/CapabilityVerification.qs
@@ -220,6 +220,11 @@ namespace Microsoft.Quantum.Testing.CapabilityVerification {
     }
 
     @Capability("QPRGen1")
+    operation OverrideUnknownToGen1(q : Qubit) : Bool {
+        return M(q) == One ? true | false;
+    }
+
+    @Capability("QPRGen1")
     operation ExplicitGen1(q : Qubit) : Unit {
         if (M(q) == One) {
             X(q);

--- a/src/QsCompiler/Tests.Compiler/TestCases/CapabilityVerification.qs
+++ b/src/QsCompiler/Tests.Compiler/TestCases/CapabilityVerification.qs
@@ -89,6 +89,18 @@ namespace Microsoft.Quantum.Testing.CapabilityVerification {
         return b;
     }
 
+    operation NestedResultIfReturn(b : Bool, result : Result) : Bool {
+        if (b) {
+            if (result == One) {
+                return true;
+            } else {
+                return false;
+            }
+        } else {
+            return false;
+        }
+    }
+
     operation ElifSet(result : Result, flag : Bool) : Bool {
         mutable b = false;
         if (flag) {

--- a/src/QsCompiler/Tests.Compiler/Tests.Compiler.fsproj
+++ b/src/QsCompiler/Tests.Compiler/Tests.Compiler.fsproj
@@ -155,6 +155,7 @@
     <Compile Include="GlobalVerificationTests.fs" />
     <Compile Include="LocalVerificationTests.fs" />
     <Compile Include="CapabilityVerificationTests.fs" />
+    <Compile Include="CapabilityInferenceTests.fs" />
     <Compile Include="TypeCheckingTests.fs" />
     <Compile Include="AutoGenerationTests.fs" />
     <Compile Include="TransformationTests.fs" />


### PR DESCRIPTION
Infers the minimum required runtime capabilities of each callable in the compilation, and adds the `@Microsoft.Quantum.Core.Capability` attribute to it, containing its capability ("QPRGen0", "QPRGen1", or "Unknown"). The inference is run as a rewrite step for libraries only, because executables have an execution target with a fixed runtime capability, so labeling is not needed. The attribute will be used later to verify that executables can't call library functions/operations with a capability that is too high.

The existing code for capability diagnostics was refactored, so both inference and verification can use the same code. The inference algorithm finds syntactic patterns in statements and expressions that imply a runtime capability. These patterns can be converted into either an inferred capability (by taking the max of all required capabilities), or diagnostics (by selecting patterns that imply a capability that is too high for the current execution target).

For now, inference only looks at the source code of callables individually - it doesn't find references or use the call graph, so the actual capability may be higher than what is currently inferred.

Part of issue #586.