### PR TITLE
Enable C# nullable reference types for CommandLineTool project

### DIFF
--- a/src/QsCompiler/CommandLineTool/CommandLineTool.csproj
+++ b/src/QsCompiler/CommandLineTool/CommandLineTool.csproj
@@ -6,6 +6,8 @@
     <AssemblyTitle>Microsoft Q# compiler command line tool.</AssemblyTitle>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <OutputType>Exe</OutputType>
+    <Nullable>enable</Nullable>
+    <WarningsAsErrors>nullable</WarningsAsErrors>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/QsCompiler/CommandLineTool/Commands/Build.cs
+++ b/src/QsCompiler/CommandLineTool/Commands/Build.cs
@@ -19,6 +19,9 @@ namespace Microsoft.Quantum.QsCompiler.CommandLineCompiler
         [Verb("build", HelpText = "Builds a compilation unit to run on the Q# quantum simulation framework.")]
         public class BuildOptions : CompilationOptions
         {
+            // TODO: Disabling nullable annotations is a workaround for
+            // https://github.com/commandlineparser/commandline/issues/136.
+#nullable disable annotations
             [Usage(ApplicationAlias = "qsCompiler")]
             public static IEnumerable<Example> UsageExamples
             {
@@ -44,7 +47,7 @@ namespace Microsoft.Quantum.QsCompiler.CommandLineCompiler
                 Required = true,
                 SetName = RESPONSE_FILES,
                 HelpText = "Response file(s) providing command arguments. Required only if no other arguments are specified. Non-default values for options specified via command line take precedence.")]
-            public IEnumerable<string>? ResponseFiles { get; set; }
+            public IEnumerable<string> ResponseFiles { get; set; }
 
             [Option(
                 'o',
@@ -52,14 +55,15 @@ namespace Microsoft.Quantum.QsCompiler.CommandLineCompiler
                 Required = false,
                 SetName = CODE_MODE,
                 HelpText = "Destination folder where the output of the compilation will be generated.")]
-            public string? OutputFolder { get; set; }
+            public string OutputFolder { get; set; }
 
             [Option(
                 "doc",
                 Required = false,
                 SetName = CODE_MODE,
                 HelpText = "Destination folder where documentation will be generated.")]
-            public string? DocFolder { get; set; }
+            public string DocFolder { get; set; }
+#nullable restore annotations
 
             [Option(
                 "proj",

--- a/src/QsCompiler/CommandLineTool/Commands/Build.cs
+++ b/src/QsCompiler/CommandLineTool/Commands/Build.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
 using CommandLine;
@@ -43,7 +44,7 @@ namespace Microsoft.Quantum.QsCompiler.CommandLineCompiler
                 Required = true,
                 SetName = RESPONSE_FILES,
                 HelpText = "Response file(s) providing command arguments. Required only if no other arguments are specified. Non-default values for options specified via command line take precedence.")]
-            public IEnumerable<string> ResponseFiles { get; set; }
+            public IEnumerable<string>? ResponseFiles { get; set; }
 
             [Option(
                 'o',
@@ -51,21 +52,21 @@ namespace Microsoft.Quantum.QsCompiler.CommandLineCompiler
                 Required = false,
                 SetName = CODE_MODE,
                 HelpText = "Destination folder where the output of the compilation will be generated.")]
-            public string OutputFolder { get; set; }
+            public string? OutputFolder { get; set; }
 
             [Option(
                 "doc",
                 Required = false,
                 SetName = CODE_MODE,
                 HelpText = "Destination folder where documentation will be generated.")]
-            public string DocFolder { get; set; }
+            public string? DocFolder { get; set; }
 
             [Option(
                 "proj",
                 Required = false,
                 SetName = CODE_MODE,
                 HelpText = "Name of the project (needs to be usable as file name).")]
-            public string ProjectName { get; set; }
+            public string? ProjectName { get; set; }
 
             [Option(
                 "emit-dll",
@@ -80,7 +81,7 @@ namespace Microsoft.Quantum.QsCompiler.CommandLineCompiler
                 Required = false,
                 SetName = CODE_MODE,
                 HelpText = "Destination folder where the output of the performance assessment will be generated.")]
