### PR TITLE
Fix @types/node version

### DIFF
--- a/src/VSCodeExtension/package.json.v.template
+++ b/src/VSCodeExtension/package.json.v.template
@@ -126,7 +126,7 @@
         "mocha": "^5.2.0",
         "yeoman-test": "^1.7.0",
         "yeoman-assert": "^3.1.0",
-        "@types/node": "^9.6.5",
+        "@types/node": "9.6.57",
         "@types/mocha": "^5.2.0",
         "@types/which": "1.3.1",
         "@types/tmp": "0.0.33",


### PR DESCRIPTION
CI builds and E2E QDK builds started failing this morning with the following error:
```
> quantum-devkit-vscode@0.9999.20091729 compile C:\QDK\qsharp-compiler\src\VSCodeExtension
> tsc -p ./

node_modules/@types/node/index.d.ts:39:1 - error TS1084: Invalid 'reference' directive syntax.

39 /// <reference lib="es2017" />
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

Somehow a new release of the npm `@types/node` package this morning caused this error. This PR pins the version of that package used in the VS Code extension compilation, choosing the patch version immediately prior to the one released this morning, which seems to fix the issue in the builds.