### PR TITLE
Add error when using library callable that exceeds execution target's capabilities

### DIFF
--- a/src/QsCompiler/DataStructures/Diagnostics.fs
+++ b/src/QsCompiler/DataStructures/Diagnostics.fs
@@ -567,7 +567,7 @@ type DiagnosticItem =
             | ErrorCode.SetInResultConditionedBlock               ->
                 "The variable \"{0}\" cannot be reassigned here. " +
                 "In conditional blocks that depend on a measurement result, the target {1} only supports reassigning variables that were declared within the block."
-            | ErrorCode.UnsupportedCapability                     -> "{0} requires runtime capabilities that are not supported by the target {1}."
+            | ErrorCode.UnsupportedCapability                     -> "The callable {0} requires runtime capabilities that are not supported by the target {1}."
 
             | ErrorCode.CallableRedefinition                      -> "Invalid callable declaration. A function or operation with the name \"{0}\" already exists."
             | ErrorCode.CallableOverlapWithTypeConstructor        -> "Invalid callable declaration. A type constructor with the name \"{0}\" already exists."

--- a/src/QsCompiler/DataStructures/Diagnostics.fs
+++ b/src/QsCompiler/DataStructures/Diagnostics.fs
@@ -171,6 +171,7 @@ type ErrorCode =
     | ResultComparisonNotInOperationIf = 5024
     | ReturnInResultConditionedBlock = 5025
     | SetInResultConditionedBlock = 5026
+    | UnsupportedCapability = 5027
 
     | CallableRedefinition = 6001
     | CallableOverlapWithTypeConstructor = 6002
@@ -566,6 +567,7 @@ type DiagnosticItem =
             | ErrorCode.SetInResultConditionedBlock               ->
                 "The variable \"{0}\" cannot be reassigned here. " +
                 "In conditional blocks that depend on a measurement result, the target {1} only supports reassigning variables that were declared within the block."
+            | ErrorCode.UnsupportedCapability                     -> "{0} requires runtime capabilities that are not supported by the target {1}."
 
             | ErrorCode.CallableRedefinition                      -> "Invalid callable declaration. A function or operation with the name \"{0}\" already exists."
             | ErrorCode.CallableOverlapWithTypeConstructor        -> "Invalid callable declaration. A type constructor with the name \"{0}\" already exists."

--- a/src/QsCompiler/SyntaxProcessor/CapabilityInference.fs
+++ b/src/QsCompiler/SyntaxProcessor/CapabilityInference.fs
@@ -242,7 +242,7 @@ let private referenceDiagnostic context (name, range : _ QsNullable) =
         let capability = declaration.Attributes |> QsNullable<_>.Choose BuiltIn.GetCapability |> maxCapability
         if level capability > level context.Capabilities
         then
-            let error = ErrorCode.UnsupportedCapability, [ name.Name.Value ]
+            let error = ErrorCode.UnsupportedCapability, [ name.Name.Value; context.ProcessorArchitecture.Value ]
             range.ValueOr Range.Zero |> QsCompilerDiagnostic.Error error |> Some
         else None
     | _ -> None

--- a/src/QsCompiler/SyntaxProcessor/CapabilityInference.fs
+++ b/src/QsCompiler/SyntaxProcessor/CapabilityInference.fs
@@ -1,4 +1,7 @@
-﻿module Microsoft.Quantum.QsCompiler.SyntaxProcessing.CapabilityInference
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+module Microsoft.Quantum.QsCompiler.SyntaxProcessing.CapabilityInference
 
 open Microsoft.Quantum.QsCompiler
 open Microsoft.Quantum.QsCompiler.DataTypes