-            public string PerfFolder { get; set; }
+            public string? PerfFolder { get; set; }
 
             /// <summary>
             /// Reads the content of all specified response files and processes it using FromResponseFiles.
@@ -88,7 +89,8 @@ namespace Microsoft.Quantum.QsCompiler.CommandLineCompiler
             /// Returns true and a new BuildOptions object as out parameter with all the settings from response files incorporated.
             /// Returns false if the content of the specified response-files could not be processed.
             /// </summary>
-            internal static bool IncorporateResponseFiles(BuildOptions options, out BuildOptions incorporated, ILogger logger = null)
+            internal static bool IncorporateResponseFiles(
+                BuildOptions options, [NotNullWhen(true)] out BuildOptions? incorporated, ILogger? logger = null)
             {
                 incorporated = null;
                 while (options.ResponseFiles != null && options.ResponseFiles.Any())
@@ -148,7 +150,7 @@ namespace Microsoft.Quantum.QsCompiler.CommandLineCompiler
         /// Logs a suitable exceptions and returns null if the parsing fails.
         /// Throws an ArgumentNullException if the given sequence of responseFiles is null.
         /// </summary>
-        private static BuildOptions FromResponseFiles(IEnumerable<string> responseFiles)
+        private static BuildOptions? FromResponseFiles(IEnumerable<string> responseFiles)
         {
             if (responseFiles == null)
             {
@@ -158,11 +160,11 @@ namespace Microsoft.Quantum.QsCompiler.CommandLineCompiler
             var args = SplitCommandLineArguments(commandLine);
             var parsed = Parser.Default.ParseArguments<BuildOptions>(args);
             return parsed.MapResult(
-                (BuildOptions opts) => opts,
+                opts => opts,
                 errs =>
                 {
                     HelpText.AutoBuild(parsed);
-                    return null;
+                    return null as BuildOptions;
                 });
         }
 
@@ -183,12 +185,13 @@ namespace Microsoft.Quantum.QsCompiler.CommandLineCompiler
             {
                 throw new ArgumentNullException(nameof(logger));
             }
-            if (!BuildOptions.IncorporateResponseFiles(options, out options))
+            if (!BuildOptions.IncorporateResponseFiles(options, out var incorporated))
             {
                 logger.Log(ErrorCode.InvalidCommandLineArgsInResponseFiles, Array.Empty<string>());
                 return ReturnCode.INVALID_ARGUMENTS;
             }
 
+            options = incorporated;
             var usesPlugins = options.Plugins != null && options.Plugins.Any();
             if (!options.ParseAssemblyProperties(out var assemblyConstants))
             {
@@ -209,7 +212,7 @@ namespace Microsoft.Quantum.QsCompiler.CommandLineCompiler
                 BuildOutputFolder = options.OutputFolder ?? (usesPlugins ? "." : null),
                 DllOutputPath = options.EmitDll ? " " : null, // set to e.g. an empty space to generate the dll in the same location as the .bson file
                 IsExecutable = options.MakeExecutable,
-                RewriteSteps = options.Plugins?.Select(step => (step, (string)null)) ?? ImmutableArray<(string, string)>.Empty,
+                RewriteSteps = options.Plugins?.Select(step => (step, (string?)null)) ?? ImmutableArray<(string, string)>.Empty,
                 EnableAdditionalChecks = false, // todo: enable debug mode?
                 ExposeReferencesViaTestNames = options.ExposeReferencesViaTestNames
             };

--- a/src/QsCompiler/CommandLineTool/Commands/Diagnose.cs
+++ b/src/QsCompiler/CommandLineTool/Commands/Diagnose.cs
@@ -154,7 +154,7 @@ namespace Microsoft.Quantum.QsCompiler.CommandLineCompiler
         /// Throws an ArgumentException if this is not possible because the given syntax tree is inconsistent with that wrapping.
         /// Throws an ArgumentNullException if the given compilation is null.
         /// </summary>
-        private static void PrintSyntaxTree(IEnumerable<QsNamespace> evaluatedTree, Compilation compilation, ILogger logger)
+        private static void PrintSyntaxTree(IEnumerable<QsNamespace>? evaluatedTree, Compilation compilation, ILogger logger)
         {
             if (compilation == null)
             {
@@ -193,7 +193,7 @@ namespace Microsoft.Quantum.QsCompiler.CommandLineCompiler
         /// Throws an ArgumentException if this is not possible because the given syntax tree is inconsistent with that wrapping.
         /// Throws an ArgumentNullException if the given compilation is null.
         /// </summary>
-        private static void PrintGeneratedQs(IEnumerable<QsNamespace> evaluatedTree, Compilation compilation, ILogger logger)
+        private static void PrintGeneratedQs(IEnumerable<QsNamespace>? evaluatedTree, Compilation compilation, ILogger logger)
         {
             if (compilation == null)
             {
@@ -281,7 +281,7 @@ namespace Microsoft.Quantum.QsCompiler.CommandLineCompiler
                 SkipSyntaxTreeTrimming = options.TrimLevel == 0,
                 AttemptFullPreEvaluation = options.TrimLevel > 2,
                 IsExecutable = options.MakeExecutable,
-                RewriteSteps = options.Plugins?.Select(step => (step, (string)null)) ?? ImmutableArray<(string, string)>.Empty,
+                RewriteSteps = options.Plugins?.Select(step => (step, (string?)null)) ?? ImmutableArray<(string, string)>.Empty,
                 EnableAdditionalChecks = true,
                 ExposeReferencesViaTestNames = options.ExposeReferencesViaTestNames
             };

--- a/src/QsCompiler/CommandLineTool/Commands/Format.cs
+++ b/src/QsCompiler/CommandLineTool/Commands/Format.cs
@@ -24,6 +24,9 @@ namespace Microsoft.Quantum.QsCompiler.CommandLineCompiler
         [Verb("format", HelpText = "Generates formatted Q# code.")]
         public class FormatOptions : Options
         {
+            // TODO: Disabling nullable annotations is a workaround for
+            // https://github.com/commandlineparser/commandline/issues/136.
+#nullable disable annotations
             [Usage(ApplicationAlias = "qsCompiler")]
             public static IEnumerable<Example> UsageExamples
             {
@@ -44,7 +47,8 @@ namespace Microsoft.Quantum.QsCompiler.CommandLineCompiler
                 Required = true,
                 SetName = CODE_MODE,
                 HelpText = "Destination folder where the formatted files will be generated.")]
-            public string? OutputFolder { get; set; }
+            public string OutputFolder { get; set; }
+#nullable restore annotations
         }
 
         /// <summary>

--- a/src/QsCompiler/CommandLineTool/Commands/Format.cs
+++ b/src/QsCompiler/CommandLineTool/Commands/Format.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Quantum.QsCompiler.CommandLineCompiler
                 Required = true,
                 SetName = CODE_MODE,
                 HelpText = "Destination folder where the formatted files will be generated.")]
-            public string OutputFolder { get; set; }
+            public string? OutputFolder { get; set; }
         }
 
         /// <summary>
@@ -117,7 +117,7 @@ namespace Microsoft.Quantum.QsCompiler.CommandLineCompiler
         /// Returns true if the generation succeeded, and false if an exception was thrown.
         /// Throws an ArgumentNullException if the given compilation, the file uri or its absolute path are null.
         /// </summary>
-        private static bool GenerateFormattedQsFile(Compilation compilation, NonNullable<string> fileName, string outputFolder, ILogger logger)
+        private static bool GenerateFormattedQsFile(Compilation compilation, NonNullable<string> fileName, string? outputFolder, ILogger logger)
         {
             if (compilation == null)
             {

--- a/src/QsCompiler/CommandLineTool/CompilationTracker.cs
+++ b/src/QsCompiler/CommandLineTool/CompilationTracker.cs
@@ -107,10 +107,11 @@ namespace Microsoft.Quantum.QsCompiler.CommandLineCompiler
                 this.Children = new Dictionary<string, CompilationTaskNode>();
             }
 
-            public void WriteToJson(Utf8JsonWriter jsonWriter, string prefix)
+            public void WriteToJson(Utf8JsonWriter jsonWriter, string? prefix)
             {
                 var preparedPrefix = "";
-                if (!string.IsNullOrEmpty(prefix)) {
+                if (!string.IsNullOrEmpty(prefix))
+                {
                     preparedPrefix = $"{prefix}.";
                 }
 

--- a/src/QsCompiler/CommandLineTool/LoadContext.cs
+++ b/src/QsCompiler/CommandLineTool/LoadContext.cs
@@ -46,16 +46,16 @@ namespace Microsoft.Quantum.QsCompiler
         }
 
         /// <inheritdoc/>
-        protected override Assembly Load(AssemblyName name)
+        protected override Assembly? Load(AssemblyName name)
         {
-            string path = this.resolver.ResolveAssemblyToPath(name);
+            var path = this.resolver.ResolveAssemblyToPath(name);
             return path == null ? null : this.LoadFromAssemblyPath(path);
         }
 
         /// <inheritdoc/>
         protected override IntPtr LoadUnmanagedDll(string name)
         {
-            string path = this.resolver.ResolveUnmanagedDllToPath(name);
+            var path = this.resolver.ResolveUnmanagedDllToPath(name);
             return path == null ? IntPtr.Zero : this.LoadUnmanagedDllFromPath(path);
         }
 
@@ -63,7 +63,7 @@ namespace Microsoft.Quantum.QsCompiler
         /// Search all fallback paths for a suitable .dll ignoring all exceptions.
         /// Returns the full path to the dll if a suitable assembly could was found.
         /// </summary>
-        private string ResolveFromFallbackPaths(AssemblyName name)
+        private string? ResolveFromFallbackPaths(AssemblyName name)
         {
             bool MatchByName(string file) =>
                 Path.GetFileNameWithoutExtension(file)
@@ -87,7 +87,7 @@ namespace Microsoft.Quantum.QsCompiler
             }
 
             var tempContext = new LoadContext(this.PathToParentAssembly);
-            var versions = new List<(string, Version)>();
+            var versions = new List<(string, Version?)>();
             foreach (var file in found)
             {
                 try
@@ -124,7 +124,7 @@ namespace Microsoft.Quantum.QsCompiler
         /// Search for a suitable .dll in the specified fallback locations.
         /// Does not load any dependencies.
         /// </summary>
-        private Assembly OnResolving(AssemblyLoadContext context, AssemblyName name)
+        private Assembly? OnResolving(AssemblyLoadContext context, AssemblyName name)
         {
             var path = this.ResolveFromFallbackPaths(name);
             return path == null ? null : this.LoadFromAssemblyPath(path);
@@ -153,7 +153,7 @@ namespace Microsoft.Quantum.QsCompiler
         /// to the list of paths where the context will try to look for assemblies that could otherwise not be loaded.
         /// Throws a FileNotFoundException if no file with the given path exists.
         /// </summary>
-        public static Assembly LoadAssembly(string path, string[] fallbackPaths = null)
+        public static Assembly LoadAssembly(string path, string[]? fallbackPaths = null)
         {
             if (!File.Exists(path))
             {

--- a/src/QsCompiler/CommandLineTool/Logging.cs
+++ b/src/QsCompiler/CommandLineTool/Logging.cs
@@ -30,9 +30,9 @@ namespace Microsoft.Quantum.QsCompiler.Diagnostics
         /// If a line number offset is specified, then the ranges for all logged diagnostics are shifted by the spedified offset.
         /// </summary>
         public ConsoleLogger(
-            Func<Diagnostic, string> format = null,
+            Func<Diagnostic, string>? format = null,
             DiagnosticSeverity verbosity = DiagnosticSeverity.Warning,
-            IEnumerable<int> noWarn = null,
+            IEnumerable<int>? noWarn = null,
             int lineNrOffset = 0)
         : base(verbosity, noWarn, lineNrOffset) =>
             this.applyFormatting = format ?? Formatting.HumanReadableFormat;

--- a/src/QsCompiler/CommandLineTool/Options.cs
+++ b/src/QsCompiler/CommandLineTool/Options.cs
@@ -41,14 +41,14 @@ namespace Microsoft.Quantum.QsCompiler.CommandLineCompiler
             Required = false,
             SetName = CODE_MODE,
             HelpText = "Path to the .NET Core dll(s) defining additional transformations to include in the compilation process.")]
-        public IEnumerable<string> Plugins { get; set; }
+        public IEnumerable<string>? Plugins { get; set; }
 
         [Option(
             "target-specific-decompositions",
             Required = false,
             SetName = CODE_MODE,
             HelpText = "[Experimental feature] Path to the .NET Core dll(s) containing target specific implementations.")]
-        public IEnumerable<string> TargetSpecificDecompositions { get; set; }
+        public IEnumerable<string>? TargetSpecificDecompositions { get; set; }
 
         [Option(
             "load-test-names",
@@ -63,7 +63,7 @@ namespace Microsoft.Quantum.QsCompiler.CommandLineCompiler
             Required = false,
             SetName = CODE_MODE,
             HelpText = "Additional properties to populate the AssemblyConstants dictionary with. Each item is expected to be of the form \"key:value\".")]
-        public IEnumerable<string> AdditionalAssemblyProperties { get; set; }
+        public IEnumerable<string>? AdditionalAssemblyProperties { get; set; }
 
         [Option(
             "runtime",
@@ -91,8 +91,9 @@ namespace Microsoft.Quantum.QsCompiler.CommandLineCompiler
             foreach (var keyValue in this.AdditionalAssemblyProperties ?? Array.Empty<string>())
             {
                 var pieces = keyValue?.Split(":");
-                var valid = pieces != null && pieces.Length == 2;
-                success = valid && parsed.TryAdd(pieces[0].Trim().Trim('"'), pieces[1].Trim().Trim('"')) && success;
+                success =
+                    success && !(pieces is null) && pieces.Length == 2 &&
+                    parsed.TryAdd(pieces[0].Trim().Trim('"'), pieces[1].Trim().Trim('"'));
             }
             return success;
         }
@@ -117,7 +118,7 @@ namespace Microsoft.Quantum.QsCompiler.CommandLineCompiler
             Required = false,
             Default = DefaultOptions.Verbosity,
             HelpText = "Specifies the verbosity of the logged output. Valid values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].")]
-        public string Verbosity { get; set; }
+        public string? Verbosity { get; set; }
 
         [Option(
             "format",
@@ -132,7 +133,7 @@ namespace Microsoft.Quantum.QsCompiler.CommandLineCompiler
             Required = true,
             SetName = CODE_MODE,
             HelpText = "Q# code or name of the Q# file to compile.")]
-        public IEnumerable<string> Input { get; set; }
+        public IEnumerable<string>? Input { get; set; }
 
         [Option(
             's',
@@ -140,7 +141,7 @@ namespace Microsoft.Quantum.QsCompiler.CommandLineCompiler
             Required = true,
             SetName = SNIPPET_MODE,
             HelpText = "Q# snippet to compile - i.e. Q# code occuring within an operation or function declaration.")]
-        public string CodeSnippet { get; set; }
+        public string? CodeSnippet { get; set; }
 
         [Option(
             'f',
@@ -157,7 +158,7 @@ namespace Microsoft.Quantum.QsCompiler.CommandLineCompiler
             Required = false,
             Default = new string[0],
             HelpText = "Referenced binaries to include in the compilation.")]
-        public IEnumerable<string> References { get; set; }
+        public IEnumerable<string>? References { get; set; }
 
         [Option(
             'n',
@@ -165,14 +166,14 @@ namespace Microsoft.Quantum.QsCompiler.CommandLineCompiler
             Required = false,
             Default = new int[0],
             HelpText = "Warnings with the given code(s) will be ignored.")]
-        public IEnumerable<int> NoWarn { get; set; }
+        public IEnumerable<int>? NoWarn { get; set; }
 
         [Option(
             "package-load-fallback-folders",
             Required = false,
             SetName = CODE_MODE,
             HelpText = "Specifies the directories the compiler will search when a compiler dependency could not be found.")]
-        public IEnumerable<string> PackageLoadFallbackFolders { get; set; }
+        public IEnumerable<string>? PackageLoadFallbackFolders { get; set; }
 
         /// <summary>
         /// Updates the settings that can be used independent on the other arguments according to the setting in the given options.
@@ -192,7 +193,7 @@ namespace Microsoft.Quantum.QsCompiler.CommandLineCompiler
         /// <summary>
         /// If a logger is given, logs the options as CommandLineArguments Information before returning the printed string.
         /// </summary>
-        public string[] Print(ILogger logger = null)
+        public string[] Print(ILogger? logger = null)
         {
             string Value(PropertyInfo p)
             {


### PR DESCRIPTION
We're planning to gradually enable null checking across the C# projects. This is the first project to get it.