### PR TITLE
Remove null argument checks and thrown ArgumentNullExceptions

### DIFF
--- a/src/QsCompiler/CommandLineTool/Commands/Build.cs
+++ b/src/QsCompiler/CommandLineTool/Commands/Build.cs
@@ -152,14 +152,9 @@ namespace Microsoft.Quantum.QsCompiler.CommandLineCompiler
         /// <summary>
         /// Reads the content off all given response files and tries to parse their concatenated content as command line arguments.
         /// Logs a suitable exceptions and returns null if the parsing fails.
-        /// Throws an ArgumentNullException if the given sequence of responseFiles is null.
         /// </summary>
         private static BuildOptions? FromResponseFiles(IEnumerable<string> responseFiles)
         {
-            if (responseFiles == null)
-            {
-                throw new ArgumentNullException(nameof(responseFiles));
-            }
             var commandLine = string.Join(" ", responseFiles.Select(File.ReadAllText));
             var args = SplitCommandLineArguments(commandLine);
             var parsed = Parser.Default.ParseArguments<BuildOptions>(args);
@@ -177,18 +172,9 @@ namespace Microsoft.Quantum.QsCompiler.CommandLineCompiler
         /// <summary>
         /// Builds the compilation for the Q# code or Q# snippet and referenced assemblies defined by the given options.
         /// Returns a suitable error code if one of the compilation or generation steps fails.
-        /// Throws an ArgumentNullException if any of the given arguments is null.
         /// </summary>
         public static int Run(BuildOptions options, ConsoleLogger logger)
         {
-            if (options == null)
-            {
-                throw new ArgumentNullException(nameof(options));
-            }
-            if (logger == null)
-            {
-                throw new ArgumentNullException(nameof(logger));
-            }
             if (!BuildOptions.IncorporateResponseFiles(options, out var incorporated))
             {
                 logger.Log(ErrorCode.InvalidCommandLineArgsInResponseFiles, Array.Empty<string>());

--- a/src/QsCompiler/CommandLineTool/Commands/Diagnose.cs
+++ b/src/QsCompiler/CommandLineTool/Commands/Diagnose.cs
@@ -78,14 +78,9 @@ namespace Microsoft.Quantum.QsCompiler.CommandLineCompiler
         /// Logs the content of each file in the given compilation as Information using the given logger.
         /// If the id of a file is consistent with the one assigned to a code snippet,
         /// strips the lines of code that correspond to the wrapping defined by WrapSnippet.
-        /// Throws an ArgumentNullException if the given compilation is null.
         /// </summary>
         private static void PrintFileContentInMemory(Compilation compilation, ILogger logger)
         {
-            if (compilation == null)
-            {
-                throw new ArgumentNullException(nameof(compilation));
-            }
             foreach (var file in compilation.SourceFiles)
             {
                 IEnumerable<string> inMemory = compilation.FileContent[file];
@@ -110,14 +105,9 @@ namespace Microsoft.Quantum.QsCompiler.CommandLineCompiler
         /// Logs the tokenization of each file in the given compilation as Information using the given logger.
         /// If the id of a file is consistent with the one assigned to a code snippet,
         /// strips the tokens that correspond to the wrapping defined by WrapSnippet.
-        /// Throws an ArgumentNullException if the given compilation is null.
         /// </summary>
         private static void PrintContentTokenization(Compilation compilation, ILogger logger)
         {
-            if (compilation == null)
-            {
-                throw new ArgumentNullException(nameof(compilation));
-            }
             foreach (var file in compilation.SourceFiles)
             {
                 var tokenization = compilation.Tokenization[file].Select(tokens => tokens.Select(token => token.Kind));
@@ -152,14 +142,9 @@ namespace Microsoft.Quantum.QsCompiler.CommandLineCompiler
         /// If the id of a file is consistent with the one assigned to a code snippet,
         /// strips the lines of code that correspond to the wrapping defined by WrapSnippet.
         /// Throws an ArgumentException if this is not possible because the given syntax tree is inconsistent with that wrapping.
-        /// Throws an ArgumentNullException if the given compilation is null.
         /// </summary>
         private static void PrintSyntaxTree(IEnumerable<QsNamespace>? evaluatedTree, Compilation compilation, ILogger logger)
         {
-            if (compilation == null)
-            {
-                throw new ArgumentNullException(nameof(compilation));
-            }
             evaluatedTree ??= compilation.SyntaxTree.Values;
 
             foreach (var file in compilation.SourceFiles)
@@ -191,14 +176,9 @@ namespace Microsoft.Quantum.QsCompiler.CommandLineCompiler
         /// If the id of a file is consistent with the one assigned to a code snippet,
         /// strips the lines of code that correspond to the wrapping defined by WrapSnippet.
         /// Throws an ArgumentException if this is not possible because the given syntax tree is inconsistent with that wrapping.
-        /// Throws an ArgumentNullException if the given compilation is null.
         /// </summary>
         private static void PrintGeneratedQs(IEnumerable<QsNamespace>? evaluatedTree, Compilation compilation, ILogger logger)
         {
-            if (compilation == null)
-            {
-                throw new ArgumentNullException(nameof(compilation));
-            }
             evaluatedTree ??= compilation.SyntaxTree.Values;
 
             foreach (var file in compilation.SourceFiles)
@@ -224,14 +204,9 @@ namespace Microsoft.Quantum.QsCompiler.CommandLineCompiler
         /// <summary>
         /// Strips the namespace and callable declaration that is consistent with the wrapping defined by WrapSnippet.
         /// Throws an ArgumentException if this is not possible because the given syntax tree is inconsistent with that wrapping.
-        /// Throws an ArgumentNullException if the given syntaxTree is null.
         /// </summary>
         public static IEnumerable<QsStatement> StripSnippetWrapping(IEnumerable<QsNamespace> syntaxTree)
         {
-            if (syntaxTree == null)
-            {
-                throw new ArgumentNullException(nameof(syntaxTree));
-            }
             var incorrectWrapperException = new ArgumentException("syntax tree does not reflect the expected wrapper");
             if (syntaxTree.Count() != 1 || syntaxTree.Single().Elements.Count() != 1)
             {
@@ -253,19 +228,9 @@ namespace Microsoft.Quantum.QsCompiler.CommandLineCompiler
         /// Builds the compilation for the Q# code or Q# snippet and referenced assemblies defined by the given options.
         /// Prints the data structures requested by the given options using the given logger.
         /// Returns a suitable error code if one of the compilation or generation steps fails.
-        /// Throws an ArgumentNullException if any of the given arguments is null.
         /// </summary>
         public static int Run(DiagnoseOptions options, ConsoleLogger logger)
         {
-            if (options == null)
-            {
-                throw new ArgumentNullException(nameof(options));
-            }
-            if (logger == null)
-            {
-                throw new ArgumentNullException(nameof(logger));
-            }
-
             if (!options.ParseAssemblyProperties(out var assemblyConstants))
             {
                 logger.Log(WarningCode.InvalidAssemblyProperties, Array.Empty<string>());

--- a/src/QsCompiler/CommandLineTool/Commands/Format.cs
+++ b/src/QsCompiler/CommandLineTool/Commands/Format.cs
@@ -71,14 +71,9 @@ namespace Microsoft.Quantum.QsCompiler.CommandLineCompiler
         /// If the id of a file is consistent with the one assigned to a code snippet,
         /// strips the lines of code that correspond to the wrapping defined by WrapSnippet.
         /// Throws an ArgumentException if this is not possible because the given syntax tree is inconsistent with that wrapping.
-        /// Throws an ArgumentNullException if the given compilation is null.
         /// </summary>
         private static IEnumerable<string> GenerateQsCode(Compilation compilation, NonNullable<string> file, ILogger logger)
         {
-            if (compilation == null)
-            {
-                throw new ArgumentNullException(nameof(compilation));
-            }
             if (Options.IsCodeSnippet(file))
             {
                 var subtree = compilation.SyntaxTree.Values.Select(ns => FilterBySourceFile.Apply(ns, file)).Where(ns => ns.Elements.Any());
@@ -119,15 +114,9 @@ namespace Microsoft.Quantum.QsCompiler.CommandLineCompiler
         /// logs the generated code using the given logger.
         /// Creates a file containing the generated code in the given output folder otherwise.
         /// Returns true if the generation succeeded, and false if an exception was thrown.
-        /// Throws an ArgumentNullException if the given compilation, the file uri or its absolute path are null.
         /// </summary>
         private static bool GenerateFormattedQsFile(Compilation compilation, NonNullable<string> fileName, string? outputFolder, ILogger logger)
         {
-            if (compilation == null)
-            {
-                throw new ArgumentNullException(nameof(compilation));
-            }
-
             var code = Enumerable.Empty<string>();
             try
             {
@@ -158,19 +147,9 @@ namespace Microsoft.Quantum.QsCompiler.CommandLineCompiler
         /// Generates formatted Q# code for each source file in the compilation.
         /// Returns a suitable error code if some of the source files or references could not be found or loaded, or if the Q# generation failed.
         /// Compilation errors are not reflected in the return code, but are logged using the given logger.
-        /// Throws an ArgumentNullException if any of the given arguments is null.
         /// </summary>
         public static int Run(FormatOptions options, ConsoleLogger logger)
         {
-            if (options == null)
-            {
-                throw new ArgumentNullException(nameof(options));
-            }
-            if (logger == null)
-            {
-                throw new ArgumentNullException(nameof(logger));
-            }
-
             ImmutableDictionary<Uri, string> LoadSources(SourceFileLoader loadFromDisk) =>
                 options.LoadSourcesOrSnippet(logger)(loadFromDisk)
                     .ToImmutableDictionary(entry => entry.Key, entry => UpdateArrayLiterals(entry.Value)); // manually replace array literals

--- a/src/QsCompiler/CommandLineTool/LoadContext.cs
+++ b/src/QsCompiler/CommandLineTool/LoadContext.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Quantum.QsCompiler
 
         private LoadContext(string parentAssembly)
         {
-            this.PathToParentAssembly = parentAssembly ?? throw new ArgumentNullException(nameof(parentAssembly));
+            this.PathToParentAssembly = parentAssembly;
             this.resolver = new AssemblyDependencyResolver(this.PathToParentAssembly);
             this.fallbackPaths = new HashSet<string>();
             this.Resolving += this.OnResolving;

--- a/src/QsCompiler/CommandLineTool/Logging.cs
+++ b/src/QsCompiler/CommandLineTool/Logging.cs
@@ -40,14 +40,9 @@ namespace Microsoft.Quantum.QsCompiler.Diagnostics
         /// <summary>
         /// Prints the given message to the Console.
         /// Errors and Warnings are printed to the error stream.
-        /// Throws an ArgumentNullException if the given message is null.
         /// </summary>
         private static void PrintToConsole(DiagnosticSeverity severity, string message)
         {
-            if (message == null)
-            {
-                throw new ArgumentNullException(nameof(message));
-            }
             var (stream, color) =
                 severity == DiagnosticSeverity.Error ? (Console.Error, ConsoleColor.Red) :
                 severity == DiagnosticSeverity.Warning ? (Console.Error, ConsoleColor.Yellow) :

--- a/src/QsCompiler/CompilationManager/AssemblyLoader.cs
+++ b/src/QsCompiler/CompilationManager/AssemblyLoader.cs
@@ -31,19 +31,16 @@ namespace Microsoft.Quantum.QsCompiler
         /// Returns false if some of the content could not be loaded successfully,
         /// possibly because the referenced assembly has been compiled with an older compiler version.
         /// If onDeserializationException is specified, invokes the given action on any exception thrown during deserialization.
-        /// Throws an ArgumentNullException if the given uri is null.
+        /// Throws an ArgumentException if the URI is not an absolute file URI.
         /// Throws a FileNotFoundException if no file with the given name exists.
         /// Throws the corresponding exceptions if the information cannot be extracted.
         /// </summary>
         public static bool LoadReferencedAssembly(Uri asm, out References.Headers headers, bool ignoreDllResources = false, Action<Exception>? onDeserializationException = null)
         {
-            if (asm == null)
+            var id = CompilationUnitManager.GetFileId(asm);
+            if (!File.Exists(asm.LocalPath))
             {
-                throw new ArgumentNullException(nameof(asm));
-            }
-            if (!CompilationUnitManager.TryGetFileId(asm, out var id) || !File.Exists(asm.LocalPath))
-            {
-                throw new FileNotFoundException($"The uri '{asm}' given to the assembly loader is invalid or the file does not exist.");
+                throw new FileNotFoundException($"The file '{asm.LocalPath}' given to the assembly loader does not exist.");
             }
 
             using var stream = File.OpenRead(asm.LocalPath);
@@ -65,7 +62,6 @@ namespace Microsoft.Quantum.QsCompiler
         /// possibly because the referenced assembly has been compiled with an older compiler version.
         /// Catches any exception throw upon loading the compilation, and invokes onException with it if such an action has been specified.
         /// Sets the out parameter to null if an exception occurred during loading.
-        /// Throws an ArgumentNullException if the given uri is null.
         /// Throws a FileNotFoundException if no file with the given name exists.
         /// </summary>
         public static bool LoadReferencedAssembly(
@@ -73,10 +69,6 @@ namespace Microsoft.Quantum.QsCompiler
             [NotNullWhen(true)] out QsCompilation? compilation,
             Action<Exception>? onException = null)
         {
-            if (asmPath == null)
-            {
-                throw new ArgumentNullException(nameof(asmPath));
-            }
             if (!File.Exists(asmPath))
             {
                 throw new FileNotFoundException($"The file '{asmPath}' does not exist.");
@@ -102,17 +94,12 @@ namespace Microsoft.Quantum.QsCompiler
         /// Given a stream containing the binary representation of compiled Q# code, returns the corresponding Q# compilation.
         /// Returns true if the compilation could be deserialized without throwing an exception, and false otherwise.
         /// If onDeserializationException is specified, invokes the given action on any exception thrown during deserialization.
-        /// Throws an ArgumentNullException if the given stream is null, but ignores exceptions thrown during deserialization.
         /// </summary>
         public static bool LoadSyntaxTree(
             Stream stream,
             [NotNullWhen(true)] out QsCompilation? compilation,
             Action<Exception>? onDeserializationException = null)
         {
-            if (stream == null)
-            {
-                throw new ArgumentNullException(nameof(stream));
-            }
             using var reader = new BsonDataReader(stream);
             (compilation, reader.ReadRootValueAsArray) = (null, false);
             try
@@ -141,7 +128,6 @@ namespace Microsoft.Quantum.QsCompiler
         /// Given a reader for the byte stream of a dotnet dll, loads any Q# compilation included as a resource.
         /// Returns true as well as the loaded compilation if the given dll includes a suitable resource, and returns false otherwise.
         /// If onDeserializationException is specified, invokes the given action on any exception thrown during deserialization.
-        /// Throws an ArgumentNullException if any of the given readers is null.
         /// May throw an exception if the given binary file has been compiled with a different compiler version.
         /// </summary>
         private static bool FromResource(
@@ -149,10 +135,6 @@ namespace Microsoft.Quantum.QsCompiler
             [NotNullWhen(true)] out QsCompilation? compilation,
             Action<Exception>? onDeserializationException = null)
         {
-            if (assemblyFile == null)
-            {
-                throw new ArgumentNullException(nameof(assemblyFile));
-            }
             var metadataReader = assemblyFile.GetMetadataReader();
             compilation = null;
 
@@ -239,15 +221,10 @@ namespace Microsoft.Quantum.QsCompiler
         /// Given a reader for the byte stream of a dotnet dll, read its custom attributes and
         /// returns a tuple containing the name of the attribute and the constructor argument
         /// for all attributes defined in a Microsoft.Quantum* namespace.
-        /// Throws an ArgumentNullException if the given stream is null.
         /// Throws the corresponding exceptions if the information cannot be extracted.
         /// </summary>
         private static IEnumerable<(string, string)> LoadHeaderAttributes(PEReader assemblyFile)
         {
-            if (assemblyFile == null)
-            {
-                throw new ArgumentNullException(nameof(assemblyFile));
-            }
             var metadataReader = assemblyFile.GetMetadataReader();
             return metadataReader.GetAssemblyDefinition().GetCustomAttributes()
                 .Select(metadataReader.GetCustomAttribute)

--- a/src/QsCompiler/CompilationManager/CompilationUnit.cs
+++ b/src/QsCompiler/CompilationManager/CompilationUnit.cs
@@ -166,15 +166,10 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// Combines the current references with the given references, and verifies that there are no conflicts.
         /// Calls the given Action onError with suitable diagnostics if two or more references conflict,
         /// i.e. if two or more references contain a declaration with the same fully qualified name.
-        /// Throws an ArgumentNullException if the given dictionary of references is null.
         /// Throws an ArgumentException if the given set shares references with the current one.
         /// </summary>
         internal References CombineWith(References other, Action<ErrorCode, string[]>? onError = null)
         {
-            if (other == null)
-            {
-                throw new ArgumentNullException(nameof(other));
-            }
             if (this.Declarations.Keys.Intersect(other.Declarations.Keys).Any())
             {
                 throw new ArgumentException("common references exist");
@@ -187,7 +182,6 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// Verifies that there are no conflicts for the new set of references.
         /// Calls the given Action onError with suitable diagnostics if two or more references conflict,
         /// i.e. if two or more references contain a declaration with the same fully qualified name.
-        /// Throws an ArgumentNullException if the given diagnostics are null.
         /// </summary>
         internal References Remove(NonNullable<string> source, Action<ErrorCode, string[]>? onError = null) =>
             new References(this.Declarations.Remove(source), onError: onError);
@@ -199,11 +193,10 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// i.e. if two or more references contain a declaration with the same fully qualified name.
         /// If loadTestNames is set to true, then public types and callables declared in referenced assemblies
         /// are exposed via their test name defined by the corresponding attribute.
-        /// Throws an ArgumentNullException if the given dictionary of references is null.
         /// </summary>
         public References(ImmutableDictionary<NonNullable<string>, Headers> refs, bool loadTestNames = false, Action<ErrorCode, string[]>? onError = null)
         {
-            this.Declarations = refs ?? throw new ArgumentNullException(nameof(refs));
+            this.Declarations = refs;
             if (loadTestNames)
             {
                 this.Declarations = this.Declarations
@@ -312,7 +305,6 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// <summary>
         /// Returns a new CompilationUnit to store and update a compilation referencing the given content (if any),
         /// with the given sequence of locks registered as dependent locks if the sequence is not null.
-        /// Throws an ArgumentNullException if any of the given locks is.
         /// </summary>
         internal CompilationUnit(
             RuntimeCapabilities capabilities,
@@ -326,10 +318,6 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
 
             this.syncRoot = new ReaderWriterLockSlim(LockRecursionPolicy.SupportsRecursion);
             this.dependentLocks = new HashSet<ReaderWriterLockSlim>(dependentLocks);
-            if (dependentLocks.Contains(null!))
-            {
-                throw new ArgumentNullException(nameof(dependentLocks), "one or more of the given locks is null");
-            }
 
             this.RuntimeCapabilities = capabilities;
             this.IsExecutable = isExecutable;
@@ -355,14 +343,13 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
 
         /// <summary>
         /// Replaces the GlobalSymbols to match the newly specified references.
-        /// Throws an ArgumentNullException if the given references are null.
         /// </summary>
         internal void UpdateReferences(References externals)
         {
             this.EnterWriteLock();
             try
             {
-                this.Externals = externals ?? throw new ArgumentNullException(nameof(externals));
+                this.Externals = externals;
                 this.GlobalSymbols = this.CreateGlobalSymbols();
             }
             finally
@@ -375,15 +362,10 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// Registers the given lock as a dependent lock -
         /// i.e. whenever both this compilation unit and a dependent lock are required,
         /// ensures that the compilation unit has to be the outer lock.
-        /// Throws an ArgumentNullException if the given lock is null.
         /// </summary>
         internal void RegisterDependentLock(ReaderWriterLockSlim depLock)
         {
             #if DEBUG
-            if (depLock == null)
-            {
-                throw new ArgumentNullException(nameof(depLock));
-            }
             this.syncRoot.EnterWriteLock();
             try
             {
@@ -402,15 +384,10 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// <summary>
         /// Removes the given lock from the set of dependent locks.
         /// Returns true if the lock was successfully removed and false otherwise.
-        /// Throws an ArgumentNullException if the given lock is null.
         /// </summary>
         internal void UnregisterDependentLock(ReaderWriterLockSlim depLock)
         {
             #if DEBUG
-            if (depLock == null)
-            {
-                throw new ArgumentNullException(nameof(depLock));
-            }
             this.syncRoot.EnterWriteLock();
             try
             {
@@ -529,19 +506,15 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// <summary>
         /// If the given updates are not null, replaces the contained types in the compilation, or adds them if they do not yet exist.
         /// Proceeds to remove any types that are not currently listed in GlobalSymbols from the compilation, and updates all position information.
-        /// Throws an ArgumentNullException if any of the given types to update is null.
         /// </summary>
         internal void UpdateTypes(IEnumerable<QsCustomType> updates)
         {
             this.syncRoot.EnterWriteLock();
             try
             {
-                if (updates != null)
+                foreach (var t in updates)
                 {
-                    foreach (var t in updates)
-                    {
-                        this.compiledTypes[t.FullName] = t ?? throw new ArgumentNullException(nameof(updates), "the given compiled type is null");
-                    }
+                    this.compiledTypes[t.FullName] = t;
                 }
 
                 // remove all types that are no listed in GlobalSymbols
@@ -593,19 +566,14 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// If the given updates are not null, replaces the contained callables in the compilation, or adds them if they do not yet exist.
         /// Proceeds to remove any callables and specializations that are not currently listed in GlobalSymbols from the compilation,
         /// and updates the position information for all callables and specializations.
-        /// Throws an ArgumentNullException if any of the given callables to update is null.
         /// </summary>
         internal void UpdateCallables(IEnumerable<QsCallable> updates)
         {
             this.syncRoot.EnterWriteLock();
             try
             {
-                foreach (var c in updates ?? Array.Empty<QsCallable>())
+                foreach (var c in updates)
                 {
-                    if (c?.Specializations == null || c.Specializations.Contains(null))
-                    {
-                        throw new ArgumentNullException(nameof(updates), "the given compiled callable or specialization is null");
-                    }
                     this.compiledCallables[c.FullName] = c;
                 }
 
@@ -718,15 +686,10 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// Constructs a suitable callable for a given callable declaration header -
         /// i.e. given all information about a callable except the implementation of its specializations,
         /// constructs a QsCallable with the implementation of each specialization set to External.
-        /// Throws an ArgumentNullException if the given header is null.
         /// </summary>
         private QsCallable GetImportedCallable(CallableDeclarationHeader header)
         {
             // TODO: this needs to be adapted if we want to support external specializations
-            if (header == null)
-            {
-                throw new ArgumentNullException(nameof(header));
-            }
             if (Namespace.IsDeclarationAccessible(false, header.Modifiers.Access))
             {
                 var definedSpecs = this.GlobalSymbols.DefinedSpecializations(header.QualifiedName);
@@ -778,15 +741,9 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
 
         /// <summary>
         /// Constructs a suitable type for a given type declaration header.
-        /// Throws an ArgumentNullException if the given header is null.
         /// </summary>
-        private QsCustomType GetImportedType(TypeDeclarationHeader header)
-        {
-            if (header == null)
-            {
-                throw new ArgumentNullException(nameof(header));
-            }
-            return new QsCustomType(
+        private QsCustomType GetImportedType(TypeDeclarationHeader header) =>
+            new QsCustomType(
                 header.QualifiedName,
                 header.Attributes,
                 header.Modifiers,
@@ -796,27 +753,17 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
                 header.TypeItems,
                 header.Documentation,
                 QsComments.Empty);
-        }
 
         /// <summary>
         /// Builds a syntax tree containing the given callables and types,
         /// and attaches the documentation specified by the given dictionary - if any - to each namespace.
         /// All elements within a namespace will be sorted in alphabetical order.
-        /// Throws an ArgumentNullException if the given callables or types are null.
         /// </summary>
         public static ImmutableArray<QsNamespace> NewSyntaxTree(
             IEnumerable<QsCallable> callables,
             IEnumerable<QsCustomType> types,
             IReadOnlyDictionary<NonNullable<string>, ILookup<NonNullable<string>, ImmutableArray<string>>>? documentation = null)
         {
-            if (callables == null)
-            {
-                throw new ArgumentNullException(nameof(callables));
-            }
-            if (types == null)
-            {
-                throw new ArgumentNullException(nameof(types));
-            }
             var emptyLookup = Array.Empty<NonNullable<string>>().ToLookup(ns => ns, _ => ImmutableArray<string>.Empty);
 
             static string QualifiedName(QsQualifiedName fullName) => $"{fullName.Namespace.Value}.{fullName.Name.Value}";
@@ -1036,22 +983,12 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// <param name="predicate">If specified, only types and callables from a source for which
         /// this function returns true are renamed.</param>
         /// <returns>The renamed and updated callables and types.</returns>
-        /// <exception cref="ArgumentNullException">Thrown when the given callables or types are null.</exception>
         internal static (IEnumerable<QsCallable>, IEnumerable<QsCustomType>) RenameInternalDeclarations(
             IEnumerable<QsCallable> callables,
             IEnumerable<QsCustomType> types,
             int additionalAssemblies = 0,
             Func<NonNullable<string>, bool>? predicate = null)
         {
-            if (callables == null)
-            {
-                throw new ArgumentNullException(nameof(callables));
-            }
-            if (types == null)
-            {
-                throw new ArgumentNullException(nameof(types));
-            }
-
             // Assign a unique ID to each reference.
 
             NameDecorator decorator = new NameDecorator($"QsRef");

--- a/src/QsCompiler/CompilationManager/ContextBuilder.cs
+++ b/src/QsCompiler/CompilationManager/ContextBuilder.cs
@@ -22,16 +22,10 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
 
         /// <summary>
         /// Verifies that all tokens are ordered according to their range.
-        /// Throws an ArgumentNullException if the given tokens are null, or if any of the contained elements are.
         /// Throws an ArgumentException if this is not the case.
         /// </summary>
         internal static void VerifyTokenOrdering(IEnumerable<CodeFragment> tokens)
         {
-            if (tokens == null || tokens.Any(x => x == null))
-            {
-                throw new ArgumentNullException(nameof(tokens));
-            }
-
             Position? previousEnding = null;
             foreach (var token in tokens)
             {
@@ -46,14 +40,9 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
 
         /// <summary>
         /// Returns the TokenIndex for the first token in the given file, or null if no such token exists.
-        /// Throws an ArgumentNullException if file is null.
         /// </summary>
         internal static CodeFragment.TokenIndex? FirstToken(this FileContentManager file)
         {
-            if (file == null)
-            {
-                throw new ArgumentNullException(nameof(file));
-            }
             var lineNr = 0;
             while (file.GetTokenizedLine(lineNr).Length == 0 && ++lineNr < file.NrLines())
             {
@@ -65,14 +54,9 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
 
         /// <summary>
         /// Returns the TokenIndex for the last token in the given file, or null if no such token exists.
-        /// Throws an ArgumentNullException if file is null.
         /// </summary>
         internal static CodeFragment.TokenIndex? LastToken(this FileContentManager file)
         {
-            if (file == null)
-            {
-                throw new ArgumentNullException(nameof(file));
-            }
             var lastNonEmpty = file.NrLines();
             while (lastNonEmpty-- > 0 && file.GetTokenizedLine(lastNonEmpty).Length == 0)
             {
@@ -84,16 +68,9 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
 
         /// <summary>
         /// Returns true if the given token is fully included in the given range.
-        /// Throws an ArgumentNullException if the token is null.
         /// </summary>
-        internal static bool IsWithinRange(this CodeFragment token, Range range)
-        {
-            if (token == null)
-            {
-                throw new ArgumentNullException(nameof(token));
-            }
-            return range.Contains(token.Range.Start) && range.ContainsEnd(token.Range.End);
-        }
+        internal static bool IsWithinRange(this CodeFragment token, Range range) =>
+            range.Contains(token.Range.Start) && range.ContainsEnd(token.Range.End);
 
         /// <summary>
         /// Returns a function that returns true if a given fragment ends at or before the given position.
@@ -244,15 +221,10 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// Returns true if the given file contains any tokens overlapping with the given fragment.
         /// The range of the tokens in the file is assumed to be relative to their start line (the index at which they are listed),
         /// whereas the range of the given fragment is assumed to be the absolute range.
-        /// Throws an ArgumentNullException if the given file or range is null.
         /// Throws an ArgumentOutOfRangeException if the given range is not a valid range within file.
         /// </summary>
         internal static bool ContainsTokensOverlappingWith(this FileContentManager file, Range range)
         {
-            if (file == null)
-            {
-                throw new ArgumentNullException(nameof(file));
-            }
             if (!file.ContainsRange(range))
             {
                 throw new ArgumentOutOfRangeException(nameof(range));
@@ -283,20 +255,10 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// <summary>
         /// Assuming both the current tokens and the tokens to update are sorted according to their range,
         /// merges the current and updated tokens such that the merged collection is sorted as well.
-        /// Throws an ArgumentNullException if either current or updated, or any of their elements are null.
-        /// Throws an ArgumentException if the token verification for the merged collection fails.
+        /// Throws a QsCompilerException if the token verification for the merged collection fails.
         /// </summary>
         internal static List<CodeFragment> MergeTokens(IEnumerable<CodeFragment> current, IEnumerable<CodeFragment> updated)
         {
-            if (current == null || current.Any(x => x == null))
-            {
-                throw new ArgumentNullException(nameof(current));
-            }
-            if (updated == null || updated.Any(x => x == null))
-            {
-                throw new ArgumentNullException(nameof(updated));
-            }
-
             var merged = new List<CodeFragment>(0);
             void NextBatch(ref IEnumerable<CodeFragment> batch, IEnumerable<CodeFragment> next)
             {
@@ -328,20 +290,9 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// Comparing for equality by value,
         /// returns the index of the first element in the given list of CodeFragments that matches the given token,
         /// or -1 if no such element exists.
-        /// Throws an ArgumentNullException if the given list is null.
         /// </summary>
         internal static int FindByValue(this IReadOnlyList<CodeFragment> list, CodeFragment token)
         {
-            if (list == null)
-            {
-                throw new ArgumentNullException(nameof(list));
-            }
-            if (token == null)
-            {
-                var nrNonNull = list.TakeWhile(x => x != null).Count();
-                return nrNonNull == list.Count ? -1 : nrNonNull;
-            }
-
             var index = -1;
             var tokenRange = token.Range;
             while (++index < list.Count && list[index].Range.Start < tokenRange.Start)
@@ -353,15 +304,9 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// <summary>
         /// Returns the index of the closest preceding non-empty token with the next lower indentation level.
         /// Returns null if no such token exists.
-        /// Throws an ArgumentNullException if tIndex is null.
         /// </summary>
         internal static CodeFragment.TokenIndex? GetNonEmptyParent(this CodeFragment.TokenIndex tIndex)
         {
-            if (tIndex == null)
-            {
-                throw new ArgumentNullException(nameof(tIndex));
-            }
-
             var tokenIndex = new CodeFragment.TokenIndex(tIndex);
             var indentation = tokenIndex.GetFragment().Indentation;
             while ((tokenIndex = tokenIndex.Previous()) != null)
@@ -377,14 +322,9 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
 
         /// <summary>
         /// Returns an IEnumerable with the indices of the closest preceding non-empty tokens with increasingly lower indentation level.
-        /// Throws an ArgumentNullException if tIndex is null.
         /// </summary>
         internal static IEnumerable<CodeFragment.TokenIndex> GetNonEmptyParents(this CodeFragment.TokenIndex tIndex)
         {
-            if (tIndex == null)
-            {
-                throw new ArgumentNullException(nameof(tIndex));
-            }
             for (var current = tIndex.GetNonEmptyParent(); current != null; current = current.GetNonEmptyParent())
             {
                 yield return current;
@@ -398,14 +338,9 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// up to the point where we are at the same indentation level again.
         /// If deep is set to false, then of those only the tokens with an indentation level that is precisely
         /// one larger than the one of the parent token are returned.
-        /// Throws an ArgumentNullException if tIndex is null.
         /// </summary>
         internal static IEnumerable<CodeFragment.TokenIndex> GetChildren(this CodeFragment.TokenIndex tIndex, bool deep = true)
         {
-            if (tIndex == null)
-            {
-                throw new ArgumentNullException(nameof(tIndex));
-            }
             var tokenIndex = new CodeFragment.TokenIndex(tIndex);
             var indentation = tokenIndex.GetFragment().Indentation;
             while ((tokenIndex = tokenIndex.Next()) != null && tokenIndex.GetFragment().Indentation > indentation)
@@ -420,15 +355,9 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// <summary>
         /// Returns the index of the preceding non-empty token on the same indentation level, or null if no such token exists.
         /// Includes empty tokens if includeEmpty is set to true.
-        /// Throws an ArgumentNullException if tIndex is null.
         /// </summary>
         internal static CodeFragment.TokenIndex? PreviousOnScope(this CodeFragment.TokenIndex tIndex, bool includeEmpty = false)
         {
-            if (tIndex == null)
-            {
-                throw new ArgumentNullException(nameof(tIndex));
-            }
-
             var tokenIndex = new CodeFragment.TokenIndex(tIndex);
             var indentation = tokenIndex.GetFragment().Indentation;
             while ((tokenIndex = tokenIndex.Previous()) != null)
@@ -445,15 +374,9 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// <summary>
         /// Returns the index of the next non-empty token on the same indenation level, or null if no such token exists.
         /// Includes empty tokens if includeEmpty is set to true.
-        /// Throws an ArgumentNullException if tIndex is null.
         /// </summary>
         internal static CodeFragment.TokenIndex? NextOnScope(this CodeFragment.TokenIndex tIndex, bool includeEmpty = false)
         {
-            if (tIndex == null)
-            {
-                throw new ArgumentNullException(nameof(tIndex));
-            }
-
             var tokenIndex = new CodeFragment.TokenIndex(tIndex);
             var indentation = tokenIndex.GetFragment().Indentation;
             while ((tokenIndex = tokenIndex.Next()) != null)
@@ -471,14 +394,9 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
 
         /// <summary>
         /// Returns the context object for the given token index, ignoring empty fragments.
-        /// Throws an ArgumentNullException if the given token index is null.
         /// </summary>
         private static Context.SyntaxTokenContext GetContext(this CodeFragment.TokenIndex tokenIndex)
         {
-            if (tokenIndex == null)
-            {
-                throw new ArgumentNullException(nameof(tokenIndex));
-            }
             QsNullable<QsFragmentKind> Nullable(CodeFragment? token, bool precedesSelf) =>
                 token?.Kind == null
                 ? QsNullable<QsFragmentKind>.Null
@@ -501,19 +419,9 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// and adds the computed diagnostics to the ones returned as out parameter.
         /// Marks the token indices which are to be excluded from compilation due to context errors.
         /// Returns the line numbers for which the context diagnostics have been recomputed.
-        /// Throws an ArgumentNullException if any of the arguments is null.
         /// </summary>
         private static HashSet<int> VerifyContext(this FileContentManager file, SortedSet<int> changedLines, out List<Diagnostic> diagnostics)
         {
-            if (file == null)
-            {
-                throw new ArgumentNullException(nameof(file));
-            }
-            if (changedLines == null)
-            {
-                throw new ArgumentNullException(nameof(changedLines));
-            }
-
             IEnumerable<CodeFragment.TokenIndex> TokenIndices(int lineNr) =>
                 Enumerable.Range(0, file.GetTokenizedLine(lineNr).Count()).Select(index => new CodeFragment.TokenIndex(file, lineNr, index));
 
@@ -567,19 +475,9 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// <summary>
         /// Given the line number of the lines that contain tokens that (possibly) have been modified,
         /// checks which callable declaration they can potentially belong to and returns the fully qualified name of those callables.
-        /// Throws an ArgumentNullException if the given file or the collection of changed lines is null.
         /// </summary>
         internal static IEnumerable<(Range, QsQualifiedName)> CallablesWithContentModifications(this FileContentManager file, IEnumerable<int> changedLines)
         {
-            if (file == null)
-            {
-                throw new ArgumentNullException(nameof(file));
-            }
-            if (changedLines == null)
-            {
-                throw new ArgumentNullException(nameof(changedLines));
-            }
-
             var lastInFile = file.LastToken()?.GetFragment()?.Range?.End ?? file.End();
             var callables = file.GetCallableDeclarations().Select(tuple => // these are sorted according to their line number
             {
@@ -619,15 +517,9 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// Dequeues all lines whose tokens has changed and verifies the positions of these tokens.
         /// Does nothing if no lines have been modified.
         /// Recomputes and pushes the context diagnostics for the processed tokens otherwise.
-        /// Throws an ArgumentNullException if file is null.
         /// </summary>
         internal static void UpdateContext(this FileContentManager file)
         {
-            if (file == null)
-            {
-                throw new ArgumentNullException(nameof(file));
-            }
-
             file.SyncRoot.EnterUpgradeableReadLock();
             try
             {

--- a/src/QsCompiler/CompilationManager/DataStructures.cs
+++ b/src/QsCompiler/CompilationManager/DataStructures.cs
@@ -147,7 +147,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder.DataStructures
                 throw new ArgumentException("a CodeFragment needs to be followed by a DelimitingChar");
             }
             this.Indentation = indent < 0 ? throw new ArgumentException("indentation needs to be positive") : indent;
-            this.Text = text?.TrimEnd() ?? throw new ArgumentNullException(nameof(text));
+            this.Text = text.TrimEnd();
             this.FollowedBy = next;
             this.Comments = comments ?? QsComments.Empty;
             this.Kind = kind; // nothing here should be modifiable
@@ -230,14 +230,12 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder.DataStructures
             /// <summary>
             /// Verifies the given line number and index *only* against the Tokens listed in file (and not against the content)
             /// and initializes an instance of TokenIndex.
-            /// Throws an ArgumentNullException if file is null.
             /// Throws an ArgumentOutOfRangeException if line or index are negative,
             /// or line is larger than or equal to the number of Tokens lists in file,
             /// or index is larger than or equal to the number of Tokens on the given line.
             /// </summary>
             internal TokenIndex(FileContentManager file, int line, int index)
             {
-                this.file = file ?? throw new ArgumentNullException(nameof(file));
                 if (line < 0 || line >= file.NrTokenizedLines())
                 {
                     throw new ArgumentOutOfRangeException(nameof(line));
@@ -247,6 +245,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder.DataStructures
                     throw new ArgumentOutOfRangeException(nameof(index));
                 }
 
+                this.file = file;
                 this.Line = line;
                 this.Index = index;
             }
@@ -391,17 +390,15 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder.DataStructures
             /// Builds the TreeNode consisting of the given fragment and children.
             /// RelativeToRoot is set to the position of the fragment start relative to the given parent start position.
             /// Throws an ArgumentException if the given parent start position is larger than the fragment start position.
-            /// Throws an ArgumentNullException if any of the given arguments is null.
             /// </summary>
             public TreeNode(CodeFragment fragment, IReadOnlyList<TreeNode> children, Position parentStart)
             {
-                this.Fragment = fragment ?? throw new ArgumentNullException(nameof(fragment));
-                this.Children = children ?? throw new ArgumentNullException(nameof(children));
-
                 if (fragment.Range.Start < parentStart)
                 {
                     throw new ArgumentException(nameof(parentStart), "parentStart needs to be smaller than or equal to the fragment start");
                 }
+                this.Fragment = fragment;
+                this.Children = children;
                 this.RootPosition = parentStart;
                 this.RelativePosition = fragment.Range.Start - parentStart;
             }
@@ -445,11 +442,6 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder.DataStructures
             ImmutableArray<string> doc,
             QsComments comments)
         {
-            if (tIndex == null)
-            {
-                throw new ArgumentNullException(nameof(tIndex));
-            }
-
             this.Position = offset;
             this.SymbolName = sym.Item1;
             this.PositionedSymbol = new Tuple<NonNullable<string>, Range>(sym.Item1, sym.Item2);
@@ -467,7 +459,6 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder.DataStructures
         /// If the keepInvalid parameter has been set to a (non-null) string, uses that string as the SymbolName for the returned HeaderEntry instance.
         /// Throws an ArgumentException if this verification fails as well.
         /// Throws an ArgumentException if the extracted declaration is Null.
-        /// Throws an ArgumentNullException if the given token index is null.
         /// </summary>
         internal static HeaderEntry<T>? From(
             Func<CodeFragment, QsNullable<Tuple<QsSymbol, T>>> getDeclaration,
@@ -476,15 +467,6 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder.DataStructures
             ImmutableArray<string> doc,
             string? keepInvalid = null)
         {
-            if (getDeclaration == null)
-            {
-                throw new ArgumentNullException(nameof(getDeclaration));
-            }
-            if (tIndex == null)
-            {
-                throw new ArgumentNullException(nameof(tIndex));
-            }
-
             var fragment = tIndex.GetFragmentWithClosingComments();
             var extractedDecl = getDeclaration(fragment);
             var (sym, decl) =
@@ -520,7 +502,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder.DataStructures
 
         public FileHeader(ReaderWriterLockSlim syncRoot)
         {
-            this.SyncRoot = syncRoot ?? throw new ArgumentNullException(nameof(syncRoot));
+            this.SyncRoot = syncRoot;
             this.namespaceDeclarations = new ManagedSortedSet(syncRoot);
             this.openDirectives = new ManagedSortedSet(syncRoot);
             this.typeDeclarations = new ManagedSortedSet(syncRoot);
@@ -935,10 +917,6 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder.DataStructures
 
         public void Replace(int start, int count, IReadOnlyList<T> replacements)
         {
-            if (replacements == null)
-            {
-                throw new ArgumentNullException(nameof(replacements));
-            }
             this.SyncRoot.EnterWriteLock();
             try
             {
@@ -963,10 +941,6 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder.DataStructures
 
         public void ReplaceAll(IEnumerable<T> replacement)
         {
-            if (replacement == null)
-            {
-                throw new ArgumentNullException(nameof(replacement));
-            }
             this.SyncRoot.EnterWriteLock();
             try
             {
@@ -980,10 +954,6 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder.DataStructures
 
         public void ReplaceAll(ManagedList<T> replacement)
         {
-            if (replacement == null)
-            {
-                throw new ArgumentNullException(nameof(replacement));
-            }
             this.SyncRoot.EnterWriteLock();
             try
             {
@@ -997,10 +967,6 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder.DataStructures
 
         public void Transform(int index, Func<T, T> transformation)
         {
-            if (transformation == null)
-            {
-                throw new ArgumentNullException(nameof(transformation));
-            }
             this.SyncRoot.EnterWriteLock();
             try
             {
@@ -1014,10 +980,6 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder.DataStructures
 
         public void Transform(Func<T, T> transformation)
         {
-            if (transformation == null)
-            {
-                throw new ArgumentNullException(nameof(transformation));
-            }
             this.SyncRoot.EnterWriteLock();
             try
             {

--- a/src/QsCompiler/CompilationManager/DiagnosticTools.cs
+++ b/src/QsCompiler/CompilationManager/DiagnosticTools.cs
@@ -64,16 +64,11 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// <summary>
         /// Returns a copy of this diagnostic with the given offset added to the line numbers.
         /// </summary>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="diagnostic"/> is null.</exception>
         /// <exception cref="ArgumentOutOfRangeException">
         /// Thrown if the new diagnostic has negative line numbers.
         /// </exception>
         public static Diagnostic WithLineNumOffset(this Diagnostic diagnostic, int offset)
         {
-            if (diagnostic is null)
-            {
-                throw new ArgumentNullException(nameof(diagnostic));
-            }
             var copy = diagnostic.Copy();
             copy.Range.Start.Line += offset;
             copy.Range.End.Line += offset;
@@ -124,31 +119,17 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// <summary>
         /// Extracts all elements satisfying the given condition and which start at a line that is larger or equal to lowerBound.
         /// Diagnostics without any range information are only extracted if no lower bound is specified or the specified lower bound is smaller than zero.
-        /// Throws an ArgumentNullException if the given condition is null.
         /// </summary>
         [return: NotNullIfNotNull("orig")]
-        public static IEnumerable<Diagnostic>? Filter(this IEnumerable<Diagnostic> orig, Func<Diagnostic, bool> condition, int lowerBound = -1)
-        {
-            if (condition == null)
-            {
-                throw new ArgumentNullException(nameof(condition));
-            }
-            return orig?.Where(m => condition(m) && lowerBound <= (m.Range?.Start?.Line ?? -1));
-        }
+        public static IEnumerable<Diagnostic>? Filter(this IEnumerable<Diagnostic>? orig, Func<Diagnostic, bool> condition, int lowerBound = -1) =>
+            orig?.Where(m => condition(m) && lowerBound <= (m.Range?.Start?.Line ?? -1));
 
         /// <summary>
         /// Extracts all elements satisfying the given condition and which start at a line that is larger or equal to lowerBound and smaller than upperBound.
-        /// Throws an ArgumentNullException if the given condition is null.
         /// </summary>
         [return: NotNullIfNotNull("orig")]
-        public static IEnumerable<Diagnostic>? Filter(this IEnumerable<Diagnostic> orig, Func<Diagnostic, bool> condition, int lowerBound, int upperBound)
-        {
-            if (condition == null)
-            {
-                throw new ArgumentNullException(nameof(condition));
-            }
-            return orig?.Where(m => condition(m) && lowerBound <= m.Range.Start.Line && m.Range.End.Line < upperBound);
-        }
+        public static IEnumerable<Diagnostic>? Filter(this IEnumerable<Diagnostic>? orig, Func<Diagnostic, bool> condition, int lowerBound, int upperBound) =>
+            orig?.Where(m => condition(m) && lowerBound <= m.Range.Start.Line && m.Range.End.Line < upperBound);
 
         /// <summary>
         /// Extracts all elements which start at a line that is larger or equal to lowerBound.

--- a/src/QsCompiler/CompilationManager/Diagnostics.cs
+++ b/src/QsCompiler/CompilationManager/Diagnostics.cs
@@ -79,16 +79,10 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// Generates a suitable Diagnostic from the given CompilerDiagnostic returned by the Q# compiler.
         /// The message range contained in the given CompilerDiagnostic is first converted to a Position object,
         /// and then added to the given positionOffset if the latter is not null.
-        /// Throws an ArgumentNullException if the Range of the given CompilerDiagnostic is null.
         /// Throws an ArgumentOutOfRangeException if the contained range contains zero or negative entries, or if its Start is bigger than its End.
         /// </summary>
-        internal static Diagnostic Generate(string filename, QsCompilerDiagnostic msg, Position? positionOffset = null)
-        {
-            if (msg.Range == null)
-            {
-                throw new ArgumentNullException(nameof(msg.Range));
-            }
-            return new Diagnostic
+        internal static Diagnostic Generate(string filename, QsCompilerDiagnostic msg, Position? positionOffset = null) =>
+            new Diagnostic
             {
                 Severity = Severity(msg),
                 Code = Code(msg),
@@ -96,7 +90,6 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
                 Message = msg.Message,
                 Range = ((positionOffset ?? Position.Zero) + msg.Range).ToLsp()
             };
-        }
 
         internal const string QsCodePrefix = "QS";
 

--- a/src/QsCompiler/CompilationManager/EditorSupport/CodeActions.cs
+++ b/src/QsCompiler/CompilationManager/EditorSupport/CodeActions.cs
@@ -25,19 +25,9 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
     {
         /// <summary>
         /// Returns the given edit for the specified file as WorkspaceEdit.
-        /// Throws an ArgumentNullException if the given file or any of the given edits is null.
         /// </summary>
         private static WorkspaceEdit GetWorkspaceEdit(this FileContentManager file, params TextEdit[] edits)
         {
-            if (file == null)
-            {
-                throw new ArgumentNullException(nameof(file));
-            }
-            if (edits == null || edits.Any(edit => edit == null))
-            {
-                throw new ArgumentNullException(nameof(edits));
-            }
-
             var versionedFileId = new VersionedTextDocumentIdentifier { Uri = file.Uri, Version = 1 }; // setting version to null here won't work in VS Code ...
             return new WorkspaceEdit
             {

--- a/src/QsCompiler/CompilationManager/EditorSupport/CodeCompletion.cs
+++ b/src/QsCompiler/CompilationManager/EditorSupport/CodeCompletion.cs
@@ -135,14 +135,9 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// Returns the completion environment at the given position in the file or null if the environment cannot be
         /// determined. Stores the code fragment found at or before the given position into an out parameter.
         /// </summary>
-        /// <exception cref="ArgumentNullException">Thrown when any argument is null.</exception>
         private static (CompletionScope?, QsFragmentKind?) GetCompletionEnvironment(
             FileContentManager file, Position position, out CodeFragment? fragment)
         {
-            if (file == null)
-            {
-                throw new ArgumentNullException(nameof(file));
-            }
             if (!file.ContainsPosition(position))
             {
                 // FileContentManager.IndentationAt will fail if the position is not within the file.
@@ -207,7 +202,6 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// <summary>
         /// Returns completion items that match the given kind.
         /// </summary>
-        /// <exception cref="ArgumentNullException">Thrown when any argument is null.</exception>
         private static IEnumerable<CompletionItem> GetCompletionsForKind(
             FileContentManager file,
             CompilationUnit compilation,
@@ -215,23 +209,6 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
             CompletionKind kind,
             string namespacePrefix = "")
         {
-            if (file == null)
-            {
-                throw new ArgumentNullException(nameof(file));
-            }
-            if (compilation == null)
-            {
-                throw new ArgumentNullException(nameof(compilation));
-            }
-            if (kind == null)
-            {
-                throw new ArgumentNullException(nameof(kind));
-            }
-            if (namespacePrefix == null)
-            {
-                throw new ArgumentNullException(nameof(namespacePrefix));
-            }
-
             switch (kind)
             {
                 case CompletionKind.Member member:
@@ -279,23 +256,9 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// part of a qualified symbol, in which case only completions for symbols matching the namespace prefix will be
         /// included.
         /// </summary>
-        /// <exception cref="ArgumentNullException">Thrown when any argument is null.</exception>
         private static IEnumerable<CompletionItem> GetFallbackCompletions(
             FileContentManager file, CompilationUnit compilation, Position position)
         {
-            if (file == null)
-            {
-                throw new ArgumentNullException(nameof(file));
-            }
-            if (compilation == null)
-            {
-                throw new ArgumentNullException(nameof(compilation));
-            }
-            if (position == null)
-            {
-                throw new ArgumentNullException(nameof(position));
-            }
-
             // If the character at the position is a dot but no valid namespace path precedes it (for example, in a
             // decimal number), then no completions are valid here.
             var nsPath = GetSymbolNamespacePath(file, position);
@@ -332,20 +295,9 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// Returns completions for local variables at the given position. If <paramref name="mutableOnly"/> is true,
         /// shows only completions for mutable local variables. Returns an empty enumerator if the position is invalid.
         /// </summary>
-        /// <exception cref="ArgumentNullException">Thrown when any argument is null.</exception>
         private static IEnumerable<CompletionItem> GetLocalCompletions(
-            FileContentManager file, CompilationUnit compilation, Position position, bool mutableOnly = false)
-        {
-            if (file == null)
-            {
-                throw new ArgumentNullException(nameof(file));
-            }
-            if (compilation == null)
-            {
-                throw new ArgumentNullException(nameof(compilation));
-            }
-            return
-                compilation
+            FileContentManager file, CompilationUnit compilation, Position position, bool mutableOnly = false) =>
+            compilation
                 .TryGetLocalDeclarations(file, position, out _, includeDeclaredAtPosition: false)
                 .Variables
                 .Where(variable => !mutableOnly || variable.InferredInformation.IsMutable)
@@ -354,34 +306,17 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
                     Label = variable.VariableName.Value,
                     Kind = CompletionItemKind.Variable
                 });
-        }
 
         /// <summary>
         /// Returns completions for all accessible callables given the current namespace and the list of open
         /// namespaces, or an empty enumerable if symbols haven't been resolved yet.
         /// </summary>
-        /// <exception cref="ArgumentNullException">
-        /// Thrown when any argument except <paramref name="currentNamespace"/> is null.
-        /// </exception>
         private static IEnumerable<CompletionItem> GetCallableCompletions(
             FileContentManager file,
             CompilationUnit compilation,
             string? currentNamespace,
             IEnumerable<string> openNamespaces)
         {
-            if (file == null)
-            {
-                throw new ArgumentNullException(nameof(file));
-            }
-            if (compilation == null)
-            {
-                throw new ArgumentNullException(nameof(compilation));
-            }
-            if (openNamespaces == null)
-            {
-                throw new ArgumentNullException(nameof(openNamespaces));
-            }
-
             if (!compilation.GlobalSymbols.ContainsResolutions)
             {
                 return Array.Empty<CompletionItem>();
@@ -407,28 +342,12 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// Returns completions for all accessible types given the current namespace and the list of open namespaces, or
         /// an empty enumerable if symbols haven't been resolved yet.
         /// </summary>
-        /// <exception cref="ArgumentNullException">
-        /// Thrown when any argument except <paramref name="currentNamespace"/> is null.
-        /// </exception>
         private static IEnumerable<CompletionItem> GetTypeCompletions(
             FileContentManager file,
             CompilationUnit compilation,
             string? currentNamespace,
             IEnumerable<string> openNamespaces)
         {
-            if (file == null)
-            {
-                throw new ArgumentNullException(nameof(file));
-            }
-            if (compilation == null)
-            {
-                throw new ArgumentNullException(nameof(compilation));
-            }
-            if (openNamespaces == null)
-            {
-                throw new ArgumentNullException(nameof(openNamespaces));
-            }
-
             if (!compilation.GlobalSymbols.ContainsResolutions)
             {
                 return Array.Empty<CompletionItem>();
@@ -452,14 +371,8 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// Returns completions for all named items in any accessible type, or an empty enumerable if symbols haven't
         /// been resolved yet.
         /// </summary>
-        /// <exception cref="ArgumentNullException">Thrown when the argument is null.</exception>
         private static IEnumerable<CompletionItem> GetNamedItemCompletions(CompilationUnit compilation)
         {
-            if (compilation == null)
-            {
-                throw new ArgumentNullException(nameof(compilation));
-            }
-
             if (!compilation.GlobalSymbols.ContainsResolutions)
             {
                 return Array.Empty<CompletionItem>();
@@ -481,19 +394,9 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// Note: a dot will be added after the given prefix if it is not the empty string, and doesn't already end with
         /// a dot.
         /// </summary>
-        /// <exception cref="ArgumentNullException">Thrown when any argument is null.</exception>
         private static IEnumerable<CompletionItem> GetGlobalNamespaceCompletions(
             CompilationUnit compilation, string prefix = "")
         {
-            if (compilation == null)
-            {
-                throw new ArgumentNullException(nameof(compilation));
-            }
-            if (prefix == null)
-            {
-                throw new ArgumentNullException(nameof(prefix));
-            }
-
             if (prefix.Length != 0 && !prefix.EndsWith("."))
             {
                 prefix += ".";
@@ -518,23 +421,9 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// Note: a dot will be added after the given prefix if it is not the empty string, and doesn't already end with
         /// a dot.
         /// </summary>
-        /// <exception cref="ArgumentNullException">Thrown when any argument is null.</exception>
         private static IEnumerable<CompletionItem> GetNamespaceAliasCompletions(
             FileContentManager file, CompilationUnit compilation, Position position, string prefix = "")
         {
-            if (file == null)
-            {
-                throw new ArgumentNullException(nameof(file));
-            }
-            if (compilation == null)
-            {
-                throw new ArgumentNullException(nameof(compilation));
-            }
-            if (prefix == null)
-            {
-                throw new ArgumentNullException(nameof(prefix));
-            }
-
             if (prefix.Length != 0 && !prefix.EndsWith("."))
             {
                 prefix += ".";
@@ -564,21 +453,12 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// the compilation unit with the given qualified name. Returns null if no documentation is available or the
         /// completion item data is missing properties.
         /// </summary>
-        /// <exception cref="ArgumentNullException">Thrown when any argument is null.</exception>
         private static string? TryGetDocumentation(
             CompilationUnit compilation, CompletionItemData data, CompletionItemKind kind, bool useMarkdown)
         {
-            if (compilation == null)
-            {
-                throw new ArgumentNullException(nameof(compilation));
-            }
-            if (data == null)
-            {
-                throw new ArgumentNullException(nameof(data));
-            }
             if (data.QualifiedName == null
-                    || data.SourceFile == null
-                    || !compilation.GlobalSymbols.NamespaceExists(data.QualifiedName.Namespace))
+                || data.SourceFile == null
+                || !compilation.GlobalSymbols.NamespaceExists(data.QualifiedName.Namespace))
             {
                 return null;
             }
@@ -611,19 +491,9 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// Returns the names of all namespaces that have been opened without an alias and are accessible from the given
         /// position in the file. Returns an empty enumerator if the position is invalid.
         /// </summary>
-        /// <exception cref="ArgumentNullException">Thrown when any argument is null.</exception>
         private static IEnumerable<string> GetOpenNamespaces(
             FileContentManager file, CompilationUnit compilation, Position position)
         {
-            if (file == null)
-            {
-                throw new ArgumentNullException(nameof(file));
-            }
-            if (compilation == null)
-            {
-                throw new ArgumentNullException(nameof(compilation));
-            }
-
             var @namespace = file.TryGetNamespaceAt(position);
             if (@namespace == null || !compilation.GlobalSymbols.NamespaceExists(NonNullable<string>.New(@namespace)))
             {
@@ -640,14 +510,8 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// Returns the namespace path for the qualified symbol at the given position, or null if there is no qualified
         /// symbol.
         /// </summary>
-        /// <exception cref="ArgumentNullException">Thrown when any argument is null.</exception>
         private static string? GetSymbolNamespacePath(FileContentManager file, Position position)
         {
-            if (file == null)
-            {
-                throw new ArgumentNullException(nameof(file));
-            }
-
             var fragment = file.TryGetFragmentAt(position, out _, includeEnd: true);
             if (fragment == null)
             {
@@ -669,18 +533,8 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// Returns the index in the fragment text corresponding to the given absolute position.
         /// </summary>
         /// <exception cref="ArgumentException">Thrown when the position is outside the fragment range.</exception>
-        /// <exception cref="ArgumentNullException">Thrown when any argument is null.</exception>
         private static int GetTextIndexFromPosition(CodeFragment fragment, Position position)
         {
-            if (fragment == null)
-            {
-                throw new ArgumentNullException(nameof(fragment));
-            }
-            if (position == null)
-            {
-                throw new ArgumentNullException(nameof(position));
-            }
-
             var relativeLine = position.Line - fragment.Range.Start.Line;
             var lines = Utils.SplitLines(fragment.Text).DefaultIfEmpty("");
             var relativeCharacter =
@@ -699,23 +553,9 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// Resolves the namespace alias and returns its full namespace name. If the alias couldn't be resolved, returns
         /// the alias unchanged.
         /// </summary>
-        /// <exception cref="ArgumentNullException">Thrown when any argument is null.</exception>
         private static string ResolveNamespaceAlias(
             FileContentManager file, CompilationUnit compilation, Position position, string alias)
         {
-            if (file == null)
-            {
-                throw new ArgumentNullException(nameof(file));
-            }
-            if (compilation == null)
-            {
-                throw new ArgumentNullException(nameof(compilation));
-            }
-            if (alias == null)
-            {
-                throw new ArgumentNullException(nameof(alias));
-            }
-
             var nsName = file.TryGetNamespaceAt(position);
             if (nsName == null || !compilation.GlobalSymbols.NamespaceExists(NonNullable<string>.New(nsName)))
             {
@@ -729,14 +569,8 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// Returns the token index at, or the closest token index before, the given position. Returns null if there is
         /// no token at or before the given position.
         /// </summary>
-        /// <exception cref="ArgumentNullException">Thrown when any argument is null.</exception>
         private static CodeFragment.TokenIndex? GetTokenAtOrBefore(FileContentManager file, Position position)
         {
-            if (file == null)
-            {
-                throw new ArgumentNullException(nameof(file));
-            }
-
             var line = position.Line;
             var tokens = file.GetTokenizedLine(line);
 
@@ -758,22 +592,12 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// Returns the position of the delimiting character that follows the given code fragment.
         /// </summary>
         /// <exception cref="ArgumentException">Thrown when the code fragment has a missing delimiter.</exception>
-        /// <exception cref="ArgumentNullException">Thrown when any argument is null.</exception>
         private static Position GetDelimiterPosition(FileContentManager file, CodeFragment fragment)
         {
-            if (file == null)
-            {
-                throw new ArgumentNullException(nameof(file));
-            }
-            if (fragment == null)
-            {
-                throw new ArgumentNullException(nameof(fragment));
-            }
             if (fragment.FollowedBy == CodeFragment.MissingDelimiter)
             {
                 throw new ArgumentException("Code fragment has a missing delimiter", nameof(fragment));
             }
-
             var end = fragment.Range.End;
             var position = file.FragmentEnd(ref end);
             return Position.Create(position.Line, position.Column - 1);
@@ -794,14 +618,9 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// position is after the end of the fragment text but before the delimiter, the entire text is returned with a
         /// space character appended to it.
         /// </summary>
-        /// <exception cref="ArgumentNullException">Thrown when file or position is null.</exception>
         private static string GetFragmentTextBeforePosition(
             FileContentManager file, CodeFragment? fragment, Position position)
         {
-            if (file == null)
-            {
-                throw new ArgumentNullException(nameof(file));
-            }
             if (fragment == null || IsPositionAfterDelimiter(file, fragment, position))
             {
                 return "";

--- a/src/QsCompiler/CompilationManager/EditorSupport/SymbolInformation.cs
+++ b/src/QsCompiler/CompilationManager/EditorSupport/SymbolInformation.cs
@@ -26,9 +26,6 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
     {
         // utils for getting the necessary information for editor commands
 
-        /// <summary>
-        /// Throws an ArgumentNullException if the given offset or relative range is null.
-        /// </summary>
         internal static Location AsLocation(NonNullable<string> source, Position offset, Range relRange) =>
             new Location
             {
@@ -36,9 +33,6 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
                 Range = (offset + relRange).ToLsp()
             };
 
-        /// <summary>
-        /// Throws an ArgumentNullException if the given reference location is null.
-        /// </summary>
         internal static Location AsLocation(IdentifierReferences.Location loc) =>
             AsLocation(loc.SourceFile, loc.DeclarationOffset + loc.RelativeStatementLocation.Offset, loc.SymbolRange);
 

--- a/src/QsCompiler/CompilationManager/EditorSupport/SymbolInformation.cs
+++ b/src/QsCompiler/CompilationManager/EditorSupport/SymbolInformation.cs
@@ -252,7 +252,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
                             : ImmutableHashSet<IdentifierReferences.Location>.Empty)
                     .Select(AsLocation);
             }
-            else if (implementation is null)
+            else if (implementation is null || specPos is null)
             {
                 return false;
             }

--- a/src/QsCompiler/CompilationManager/FileContentManager.cs
+++ b/src/QsCompiler/CompilationManager/FileContentManager.cs
@@ -111,7 +111,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         internal FileContentManager(Uri uri, NonNullable<string> fileName)
         {
             this.SyncRoot = new ReaderWriterLockSlim(LockRecursionPolicy.SupportsRecursion);
-            this.Uri = uri ?? throw new ArgumentNullException(nameof(uri));
+            this.Uri = uri;
             this.FileName = fileName;
 
             this.content = new ManagedList<CodeLine>(this.SyncRoot);
@@ -189,14 +189,9 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// Given the position where the syntax check starts and ends relative to the original file content before the update, and the lineNrChange,
         /// removes all diagnostics that are no longer valid due to that change, and
         /// updates the line numbers of the remaining diagnostics if needed.
-        /// Throws an ArgumentNullException if the given diagnostics to update or if the syntax check delimiters are null.
         /// </summary>
         private static void InvalidateOrUpdateBySyntaxCheckDelimeters(ManagedList<Diagnostic> diagnostics, Range syntaxCheckDelimiters, int lineNrChange)
         {
-            if (diagnostics == null)
-            {
-                throw new ArgumentNullException(nameof(diagnostics));
-            }
             Diagnostic UpdateLineNrs(Diagnostic m) => m.SelectByStart(syntaxCheckDelimiters.End) ? m.WithLineNumOffset(lineNrChange) : m;
             diagnostics.SyncRoot.EnterWriteLock();
             try
@@ -219,7 +214,6 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// <summary>
         /// Updates the line numbers of diagnostics that start after the syntax check end delimiter in both lists of diagnostics,
         /// and removes all diagnostics that overlap with the given range for the syntax check update in the updated diagnostics only.
-        /// Throws an ArgumentNullException if the given current and/or latest diagnostics are null, or if the syntax check delimiters are null.
         /// Throws an ArgumentException if the given start and end position do not denote a valid range.
         /// </summary>
         private static void DelayInvalidateOrUpdate(
@@ -228,15 +222,6 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
             Range syntaxCheckDelimiters,
             int lineNrChange)
         {
-            if (diagnostics == null)
-            {
-                throw new ArgumentNullException(nameof(diagnostics));
-            }
-            if (updated == null)
-            {
-                throw new ArgumentNullException(nameof(updated));
-            }
-
             InvalidateOrUpdateBySyntaxCheckDelimeters(updated, syntaxCheckDelimiters, lineNrChange);
             Diagnostic UpdateLineNrs(Diagnostic m) => m.SelectByStart(syntaxCheckDelimiters.End) ? m.WithLineNumOffset(lineNrChange) : m;
             if (lineNrChange != 0)
@@ -304,7 +289,6 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// Given the position where the syntax check starts and ends relative to the original file content before the update, and the lineNrChange,
         /// removes all diagnostics that are no longer valid due to that change, and
         /// updates the line numbers of the remaining diagnostics if needed.
-        /// Throws an ArgumentNullException if the given diagnostics to update or the syntax check delimiters are null.
         /// Throws an ArgumentException if the given start and end position do not denote a valid range.
         /// </summary>
         private void InvalidateOrUpdateSyntaxDiagnostics(Range syntaxCheckDelimiters, int lineNrChange) =>
@@ -314,15 +298,10 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// Given the line numbers for which the context diagnostics are now obsolete,
         /// removes all context diagnostics that start on a line marked as obsolete,
         /// and replaces them with the given sequence of context diagnostics.
-        /// Throws an ArgumentNullException if the if the given sequence of line numbers for which the context diagnostics are obsolete is null.
         /// Throws an ArgumentOutOfRangeException if that sequence contains a value that is negative.
         /// </summary>
         internal void UpdateContextDiagnostics(HashSet<int> obsolete, IEnumerable<Diagnostic> updates)
         {
-            if (obsolete == null)
-            {
-                throw new ArgumentNullException(nameof(obsolete));
-            }
             if (obsolete.Any() && obsolete.Min() < 0)
             {
                 throw new ArgumentOutOfRangeException(nameof(obsolete));
@@ -394,7 +373,6 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// Given the position where the syntax check starts and ends relative to the original file content before the update, and the lineNrChange,
         /// removes all diagnostics that are no longer valid due to that change, and
         /// updates the line numbers of the remaining diagnostics if needed.
-        /// Throws an ArgumentNullException if the given diagnostics to update or the syntax check delimiters are null.
         /// Throws an ArgumentException if the given start and end position do not denote a valid range.
         /// </summary>
         private void InvalidateOrUpdateHeaderDiagnostics(Range syntaxCheckDelimiters, int lineNrChange) =>
@@ -422,7 +400,6 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// Given the position where the syntax check starts and ends relative to the original file content before the update, and the lineNrChange,
         /// removes all diagnostics that are no longer valid due to that change, and
         /// updates the line numbers of the remaining diagnostics if needed.
-        /// Throws an ArgumentNullException if the given diagnostics to update or the syntax check delimiters are null.
         /// Throws an ArgumentException if the given start and end position do not denote a valid range.
         /// </summary>
         private void InvalidateOrUpdateSemanticDiagnostics(Range syntaxCheckDelimiters, int lineNrChange) =>
@@ -469,7 +446,6 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         internal int NrLines() => this.content.Count();
 
         /// <summary>
-        /// Throws an ArgumentNullException if any of the given arguments is null.
         /// Throws an ArgumentOutOfRangeException if start and count are not valid for the current file content, where count needs to be at least one.
         /// Throws an ArgumentException if the replacements do not at least contain one element, or the indentation change is non-zero,
         /// or if a replacement does not have a suitable line ending.
@@ -483,11 +459,6 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
             if (count < 1 || start + count > this.NrLines())
             {
                 throw new ArgumentOutOfRangeException(nameof(count));
-            }
-            // make sure properties are never set to null!
-            if (replacements == null)
-            {
-                throw new ArgumentNullException(nameof(replacements));
             }
             if (replacements.Count == 0)
             {
@@ -634,7 +605,6 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// Applies ModifiedTokens to the tokens at the given lineNr to obtain the list of tokens for which to mark all connections as edited.
         /// Then constructs and returns an Action as out parameter
         /// that adds lineNr as well as all lines containing connections to mark to EditedTokens.
-        /// Throws an ArgumentNullException if UpdatedTokens or ModifiedTokens is null.
         /// Throws an ArgumentException if any of the values returned by UpdatedTokens or ModifiedTokens is null.
         /// Throws an ArgumentOutOfRangeException if linrNr is not a valid index for the current Tokens.
         /// </summary>
@@ -648,14 +618,6 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
             this.tokens.SyncRoot.EnterWriteLock();
             try
             {
-                if (updatedTokens == null)
-                {
-                    throw new ArgumentNullException(nameof(updatedTokens));
-                }
-                if (modifiedTokens == null)
-                {
-                    throw new ArgumentNullException(nameof(modifiedTokens));
-                }
                 if (lineNr < 0 || lineNr >= this.tokens.Count())
                 {
                     throw new ArgumentOutOfRangeException(nameof(lineNr));
@@ -708,7 +670,6 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// marks the lines with the removed tokens as well as any lines that contain connected tokens as edited.
         /// Tokens starting at range.End or ending at range.Start are *not* considered to be overlapping.
         /// Futs a write-lock on the Tokens during the entire routine.
-        /// Throws an ArgumentNullException if the given range or it start or end position is null.
         /// Throws an ArgumentOutOfRangeException if the line number of the range end is larger than the number of currently saved tokens.
         /// </summary>
         private void RemoveTokensInRange(Range range)
@@ -784,14 +745,9 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// Attaches end of line comments for the lines on which fragments have been modified to suitable tokens.
         /// Verifies the given fragments and
         /// throws the corresponding exception if the verification fails.
-        /// Throws an ArgumentNullException if any of the given fragments are null.
         /// </summary>
         internal void TokensUpdate(IReadOnlyList<CodeFragment> fragments)
         {
-            if (fragments == null || fragments.Any(x => x == null))
-            {
-                throw new ArgumentNullException(nameof(fragments));
-            }
             if (!fragments.Any())
             {
                 return;
@@ -1031,17 +987,12 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// An update is considered necessary if the given change replaces more than one line of the current content,
         /// or if the inserted text cannot be a symbol or keyword (i.e. includes any whitespace, numbers and/or special characters).
         /// Sets the out parameter to true if diagnostics are to be published.
-        /// Throws an ArgumentNullException if the change or any of its fields are null.
         /// Throws an ArgumentException if the range of the change is invalid.
         /// </summary>
         internal void PushChange(TextDocumentContentChangeEvent change, out bool publishDiagnostics)
         {
             // NOTE: since there may be still unprocessed changes aggregated in UnprocessedChanges we cannot verify the range of the change against the current file content,
-            // however, let's at least check that nothing is null, all entries are positive, and the range start is smaller than or equal to the range end
-            if (change == null)
-            {
-                throw new ArgumentNullException(nameof(change));
-            }
+            // however, let's at least check that all entries are positive, and the range start is smaller than or equal to the range end
 
             this.timer.Stop(); // will be restarted if needed
             var range = change.Range.ToQSharp();
@@ -1084,17 +1035,12 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// <summary>
         /// Replaces the entire file content with the given text.
         /// Forces the update to be processed rather than queued.
-        /// Throws an ArgumentNullException if the given text is null.
         /// </summary>
         internal void ReplaceFileContent(string text)
         {
             this.SyncRoot.EnterUpgradeableReadLock();
             try
             {
-                if (text == null)
-                {
-                    throw new ArgumentNullException(nameof(text));
-                }
                 var change = new TextDocumentContentChangeEvent
                 {
                     Range = new Lsp.Range { Start = new Lsp.Position(), End = this.End().ToLsp() },

--- a/src/QsCompiler/CompilationManager/ProcessingQueue.cs
+++ b/src/QsCompiler/CompilationManager/ProcessingQueue.cs
@@ -58,14 +58,9 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// <summary>
         /// Enqueues the given Action for exclusive (serialized) execution.
         /// Uses the set exception logger to log any exception that occurs during execution.
-        /// Throws an ArgumentNullException if the given Action is null.
         /// </summary>
         public Task QueueForExecutionAsync(Action processing)
         {
-            if (processing == null)
-            {
-                throw new ArgumentNullException(nameof(processing));
-            }
             var processingTask = this.ProcessingTaskAsync(processing);
             processingTask.Start(this.scheduler.ExclusiveScheduler);
             return processingTask;
@@ -74,37 +69,26 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// <summary>
         /// Executes the given Action synchronously, with no exclusive actions running.
         /// Uses the set exception logger to log any exception that occurs during execution.
-        /// Throws an ArgumentNullException if the given Action is null.
         /// NOTE: may deadlock if the given function to execute calls this processing queue.
         /// </summary>
-        public void QueueForExecution(Action processing)
-        {
-            if (processing == null)
-            {
-                throw new ArgumentNullException(nameof(processing));
-            }
+        public void QueueForExecution(Action processing) =>
             this.QueueForExecution(
                 () =>
                 {
                     processing();
                     return new object();
-                }, out _);
-        }
+                },
+                out _);
 
         /// <summary>
         /// Executes the given function synchronously without any exclusive tasks running,
         /// returning its result as out parameter.
         /// Uses the set exception logger to log any exception that occurs during execution.
         /// Returns true if the execution succeeded without throwing an exception, and false otherwise.
-        /// Throws an ArgumentNullException if the given function to execute is null.
         /// NOTE: may deadlock if the given function to execute calls this processing queue.
         /// </summary>
         public bool QueueForExecution<T>(Func<T> execute, [MaybeNull] out T result)
         {
-            if (execute == null)
-            {
-                throw new ArgumentNullException(nameof(execute));
-            }
             T res = default(T);
             var succeeded = true;
             this.QueueForExecutionAsync(() =>
@@ -130,14 +114,9 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// <summary>
         /// Enqueues the given Action for concurrent (background) execution.
         /// Uses the set exception logger to log any exception that occurs during execution.
-        /// Throws an ArgumentNullException if the given Action is null.
         /// </summary>
         public Task ConcurrentExecutionAsync(Action processing)
         {
-            if (processing == null)
-            {
-                throw new ArgumentNullException(nameof(processing));
-            }
             var processingTask = this.ProcessingTaskAsync(processing);
             processingTask.Start(this.scheduler.ConcurrentScheduler);
             return processingTask;
@@ -146,36 +125,25 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// <summary>
         /// Executes the given Action synchronously and concurrently (background).
         /// Uses the set exception logger to log any exception that occurs during execution.
-        /// Throws an ArgumentNullException if the given Action is null.
         /// NOTE: may deadlock if the given function to execute calls this processing queue.
         /// </summary>
-        public void ConcurrentExecution(Action processing)
-        {
-            if (processing == null)
-            {
-                throw new ArgumentNullException(nameof(processing));
-            }
+        public void ConcurrentExecution(Action processing) =>
             this.ConcurrentExecution(
                 () =>
                 {
                     processing();
                     return new object();
-                }, out _);
-        }
+                },
+                out _);
 
         /// <summary>
         /// Executes the given function synchronously and concurrently, returning its result as out parameter.
         /// Returns true if the execution succeeded without throwing an exception, and false otherwise.
         /// Uses the set exception logger to log any exception that occurs during execution.
-        /// Throws an ArgumentNullException if the given Action is null.
         /// NOTE: may deadlock if the given function to execute calls this processing queue.
         /// </summary>
         public bool ConcurrentExecution<T>(Func<T> execute, [MaybeNull] out T result)
         {
-            if (execute == null)
-            {
-                throw new ArgumentNullException(nameof(execute));
-            }
             T res = default(T);
             var succeeded = true;
             this.ConcurrentExecutionAsync(() =>

--- a/src/QsCompiler/CompilationManager/ScopeTracking.cs
+++ b/src/QsCompiler/CompilationManager/ScopeTracking.cs
@@ -18,18 +18,9 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// <summary>
         /// Checks that all delimiters are within -1 and the string length, and that they are sorted in ascending order.
         /// Throws an ArgumentException if the checks fail.
-        /// Throws an ArgumentNullException if any of the given arguments is null.
         /// </summary>
         internal static void VerifyStringDelimiters(string text, IEnumerable<int> delimiters)
         {
-            if (text == null)
-            {
-                throw new ArgumentNullException(nameof(text));
-            }
-            if (delimiters == null)
-            {
-                throw new ArgumentNullException(nameof(delimiters));
-            }
             var last = -2;
             foreach (int delim in delimiters)
             {
@@ -53,19 +44,9 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// Checks that all positions are a valid index in the line text, and that they are sorted in ascending order.
         /// Checks that none of the positions lays within a string.
         /// Throws an ArgumentException if the checks fail.
-        /// Throws an ArgumentNullException if any of the given arguments is null.
         /// </summary>
         internal static void VerifyExcessBracketPositions(CodeLine line, IEnumerable<int> positions)
         {
-            if (line == null)
-            {
-                throw new ArgumentNullException(nameof(line));
-            }
-            if (positions == null)
-            {
-                throw new ArgumentNullException(nameof(positions));
-            }
-
             var last = -1;
             foreach (var pos in positions)
             {
@@ -89,15 +70,10 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// Computes the updated code line based on the given previous line predecessing it,
         /// and compares its indentation with the current line at continueAt in the given file.
         /// Returns the difference of the new indentation and the current one.
-        /// Throws an ArgumentNullException if file is null.
         /// Throws an ArgumentOutOfRangeException if the given index to continue at is less than zero or more than the number of lines in the given file.
         /// </summary>
         internal static int GetIndentationChange(FileContentManager file, int continueAt, CodeLine previous) // previous: last element before the one at continueAt
         {
-            if (file == null)
-            {
-                throw new ArgumentNullException(nameof(file));
-            }
             if (continueAt < 0 || continueAt > file.NrLines())
             {
                 throw new ArgumentOutOfRangeException(nameof(continueAt));
@@ -130,15 +106,9 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
 
         /// <summary>
         /// Computes the location of the string delimiters within a given text.
-        /// Throws an ArgumentNullException if the given text is null.
         /// </summary>
         private static IEnumerable<int> ComputeStringDelimiters(string text, bool isContinuation)
         {
-            if (text == null)
-            {
-                throw new ArgumentNullException(nameof(text));
-            }
-
             var nrDelimiters = 0;
             if (isContinuation)
             {
@@ -195,14 +165,9 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// <summary>
         /// Given an index computed before applying RemoveStrings, computes the index after applying RemoveStrings.
         /// Returns -1 if the given index is within a string.
-        /// Throws an ArgumentNullException if delimiters is null.
         /// </summary>
         private static int IndexExcludingStrings(int indexInFullText, IEnumerable<int> delimiters)
         {
-            if (delimiters == null)
-            {
-                throw new ArgumentNullException(nameof(delimiters));
-            }
             var iter = delimiters.GetEnumerator();
             var index = indexInFullText;
             int GetStart(int pos) => pos < 0 ? 0 : StartDelimiter(pos);
@@ -225,14 +190,9 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// <summary>
         /// Given and index computed before applying RelevantCode, computes the index after applying RelevantCode.
         /// Returns -1 if the given index is negative, or is within a string or a comment, or denotes an excess bracket.
-        /// Throws an ArgumentNullException if line is null.
         /// </summary>
         private static int IndexInRelevantCode(int indexInFullText, CodeLine line)
         {
-            if (line == null)
-            {
-                throw new ArgumentNullException(nameof(line));
-            }
             if (indexInFullText < 0 || line.WithoutEnding.Length <= indexInFullText)
             {
                 return -1;
@@ -260,14 +220,9 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
 
         /// <summary>
         /// Given an index computed after applying RemoveStrings, computes the index in the original text.
-        /// Throws an ArgumentNullException if delimiters is null.
         /// </summary>
         private static int IndexIncludingStrings(int indexInTrimmed, IEnumerable<int> delimiters)
         {
-            if (delimiters == null)
-            {
-                throw new ArgumentNullException(nameof(delimiters));
-            }
             var iter = delimiters.GetEnumerator();
             var index = indexInTrimmed;
             int GetStart(int pos) => pos < 0 ? 0 : StartDelimiter(pos);
@@ -284,7 +239,6 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
 
         /// <summary>
         /// Given an index computed after applying RelevantCode, computes the index in the original text.
-        /// Throws an ArgumentNullException if line is null.
         /// </summary>
         private static int IndexInFullString(int indexInTrimmed, CodeLine line)
         {
@@ -352,7 +306,6 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
 
         /// <summary>
         /// Computes the string delimiters for a truncated substring of length count starting at start based on the delimiters of the original string.
-        /// Throws an ArgumentNullException if the given delimiters are null.
         /// Throws an ArgumentException if start or count is smaller than zero.
         /// </summary>
         private static IEnumerable<int> TruncateStringDelimiters(IEnumerable<int> delimiters, int start, int count)
@@ -364,10 +317,6 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
             if (count < 0)
             {
                 throw new ArgumentOutOfRangeException(nameof(count));
-            }
-            if (delimiters == null)
-            {
-                throw new ArgumentNullException(nameof(delimiters));
             }
 
             var nrDelim = 0;
@@ -395,14 +344,9 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// The returned index is relative to the original text.
         /// If the value returned by FindIndex is smaller than zero it is returned unchanged.
         /// Throws an ArgumentOutOfRangeException if start and count do not define a valid range in the text of the given line.
-        /// Throws an ArgumentNullException if any of the given arguments is null.
         /// </summary>
         internal static int FindInCode(this CodeLine line, Func<string, int> findIndex, bool ignoreExcessBrackets = true)
         {
-            if (findIndex == null)
-            {
-                throw new ArgumentNullException(nameof(findIndex));
-            }
             if (ignoreExcessBrackets)
             {
                 return IndexInFullString(findIndex(RelevantCode(line)), line); // fine also for index = -1
@@ -419,11 +363,10 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// Important: This function returns the index relative to the original text, not the substring.
         /// If the value returned by FindIndex is smaller than zero it is returned unchanged.
         /// Throws an ArgumentOutOfRangeException if start and count do not define a valid range in the text of the given line.
-        /// Throws an ArgumentNullException if any of the given arguments is null.
         /// </summary>
         internal static int FindInCode(this CodeLine line, Func<string, int> findIndex, int start, int count, bool ignoreExcessBrackets = true)
         {
-            var truncatedDelims = TruncateStringDelimiters(line.StringDelimiters, start, count); // TruncateStringDelimiters will throw if line is null
+            var truncatedDelims = TruncateStringDelimiters(line.StringDelimiters, start, count);
             var truncatedText = line.Text.Substring(start, count); // will throw if start and count are out of range
             var truncatedExcessClosings =
                 line.ExcessBracketPositions
@@ -475,23 +418,9 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
 
         // utils for computing indentations and excess closings
 
-        private static int NrIndents(string text)
-        {
-            if (text == null)
-            {
-                throw new ArgumentNullException(nameof(text));
-            }
-            return text.Length - text.Replace("{", "").Length;
-        }
+        private static int NrIndents(string text) => text.Length - text.Replace("{", "").Length;
 
-        private static int NrUnindents(string text)
-        {
-            if (text == null)
-            {
-                throw new ArgumentNullException(nameof(text));
-            }
-            return text.Length - text.Replace("}", "").Length;
-        }
+        private static int NrUnindents(string text) => text.Length - text.Replace("}", "").Length;
 
         /// <summary>
         /// Returns the indentation at the end of the line.
@@ -506,7 +435,6 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// <summary>
         /// Computes the number of excess brackets on the given line based in the given line number
         /// and the list of lines containing the excess closings before that line.
-        /// Throws an ArgumentNullException if any of the arguments is null.
         /// </summary>
         private static int[] ComputeExcessClosings(CodeLine line, int effectiveIndent)
         {
@@ -553,14 +481,9 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// with suitable string delimiters and the correct end of line comment position,
         /// leaving the indentation at its default value and the excess brackets uncomputed.
         /// The previous line being null or not provided indicates that there is no previous line.
-        /// Throws an ArgumentNullExceptions if the given texts are null.
         /// </summary>
         private static IEnumerable<CodeLine> InitializeCodeLines(IEnumerable<string> texts, CodeLine? previousLine = null)
         {
-            if (texts == null)
-            {
-                throw new ArgumentNullException(nameof(texts));
-            }
             var continueString = ContinueString(previousLine);
             foreach (string text in texts)
             {
@@ -579,14 +502,9 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// Given the initial indentation of a sequence of CodeLines, and a sequence of code lines with the correct string delimiters set,
         /// computes and sets the correct indentation level and excess bracket positions for each line.
         /// The previous line being null or not provided indicates that there is no previous line.
-        /// Throws an ArgumentNullExceptions if the given texts are null.
         /// </summary>
         private static IEnumerable<CodeLine> SetIndentations(IEnumerable<CodeLine> lines, int currentIndentation)
         {
-            if (lines == null)
-            {
-                throw new ArgumentNullException(nameof(lines));
-            }
             foreach (var line in lines)
             {
                 var updated = line.SetIndentation(currentIndentation);
@@ -616,40 +534,25 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// <summary>
         /// Based on the previous line, computes the new CodeLines for the given texts.
         /// The previous line being null or not provided indicates that there is no previous line.
-        /// Throws an ArgumentNullExceptions if the given texts are null.
         /// </summary>
-        private static IEnumerable<CodeLine> ComputeCodeLines(IEnumerable<string> texts, CodeLine? previousLine = null)
-        {
-            return SetIndentations(InitializeCodeLines(texts, previousLine), previousLine == null ? 0 : previousLine.FinalIndentation());
-        }
+        private static IEnumerable<CodeLine> ComputeCodeLines(IEnumerable<string> texts, CodeLine? previousLine = null) =>
+            SetIndentations(InitializeCodeLines(texts, previousLine), previousLine == null ? 0 : previousLine.FinalIndentation());
 
         /// <summary>
         /// Returns an enumerable sequence of new CodeLines when the initial indentation of the sequence is initialIndentation,
         /// (re-)computing the positions of excess brackets if needed.
-        /// Throws an ArgumentNullException if the given sequence of code lines is null.
         /// </summary>
-        private static List<CodeLine> GetUpdatedLines(this IEnumerable<CodeLine> lines, int initialIndentation)
-        {
-            return SetIndentations(lines, initialIndentation).ToList();
-        }
+        private static List<CodeLine> GetUpdatedLines(this IEnumerable<CodeLine> lines, int initialIndentation) =>
+            SetIndentations(lines, initialIndentation).ToList();
 
         /// <summary>
         /// Computes the excess closing and scope error updates for the given replacements at the position specified by start and count in the given file.
         /// Returns a sequence of CodeLines for the remaining file, if the made replacements require updating the remaining file as well, and null otherwise.
-        /// Throws an ArgumentNullException if file or replacements is null.
         /// Throws an ArgumentException if replacements does not at least contain one CodeLine.
         /// Throws an ArgumentOutOfRangeException if the range defined by start and count is not within the given file, where count needs to be at least one.
         /// </summary>
         private static IEnumerable<CodeLine>? ComputeUpdates(FileContentManager file, int start, int count, CodeLine[] replacements)
         {
-            if (file == null)
-            {
-                throw new ArgumentNullException(nameof(file));
-            }
-            if (replacements == null)
-            {
-                throw new ArgumentNullException(nameof(replacements));
-            }
             if (start < 0 || start >= file.NrLines())
             {
                 throw new ArgumentOutOfRangeException(nameof(start));
@@ -692,15 +595,10 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// <summary>
         /// Given the total number of excess closings in the file
         /// checks for both an unclosed scope and a missing string ending on lastLine, and adds the corresponding error(s) to updatedScopeErrors.
-        /// Throws an ArgumentNullException if file is null.
         /// Throws an ArgumentException if the number of lines in the file is zero.
         /// </summary>
         private static IEnumerable<Diagnostic> CheckForMissingClosings(this FileContentManager file)
         {
-            if (file == null)
-            {
-                throw new ArgumentNullException(nameof(file));
-            }
             if (file.NrLines() == 0)
             {
                 throw new ArgumentException("the number of lines in a file can never be zero");
@@ -718,15 +616,10 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
 
         /// <summary>
         /// Computes excess bracket errors for the given range of lines in file based on the corresponding CodeLine.
-        /// Throws an ArgumentNullException if file is null.
         /// Throws an ArgumentOutOfRangeException if the range [start, start + count) is not within file.
         /// </summary>
         private static IEnumerable<Diagnostic> ComputeScopeDiagnostics(this FileContentManager file, int start, int count)
         {
-            if (file == null)
-            {
-                throw new ArgumentNullException(nameof(file));
-            }
             foreach (var line in file.GetLines(start, count))
             {
                 foreach (var pos in line.ExcessBracketPositions)
@@ -739,14 +632,10 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
 
         /// <summary>
         /// Computes excess bracket errors for the given range of lines in file based on the corresponding CodeLine.
-        /// Throws an ArgumentNullException if file is null.
         /// Throws an ArgumentOutOfRangeException if start is not within file.
         /// </summary>
-        private static IEnumerable<Diagnostic> ComputeScopeDiagnostics(this FileContentManager file, int start)
-        {
-            // will raise an exception if file is null
-            return ComputeScopeDiagnostics(file, start, file == null ? 0 : file.NrLines() - start);
-        }
+        private static IEnumerable<Diagnostic> ComputeScopeDiagnostics(this FileContentManager file, int start) =>
+            ComputeScopeDiagnostics(file, start, file == null ? 0 : file.NrLines() - start);
 
         // the actual update routine
 
@@ -798,16 +687,9 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// Attempts to compute an incremental update for the change specified by start, count and newText, and updates file accordingly.
         /// The given argument newText replaces the entire lines from start to (but not including) start + count.
         /// If the given change is null, then (only) the currently queued unprocessed changes are processed.
-        /// Throws an ArgumentNullException if file is null.
-        /// Any other exceptions should be throws (and caught, and possibly re-thrown) during the updating.
         /// </summary>
         internal static void UpdateScopeTacking(this FileContentManager file, TextDocumentContentChangeEvent? change)
         {
-            if (file == null)
-            {
-                throw new ArgumentNullException(nameof(file));
-            }
-
             /// <summary>
             /// Replaces the lines in the range [start, end] with those for the given text.
             /// </summary>

--- a/src/QsCompiler/CompilationManager/TextProcessor.cs
+++ b/src/QsCompiler/CompilationManager/TextProcessor.cs
@@ -7,7 +7,6 @@ using System.Linq;
 using Microsoft.Quantum.QsCompiler.CompilationBuilder.DataStructures;
 using Microsoft.Quantum.QsCompiler.TextProcessing;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
-using Lsp = Microsoft.VisualStudio.LanguageServer.Protocol;
 using Position = Microsoft.Quantum.QsCompiler.DataTypes.Position;
 using Range = Microsoft.Quantum.QsCompiler.DataTypes.Range;
 
@@ -24,14 +23,9 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// For any fragment where the code only consistes of whitespace,
         /// adds a warning to the returned diagnostics if such a fragment terminates in a semicolon,
         /// adds an error to the returned diagnostics if it ends in and opening bracket.
-        /// Throws an ArgumentNullException if the given diagnostics or fragments are null.
         /// </summary>
         private static IEnumerable<Diagnostic> CheckForEmptyFragments(this IEnumerable<CodeFragment> fragments, string filename)
         {
-            if (fragments == null)
-            {
-                throw new ArgumentNullException(nameof(fragments));
-            }
             // opting to not complain about semicolons not following code anywhere in the file (i.e. on any scope)
             var diagnostics = fragments.Where(snippet => snippet.Text.Length == 0 && snippet.FollowedBy == ';')
                 .Select(snippet => Warnings.EmptyStatementWarning(filename, snippet.Range.End))
@@ -44,11 +38,10 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// Compares the saved fragment ending of the given fragment against the expected continuation and
         /// adds the corresponding error to the returned diagnostics if they don't match.
         /// Throws an ArgumentException if the code fragment kind of the given fragment is unspecified (i.e. null).
-        /// Throws an ArgumentNullException if the diagnostics are null.
         /// </summary>
         private static IEnumerable<Diagnostic> CheckFragmentDelimiters(this CodeFragment fragment, string filename)
         {
-            if (fragment?.Kind == null)
+            if (fragment.Kind == null)
             {
                 throw new ArgumentException("missing specification of the fragment kind");
             }
@@ -64,14 +57,9 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// (i.e. modifies the list of given fragments!).
         /// Fragments for which the code only consists of whitespace are left unchanged (i.e. the Kind remains set to null).
         /// Adds a suitable error to the returned diagnostics for each fragment that cannot be processed.
-        /// Raises an ArgumentNullException if the given diagnostics or fragments are null.
         /// </summary>
         private static IEnumerable<Diagnostic> ParseCode(ref List<CodeFragment> fragments, string filename)
         {
-            if (fragments == null)
-            {
-                throw new ArgumentNullException(nameof(fragments));
-            }
             var processedFragments = new List<CodeFragment>(fragments.Count());
             var diagnostics = new List<Diagnostic>();
 
@@ -204,13 +192,13 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
 
         /// <summary>
         /// Returns the Position after the last character in the file (including comments).
-        /// Throws an ArgumentNullException is file is null or does not have any content.
+        /// Throws an ArgumentException is file does not have any content.
         /// </summary>
         public static Position End(this FileContentManager file)
         {
-            if (file == null || file.NrLines() == 0)
+            if (file.NrLines() == 0)
             {
-                throw new ArgumentNullException(nameof(file), "file is null or empty");
+                throw new ArgumentException("file is empty", nameof(file));
             }
             return Position.Create(file.NrLines() - 1, file.GetLine(file.NrLines() - 1).Text.Length);
         }
@@ -218,13 +206,13 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// <summary>
         /// Returns the Position right after where the last relevant (i.e. non-comment) code in the file ends,
         /// or the position (0,0) if no such line exists.
-        /// Throws an ArgumentNullException if file is null or does not contain any lines.
+        /// Throws an ArgumentException if file does not contain any lines.
         /// </summary>
         private static Position LastInFile(FileContentManager file)
         {
-            if (file == null || file.NrLines() == 0)
+            if (file.NrLines() == 0)
             {
-                throw new ArgumentNullException(nameof(file), "file is null or missing content");
+                throw new ArgumentException("file is null or missing content", nameof(file));
             }
             var endIndex = file.NrLines();
             while (endIndex-- > 0 && file.GetLine(endIndex).WithoutEnding.Trim().Length == 0)
@@ -240,7 +228,6 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// If the closest previous ending was on the last character in a line, then the returned position is on the same line after the last character.
         /// Updates the given position to point to the first character in the fragment that contains code.
         /// Throws an ArgumentException if the given position is not smaller than the position after the last piece of code in the file (given by LastInFile).
-        /// Throws an ArgumentNullException if any of the arguments is null.
         /// Throws an ArgumentException if the given position is not within file.
         /// </summary>
         internal static Position FragmentEnd(this FileContentManager file, ref Position current)
@@ -295,7 +282,6 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// Returns the position right after where the fragment before the one containing the given position ends.
         /// If the closest previous ending was on the last character in a line, then the returned position is on the same line after the last character.
         /// If there is no such fragment, returns the position (0,0).
-        /// Throws an ArgumentNullException if any of the arguments is null.
         /// Throws an ArgumentException if the given position is not within file.
         /// </summary>
         private static Position PositionAfterPrevious(this FileContentManager file, Position current)
@@ -317,19 +303,10 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// Extracts the code fragments based on the current file content that need to be re-processed due to content changes on the given lines.
         /// Ignores any whitespace or comments at the beginning of the file (whether they have changed or not).
         /// Ignores any whitespace or comments that occur after the last piece of code in the file.
-        /// Throws an ArgumentNullException if any of the arguments is null.
         /// </summary>
         private static IEnumerable<CodeFragment> FragmentsToProcess(this FileContentManager file, SortedSet<int> changedLines)
         {
             // NOTE: I suggest not to touch this routine unless absolutely necessary...(things *will* break)
-            if (file == null)
-            {
-                throw new ArgumentNullException(nameof(file));
-            }
-            if (changedLines == null)
-            {
-                throw new ArgumentNullException(nameof(changedLines));
-            }
 
             var iter = changedLines.GetEnumerator();
             var lastInFile = LastInFile(file);
@@ -380,15 +357,10 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// <summary>
         /// Given the start line of a change, and how many lines have been updated from there,
         /// computes the position where the syntax check will start and end.
-        /// Throws an ArgumentNullException if file is null.
         /// Throws an ArgumentOutOfRangeException if the range [start, start + count) is not a valid range within the current file content.
         /// </summary>
         internal static Range GetSyntaxCheckDelimiters(this FileContentManager file, int start, int count)
         {
-            if (file == null)
-            {
-                throw new ArgumentNullException(nameof(file));
-            }
             if (start < 0 || start >= file.NrLines())
             {
                 throw new ArgumentOutOfRangeException(nameof(start));
@@ -416,15 +388,9 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// Does nothing if no lines have been modified.
         /// Recomputes and pushes the syntax diagnostics for the extracted fragments and all end-of-file diagnostics otherwise.
         /// Processes the extracted fragment and inserts the processed fragments into the corresponding data structure
-        /// Throws an ArgumentNullException if file is null.
         /// </summary>
         internal static void UpdateLanguageProcessing(this FileContentManager file)
         {
-            if (file == null)
-            {
-                throw new ArgumentNullException(nameof(file));
-            }
-
             file.SyncRoot.EnterUpgradeableReadLock();
             try
             {

--- a/src/QsCompiler/CompilationManager/TypeChecking.cs
+++ b/src/QsCompiler/CompilationManager/TypeChecking.cs
@@ -29,8 +29,6 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// as well as function that extracts the declaration, builds the corresponding HeaderEntries,
         /// throwing the corresponding exceptions if the building fails.
         /// Returns all HeaderEntries for which the extracted name of the declaration is valid.
-        /// Returns null if the given collection of tokens is null.
-        /// Throws an ArgumentNullException if the given function for extracting the declaration is null.
         /// </summary>
         private static IEnumerable<(CodeFragment.TokenIndex, HeaderEntry<T>)> GetHeaderItems<T>(
                 this FileContentManager file,
@@ -64,8 +62,6 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// ignoring any attribute annotations unless ignorePrecedingAttributes is set to false.
         /// Documenting comments may be separated by an empty lines.
         /// Strips the preceding triple-slash for the comments, as well as whitespace and the line break at the end.
-        /// Returns null if no documenting comment is given, or if the documenting comments do not have any non-whitespace content.
-        /// Throws an ArgumentNullException if the given file or position is null.
         /// Throws an ArgumentException if the given position is not a valid position within the given file.
         /// </summary>
         internal static ImmutableArray<string> DocumentingComments(this FileContentManager file, Position pos, bool ignorePrecedingAttributes = true)
@@ -173,15 +169,10 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
 
         /// <summary>
         /// Given a collection of positioned items, returns the closest proceeding item for the given position.
-        /// Throws an ArgumentNullException if the given position or collection of items is null.
         /// Throws an ArgumentException if no item precedes the given position.
         /// </summary>
         private static T ContainingParent<T>(Position pos, IReadOnlyCollection<(Position, T)> items)
         {
-            if (items == null)
-            {
-                throw new ArgumentNullException(nameof(items));
-            }
             var preceding = items.TakeWhile(tuple => tuple.Item1 < pos);
             return preceding.Any()
                 ? preceding.Last().Item2
@@ -192,7 +183,6 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// Calls the given function on each of the given items to add,
         /// and adds the returned diagnostics to the given list of diagnostics.
         /// Returns a List of the token indices and the corresponding header items for which no errors were generated.
-        /// Throws an ArgumentNullException if the given diagnostics or items, or the function to add them is null.
         /// </summary>
         private static List<(TItem, HeaderEntry<THeader>)> AddItems<TItem, THeader>(
             IEnumerable<(TItem, HeaderEntry<THeader>)> itemsToAdd,
@@ -200,19 +190,6 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
             string fileName,
             List<Diagnostic> diagnostics)
         {
-            if (itemsToAdd == null)
-            {
-                throw new ArgumentNullException(nameof(itemsToAdd));
-            }
-            if (add == null)
-            {
-                throw new ArgumentNullException(nameof(add));
-            }
-            if (diagnostics == null)
-            {
-                throw new ArgumentNullException(nameof(diagnostics));
-            }
-
             var itemsToCompile = new List<(TItem, HeaderEntry<THeader>)>();
             foreach (var (tIndex, headerItem) in itemsToAdd)
             {
@@ -233,7 +210,6 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// with either a list of the token indices that contain its specializations to be included in the compilation,
         /// or a list consisting of the token index of the callable declaration, if the declaration does not contain any specializations.
         /// Note: This routine assumes that all empty or invalid fragments have been excluded from compilation prior to calling this routine.
-        /// Throws an ArgumentNullException if any of the given arguments is null.
         /// Throws an InvalidOperationException if the given file is not at least read-locked,
         /// since the returned token indices will only be valid until the next write operation that affects the tokens in the file.
         /// Throws an InvalidOperationException if the lock for the given compilation cannot be set because a dependent lock is the gating lock ("outermost lock").
@@ -241,18 +217,6 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         internal static ImmutableDictionary<QsQualifiedName, (QsComments, IEnumerable<CodeFragment.TokenIndex>?)> UpdateGlobalSymbols(
             this FileContentManager file, CompilationUnit compilation, List<Diagnostic> diagnostics)
         {
-            if (file == null)
-            {
-                throw new ArgumentNullException(nameof(file));
-            }
-            if (compilation == null)
-            {
-                throw new ArgumentNullException(nameof(compilation));
-            }
-            if (diagnostics == null)
-            {
-                throw new ArgumentNullException(nameof(diagnostics));
-            }
             if (!file.SyncRoot.IsAtLeastReadLockHeld())
             {
                 throw new InvalidOperationException("file needs to be locked in order to update global symbols");
@@ -329,7 +293,6 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// returns a list of the token indices that contain the specializations to be included in the compilation.
         /// If the given callable does not contain any specializations,
         /// returns a list of token indices containing only the token of the callable declaration.
-        /// Throws an ArgumentNullException if either the given namespace or diagnostics are null.
         /// </summary>
         private static List<CodeFragment.TokenIndex> AddSpecializationsToNamespace(
             FileContentManager file,
@@ -337,14 +300,6 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
             (CodeFragment.TokenIndex, HeaderEntry<Tuple<QsCallableKind, Modifiers, CallableSignature>>) parent,
             List<Diagnostic> diagnostics)
         {
-            if (ns == null)
-            {
-                throw new ArgumentNullException(nameof(ns));
-            }
-            if (diagnostics == null)
-            {
-                throw new ArgumentNullException(nameof(diagnostics));
-            }
             var contentToCompile = new List<CodeFragment.TokenIndex>();
             var callableDecl = parent.Item2.Declaration;
             var parentName = parent.Item2.PositionedSymbol;
@@ -410,19 +365,9 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// If no fileName is given or the given fileName is null,
         /// adds all diagnostics generated during resolution and verification to the given list of diagnostics.
         /// If the given fileName is not null, adds only the diagnostics for the file with that name to the given list of diagnostics.
-        /// Throws an ArgumentNullException if the given NamespaceManager or list of diagnostics is null.
         /// </summary>
         internal static void ResolveGlobalSymbols(NamespaceManager symbols, List<Diagnostic> diagnostics, string? fileName = null)
         {
-            if (symbols == null)
-            {
-                throw new ArgumentNullException(nameof(symbols));
-            }
-            if (diagnostics == null)
-            {
-                throw new ArgumentNullException(nameof(diagnostics));
-            }
-
             var declDiagnostics = symbols.ResolveAll(BuiltIn.NamespacesToAutoOpen);
             var cycleDiagnostics = SyntaxProcessing.SyntaxTree.CheckDefinedTypesForCycles(symbols.DefinedTypes());
 
@@ -457,24 +402,10 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// <summary>
         /// Updates the symbol information in the given compilation unit with all (validly placed) open directives in the given file,
         /// and adds the generated diagnostics for the given file *only* to the given list of diagnostics.
-        /// Throws an ArgumentNullException if the given compilation unit, the given file or the given diagnostics are null.
         /// Throws an InvalidOperationException if the lock for the given compilation cannot be set because a dependent lock is the gating lock ("outermost lock").
         /// </summary>
         internal static void ImportGlobalSymbols(this FileContentManager file, CompilationUnit compilation, List<Diagnostic> diagnostics)
         {
-            if (file == null)
-            {
-                throw new ArgumentNullException(nameof(file));
-            }
-            if (compilation == null)
-            {
-                throw new ArgumentNullException(nameof(compilation));
-            }
-            if (diagnostics == null)
-            {
-                throw new ArgumentNullException(nameof(diagnostics));
-            }
-
             // While in principle the file does not need to be externally locked for this routine to evaluate correctly,
             // it is to be expected that the file is indeed locked, such that the information about open directives is consistent with the one on header items -
             // of course there is no way to verify that even if the file is locked, let's still call QsCompilerError.Verify on the file lock.
@@ -498,7 +429,6 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// <summary>
         /// Builds a FragmentTree containting the given grouping of token indices for a certain parent.
         /// Assumes that all given token indices are associated with the given file.
-        /// Throws an ArgumentNullException if the given file or any of the given groupings is null.
         /// Throws an InvalidOperationException if the given file is not at least read-locked,
         /// since token indices are only ever valid until the next write operation to the file they are associated with.
         /// </summary>
@@ -506,14 +436,6 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
             this FileContentManager file,
             ImmutableDictionary<QsQualifiedName, (QsComments, IEnumerable<CodeFragment.TokenIndex>?)> content)
         {
-            if (file == null)
-            {
-                throw new ArgumentNullException(nameof(file));
-            }
-            if (content == null)
-            {
-                throw new ArgumentNullException(nameof(content));
-            }
             if (!file.SyncRoot.IsAtLeastReadLockHeld())
             {
                 throw new InvalidOperationException("file needs to be locked in order to build the FragmentTrees from the given token indices");
@@ -548,21 +470,10 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// and clears all semantic diagnostics without pushing them.
         /// If the given Action for publishing diagnostics is not null,
         /// invokes it for the diagnostics of each given file after updating them.
-        /// Throws an ArgumentNullException if the given compilation is null,
-        /// or if the given files, or any file contained in files, is null.
         /// </summary>
         internal static ImmutableDictionary<QsQualifiedName, (QsComments, FragmentTree)> UpdateGlobalSymbolsFor(
             this CompilationUnit compilation, IEnumerable<FileContentManager> files)
         {
-            if (compilation == null)
-            {
-                throw new ArgumentNullException(nameof(compilation));
-            }
-            if (files == null || files.Contains(null!))
-            {
-                throw new ArgumentNullException(nameof(files));
-            }
-
             compilation.EnterWriteLock();
             foreach (var file in files)
             {
@@ -613,7 +524,6 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// The declarations the scope inherits from its parents are assumed to be the current declarations in the given scope context.
         /// If a required set of functors are specified, then each operation called within the built scope needs to support these functors.
         /// If the set of required functors is unspecified or null, then the functors to support are determined by the parent scope.
-        /// Throws an ArgumentNullException if the given list of tree nodes, scope context or diagnostics are null.
         /// </summary>
         private static QsScope BuildScope(
             IReadOnlyList<FragmentTree.TreeNode> nodeContent,
@@ -621,19 +531,6 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
             List<Diagnostic> diagnostics,
             ImmutableHashSet<QsFunctor>? requiredFunctorSupport = null)
         {
-            if (nodeContent == null)
-            {
-                throw new ArgumentNullException(nameof(nodeContent));
-            }
-            if (context == null)
-            {
-                throw new ArgumentNullException(nameof(context));
-            }
-            if (diagnostics == null)
-            {
-                throw new ArgumentNullException(nameof(diagnostics));
-            }
-
             var inheritedSymbols = context.Symbols.CurrentDeclarations;
             context.Symbols.BeginScope(requiredFunctorSupport);
             var statements = BuildStatements(nodeContent.GetEnumerator(), context, diagnostics);
@@ -646,28 +543,12 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// to get the desired object as well as a list of diagnostics.
         /// Adds the generated diagnostics to the given list of diagnostics, and returns the build object.
         /// </summary>
-        /// <exception cref="ArgumentNullException">
-        /// Thrown if the given build function, scope context, or diagnostics are null.
-        /// </exception>
         private static T BuildStatement<T>(
             FragmentTree.TreeNode node,
             Func<QsLocation, ScopeContext, Tuple<T, QsCompilerDiagnostic[]>> build,
             ScopeContext context,
             List<Diagnostic> diagnostics)
         {
-            if (build == null)
-            {
-                throw new ArgumentNullException(nameof(build));
-            }
-            if (context == null)
-            {
-                throw new ArgumentNullException(nameof(context));
-            }
-            if (diagnostics == null)
-            {
-                throw new ArgumentNullException(nameof(diagnostics));
-            }
-
             var statementPos = node.Fragment.Range.Start;
             var location = new QsLocation(node.RelativePosition, node.Fragment.HeaderRange);
             var (statement, messages) = build(location, context);
@@ -686,7 +567,6 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// i.e. it is set to true if either the iterator has not been moved (no statement built),
         /// or if the last MoveNext() returned true, and is otherwise set to false.
         /// This routine will fail if accessing the current iterator item fails.
-        /// Throws an ArgumentNullException if any of the given arguments is null.
         /// Throws an ArgumentException if the given scope context does not currently contain an open scope.
         /// </summary>
         private static bool TryBuildUsingStatement(
@@ -696,21 +576,9 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
             out bool proceed,
             [NotNullWhen(true)] out QsStatement? statement)
         {
-            if (nodes == null)
-            {
-                throw new ArgumentNullException(nameof(nodes));
-            }
-            if (context == null)
-            {
-                throw new ArgumentNullException(nameof(context));
-            }
             if (context.Symbols.AllScopesClosed)
             {
                 throw new ArgumentException("invalid scope context state - statements may only occur within a scope");
-            }
-            if (diagnostics == null)
-            {
-                throw new ArgumentException(nameof(diagnostics));
             }
 
             if (nodes.Current.Fragment.Kind is QsFragmentKind.UsingBlockIntro allocate)
@@ -742,7 +610,6 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// i.e. it is set to true if either the iterator has not been moved (no statement built),
         /// or if the last MoveNext() returned true, and is otherwise set to false.
         /// This routine will fail if accessing the current iterator item fails.
-        /// Throws an ArgumentNullException if any of the given arguments is null.
         /// Throws an ArgumentException if the given scope context does not currently contain an open scope.
         /// </summary>
         private static bool TryBuildBorrowStatement(
@@ -752,21 +619,9 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
             out bool proceed,
             [NotNullWhen(true)] out QsStatement? statement)
         {
-            if (nodes == null)
-            {
-                throw new ArgumentNullException(nameof(nodes));
-            }
-            if (context == null)
-            {
-                throw new ArgumentNullException(nameof(context));
-            }
             if (context.Symbols.AllScopesClosed)
             {
                 throw new ArgumentException("invalid scope context state - statements may only occur within a scope");
-            }
-            if (diagnostics == null)
-            {
-                throw new ArgumentException(nameof(diagnostics));
             }
 
             if (nodes.Current.Fragment.Kind is QsFragmentKind.BorrowingBlockIntro borrow)
@@ -798,7 +653,6 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// i.e. it is set to true if either the iterator has not been moved (no statement built),
         /// or if the last MoveNext() returned true, and is otherwise set to false.
         /// This routine will fail if accessing the current iterator item fails.
-        /// Throws an ArgumentNullException if any of the given arguments is null.
         /// Throws an ArgumentException if the given scope context does not currently contain an open scope,
         /// or if the repeat header is not followed by a until-success clause.
         /// </summary>
@@ -809,21 +663,9 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
             out bool proceed,
             [NotNullWhen(true)] out QsStatement? statement)
         {
-            if (nodes == null)
-            {
-                throw new ArgumentNullException(nameof(nodes));
-            }
-            if (context == null)
-            {
-                throw new ArgumentNullException(nameof(context));
-            }
             if (context.Symbols.AllScopesClosed)
             {
                 throw new ArgumentException("invalid scope context state - statements may only occur within a scope");
-            }
-            if (diagnostics == null)
-            {
-                throw new ArgumentException(nameof(diagnostics));
             }
 
             if (nodes.Current.Fragment.Kind?.IsRepeatIntro ?? false)
@@ -879,7 +721,6 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// i.e. it is set to true if either the iterator has not been moved (no statement built),
         /// or if the last MoveNext() returned true, and is otherwise set to false.
         /// This routine will fail if accessing the current iterator item fails.
-        /// Throws an ArgumentNullException if any of the given arguments is null.
         /// Throws an ArgumentException if the given scope context does not currently contain an open scope.
         /// </summary>
         private static bool TryBuildForStatement(
@@ -889,21 +730,9 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
             out bool proceed,
             [NotNullWhen(true)] out QsStatement? statement)
         {
-            if (nodes == null)
-            {
-                throw new ArgumentNullException(nameof(nodes));
-            }
-            if (context == null)
-            {
-                throw new ArgumentNullException(nameof(context));
-            }
             if (context.Symbols.AllScopesClosed)
             {
                 throw new ArgumentException("invalid scope context state - statements may only occur within a scope");
-            }
-            if (diagnostics == null)
-            {
-                throw new ArgumentException(nameof(diagnostics));
             }
 
             if (nodes.Current.Fragment.Kind is QsFragmentKind.ForLoopIntro forStatement)
@@ -935,7 +764,6 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// i.e. it is set to true if either the iterator has not been moved (no statement built),
         /// or if the last MoveNext() returned true, and is otherwise set to false.
         /// This routine will fail if accessing the current iterator item fails.
-        /// Throws an ArgumentNullException if any of the given arguments is null.
         /// Throws an ArgumentException if the given scope context does not currently contain an open scope.
         /// </summary>
         private static bool TryBuildWhileStatement(
@@ -945,21 +773,9 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
             out bool proceed,
             [NotNullWhen(true)] out QsStatement? statement)
         {
-            if (nodes == null)
-            {
-                throw new ArgumentNullException(nameof(nodes));
-            }
-            if (context == null)
-            {
-                throw new ArgumentNullException(nameof(context));
-            }
             if (context.Symbols.AllScopesClosed)
             {
                 throw new ArgumentException("invalid scope context state - statements may only occur within a scope");
-            }
-            if (diagnostics == null)
-            {
-                throw new ArgumentException(nameof(diagnostics));
             }
 
             if (nodes.Current.Fragment.Kind is QsFragmentKind.WhileLoopIntro whileStatement)
@@ -991,7 +807,6 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// i.e. it is set to true if either the iterator has not been moved (no statement built),
         /// or if the last MoveNext() returned true, and is otherwise set to false.
         /// This routine will fail if accessing the current iterator item fails.
-        /// Throws an ArgumentNullException if any of the given arguments is null.
         /// Throws an ArgumentException if the given scope context does not currently contain an open scope.
         /// </summary>
         private static bool TryBuildIfStatement(
@@ -1001,21 +816,9 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
             out bool proceed,
             [NotNullWhen(true)] out QsStatement? statement)
         {
-            if (nodes == null)
-            {
-                throw new ArgumentNullException(nameof(nodes));
-            }
-            if (context == null)
-            {
-                throw new ArgumentNullException(nameof(context));
-            }
             if (context.Symbols.AllScopesClosed)
             {
                 throw new ArgumentException("invalid scope context state - statements may only occur within a scope");
-            }
-            if (diagnostics == null)
-            {
-                throw new ArgumentException(nameof(diagnostics));
             }
 
             if (nodes.Current.Fragment.Kind is QsFragmentKind.IfClause ifCond)
@@ -1077,7 +880,6 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// i.e. it is set to true if either the iterator has not been moved (no statement built),
         /// or if the last MoveNext() returned true, and is otherwise set to false.
         /// This routine will fail if accessing the current iterator item fails.
-        /// Throws an ArgumentNullException if any of the given arguments is null.
         /// Throws an ArgumentException if the given scope context does not currently contain an open scope.
         /// </summary>
         private static bool TryBuildConjugationStatement(
@@ -1087,21 +889,9 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
             out bool proceed,
             [NotNullWhen(true)] out QsStatement? statement)
         {
-            if (nodes == null)
-            {
-                throw new ArgumentNullException(nameof(nodes));
-            }
-            if (context == null)
-            {
-                throw new ArgumentNullException(nameof(context));
-            }
             if (context.Symbols.AllScopesClosed)
             {
                 throw new ArgumentException("invalid scope context state - statements may only occur within a scope");
-            }
-            if (diagnostics == null)
-            {
-                throw new ArgumentException(nameof(diagnostics));
             }
 
             QsNullable<QsLocation> RelativeLocation(FragmentTree.TreeNode node) =>
@@ -1147,7 +937,6 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// i.e. it is set to true if either the iterator has not been moved (no statement built),
         /// or if the last MoveNext() returned true, and is otherwise set to false.
         /// This routine will fail if accessing the current iterator item fails.
-        /// Throws an ArgumentNullException if any of the given arguments is null.
         /// Throws an ArgumentException if the given scope context does not currently contain an open scope.
         /// </summary>
         private static bool TryBuildLetStatement(
@@ -1157,21 +946,9 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
             out bool proceed,
             [NotNullWhen(true)] out QsStatement? statement)
         {
-            if (nodes == null)
-            {
-                throw new ArgumentNullException(nameof(nodes));
-            }
-            if (context == null)
-            {
-                throw new ArgumentNullException(nameof(context));
-            }
             if (context.Symbols.AllScopesClosed)
             {
                 throw new ArgumentException("invalid scope context state - statements may only occur within a scope");
-            }
-            if (diagnostics == null)
-            {
-                throw new ArgumentException(nameof(diagnostics));
             }
 
             if (nodes.Current.Fragment.Kind is QsFragmentKind.ImmutableBinding letStatement)
@@ -1199,7 +976,6 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// i.e. it is set to true if either the iterator has not been moved (no statement built),
         /// or if the last MoveNext() returned true, and is otherwise set to false.
         /// This routine will fail if accessing the current iterator item fails.
-        /// Throws an ArgumentNullException if any of the given arguments is null.
         /// Throws an ArgumentException if the given scope context does not currently contain an open scope.
         /// </summary>
         private static bool TryBuildMutableStatement(
@@ -1209,21 +985,9 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
             out bool proceed,
             [NotNullWhen(true)] out QsStatement? statement)
         {
-            if (nodes == null)
-            {
-                throw new ArgumentNullException(nameof(nodes));
-            }
-            if (context == null)
-            {
-                throw new ArgumentNullException(nameof(context));
-            }
             if (context.Symbols.AllScopesClosed)
             {
                 throw new ArgumentException("invalid scope context state - statements may only occur within a scope");
-            }
-            if (diagnostics == null)
-            {
-                throw new ArgumentException(nameof(diagnostics));
             }
 
             if (nodes.Current.Fragment.Kind is QsFragmentKind.MutableBinding mutableStatement)
@@ -1251,7 +1015,6 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// i.e. it is set to true if either the iterator has not been moved (no statement built),
         /// or if the last MoveNext() returned true, and is otherwise set to false.
         /// This routine will fail if accessing the current iterator item fails.
-        /// Throws an ArgumentNullException if any of the given arguments is null.
         /// Throws an ArgumentException if the given scope context does not currently contain an open scope.
         /// </summary>
         private static bool TryBuildSetStatement(
@@ -1261,21 +1024,9 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
             out bool proceed,
             [NotNullWhen(true)] out QsStatement? statement)
         {
-            if (nodes == null)
-            {
-                throw new ArgumentNullException(nameof(nodes));
-            }
-            if (context == null)
-            {
-                throw new ArgumentNullException(nameof(context));
-            }
             if (context.Symbols.AllScopesClosed)
             {
                 throw new ArgumentException("invalid scope context state - statements may only occur within a scope");
-            }
-            if (diagnostics == null)
-            {
-                throw new ArgumentException(nameof(diagnostics));
             }
 
             if (nodes.Current.Fragment.Kind is QsFragmentKind.ValueUpdate setStatement)
@@ -1303,7 +1054,6 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// i.e. it is set to true if either the iterator has not been moved (no statement built),
         /// or if the last MoveNext() returned true, and is otherwise set to false.
         /// This routine will fail if accessing the current iterator item fails.
-        /// Throws an ArgumentNullException if any of the given arguments is null.
         /// Throws an ArgumentException if the given scope context does not currently contain an open scope.
         /// </summary>
         private static bool TryBuildFailStatement(
@@ -1313,21 +1063,9 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
             out bool proceed,
             [NotNullWhen(true)] out QsStatement? statement)
         {
-            if (nodes == null)
-            {
-                throw new ArgumentNullException(nameof(nodes));
-            }
-            if (context == null)
-            {
-                throw new ArgumentNullException(nameof(context));
-            }
             if (context.Symbols.AllScopesClosed)
             {
                 throw new ArgumentException("invalid scope context state - statements may only occur within a scope");
-            }
-            if (diagnostics == null)
-            {
-                throw new ArgumentException(nameof(diagnostics));
             }
 
             if (nodes.Current.Fragment.Kind is QsFragmentKind.FailStatement failStatement)
@@ -1355,7 +1093,6 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// i.e. it is set to true if either the iterator has not been moved (no statement built),
         /// or if the last MoveNext() returned true, and is otherwise set to false.
         /// This routine will fail if accessing the current iterator item fails.
-        /// Throws an ArgumentNullException if any of the given arguments is null.
         /// Throws an ArgumentException if the given scope context does not currently contain an open scope.
         /// </summary>
         private static bool TryBuildReturnStatement(
@@ -1365,21 +1102,9 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
             out bool proceed,
             [NotNullWhen(true)] out QsStatement? statement)
         {
-            if (nodes == null)
-            {
-                throw new ArgumentNullException(nameof(nodes));
-            }
-            if (context == null)
-            {
-                throw new ArgumentNullException(nameof(context));
-            }
             if (context.Symbols.AllScopesClosed)
             {
                 throw new ArgumentException("invalid scope context state - statements may only occur within a scope");
-            }
-            if (diagnostics == null)
-            {
-                throw new ArgumentException(nameof(diagnostics));
             }
 
             if (nodes.Current.Fragment.Kind is QsFragmentKind.ReturnStatement returnStatement)
@@ -1407,7 +1132,6 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// i.e. it is set to true if either the iterator has not been moved (no statement built),
         /// or if the last MoveNext() returned true, and is otherwise set to false.
         /// This routine will fail if accessing the current iterator item fails.
-        /// Throws an ArgumentNullException if any of the given arguments is null.
         /// Throws an ArgumentException if the given scope context does not currently contain an open scope.
         /// </summary>
         private static bool TryBuildExpressionStatement(
@@ -1417,21 +1141,9 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
             out bool proceed,
             [NotNullWhen(true)] out QsStatement? statement)
         {
-            if (nodes == null)
-            {
-                throw new ArgumentNullException(nameof(nodes));
-            }
-            if (context == null)
-            {
-                throw new ArgumentNullException(nameof(context));
-            }
             if (context.Symbols.AllScopesClosed)
             {
                 throw new ArgumentException("invalid scope context state - statements may only occur within a scope");
-            }
-            if (diagnostics == null)
-            {
-                throw new ArgumentException(nameof(diagnostics));
             }
 
             if (nodes.Current.Fragment.Kind is QsFragmentKind.ExpressionStatement expressionStatement)
@@ -1454,36 +1166,23 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// provided each statement consists of a suitable statement header followed by the required continuation(s), if any.
         /// Throws an ArgumentException if this is not the case,
         /// or if the given scope context does not currently contain an open scope.
-        /// Throws an ArgumentNullException if any of the given arguments is null,
         /// or if any of the fragments contained in the given nodes is null.
         /// </summary>
         private static ImmutableArray<QsStatement> BuildStatements(
             IEnumerator<FragmentTree.TreeNode> nodes, ScopeContext context, List<Diagnostic> diagnostics)
         {
-            if (nodes == null)
-            {
-                throw new ArgumentNullException(nameof(nodes));
-            }
-            if (context == null)
-            {
-                throw new ArgumentNullException(nameof(context));
-            }
             if (context.Symbols.AllScopesClosed)
             {
                 throw new ArgumentException("invalid scope context state - statements may only occur within a scope");
-            }
-            if (diagnostics == null)
-            {
-                throw new ArgumentException(nameof(diagnostics));
             }
 
             var proceed = nodes.MoveNext();
             var statements = new List<QsStatement>();
             while (proceed)
             {
-                if (nodes.Current.Fragment?.Kind == null)
+                if (nodes.Current.Fragment.Kind == null)
                 {
-                    throw new ArgumentNullException(nameof(nodes.Current.Fragment), "fragment kind cannot be null");
+                    throw new ArgumentException("fragment kind cannot be null", nameof(nodes.Current.Fragment));
                 }
                 else if (TryBuildExpressionStatement(nodes, context, diagnostics, out proceed, out var expressionStatement))
                 {
@@ -1557,7 +1256,6 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// for argument variables defined in the callable declaration).
         /// If the expected return type for the specialization is not Unit, verifies that all paths return a value or fail, generating suitable diagnostics.
         /// Adds the generated diagnostics to the given list of diagnostics.
-        /// Throws an ArgumentNullException if the given argument, the scope context, or diagnostics are null.
         /// </summary>
         private static SpecializationImplementation BuildUserDefinedImplementation(
             FragmentTree.TreeNode root,
@@ -1567,23 +1265,6 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
             ScopeContext context,
             List<Diagnostic> diagnostics)
         {
-            if (argTuple == null)
-            {
-                throw new ArgumentNullException(nameof(argTuple));
-            }
-            if (context == null)
-            {
-                throw new ArgumentNullException(nameof(context));
-            }
-            if (requiredFunctorSupport == null)
-            {
-                throw new ArgumentNullException(nameof(requiredFunctorSupport));
-            }
-            if (diagnostics == null)
-            {
-                throw new ArgumentNullException(nameof(diagnostics));
-            }
-
             // the variable defined on the declaration need to be verified upon building the callable (otherwise we get duplicate diagnostics),
             // but they need to be pushed *first* such that we get suitable re-declaration errors on those defined on the specialization
             // -> the position information is set to null (only) for variables defined in the declaration
@@ -1622,22 +1303,11 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// <summary>
         /// Given a function that returns the generator directive for a given specialization kind, or null if none has been defined for that kind,
         /// determines the necessary functor support required for each operation call within a user defined implementation of the specified specialization.
-        /// Throws an ArgumentNullException if the given specialization for which to determine the required functor support is null,
-        /// or if the given function to query the directives is.
         /// </summary>
         private static IEnumerable<QsFunctor> RequiredFunctorSupport(
             QsSpecializationKind spec,
             Func<QsSpecializationKind, QsGeneratorDirective?> directives)
         {
-            if (spec == null)
-            {
-                throw new ArgumentNullException(nameof(spec));
-            }
-            if (directives == null)
-            {
-                throw new ArgumentNullException(nameof(directives));
-            }
-
             var adjDir = directives(QsSpecializationKind.QsAdjoint);
             var ctlDir = directives(QsSpecializationKind.QsControlled);
             var ctlAdjDir = directives(QsSpecializationKind.QsControlledAdjoint);
@@ -1697,8 +1367,6 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// If the given root is a callable declaration, a default body specialization with its children as the implementation is returned -
         /// provided the children are exclusively valid statements. Fails with the corresponding exception otherwise.
         /// Adds the generated diagnostics to the given list of diagnostics.
-        /// Throws an ArgumentNullException if the parent signature, its argument tuple,
-        /// the compilation unit, or the given list of diagnostics is null.
         /// Throws an ArgumentException if the given root is neither a specialization declaration, nor a callable declaration,
         /// or if the callable the specialization belongs to does not support that specialization according to the given NamespaceManager.
         /// </summary>
@@ -1710,22 +1378,6 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
             List<Diagnostic> diagnostics,
             CancellationToken cancellationToken)
         {
-            if (parentSignature == null)
-            {
-                throw new ArgumentNullException(nameof(parentSignature));
-            }
-            if (argTuple == null)
-            {
-                throw new ArgumentNullException(nameof(argTuple));
-            }
-            if (compilation == null)
-            {
-                throw new ArgumentNullException(nameof(compilation));
-            }
-            if (diagnostics == null)
-            {
-                throw new ArgumentNullException(nameof(diagnostics));
-            }
             if (cancellationToken.IsCancellationRequested)
             {
                 return ImmutableArray<QsSpecialization>.Empty;
@@ -1910,26 +1562,12 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// For each namespace and callable name that occurs in the given FragmentTrees builds the corresponding QsCallable.
         /// Updates the given CompilationUnit with all built callables. Checks all types defined in the NamespaceManager for cycles.
         /// Returns a list with all accumulated diagnostics. If the request has been cancelled, returns null.
-        /// Throws an ArgumentNullException if any of the arguments is null.
         /// </summary>
         internal static List<Diagnostic>? RunTypeChecking(
             CompilationUnit compilation,
             ImmutableDictionary<QsQualifiedName, (QsComments, FragmentTree)> roots,
             CancellationToken cancellationToken)
         {
-            if (compilation == null)
-            {
-                throw new ArgumentNullException(nameof(compilation));
-            }
-            if (roots == null)
-            {
-                throw new ArgumentNullException(nameof(roots));
-            }
-            if (cancellationToken == null)
-            {
-                throw new ArgumentNullException(nameof(cancellationToken));
-            }
-
             var diagnostics = new List<Diagnostic>();
             compilation.EnterUpgradeableReadLock();
             try
@@ -2051,11 +1689,6 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         private static (LocalDeclarations, IEnumerable<QsStatement>) StatementsAfterAndLocalDeclarationsAt(
             this QsScope scope, Position relativePosition, bool includeDeclaredAtPosition)
         {
-            if (scope == null)
-            {
-                throw new ArgumentNullException(nameof(scope));
-            }
-
             LocalDeclarations Concat(LocalDeclarations fst, LocalDeclarations snd)
                 => new LocalDeclarations(fst.Variables.Concat(snd.Variables).ToImmutableArray());
             bool BeforePosition(QsNullable<QsLocation> location) =>
@@ -2171,19 +1804,9 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// directly proceeds to do the type checking for the entire file content, independent on what parts have been changed.
         /// If the globally declared types/callables have changed, a global type checking event is triggered,
         /// since the type checking for the entire compilation unit and all compilation units depending on it needs to be recomputed.
-        /// Throws an ArgumentNullException if the given file or compilation unit is null.
         /// </summary>
         internal static void UpdateTypeChecking(this FileContentManager file, CompilationUnit compilation)
         {
-            if (file == null)
-            {
-                throw new ArgumentNullException(nameof(file));
-            }
-            if (compilation == null)
-            {
-                throw new ArgumentNullException(nameof(compilation));
-            }
-
             compilation.EnterWriteLock();
             file.SyncRoot.EnterUpgradeableReadLock();
             try

--- a/src/QsCompiler/CompilationManager/Utils.cs
+++ b/src/QsCompiler/CompilationManager/Utils.cs
@@ -102,19 +102,14 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// <summary>
         /// Given a string, replaces the range [starChar, endChar) with the given string to insert.
         /// Returns null if the given text is null.
-        /// Throws an ArgumentNullException if the given text to insert is null.
         /// Throws an ArgumentOutOfRangeException if the given start and end points do not denote a valid range within the string.
         /// </summary>
         [return: NotNullIfNotNull("lineText")]
-        internal static string? GetChangedText(string lineText, int startChar, int endChar, string insert)
+        internal static string? GetChangedText(string? lineText, int startChar, int endChar, string insert)
         {
             if (lineText == null)
             {
                 return null;
-            }
-            if (insert == null)
-            {
-                throw new ArgumentNullException(nameof(insert));
             }
             if (startChar < 0 || startChar > lineText.Length)
             {
@@ -128,19 +123,16 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         }
 
         /// <summary>
-        /// Return a string with the new content of the (entire) lines in the range [start, end] where start and end are the start and end line of the given change.
-        /// Verifies that the given change is consistent with the given file - i.e. the range is a valid range in file, and the text is not null, and
-        /// throws the correspoding exceptions if this is not the case.
+        /// Return a string with the new content of the (entire) lines in the range [start, end] where start and end are
+        /// the start and end line of the given change.
         /// </summary>
+        /// <exception cref="ArgumentException">Thrown if the range is invalid.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown if the range is not contained in the file.</exception>
         internal static string GetTextChangedLines(FileContentManager file, TextDocumentContentChangeEvent change)
         {
             if (!file.ContainsRange(change.Range.ToQSharp()))
             {
                 throw new ArgumentOutOfRangeException(nameof(change)); // range can be empty
-            }
-            if (change.Text == null)
-            {
-                throw new ArgumentNullException(nameof(change.Text), "the given text change is null");
             }
 
             var first = file.GetLine(change.Range.Start.Line).Text;
@@ -154,111 +146,55 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
 
         /// <summary>
         /// Partitions the given IEnumerable into the elements for which predicate returns true and those for which it returns false.
-        /// Throws an ArgumentNullException if the given IEnumerable or predicate is null.
         /// </summary>
-        public static (List<T>, List<T>) Partition<T>(this IEnumerable<T> collection, Func<T, bool> predicate)
-        {
-            if (collection is null)
-            {
-                throw new ArgumentNullException(nameof(collection));
-            }
-            if (predicate == null)
-            {
-                throw new ArgumentNullException(nameof(predicate));
-            }
-            return (collection.Where(predicate).ToList(), collection.Where(x => !predicate(x)).ToList());
-        }
+        public static (List<T>, List<T>) Partition<T>(this IEnumerable<T> collection, Func<T, bool> predicate) =>
+            (collection.Where(predicate).ToList(), collection.Where(x => !predicate(x)).ToList());
 
         /// <summary>
         /// Returns true if the given lock is either ReadLockHeld, or is UpgradeableReadLockHeld, or isWriteLockHeld.
-        /// Throws an ArgumentNullException if the given lock is null.
         /// </summary>
-        public static bool IsAtLeastReadLockHeld(this ReaderWriterLockSlim syncRoot)
-        {
-            if (syncRoot == null)
-            {
-                throw new ArgumentNullException(nameof(syncRoot));
-            }
-            return syncRoot.IsReadLockHeld || syncRoot.IsUpgradeableReadLockHeld || syncRoot.IsWriteLockHeld;
-        }
+        public static bool IsAtLeastReadLockHeld(this ReaderWriterLockSlim syncRoot) =>
+            syncRoot.IsReadLockHeld || syncRoot.IsUpgradeableReadLockHeld || syncRoot.IsWriteLockHeld;
 
         // utils for dealing with positions and ranges
 
         /// <summary>
         /// Converts the language server protocol position into a Q# compiler position.
         /// </summary>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="position"/> is null.</exception>
         /// <exception cref="ArgumentException">Thrown if <paramref name="position"/> is invalid.</exception>
         public static Position ToQSharp(this Lsp.Position position) =>
-            position is null
-                ? throw new ArgumentNullException(nameof(position))
-                : Position.Create(position.Line, position.Character);
+            Position.Create(position.Line, position.Character);
 
         /// <summary>
         /// Converts the Q# compiler position into a language server protocol position.
         /// </summary>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="position"/> is null.</exception>
         public static Lsp.Position ToLsp(this Position position) =>
-            position is null
-                ? throw new ArgumentNullException(nameof(position))
-                : new Lsp.Position(position.Line, position.Column);
+            new Lsp.Position(position.Line, position.Column);
 
         /// <summary>
         /// Converts the language server protocol range into a Q# compiler range.
         /// </summary>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="range"/> is null.</exception>
         /// <exception cref="ArgumentException">Thrown if <paramref name="range"/> is invalid.</exception>
         public static Range ToQSharp(this Lsp.Range range) =>
-            range is null
-                ? throw new ArgumentNullException(nameof(range))
-                : Range.Create(range.Start.ToQSharp(), range.End.ToQSharp());
+            Range.Create(range.Start.ToQSharp(), range.End.ToQSharp());
 
         /// <summary>
         /// Converts the Q# compiler range into a language server protocol range.
         /// </summary>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="range"/> is null.</exception>
         public static Lsp.Range ToLsp(this Range range) =>
-            range is null
-                ? throw new ArgumentNullException(nameof(range))
-                : new Lsp.Range { Start = range.Start.ToLsp(), End = range.End.ToLsp() };
+            new Lsp.Range { Start = range.Start.ToLsp(), End = range.End.ToLsp() };
 
         /// <summary>
         /// Returns true if the position is within the bounds of the file contents.
         /// </summary>
-        /// <exception cref="ArgumentNullException">
-        /// Thrown if <paramref name="file"/> or <paramref name="position"/> is null.
-        /// </exception>
-        internal static bool ContainsPosition(this FileContentManager file, Position position)
-        {
-            if (file is null)
-            {
-                throw new ArgumentNullException(nameof(file));
-            }
-            if (position is null)
-            {
-                throw new ArgumentNullException(nameof(position));
-            }
-            return position.Line < file.NrLines() && position.Column <= file.GetLine(position.Line).Text.Length;
-        }
+        internal static bool ContainsPosition(this FileContentManager file, Position position) =>
+            position.Line < file.NrLines() && position.Column <= file.GetLine(position.Line).Text.Length;
 
         /// <summary>
         /// Returns true if the range is within the bounds of the file contents.
         /// </summary>
-        /// <exception cref="ArgumentNullException">
-        /// Thrown if <paramref name="file"/> or <paramref name="range"/> is null.
-        /// </exception>
-        internal static bool ContainsRange(this FileContentManager file, Range range)
-        {
-            if (file is null)
-            {
-                throw new ArgumentNullException(nameof(file));
-            }
-            if (range is null)
-            {
-                throw new ArgumentNullException(nameof(range));
-            }
-            return file.ContainsPosition(range.Start) && file.ContainsPosition(range.End) && range.Start <= range.End;
-        }
+        internal static bool ContainsRange(this FileContentManager file, Range range) =>
+            file.ContainsPosition(range.Start) && file.ContainsPosition(range.End) && range.Start <= range.End;
 
         // tools for debugging
 

--- a/src/QsCompiler/Compiler/CompilationLoader.cs
+++ b/src/QsCompiler/Compiler/CompilationLoader.cs
@@ -453,7 +453,7 @@ namespace Microsoft.Quantum.QsCompiler
         /// executing the compilation steps specified by the given options.
         /// Uses the specified logger to log all diagnostic events.
         /// </summary>
-        public CompilationLoader(SourceLoader loadSources, ReferenceLoader loadReferences, Configuration options = default, ILogger? logger = null)
+        public CompilationLoader(SourceLoader loadSources, ReferenceLoader loadReferences, Configuration? options = null, ILogger? logger = null)
         {
             this.RaiseCompilationTaskStart(null, "OverallCompilation");
 
@@ -461,7 +461,7 @@ namespace Microsoft.Quantum.QsCompiler
 
             this.logger = logger;
             this.LoadDiagnostics = ImmutableArray<Diagnostic>.Empty;
-            this.config = options;
+            this.config = options ?? default;
 
             Status rewriteStepLoading = Status.Succeeded;
             this.externalRewriteSteps = RewriteSteps.Load(
@@ -632,7 +632,7 @@ namespace Microsoft.Quantum.QsCompiler
         /// executing the compilation steps specified by the given options.
         /// Uses the specified logger to log all diagnostic events.
         /// </summary>
-        public CompilationLoader(IEnumerable<string> sources, IEnumerable<string> references, Configuration options = default, ILogger? logger = null)
+        public CompilationLoader(IEnumerable<string> sources, IEnumerable<string> references, Configuration? options = null, ILogger? logger = null)
             : this(load => load(sources), load => load(references), options, logger)
         {
         }
@@ -642,7 +642,7 @@ namespace Microsoft.Quantum.QsCompiler
         /// executing the compilation steps specified by the given options.
         /// Uses the specified logger to log all diagnostic events.
         /// </summary>
-        public CompilationLoader(IEnumerable<string> sources, ReferenceLoader loadReferences, Configuration options = default, ILogger? logger = null)
+        public CompilationLoader(IEnumerable<string> sources, ReferenceLoader loadReferences, Configuration? options = null, ILogger? logger = null)
             : this(load => load(sources), loadReferences, options, logger)
         {
         }
@@ -652,7 +652,7 @@ namespace Microsoft.Quantum.QsCompiler
         /// executing the compilation steps specified by the given options.
         /// Uses the specified logger to log all diagnostic events.
         /// </summary>
-        public CompilationLoader(SourceLoader loadSources, IEnumerable<string> references, Configuration options = default, ILogger? logger = null)
+        public CompilationLoader(SourceLoader loadSources, IEnumerable<string> references, Configuration? options = null, ILogger? logger = null)
             : this(loadSources, load => load(references), options, logger)
         {
         }

--- a/src/QsCompiler/Compiler/CompilationLoader.cs
+++ b/src/QsCompiler/Compiler/CompilationLoader.cs
@@ -144,7 +144,7 @@ namespace Microsoft.Quantum.QsCompiler
             /// If the output folder is not null,
             /// documentation is generated in the specified folder based on doc comments in the source code.
             /// </summary>
-            public string DocumentationOutputFolder;
+            public string? DocumentationOutputFolder;
 
             /// <summary>
             /// Directory where the compiled binaries will be generated.
@@ -175,7 +175,7 @@ namespace Microsoft.Quantum.QsCompiler
             /// (i.e. classes implementing IRewriteStep) and the corresponding output folder.
             /// The contained rewrite steps will be executed in the defined order and priority at the end of the compilation.
             /// </summary>
-            public IEnumerable<(string, string?)> RewriteSteps;
+            public IEnumerable<(string, string?)>? RewriteSteps;
 
             /// <summary>
             /// If set to true, the post-condition for loaded rewrite steps is checked if the corresponding verification is implemented.
@@ -189,14 +189,14 @@ namespace Microsoft.Quantum.QsCompiler
             /// However, the compiler may overwrite the assembly constants defined for the Q# compilation unit in the dictionary of the loaded step.
             /// The given dictionary in this configuration is left unchanged in any case.
             /// </summary>
-            public IReadOnlyDictionary<string, string> AssemblyConstants;
+            public IReadOnlyDictionary<string, string>? AssemblyConstants;
 
             /// <summary>
             /// Paths to the assemblies that contains a syntax tree with target specific implementations for certain functions and operations.
             /// The functions and operations defined in these assemblies replace the ones declared within the compilation unit.
             /// If no paths are specified here or the sequence is null then this compilation step is omitted.
             /// </summary>
-            public IEnumerable<string> TargetPackageAssemblies;
+            public IEnumerable<string>? TargetPackageAssemblies;
 
             /// <summary>
             /// Indicates whether a serialization of the syntax tree needs to be generated.
@@ -452,9 +452,8 @@ namespace Microsoft.Quantum.QsCompiler
         /// Builds the compilation for the source files and references loaded by the given loaders,
         /// executing the compilation steps specified by the given options.
         /// Uses the specified logger to log all diagnostic events.
-        /// Throws an ArgumentNullException if either one of the given loaders is null or returns null.
         /// </summary>
-        public CompilationLoader(SourceLoader loadSources, ReferenceLoader loadReferences, Configuration? options = null, ILogger? logger = null)
+        public CompilationLoader(SourceLoader loadSources, ReferenceLoader loadReferences, Configuration options = default, ILogger? logger = null)
         {
             this.RaiseCompilationTaskStart(null, "OverallCompilation");
 
@@ -462,7 +461,7 @@ namespace Microsoft.Quantum.QsCompiler
 
             this.logger = logger;
             this.LoadDiagnostics = ImmutableArray<Diagnostic>.Empty;
-            this.config = options ?? default;
+            this.config = options;
 
             Status rewriteStepLoading = Status.Succeeded;
             this.externalRewriteSteps = RewriteSteps.Load(
@@ -474,16 +473,14 @@ namespace Microsoft.Quantum.QsCompiler
             this.compilationStatus.PluginLoading = rewriteStepLoading;
 
             this.RaiseCompilationTaskStart("OverallCompilation", "SourcesLoading");
-            var sourceFiles = loadSources?.Invoke(this.LoadSourceFiles)
-                ?? throw new ArgumentNullException("unable to load source files");
+            var sourceFiles = loadSources(this.LoadSourceFiles);
             this.RaiseCompilationTaskEnd("OverallCompilation", "SourcesLoading");
             this.RaiseCompilationTaskStart("OverallCompilation", "ReferenceLoading");
-            var references = loadReferences?.Invoke(
+            var references = loadReferences(
                 refs => this.LoadAssemblies(
                     refs,
                     loadTestNames: this.config.ExposeReferencesViaTestNames,
-                    ignoreDllResources: this.config.LoadReferencesBasedOnGeneratedCsharp))
-                ?? throw new ArgumentNullException("unable to load referenced binary files");
+                    ignoreDllResources: this.config.LoadReferencesBasedOnGeneratedCsharp));
             this.RaiseCompilationTaskEnd("OverallCompilation", "ReferenceLoading");
 
             // building the compilation
@@ -530,7 +527,10 @@ namespace Microsoft.Quantum.QsCompiler
             if (this.config.LoadTargetSpecificDecompositions)
             {
                 this.RaiseCompilationTaskStart("Build", "ReplaceTargetSpecificImplementations");
-                this.CompilationOutput = this.ReplaceTargetSpecificImplementations(this.config.TargetPackageAssemblies, thisDllUri, references.Declarations.Count);
+                this.CompilationOutput = this.ReplaceTargetSpecificImplementations(
+                    this.config.TargetPackageAssemblies ?? Enumerable.Empty<string>(),
+                    thisDllUri,
+                    references.Declarations.Count);
                 this.RaiseCompilationTaskEnd("Build", "ReplaceTargetSpecificImplementations");
             }
 
@@ -632,7 +632,7 @@ namespace Microsoft.Quantum.QsCompiler
         /// executing the compilation steps specified by the given options.
         /// Uses the specified logger to log all diagnostic events.
         /// </summary>
-        public CompilationLoader(IEnumerable<string> sources, IEnumerable<string> references, Configuration? options = null, ILogger? logger = null)
+        public CompilationLoader(IEnumerable<string> sources, IEnumerable<string> references, Configuration options = default, ILogger? logger = null)
             : this(load => load(sources), load => load(references), options, logger)
         {
         }
@@ -641,9 +641,8 @@ namespace Microsoft.Quantum.QsCompiler
         /// Builds the compilation of the specified source files and the loaded references returned by the given loader,
         /// executing the compilation steps specified by the given options.
         /// Uses the specified logger to log all diagnostic events.
-        /// Throws an ArgumentNullException if the given loader is null or returns null.
         /// </summary>
-        public CompilationLoader(IEnumerable<string> sources, ReferenceLoader loadReferences, Configuration? options = null, ILogger? logger = null)
+        public CompilationLoader(IEnumerable<string> sources, ReferenceLoader loadReferences, Configuration options = default, ILogger? logger = null)
             : this(load => load(sources), loadReferences, options, logger)
         {
         }
@@ -652,9 +651,8 @@ namespace Microsoft.Quantum.QsCompiler
         /// Builds the compilation of the content returned by the given loader and the specified references,
         /// executing the compilation steps specified by the given options.
         /// Uses the specified logger to log all diagnostic events.
-        /// Throws an ArgumentNullException if the given loader is null or returns null.
         /// </summary>
-        public CompilationLoader(SourceLoader loadSources, IEnumerable<string> references, Configuration? options = null, ILogger? logger = null)
+        public CompilationLoader(SourceLoader loadSources, IEnumerable<string> references, Configuration options = default, ILogger? logger = null)
             : this(loadSources, load => load(references), options, logger)
         {
         }
@@ -663,7 +661,6 @@ namespace Microsoft.Quantum.QsCompiler
 
         /// <summary>
         /// Logs the given diagnostic and updates the status passed as reference accordingly.
-        /// Throws an ArgumentNullException if the given diagnostic is null.
         /// </summary>
         private void LogAndUpdate(ref Status current, Diagnostic d)
         {
@@ -695,7 +692,6 @@ namespace Microsoft.Quantum.QsCompiler
         /// <summary>
         /// Logs the given diagnostic and updates the status passed as reference accordingly.
         /// Adds the given diagnostic to the tracked load diagnostics.
-        /// Throws an ArgumentNullException if the given diagnostic is null.
         /// </summary>
         private void LogAndUpdateLoadDiagnostics(ref Status current, Diagnostic d)
         {
@@ -718,10 +714,6 @@ namespace Microsoft.Quantum.QsCompiler
         /// </summary>
         private void PrintResolvedFiles(IEnumerable<Uri> sourceFiles)
         {
-            if (sourceFiles == null)
-            {
-                return;
-            }
             var args = sourceFiles.Any()
                 ? sourceFiles.Select(f => f.LocalPath).ToArray()
                 : new string[] { "(none)" };
@@ -775,13 +767,14 @@ namespace Microsoft.Quantum.QsCompiler
             CompilationTaskEvent?.Invoke(this, new CompilationTaskEventArgs(CompilationTaskEventType.End, parentTaskName, taskName));
 
         /// <summary>
-        /// Executes the given rewrite step on the current CompilationOutput, and updates the given status accordingly.
-        /// Sets the CompilationOutput to the transformed compilation if the status indicates success.
+        /// Executes the given rewrite step on the current CompilationOutput if it is valid, and updates the given
+        /// status accordingly. Sets the CompilationOutput to the transformed compilation if the status indicates
+        /// success.
         /// </summary>
         private QsCompilation? ExecuteAsAtomicTransformation(RewriteSteps.LoadedStep rewriteStep, ref Status status)
         {
             QsCompilation? transformed = null;
-            if (this.compilationStatus.Validation != Status.Succeeded)
+            if (this.CompilationOutput is null || this.compilationStatus.Validation != Status.Succeeded)
             {
                 status = Status.NotRun;
             }
@@ -794,20 +787,14 @@ namespace Microsoft.Quantum.QsCompiler
 
         /// <summary>
         /// Attempts to load the target package assemblies with the given paths, logging diagnostics
-        /// when a path is null or invalid, or loading fails. Logs suitable diagnostics if the loaded dlls
+        /// when a path is invalid, or loading fails. Logs suitable diagnostics if the loaded dlls
         /// contains conflicting declarations. Updates the compilation status accordingly.
         /// Executes the transformation to replace target specific implementations as atomic rewrite step.
         /// Returns the transformed compilation if all assemblies have been successfully loaded and combined.
         /// Returns the unmodified CompilationOutput otherwise.
-        /// Throws an ArgumentNullException if the given sequence of paths is null.
         /// </summary>
         private QsCompilation? ReplaceTargetSpecificImplementations(IEnumerable<string> paths, Uri rewriteStepOrigin, int nrReferences)
         {
-            if (paths == null)
-            {
-                throw new ArgumentNullException(nameof(paths));
-            }
-
             void LogError(ErrorCode errCode, string[] args) => this.LogAndUpdate(ref this.compilationStatus.TargetSpecificReplacements, errCode, args);
             void LogException(Exception ex) => this.LogAndUpdate(ref this.compilationStatus.TargetSpecificReplacements, ex);
 
@@ -846,19 +833,9 @@ namespace Microsoft.Quantum.QsCompiler
         /// <summary>
         /// Executes the given rewrite step on the given compilation, returning a transformed compilation as an out parameter.
         /// Catches and logs any thrown exception. Returns the status of the rewrite step.
-        /// Throws an ArgumentNullException if the rewrite step to execute or the given compilation is null.
         /// </summary>
-        private Status ExecuteRewriteStep(RewriteSteps.LoadedStep rewriteStep, QsCompilation? compilation, out QsCompilation? transformed)
+        private Status ExecuteRewriteStep(RewriteSteps.LoadedStep rewriteStep, QsCompilation compilation, out QsCompilation? transformed)
         {
-            if (rewriteStep == null)
-            {
-                throw new ArgumentNullException(nameof(rewriteStep));
-            }
-            if (compilation == null)
-            {
-                throw new ArgumentNullException(nameof(compilation));
-            }
-
             string? GetDiagnosticsCode(DiagnosticSeverity severity) =>
                 rewriteStep.Name == "CsharpGeneration" && severity == DiagnosticSeverity.Error ? Errors.Code(ErrorCode.CsharpGenerationGeneratedError) :
                 rewriteStep.Name == "CsharpGeneration" && severity == DiagnosticSeverity.Warning ? Warnings.Code(WarningCode.CsharpGenerationGeneratedWarning) :
@@ -976,17 +953,12 @@ namespace Microsoft.Quantum.QsCompiler
         /// Logs suitable diagnostics in the process and modifies the compilation status accordingly.
         /// Does *not* close the given memory stream, and
         /// returns true if the serialization has been successfully generated.
-        /// Throws an ArgumentNullException if the given memory stream is null.
         /// </summary>
         private bool SerializeSyntaxTree(MemoryStream ms)
         {
             void LogError() => this.LogAndUpdate(
                 ref this.compilationStatus.Serialization, ErrorCode.SerializationFailed, Enumerable.Empty<string>());
 
-            if (ms == null)
-            {
-                throw new ArgumentNullException(nameof(ms));
-            }
             this.compilationStatus.Serialization = 0;
             if (this.CompilationOutput == null)
             {
@@ -1018,14 +990,9 @@ namespace Microsoft.Quantum.QsCompiler
         /// Returns the absolute path of the file where the binary representation has been generated.
         /// Returns null if the binary file could not be generated.
         /// Does *not* close the given memory stream.
-        /// Throws an ArgumentNullException if the given memory stream is null.
         /// </summary>
         private string? GenerateBinary(MemoryStream serialization)
         {
-            if (serialization == null)
-            {
-                throw new ArgumentNullException(nameof(serialization));
-            }
             this.compilationStatus.BinaryFormat = 0;
 
             var projId = NonNullable<string>.New(Path.GetFullPath(this.config.ProjectNameWithExtension ?? Path.GetRandomFileName()));
@@ -1057,14 +1024,9 @@ namespace Microsoft.Quantum.QsCompiler
         /// Returns the absolute path of the file where the dll has been generated.
         /// Returns null if the dll could not be generated.
         /// Does *not* close the given memory stream.
-        /// Throws an ArgumentNullException if the given memory stream is null.
         /// </summary>
         private string? GenerateDll(MemoryStream serialization)
         {
-            if (serialization == null)
-            {
-                throw new ArgumentNullException(nameof(serialization));
-            }
             this.compilationStatus.DllGeneration = 0;
 
             var fallbackFileName = (this.PathToCompiledBinary ?? this.config.ProjectNameWithExtension) ?? Path.GetRandomFileName();
@@ -1147,7 +1109,6 @@ namespace Microsoft.Quantum.QsCompiler
 
         /// <summary>
         /// Given a stream with the content of a Q# binary file, returns the corresponding compilation as out parameter.
-        /// Throws an ArgumentNullException if the given stream is null.
         /// </summary>
         public static bool ReadBinary(Stream stream, [NotNullWhen(true)] out QsCompilation? syntaxTree) =>
             AssemblyLoader.LoadSyntaxTree(stream, out syntaxTree);

--- a/src/QsCompiler/Compiler/ExternalRewriteSteps.cs
+++ b/src/QsCompiler/Compiler/ExternalRewriteSteps.cs
@@ -62,8 +62,8 @@ namespace Microsoft.Quantum.QsCompiler
             /// </summary>
             internal LoadedStep(object implementation, Type interfaceType, Uri origin)
             {
-                this.Origin = origin ?? throw new ArgumentNullException(nameof(origin));
-                this.selfAsObject = implementation ?? throw new ArgumentNullException(nameof(implementation));
+                this.Origin = origin;
+                this.selfAsObject = implementation;
 
                 // Initializing the _InterfaceMethods even if the implementation implements IRewriteStep
                 // would result in certain properties being loaded via reflection instead of simply being accessed via _SelfAsStep.

--- a/src/QsCompiler/Compiler/FunctorGeneration.cs
+++ b/src/QsCompiler/Compiler/FunctorGeneration.cs
@@ -31,14 +31,9 @@ namespace Microsoft.Quantum.QsCompiler
         /// <summary>
         /// Given a sequence of specializations, returns the implementation of the given kind, or null if no such specialization exists.
         /// Throws an ArgumentException if more than one specialization of that kind exist.
-        /// Throws an ArgumentNullException if the sequence of specializations is null, or contains any entries that are null.
         /// </summary>
         private static QsSpecialization? GetSpecialization(this IEnumerable<QsSpecialization> specs, QsSpecializationKind kind)
         {
-            if (specs == null || specs.Any(s => s == null))
-            {
-                throw new ArgumentNullException(nameof(specs));
-            }
             specs = specs.Where(spec => spec.Kind == kind);
             if (specs.Count() > 1)
             {
@@ -90,7 +85,6 @@ namespace Microsoft.Quantum.QsCompiler
         /// Only valid functor generator directives are evaluated, anything else remains unmodified.
         /// The directives 'invert' and 'self' are considered to be valid functor generator directives.
         /// Assumes that operation calls may only ever occur within expression statements.
-        /// Throws an ArgumentNullException if the given callable or a relevant property is null.
         /// Throws an ArgumentException if more than one body or adjoint specialization exists.
         /// Throws an ArgumentException if the callable is not intrinsic or external and the implementation for the body is not provided.
         /// </summary>
@@ -99,7 +93,7 @@ namespace Microsoft.Quantum.QsCompiler
             var bodyDecl = BodyImplementation(callable);
             if (bodyDecl == null)
             {
-                return callable ?? throw new ArgumentNullException(nameof(callable));
+                return callable;
             }
 
             var adj = callable.Specializations.GetSpecialization(QsSpecializationKind.QsAdjoint);
@@ -124,7 +118,6 @@ namespace Microsoft.Quantum.QsCompiler
         /// or set to the original specialization if the specialization was not requested to be auto-generated.
         /// Only valid functor generator directives are evaluated, anything else remains unmodified.
         /// The directive 'distributed' is the only directive considered to be valid.
-        /// Throws an ArgumentNullException if the given callable or a relevant property is null.
         /// Throws an ArgumentException if more than one body or controlled specialization exists.
         /// Throws an ArgumentException if the callable is not intrinsic or external and the implementation for the body is not provided.
         /// </summary>
@@ -133,7 +126,7 @@ namespace Microsoft.Quantum.QsCompiler
             var bodyDecl = BodyImplementation(callable);
             if (bodyDecl == null)
             {
-                return callable ?? throw new ArgumentNullException(nameof(callable));
+                return callable;
             }
 
             var ctl = callable.Specializations.GetSpecialization(QsSpecializationKind.QsControlled);
@@ -158,7 +151,6 @@ namespace Microsoft.Quantum.QsCompiler
         /// The directives 'invert', 'self', and 'distributed' are considered to be valid functor generator directives.
         /// Assumes that if the controlled adjoint version is to be generated based on the controlled version,
         /// operation calls may only ever occur within expression statements.
-        /// Throws an ArgumentNullException if the given callable or a relevant property is null.
         /// Throws an ArgumentException if more than one body, adjoint or controlled specialization (depending on the generator directive) exists.
         /// Throws an ArgumentException if the callable is not intrinsic or external and the implementation for the body is not provided,
         /// or if the implementation for the adjoint or controlled specialization (depending on the generator directive) is not provided.
@@ -168,7 +160,7 @@ namespace Microsoft.Quantum.QsCompiler
             var bodyDecl = BodyImplementation(callable);
             if (bodyDecl == null)
             {
-                return callable ?? throw new ArgumentNullException(nameof(callable));
+                return callable;
             }
 
             var ctlAdj = callable.Specializations.GetSpecialization(QsSpecializationKind.QsControlledAdjoint);
@@ -200,14 +192,9 @@ namespace Microsoft.Quantum.QsCompiler
         /// This is the case e.g. if more than one specialization of the same kind exists for a callable which causes an ArgumentException to be thrown.
         /// Any thrown exception is logged using the given onException action and are silently ignored if onException is not specified or null.
         /// Returns a boolean indicating if the evaluation of all directives was successful.
-        /// Throws an ArgumentNullException (that is not logged or ignored) if the given compilation is null.
         /// </summary>
         public static bool GenerateFunctorSpecializations(QsCompilation compilation, out QsCompilation built, Action<Exception>? onException = null)
         {
-            if (compilation == null)
-            {
-                throw new ArgumentNullException(nameof(compilation));
-            }
             var success = true;
             var namespaces = compilation.Namespaces.Where(ns => ns != null).Select(ns =>
             {

--- a/src/QsCompiler/Compiler/Logging.cs
+++ b/src/QsCompiler/Compiler/Logging.cs
@@ -153,14 +153,9 @@ namespace Microsoft.Quantum.QsCompiler.Diagnostics
         /// prints the given diagnostic ff the logger verbosity is sufficiently high.
         /// Before printing, the line numbers are shifted by the offset specified upon initialization.
         /// Returns without doing anything if the given diagnostic is a warning that is to be ignored.
-        /// Throws an ArgumentNullException if the given diagnostic is null.
         /// </summary>
         public void Log(Diagnostic m)
         {
-            if (m == null)
-            {
-                throw new ArgumentNullException(nameof(m));
-            }
             if (m.Severity == DiagnosticSeverity.Warning &&
                 CompilationBuilder.Diagnostics.TryGetCode(m.Code, out int code)
                 && this.noWarn.Contains(code))
@@ -183,14 +178,9 @@ namespace Microsoft.Quantum.QsCompiler.Diagnostics
 
         /// <summary>
         /// Increases the exception counter and calls OnException with the given exception.
-        /// Throws an ArgumentNullException if the given exception is null.
         /// </summary>
         public void Log(Exception ex)
         {
-            if (ex == null)
-            {
-                throw new ArgumentNullException(nameof(ex));
-            }
             ++this.NrExceptionsLogged;
             this.OnException(ex);
         }
@@ -205,14 +195,9 @@ namespace Microsoft.Quantum.QsCompiler.Diagnostics
         /// Returns a string that contains all information about the given diagnostic in human readable format.
         /// The string contains one-based position information if the range information is not null,
         /// assuming the given position information is zero-based.
-        /// Throws an ArgumentNullException if the given message is null.
         /// </summary>
         public static string HumanReadableFormat(Diagnostic msg)
         {
-            if (msg == null)
-            {
-                throw new ArgumentNullException(nameof(msg));
-            }
             var codeStr = msg.Code == null ? string.Empty : $" {msg.Code}";
             var (startLine, startChar) = (msg.Range?.Start?.Line + 1 ?? 0, msg.Range?.Start?.Character + 1 ?? 0);
 
@@ -231,14 +216,9 @@ namespace Microsoft.Quantum.QsCompiler.Diagnostics
         /// in a format that is detected and processed as a diagnostic by VS and VS Code.
         /// The string contains one-based position information if the range information is not null,
         /// assuming the given position information is zero-based.
-        /// Throws an ArgumentNullException if the given message is null.
         /// </summary>
         public static string MsBuildFormat(Diagnostic msg)
         {
-            if (msg == null)
-            {
-                throw new ArgumentNullException(nameof(msg));
-            }
             var codeStr = msg.Code == null ? string.Empty : $" {msg.Code}";
             var (startLine, startChar) = (msg.Range?.Start?.Line + 1 ?? 0, msg.Range?.Start?.Character + 1 ?? 0);
 

--- a/src/QsCompiler/LanguageServer/FileSystemWatcher.cs
+++ b/src/QsCompiler/LanguageServer/FileSystemWatcher.cs
@@ -56,9 +56,9 @@ namespace Microsoft.Quantum.QsLanguageServer
         public delegate void FileEventHandler(FileEvent e);
 
         [PermissionSet(SecurityAction.Demand, Name = "FullTrust")]
-        public FileWatcher(Action<Exception>? onException = null)
+        public FileWatcher(Action<Exception> onException)
         {
-            this.onException = onException ?? throw new ArgumentNullException(nameof(onException));
+            this.onException = onException;
             this.watchers = new ConcurrentBag<System.IO.FileSystemWatcher>();
             this.watchedDirectories = new Dictionary<Uri, ImmutableHashSet<string>>();
             this.processing = new ProcessingQueue(this.onException, "error in file system watcher");

--- a/src/QsCompiler/LanguageServer/LanguageServer.cs
+++ b/src/QsCompiler/LanguageServer/LanguageServer.cs
@@ -189,7 +189,7 @@ namespace Microsoft.Quantum.QsLanguageServer
                 return new InitializeError { Retry = true };
             }
 
-            arg?.SelectToken("capabilities.textDocument.codeAction")?.Replace(null); // setting this to null for now, since we are not using it and the deserialization causes issues
+            arg.SelectToken("capabilities.textDocument.codeAction")?.Replace(null); // setting this to null for now, since we are not using it and the deserialization causes issues
             var param = Utils.TryJTokenAs<InitializeParams>(arg);
             this.clientCapabilities = param.Capabilities;
 
@@ -557,10 +557,10 @@ namespace Microsoft.Quantum.QsLanguageServer
         [JsonRpcMethod(Methods.WorkspaceExecuteCommandName)]
         public object? OnExecuteCommand(JToken arg)
         {
-            var param = Utils.TryJTokenAs<ExecuteCommandParams>(arg);
+            ExecuteCommandParams param = Utils.TryJTokenAs<ExecuteCommandParams>(arg);
             object? CastAndExecute<T>(Func<T, object?> command) where T : class =>
                 QsCompilerError.RaiseOnFailure(
-                    () => command(Utils.TryJTokenAs<T>(param.Arguments.Single() as JObject)), // currently all supported commands take a single argument
+                    () => command(Utils.TryJTokenAs<T>((JObject)param.Arguments.Single())), // currently all supported commands take a single argument
                     "ExecuteCommand threw an exception");
             try
             {

--- a/src/QsCompiler/LanguageServer/ProjectLoader.cs
+++ b/src/QsCompiler/LanguageServer/ProjectLoader.cs
@@ -173,20 +173,11 @@ namespace Microsoft.Quantum.QsLanguageServer
         /// <summary>
         /// Loads the project corresponding to the given project file with the given properties,
         /// applies the given query to it, and unloads it. Returns the result of the query.
-        /// Throws an ArgumentNullException if the given query or properties are null.
         /// Throws an ArgumentException if the given project file is null or does not exist.
         /// NOTE: unloads the GlobalProjectCollection to force a cache clearing.
         /// </summary>
         private static T LoadAndApply<T>(string projectFile, IDictionary<string, string> properties, Func<Project, T> query)
         {
-            if (query == null)
-            {
-                throw new ArgumentNullException(nameof(query));
-            }
-            if (properties == null)
-            {
-                throw new ArgumentNullException(nameof(properties));
-            }
             if (!File.Exists(projectFile))
             {
                 throw new ArgumentException("given project file is null or does not exist", nameof(projectFile));
@@ -259,14 +250,9 @@ namespace Microsoft.Quantum.QsLanguageServer
         /// Returns a dictionary with additional project information (e.g. for telemetry) as out parameter.
         /// Logs suitable messages using the given log function if the project file cannot be found, or if the design time build fails.
         /// Logs whether or not the project is recognized as Q# project.
-        /// Throws an ArgumentNullException if the given project file is null.
         /// </summary>
         public ProjectInstance? TryGetQsProjectInstance(string projectFile, out Dictionary<string, string?> metadata)
         {
-            if (projectFile == null)
-            {
-                throw new ArgumentNullException(nameof(projectFile));
-            }
             metadata = new Dictionary<string, string?>();
             if (!projectFile.ToLowerInvariant().EndsWith(".csproj"))
             {

--- a/src/QsCompiler/LanguageServer/SynchronizationContext.cs
+++ b/src/QsCompiler/LanguageServer/SynchronizationContext.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using System;
 using System.Threading;
 using Microsoft.Quantum.QsCompiler;
 using Microsoft.VisualStudio.Threading;
@@ -30,10 +29,6 @@ namespace Microsoft.Quantum.QsLanguageServer
         /// <inheritdoc/>
         public override void Post(SendOrPostCallback fct, object? arg)
         {
-            if (fct == null)
-            {
-                throw new ArgumentNullException(nameof(fct));
-            }
             this.queued.Enqueue((fct, arg));
             this.Send(_ => this.ProcessNext(), null);
         }

--- a/src/QsCompiler/LanguageServer/Utils.cs
+++ b/src/QsCompiler/LanguageServer/Utils.cs
@@ -17,49 +17,29 @@ namespace Microsoft.Quantum.QsLanguageServer
         // language server tools -
         // wrapping these into a try .. catch .. to make sure errors don't go unnoticed as they otherwise would
 
-        public static T TryJTokenAs<T>(JToken? arg) where T : class =>
-            QsCompilerError.RaiseOnFailure(
-                () => arg == null ? throw new ArgumentNullException(nameof(arg)) : arg.ToObject<T>(),
-                "could not cast given JToken");
+        public static T TryJTokenAs<T>(JToken arg) where T : class =>
+            QsCompilerError.RaiseOnFailure(() => arg.ToObject<T>(), "could not cast given JToken");
 
         private static ShowMessageParams? AsMessageParams(string text, MessageType severity) =>
             text == null ? null : new ShowMessageParams { Message = text, MessageType = severity };
 
         /// <summary>
         /// Shows the given text in the editor.
-        /// Throws an ArgumentNullException if either the server or the text to display is null.
         /// </summary>
         internal static void ShowInWindow(this QsLanguageServer server, string text, MessageType severity)
         {
             var message = AsMessageParams(text, severity);
             QsCompilerError.Verify(server != null && message != null, "cannot show message - given server or text was null");
-            if (server == null)
-            {
-                throw new ArgumentNullException(nameof(server));
-            }
-            if (message == null)
-            {
-                throw new ArgumentNullException(nameof(message));
-            }
             _ = server.NotifyClientAsync(Methods.WindowShowMessageName, message);
         }
 
         /// <summary>
         /// Logs the given text in the editor.
-        /// Throws an ArgumentNullException if either the server or the text to display is null.
         /// </summary>
         internal static void LogToWindow(this QsLanguageServer server, string text, MessageType severity)
         {
             var message = AsMessageParams(text, severity);
             QsCompilerError.Verify(server != null && message != null, "cannot log message - given server or text was null");
-            if (server == null)
-            {
-                throw new ArgumentNullException(nameof(server));
-            }
-            if (message == null)
-            {
-                throw new ArgumentNullException(nameof(message));
-            }
             _ = server.NotifyClientAsync(Methods.WindowLogMessageName, message);
         }
 
@@ -76,15 +56,6 @@ namespace Microsoft.Quantum.QsLanguageServer
             Func<TSource, TResult> mapper,
             out ImmutableArray<TResult> mapped)
         {
-            if (source == null)
-            {
-                throw new ArgumentNullException(nameof(source));
-            }
-            if (mapper == null)
-            {
-                throw new ArgumentNullException(nameof(mapper));
-            }
-
             var succeeded = true;
             var enumerator = source.GetEnumerator();
 

--- a/src/QsCompiler/Tests.Compiler/CommandLineTests.fs
+++ b/src/QsCompiler/Tests.Compiler/CommandLineTests.fs
@@ -188,7 +188,7 @@ let ``execute rewrite steps only if validation passes`` () =
     let config = new CompilationLoader.Configuration(GenerateFunctorSupport = true, BuildOutputFolder = null, RuntimeCapabilities = AssemblyConstants.RuntimeCapabilities.QPRGen0)
     
     let loadSources (loader : Func<_ seq,_>) = loader.Invoke([source1; source2])
-    let loaded = new CompilationLoader(new CompilationLoader.SourceLoader(loadSources), Seq.empty, config);
+    let loaded = new CompilationLoader(new CompilationLoader.SourceLoader(loadSources), Seq.empty, new Nullable<_>(config));
     Assert.Equal(CompilationLoader.Status.Succeeded, loaded.SourceFileLoading)
     Assert.Equal(CompilationLoader.Status.Succeeded, loaded.ReferenceLoading)
     Assert.Equal(CompilationLoader.Status.Succeeded, loaded.Validation)
@@ -196,7 +196,7 @@ let ``execute rewrite steps only if validation passes`` () =
     Assert.Equal(CompilationLoader.Status.NotRun, loaded.Monomorphization) // no entry point
 
     let loadSources (loader : Func<_ seq,_>) = loader.Invoke([source2])
-    let loaded = new CompilationLoader(new CompilationLoader.SourceLoader(loadSources), Seq.empty, config);
+    let loaded = new CompilationLoader(new CompilationLoader.SourceLoader(loadSources), Seq.empty, new Nullable<_>(config));
     Assert.Equal(CompilationLoader.Status.Succeeded, loaded.SourceFileLoading)
     Assert.Equal(CompilationLoader.Status.Succeeded, loaded.ReferenceLoading)
     Assert.Equal(CompilationLoader.Status.Failed, loaded.Validation)

--- a/src/QsCompiler/Tests.Compiler/CommandLineTests.fs
+++ b/src/QsCompiler/Tests.Compiler/CommandLineTests.fs
@@ -188,7 +188,7 @@ let ``execute rewrite steps only if validation passes`` () =
     let config = new CompilationLoader.Configuration(GenerateFunctorSupport = true, BuildOutputFolder = null, RuntimeCapabilities = AssemblyConstants.RuntimeCapabilities.QPRGen0)
     
     let loadSources (loader : Func<_ seq,_>) = loader.Invoke([source1; source2])
-    let loaded = new CompilationLoader(new CompilationLoader.SourceLoader(loadSources), Seq.empty, new Nullable<_>(config));
+    let loaded = new CompilationLoader(new CompilationLoader.SourceLoader(loadSources), Seq.empty, config);
     Assert.Equal(CompilationLoader.Status.Succeeded, loaded.SourceFileLoading)
     Assert.Equal(CompilationLoader.Status.Succeeded, loaded.ReferenceLoading)
     Assert.Equal(CompilationLoader.Status.Succeeded, loaded.Validation)
@@ -196,7 +196,7 @@ let ``execute rewrite steps only if validation passes`` () =
     Assert.Equal(CompilationLoader.Status.NotRun, loaded.Monomorphization) // no entry point
 
     let loadSources (loader : Func<_ seq,_>) = loader.Invoke([source2])
-    let loaded = new CompilationLoader(new CompilationLoader.SourceLoader(loadSources), Seq.empty, new Nullable<_>(config));
+    let loaded = new CompilationLoader(new CompilationLoader.SourceLoader(loadSources), Seq.empty, config);
     Assert.Equal(CompilationLoader.Status.Succeeded, loaded.SourceFileLoading)
     Assert.Equal(CompilationLoader.Status.Succeeded, loaded.ReferenceLoading)
     Assert.Equal(CompilationLoader.Status.Failed, loaded.Validation)

--- a/src/QsCompiler/Transformations/Attributes.cs
+++ b/src/QsCompiler/Transformations/Attributes.cs
@@ -51,7 +51,6 @@ namespace Microsoft.Quantum.QsCompiler.Transformations
         /// <summary>
         /// Adds the given attribute to all callables in the given compilation that satisfy the given predicate
         /// - if the predicate is specified and not null.
-        /// Throws an ArgumentNullException if the given attribute or compilation is null.
         /// </summary>
         public static QsCompilation AddToCallables(QsCompilation compilation, QsDeclarationAttribute attribute, CallablePredicate? predicate = null) =>
             new AddAttributes(new[] { (attribute, predicate) }).OnCompilation(compilation);
@@ -59,14 +58,12 @@ namespace Microsoft.Quantum.QsCompiler.Transformations
         /// <summary>
         /// Adds the given attribute(s) to all callables in the given compilation that satisfy the given predicate
         /// - if the predicate is specified and not null.
-        /// Throws an ArgumentNullException if one of the given attributes or the compilation is null.
         /// </summary>
         public static QsCompilation AddToCallables(QsCompilation compilation, params (QsDeclarationAttribute, CallablePredicate?)[] attributes) =>
             new AddAttributes(attributes).OnCompilation(compilation);
 
         /// <summary>
         /// Adds the given attribute(s) to all callables in the given compilation.
-        /// Throws an ArgumentNullException if one of the given attributes or the compilation is null.
         /// </summary>
         public static QsCompilation AddToCallables(QsCompilation compilation, params QsDeclarationAttribute[] attributes) =>
             new AddAttributes(attributes.Select(att => (att, (CallablePredicate?)null))).OnCompilation(compilation);
@@ -74,7 +71,6 @@ namespace Microsoft.Quantum.QsCompiler.Transformations
         /// <summary>
         /// Adds the given attribute to all callables in the given namespace that satisfy the given predicate
         /// - if the predicate is specified and not null.
-        /// Throws an ArgumentNullException if the given attribute or namespace is null.
         /// </summary>
         public static QsNamespace AddToCallables(QsNamespace ns, QsDeclarationAttribute attribute, CallablePredicate? predicate = null) =>
             new AddAttributes(new[] { (attribute, predicate) }).Namespaces.OnNamespace(ns);
@@ -82,14 +78,12 @@ namespace Microsoft.Quantum.QsCompiler.Transformations
         /// <summary>
         /// Adds the given attribute(s) to all callables in the given namespace that satisfy the given predicate
         /// - if the predicate is specified and not null.
-        /// Throws an ArgumentNullException if one of the given attributes or the namespace is null.
         /// </summary>
         public static QsNamespace AddToCallables(QsNamespace ns, params (QsDeclarationAttribute, CallablePredicate?)[] attributes) =>
             new AddAttributes(attributes).Namespaces.OnNamespace(ns);
 
         /// <summary>
         /// Adds the given attribute(s) to all callables in the given namespace.
-        /// Throws an ArgumentNullException if one of the given attributes or the namespace is null.
         /// </summary>
         public static QsNamespace AddToCallables(QsNamespace ns, params QsDeclarationAttribute[] attributes) =>
             new AddAttributes(attributes.Select(att => (att, (CallablePredicate?)null))).Namespaces.OnNamespace(ns);
@@ -106,18 +100,13 @@ namespace Microsoft.Quantum.QsCompiler.Transformations
             {
                 internal readonly ImmutableArray<(QsDeclarationAttribute, CallablePredicate)> AttributeSelection;
 
-                /// <exception cref="ArgumentNullException">Thrown when the given selection is null.</exception>
-                internal TransformationState(IEnumerable<(QsDeclarationAttribute, CallablePredicate)>? selections) =>
-                    this.AttributeSelection = selections?.ToImmutableArray() ?? throw new ArgumentNullException(nameof(selections));
+                internal TransformationState(IEnumerable<(QsDeclarationAttribute, CallablePredicate)> selections) =>
+                    this.AttributeSelection = selections.ToImmutableArray();
             }
 
             internal AddAttributes(IEnumerable<(QsDeclarationAttribute, CallablePredicate?)> attributes)
-            : base(new TransformationState(attributes?.Select(entry => (entry.Item1, entry.Item2 ?? (_ => true)))))
+            : base(new TransformationState(attributes.Select(entry => (entry.Item1, entry.Item2 ?? (_ => true)))))
             {
-                if (attributes == null || attributes.Any(entry => entry.Item1 == null))
-                {
-                    throw new ArgumentNullException(nameof(attributes));
-                }
                 this.Namespaces = new NamespaceTransformation(this);
                 this.Statements = new Core.StatementTransformation<TransformationState>(this, Core.TransformationOptions.Disabled);
                 this.StatementKinds = new Core.StatementKindTransformation<TransformationState>(this, Core.TransformationOptions.Disabled);

--- a/src/QsCompiler/Transformations/BasicTransformations.cs
+++ b/src/QsCompiler/Transformations/BasicTransformations.cs
@@ -33,14 +33,9 @@ namespace Microsoft.Quantum.QsCompiler.Transformations.BasicTransformations
 
         /// <summary>
         /// Returns a hash set containing all source files in the given namespaces.
-        /// Throws an ArgumentNullException if the given sequence or any of the given namespaces is null.
         /// </summary>
         public static ImmutableHashSet<NonNullable<string>> Apply(IEnumerable<QsNamespace> namespaces)
         {
-            if (namespaces == null || namespaces.Contains(null!))
-            {
-                throw new ArgumentNullException(nameof(namespaces));
-            }
             var filter = new GetSourceFiles();
             foreach (var ns in namespaces)
             {
@@ -51,7 +46,6 @@ namespace Microsoft.Quantum.QsCompiler.Transformations.BasicTransformations
 
         /// <summary>
         /// Returns a hash set containing all source files in the given namespace(s).
-        /// Throws an ArgumentNullException if any of the given namespaces is null.
         /// </summary>
         public static ImmutableHashSet<NonNullable<string>> Apply(params QsNamespace[] namespaces) =>
             Apply((IEnumerable<QsNamespace>)namespaces);
@@ -96,7 +90,7 @@ namespace Microsoft.Quantum.QsCompiler.Transformations.BasicTransformations
                 new List<(int?, QsNamespaceElement)>();
 
             public TransformationState(Func<NonNullable<string>, bool> predicate) =>
-                this.Predicate = predicate ?? throw new ArgumentNullException(nameof(predicate));
+                this.Predicate = predicate;
         }
 
         public FilterBySourceFile(Func<NonNullable<string>, bool> predicate)
@@ -112,10 +106,6 @@ namespace Microsoft.Quantum.QsCompiler.Transformations.BasicTransformations
 
         public static QsNamespace Apply(QsNamespace ns, Func<NonNullable<string>, bool> predicate)
         {
-            if (ns == null)
-            {
-                throw new ArgumentNullException(nameof(ns));
-            }
             var filter = new FilterBySourceFile(predicate);
             return filter.Namespaces.OnNamespace(ns);
         }
@@ -215,8 +205,8 @@ namespace Microsoft.Quantum.QsCompiler.Transformations.BasicTransformations
                 this.Recur = recur;
                 this.Seed = seed;
                 this.FoldResult = seed;
-                this.Condition = condition ?? throw new ArgumentNullException(nameof(condition));
-                this.ConstructFold = fold ?? throw new ArgumentNullException(nameof(fold));
+                this.Condition = condition;
+                this.ConstructFold = fold;
             }
         }
 
@@ -244,7 +234,7 @@ namespace Microsoft.Quantum.QsCompiler.Transformations.BasicTransformations
             /// </summary>
             public StatementTransformation(Func<TransformationState, TSelector> createSelector, SyntaxTreeTransformation<TransformationState> parent)
             : base(parent) =>
-                this.CreateSelector = createSelector ?? throw new ArgumentNullException(nameof(createSelector));
+                this.CreateSelector = createSelector;
 
             /// <inheritdoc/>
             public override QsStatement OnStatement(QsStatement stm)
@@ -357,11 +347,11 @@ namespace Microsoft.Quantum.QsCompiler.Transformations.BasicTransformations
     {
         public TypedExpressionWalker(Action<TypedExpression> onExpression, SyntaxTreeTransformation<T> parent)
         : base(parent, TransformationOptions.NoRebuild) =>
-            this.OnExpression = onExpression ?? throw new ArgumentNullException(nameof(onExpression));
+            this.OnExpression = onExpression;
 
         public TypedExpressionWalker(Action<TypedExpression> onExpression, T internalState = default)
         : base(internalState, TransformationOptions.NoRebuild) =>
-            this.OnExpression = onExpression ?? throw new ArgumentNullException(nameof(onExpression));
+            this.OnExpression = onExpression;
 
         public readonly Action<TypedExpression> OnExpression;
 

--- a/src/QsCompiler/Transformations/CodeTransformations.cs
+++ b/src/QsCompiler/Transformations/CodeTransformations.cs
@@ -21,7 +21,6 @@ namespace Microsoft.Quantum.QsCompiler
         /// Given the body of an operation, auto-generates the (content of the) adjoint specialization,
         /// under the assumption that operation calls may only ever occur within expression statements,
         /// and while-loops cannot occur within operations.
-        /// Throws an ArgumentNullException if the given scope is null.
         /// </summary>
         public static QsScope GenerateAdjoint(this QsScope scope)
         {
@@ -36,7 +35,6 @@ namespace Microsoft.Quantum.QsCompiler
         /// <summary>
         /// Given the body of an operation, auto-generates the (content of the) controlled specialization using the default name
         /// for control qubits. Adds the control qubits names to the list of defined variables for the scope and each subscope.
-        /// Throws an ArgumentNullException if the given scope is null.
         /// </summary>
         public static QsScope GenerateControlled(this QsScope scope)
         {
@@ -51,14 +49,9 @@ namespace Microsoft.Quantum.QsCompiler
         /// throws an InvalidOperationException if the outer block contains while-loops.
         /// Any thrown exception is logged using the given onException action and silently ignored if onException is not specified or null.
         /// Returns true if the transformation succeeded without throwing an exception, and false otherwise.
-        /// Throws an ArgumentNullException (that is not logged or ignored) if the given compilation is null.
         /// </summary>
         public static bool InlineConjugations(this QsCompilation compilation, out QsCompilation inlined, Action<Exception>? onException = null)
         {
-            if (compilation == null)
-            {
-                throw new ArgumentNullException(nameof(compilation));
-            }
             var inline = new InlineConjugations(onException);
             var namespaces = compilation.Namespaces.Select(inline.Namespaces.OnNamespace).ToImmutableArray();
             inlined = new QsCompilation(namespaces, compilation.EntryPoints);
@@ -69,14 +62,9 @@ namespace Microsoft.Quantum.QsCompiler
         /// Pre-evaluates as much of the classical computations as possible in the given compilation.
         /// Any thrown exception is logged using the given onException action and silently ignored if onException is not specified or null.
         /// Returns true if the transformation succeeded without throwing an exception, and false otherwise.
-        /// Throws an ArgumentNullException (that is not logged or ignored) if the given compilation is null.
         /// </summary>
         public static bool PreEvaluateAll(this QsCompilation compilation, out QsCompilation evaluated, Action<Exception>? onException = null)
         {
-            if (compilation == null)
-            {
-                throw new ArgumentNullException(nameof(compilation));
-            }
             try
             {
                 evaluated = PreEvaluation.All(compilation);

--- a/src/QsCompiler/Transformations/FunctorGeneration.cs
+++ b/src/QsCompiler/Transformations/FunctorGeneration.cs
@@ -28,8 +28,7 @@ namespace Microsoft.Quantum.QsCompiler.Transformations.FunctorGeneration
         {
             public readonly QsFunctor FunctorToApply;
 
-            public TransformationsState(QsFunctor functor) =>
-                this.FunctorToApply = functor ?? throw new ArgumentNullException(nameof(functor));
+            public TransformationsState(QsFunctor functor) => this.FunctorToApply = functor;
         }
 
         public ApplyFunctorToOperationCalls(QsFunctor functor)
@@ -116,7 +115,7 @@ namespace Microsoft.Quantum.QsCompiler.Transformations.FunctorGeneration
 
         public AddVariableDeclarations(SyntaxTreeTransformation<T> parent, params LocalVariableDeclaration<NonNullable<string>>[] addedVars)
         : base(parent) =>
-            this.addedVariableDeclarations = addedVars ?? throw new ArgumentNullException(nameof(addedVars));
+            this.addedVariableDeclarations = addedVars;
 
         /// <inheritdoc/>
         public override LocalDeclarations OnLocalDeclarations(LocalDeclarations decl) =>

--- a/src/QsCompiler/Transformations/Monomorphization.cs
+++ b/src/QsCompiler/Transformations/Monomorphization.cs
@@ -46,11 +46,6 @@ namespace Microsoft.Quantum.QsCompiler.Transformations.Monomorphization
 
         public static QsCompilation Apply(QsCompilation compilation)
         {
-            if (compilation == null || compilation.Namespaces.Contains(null))
-            {
-                throw new ArgumentNullException(nameof(compilation));
-            }
-
             var globals = compilation.Namespaces.GlobalCallableResolutions();
 
             var intrinsicCallableSet = globals

--- a/src/QsCompiler/Transformations/QsharpCodeOutput.cs
+++ b/src/QsCompiler/Transformations/QsharpCodeOutput.cs
@@ -169,7 +169,6 @@ namespace Microsoft.Quantum.QsCompiler.Transformations.QsCodeOutput
         /// generates a dictionary that maps (the name of) each partial namespace contained in the file
         /// to a string containing the formatted Q# code for the part of the namespace.
         /// Qualified or unqualified names for types and identifiers are generated based on the given namespace and open directives.
-        /// Throws an ArgumentNullException if the given namespace is null.
         /// -> IMPORTANT: The given namespace is expected to contain *all* elements in that namespace for the *entire* compilation unit!
         /// </summary>
         public static bool Apply(
@@ -177,11 +176,6 @@ namespace Microsoft.Quantum.QsCompiler.Transformations.QsCodeOutput
             IEnumerable<QsNamespace> namespaces,
             params (NonNullable<string>, ImmutableDictionary<NonNullable<string>, ImmutableArray<(NonNullable<string>, string?)>>)[] openDirectives)
         {
-            if (namespaces == null)
-            {
-                throw new ArgumentNullException(nameof(namespaces));
-            }
-
             generatedCode = new List<ImmutableDictionary<NonNullable<string>, string>>();
             var symbolsInNS = namespaces.ToImmutableDictionary(ns => ns.Name, ns => ns.Elements
                 .SelectNotNull(element => (element as QsNamespaceElement.QsCallable)?.Item.FullName.Name.Value)

--- a/src/QsCompiler/Transformations/SearchAndReplace.cs
+++ b/src/QsCompiler/Transformations/SearchAndReplace.cs
@@ -50,9 +50,9 @@ namespace Microsoft.Quantum.QsCompiler.Transformations.SearchAndReplace
             public Location(NonNullable<string> source, Position declOffset, QsLocation stmLoc, Range range)
             {
                 this.SourceFile = source;
-                this.DeclarationOffset = declOffset ?? throw new ArgumentNullException(nameof(declOffset));
-                this.RelativeStatementLocation = stmLoc ?? throw new ArgumentNullException(nameof(stmLoc));
-                this.SymbolRange = range ?? throw new ArgumentNullException(nameof(range));
+                this.DeclarationOffset = declOffset;
+                this.RelativeStatementLocation = stmLoc;
+                this.SymbolRange = range;
             }
 
             /// <inheritdoc/>
@@ -117,7 +117,7 @@ namespace Microsoft.Quantum.QsCompiler.Transformations.SearchAndReplace
                 QsLocation? defaultOffset = null,
                 IImmutableSet<NonNullable<string>>? limitToSourceFiles = null)
             {
-                this.TrackIdentifier = trackId ?? throw new ArgumentNullException(nameof(trackId));
+                this.TrackIdentifier = trackId;
                 this.relevantSourceFiles = limitToSourceFiles;
                 this.Locations = ImmutableHashSet<Location>.Empty;
                 this.defaultOffset = defaultOffset;
@@ -133,7 +133,7 @@ namespace Microsoft.Quantum.QsCompiler.Transformations.SearchAndReplace
                 internal get => this.rootOffset;
                 set
                 {
-                    this.rootOffset = value ?? throw new ArgumentNullException(nameof(value), "declaration offset cannot be null");
+                    this.rootOffset = value;
                     this.CurrentLocation = this.defaultOffset;
                 }
             }
@@ -187,10 +187,6 @@ namespace Microsoft.Quantum.QsCompiler.Transformations.SearchAndReplace
         public IdentifierReferences(QsQualifiedName idName, QsLocation? defaultOffset, IImmutableSet<NonNullable<string>>? limitToSourceFiles = null)
         : this(new TransformationState(id => id is Identifier.GlobalCallable cName && cName.Item.Equals(idName), defaultOffset, limitToSourceFiles))
         {
-            if (idName == null)
-            {
-                throw new ArgumentNullException(nameof(idName));
-            }
         }
 
         // static methods for convenience
@@ -199,12 +195,12 @@ namespace Microsoft.Quantum.QsCompiler.Transformations.SearchAndReplace
             NonNullable<string> idName,
             QsScope scope,
             NonNullable<string> sourceFile,
-            Position? rootLoc)
+            Position rootLoc)
         {
             var finder = new IdentifierReferences(idName, null, ImmutableHashSet.Create(sourceFile));
             finder.SharedState.Source = sourceFile;
-            finder.SharedState.DeclarationOffset = rootLoc; // will throw if null
-            finder.Statements.OnScope(scope ?? throw new ArgumentNullException(nameof(scope)));
+            finder.SharedState.DeclarationOffset = rootLoc;
+            finder.Statements.OnScope(scope);
             return finder.SharedState.Locations;
         }
 
@@ -216,7 +212,7 @@ namespace Microsoft.Quantum.QsCompiler.Transformations.SearchAndReplace
             IImmutableSet<NonNullable<string>>? limitToSourceFiles = null)
         {
             var finder = new IdentifierReferences(idName, defaultOffset, limitToSourceFiles);
-            finder.Namespaces.OnNamespace(ns ?? throw new ArgumentNullException(nameof(ns)));
+            finder.Namespaces.OnNamespace(ns);
             declarationLocation = finder.SharedState.DeclarationLocation;
             return finder.SharedState.Locations;
         }


### PR DESCRIPTION
With C#'s nullable reference types feature enabled in all projects, checking if every argument is null and throwing `ArgumentNullException` is not as important. Null values can still appear even with non-nullable types, especially with public members or when interacting with code that doesn't have nullable references types enabled, but it's much less likely now. We have decided that the benefit of catching nulls at runtime that should already be checked by the compiler is not worth the cost of decreased code readability, so they're being removed.