--- a/src/QsCompiler/SyntaxProcessor/ScopeTools.fs
+++ b/src/QsCompiler/SyntaxProcessor/ScopeTools.fs
@@ -285,17 +285,23 @@ type SymbolTracker(globals : NamespaceManager, sourceFile, parent : QsQualifiedN
 
 /// The context used for symbol resolution and type checking within the scope of a callable.
 type ScopeContext =
-    { /// The symbol tracker for the parent callable.
+    { /// The namespace manager for global symbols.
+      Globals : NamespaceManager
+
+      /// The symbol tracker for the parent callable.
       Symbols : SymbolTracker
+
       /// True if the parent callable for the current scope is an operation.
       IsInOperation : bool
+
       /// The return type of the parent callable for the current scope.
       ReturnType : ResolvedType
+
       /// The runtime capabilities for the compilation unit.
       Capabilities : RuntimeCapabilities
+
       /// The name of the processor architecture for the compilation unit.
       ProcessorArchitecture : NonNullable<string> }
-    with
 
     /// <summary>
     /// Creates a scope context for the specialization.
@@ -314,7 +320,8 @@ type ScopeContext =
                          (spec : SpecializationDeclarationHeader) =
         match nsManager.TryGetCallable spec.Parent (spec.Parent.Namespace, spec.SourceFile) with
         | Found declaration ->
-            { Symbols = SymbolTracker (nsManager, spec.SourceFile, spec.Parent)
+            { Globals = nsManager
+              Symbols = SymbolTracker (nsManager, spec.SourceFile, spec.Parent)
               IsInOperation = declaration.Kind = Operation
               ReturnType = StripPositionInfo.Apply declaration.Signature.ReturnType
               Capabilities = capabilities

--- a/src/QsCompiler/TestTargets/Libraries/Library1/Capability.qs
+++ b/src/QsCompiler/TestTargets/Libraries/Library1/Capability.qs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace Microsoft.Quantum.Testing.Capability {
+    operation LibraryGen0(q : Qubit) : Unit { }
+
+    operation LibraryGen1(q : Qubit) : Unit {
+        let r = One;
+        if (r == One) {
+            LibraryGen0(q);
+        }
+    }
+
+    operation LibraryUnknown(q : Qubit) : Unit {
+        let r = One;
+        let isOne = r == One;
+        if (isOne) {
+            LibraryGen0(q);
+        }
+    }
+}

--- a/src/QsCompiler/Tests.Compiler/CapabilityVerificationTests.fs
+++ b/src/QsCompiler/Tests.Compiler/CapabilityVerificationTests.fs
@@ -8,12 +8,16 @@ open Microsoft.Quantum.QsCompiler.Diagnostics
 open Microsoft.Quantum.QsCompiler.ReservedKeywords.AssemblyConstants
 open Microsoft.Quantum.QsCompiler.SyntaxExtensions
 open Microsoft.Quantum.QsCompiler.SyntaxTree
+open System.IO
 open Xunit
 
 /// Compiles the capability verification test cases using the given capability.
 let private compile capabilities =
     CompilerTests.Compile
-        ("TestCases", ["CapabilityTests/Verification.qs"; "CapabilityTests/Inference.qs"], capabilities = capabilities)
+        ("TestCases",
+         ["CapabilityTests/Verification.qs"; "CapabilityTests/Inference.qs"],
+         references = [File.ReadAllLines("ReferenceTargets.txt").[1]],
+         capabilities = capabilities)
 
 /// The unknown capability tester.
 let private unknown = compile RuntimeCapabilities.Unknown |> CompilerTests
@@ -151,3 +155,24 @@ let ``QPRGen1 allows operation call from Result if`` () =
       "OverrideGen1ToGen0"
       "ExplicitGen1" ]
     |> List.iter (expect gen1 [])
+
+[<Fact>]
+let ``Unknown allows all library calls`` () =
+    [ "CallLibraryGen0"
+      "CallLibraryGen1"
+      "CallLibraryUnknown" ]
+    |> List.iter (expect unknown [])
+
+[<Fact>]
+let ``QPRGen1 restricts library calls`` () =
+    [ "CallLibraryGen0"
+      "CallLibraryGen1" ]
+    |> List.iter (expect gen1 [])
+    "CallLibraryUnknown" |> expect gen1 [ErrorCode.UnsupportedCapability]
+
+[<Fact>]
+let ``QPRGen0 restricts library calls`` () =
+    "CallLibraryGen0" |> expect gen0 []
+    [ "CallLibraryGen1"
+      "CallLibraryUnknown" ]
+    |> List.iter (expect gen0 [ErrorCode.UnsupportedCapability])

--- a/src/QsCompiler/Tests.Compiler/CapabilityVerificationTests.fs
+++ b/src/QsCompiler/Tests.Compiler/CapabilityVerificationTests.fs
@@ -157,22 +157,31 @@ let ``QPRGen1 allows operation call from Result if`` () =
     |> List.iter (expect gen1 [])
 
 [<Fact>]
-let ``Unknown allows all library calls`` () =
+let ``Unknown allows all library calls and references`` () =
     [ "CallLibraryGen0"
+      "ReferenceLibraryGen0"
       "CallLibraryGen1"
-      "CallLibraryUnknown" ]
+      "ReferenceLibraryGen1"
+      "CallLibraryUnknown"
+      "ReferenceLibraryUnknown" ]
     |> List.iter (expect unknown [])
 
 [<Fact>]
-let ``QPRGen1 restricts library calls`` () =
+let ``QPRGen1 restricts library calls and references`` () =
     [ "CallLibraryGen0"
       "CallLibraryGen1" ]
     |> List.iter (expect gen1 [])
-    "CallLibraryUnknown" |> expect gen1 [ErrorCode.UnsupportedCapability]
+    [ "CallLibraryUnknown"
+      "ReferenceLibraryUnknown" ]
+    |> List.iter (expect gen1 [ErrorCode.UnsupportedCapability])
 
 [<Fact>]
-let ``QPRGen0 restricts library calls`` () =
-    "CallLibraryGen0" |> expect gen0 []
+let ``QPRGen0 restricts library calls and references`` () =
+    [ "CallLibraryGen0"
+      "ReferenceLibraryGen0" ]
+    |> List.iter (expect gen0 [])
     [ "CallLibraryGen1"
-      "CallLibraryUnknown" ]
+      "ReferenceLibraryGen1"
+      "CallLibraryUnknown"
+      "ReferenceLibraryUnknown" ]
     |> List.iter (expect gen0 [ErrorCode.UnsupportedCapability])

--- a/src/QsCompiler/Tests.Compiler/TestCases/CapabilityTests/Inference.qs
+++ b/src/QsCompiler/Tests.Compiler/TestCases/CapabilityTests/Inference.qs
@@ -85,8 +85,8 @@
 
     // Override QPRGen1 to Unknown (2 dependencies)
 
-    operation CallUnknownOverrideA(q : Qubit) : Bool {
-        return CallUnknownOverrideB(q);
+    operation CallUnknownOverrideA(q : Qubit) : Unit {
+        CallUnknownOverrideB(q);
     }
 
     @Capability("Unknown")
@@ -107,11 +107,11 @@
     }
 
     @Capability("QPRGen1")
-    operation CallQPRGen1OverrideB(q : Qubit) : Result {
+    operation CallQPRGen1OverrideB(q : Qubit) : Bool {
         return CallQPRGen1OverrideC(q);
     }
 
-    operation CallQPRGen1OverrideC(q : Qubit) : Result {
+    operation CallQPRGen1OverrideC(q : Qubit) : Bool {
         let r = M(q);
         if (r == One) {
             X(q);

--- a/src/QsCompiler/Tests.Compiler/TestCases/CapabilityTests/Verification.qs
+++ b/src/QsCompiler/Tests.Compiler/TestCases/CapabilityTests/Verification.qs
@@ -198,18 +198,33 @@ namespace Microsoft.Quantum.Testing.Capability {
         return rs == [One] ? true | false;
     }
 
-    // Test calls to operations in referenced libraries.
+    // Test references to operations in libraries.
 
     operation CallLibraryGen0(q : Qubit) : Unit {
         LibraryGen0(q);
+    }
+
+    operation ReferenceLibraryGen0() : (Qubit => Unit) {
+        let f = LibraryGen0;
+        return f;
     }
 
     operation CallLibraryGen1(q : Qubit) : Unit {
         LibraryGen1(q);
     }
 
+    operation ReferenceLibraryGen1() : (Qubit => Unit) {
+        let f = LibraryGen1;
+        return f;
+    }
+
     operation CallLibraryUnknown(q : Qubit) : Unit {
         LibraryUnknown(q);
+    }
+
+    operation ReferenceLibraryUnknown() : (Qubit => Unit) {
+        let f = LibraryUnknown;
+        return f;
     }
 }
 

--- a/src/QsCompiler/Tests.Compiler/TestCases/CapabilityTests/Verification.qs
+++ b/src/QsCompiler/Tests.Compiler/TestCases/CapabilityTests/Verification.qs
@@ -197,6 +197,20 @@ namespace Microsoft.Quantum.Testing.Capability {
     function ResultArray(rs : Result[]) : Bool {
         return rs == [One] ? true | false;
     }
+
+    // Test calls to operations in referenced libraries.
+
+    operation CallLibraryGen0(q : Qubit) : Unit {
+        LibraryGen0(q);
+    }
+
+    operation CallLibraryGen1(q : Qubit) : Unit {
+        LibraryGen1(q);
+    }
+
+    operation CallLibraryUnknown(q : Qubit) : Unit {
+        LibraryUnknown(q);
+    }
 }
 
 namespace Microsoft.Quantum.Intrinsic {


### PR DESCRIPTION
Adds an error message when using a callable defined in a library with a capability that is too high for the execution target:

![grafik](https://user-images.githubusercontent.com/33814365/92977600-43c19380-f442-11ea-8d6e-660718988b62.png)

Part of #600.