### PR TITLE
Add vsce to devDependencies

### DIFF
--- a/build/init.yml
+++ b/build/init.yml
@@ -20,11 +20,3 @@ steps:
   inputs:
     packageType: sdk
     version: '3.1.300'
-
-- task: Npm@1
-  displayName: 'Install vsce'
-  inputs:
-    command: custom
-    verbose: false
-    customCommand: 'install -g vsce'
- 

--- a/build/pack.ps1
+++ b/build/pack.ps1
@@ -159,9 +159,9 @@ function Pack-SelfContained() {
 function Pack-VSCode() {
     Write-Host "##[info]Packing VS Code extension..."
     Push-Location (Join-Path $PSScriptRoot '../src/VSCodeExtension')
-    if (Get-Command vsce -ErrorAction SilentlyContinue) {
+    if (Get-Command npx -ErrorAction SilentlyContinue) {
         Try {
-            vsce package
+            npx vsce package
     
             if ($LastExitCode -ne 0) {
                 throw;
@@ -171,7 +171,7 @@ function Pack-VSCode() {
             $Script:all_ok = $False
         }
     } else {
-        Write-Host "##vso[task.logissue type=warning;]vsce not installed. Will skip creation of VS Code extension package"
+        Write-Host "##vso[task.logissue type=warning;]npx not installed. Will skip creation of VS Code extension package"
     }
     Pop-Location
 }

--- a/src/VSCodeExtension/BUILDING.md
+++ b/src/VSCodeExtension/BUILDING.md
@@ -2,11 +2,11 @@
 
 ## Prerequisites ##
 
-- npm and vsce
+- NPM
 - PowerShell Core (6.0 or later)
 - .NET Core SDK 3.1 or later
 
-### Obtaining npm and vsce ###
+### Obtaining NPM ###
 
 All Visual Studio Code extensions require a local install of the Node Package Manager to work.
 NPM is distributed with Node.js, which can be obtained from https://nodejs.org/en/, or using Chocolatey:
@@ -15,20 +15,22 @@ NPM is distributed with Node.js, which can be obtained from https://nodejs.org/e
 choco install nodejs
 ```
 
-Once you have NPM, we strongly suggest installing the VS Code Extension (vsce) tool:
-
-```
-npm i -g vsce
-```
-
-Here, `npm i -g` instructs NPM to *install globally* the vsce package.
-After doing so, `vsce` can be used from the command line.
-
-
 ## Steps ##
 
 Before doing any local development, you will need to run `bootstrap.ps1` to set version numbers and other metadata for the Quantum Development Kit.
 Please see [the root README](../../README.md) for more information.
+
+You can then install the dependencies needed by the Visual Studio Code extension by running this command in the `VSCodeExtension` folder:
+
+```
+npm install
+```
+
+To package the extension into a VSIX file that can be installed from Visual Studio Code, run:
+
+```
+npx vsce package
+```
 
 As of version 0.10 of the Quantum Development Kit, the Visual Studio Code extension no longer includes the Q# language server, but downloads a copy of the server at runtime.
 This process is controlled by metadata stored in `package.json`, which is in turn generated from `package.json.v.template` when running `bootstrap.ps1` in the root of the repository.
@@ -72,7 +74,7 @@ PS> Resolve-Path bin/Debug/netcoreapp3.1/win10-x64/publish/Microsoft.Quantum.QsL
 
 ## Debugging ##
 
-As an alternative to using `vsce package` to produce an installable VSIX, the VS Code extension can be run in an experimental instance of VS Code.
+As an alternative to using `npx vsce package` to produce an installable VSIX, the VS Code extension can be run in an experimental instance of VS Code.
 From the Debug tab in VS Code, ensure that "Extension" is selected in the Debug target menu and press the green ‣.
 
 If you would like to also debug the language server at the same time, this can be done using the ".NET Core Attach" debugging target along with the "Extension" target.

--- a/src/VSCodeExtension/package-lock.json.v.template
+++ b/src/VSCodeExtension/package-lock.json.v.template
@@ -467,6 +467,18 @@
                 }
             }
         },
+        "azure-devops-node-api": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/azure-devops-node-api/-/azure-devops-node-api-7.2.0.tgz",
+            "integrity": "sha512-pMfGJ6gAQ7LRKTHgiRF+8iaUUeGAI0c8puLaqHLc7B8AR7W6GJLozK9RFeUHFjEGybC9/EB3r67WPd7e46zQ8w==",
+            "dev": true,
+            "requires": {
+                "os": "0.1.1",
+                "tunnel": "0.0.4",
+                "typed-rest-client": "1.2.0",
+                "underscore": "1.8.3"
+            }
+        },
         "balanced-match": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
@@ -544,6 +556,12 @@
             "resolved": "https://registry.npmjs.org/binaryextensions/-/binaryextensions-2.3.0.tgz",
             "integrity": "sha512-nAihlQsYGyc5Bwq6+EsubvANYGExeJKHDO3RjnvwU042fawQTQfM3Kxn7IHUXQOz4bzfwsGYYHGSvXyW4zOGLg=="
         },
+        "boolbase": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+            "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24=",
+            "dev": true
+        },
         "brace-expansion": {
             "version": "1.1.11",
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -599,6 +617,12 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
             "integrity": "sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg=="
+        },
+        "buffer-crc32": {
+            "version": "0.2.13",
+            "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+            "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=",
+            "dev": true
         },
         "buffer-fill": {
             "version": "1.0.0",
@@ -675,6 +699,20 @@
             "version": "0.7.0",
             "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
             "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA=="
+        },
+        "cheerio": {
+            "version": "1.0.0-rc.3",
+            "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.3.tgz",
+            "integrity": "sha512-0td5ijfUPuubwLUu0OBoe98gZj8C/AA+RW3v67GPlGOrvxWjZmBXiBCRU+I8VEiNyJzjth40POfHiz2RB3gImA==",
+            "dev": true,
+            "requires": {
+                "css-select": "~1.2.0",
+                "dom-serializer": "~0.1.1",
+                "entities": "~1.1.1",
+                "htmlparser2": "^3.9.1",
+                "lodash": "^4.15.0",
+                "parse5": "^3.0.1"
+            }
         },
         "class-utils": {
             "version": "0.3.6",
@@ -891,6 +929,24 @@
                 }
             }
         },
+        "css-select": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
+            "integrity": "sha1-KzoRBTnFNV8c2NMUYj6HCxIeyFg=",
+            "dev": true,
+            "requires": {
+                "boolbase": "~1.0.0",
+                "css-what": "2.1",
+                "domutils": "1.5.1",
+                "nth-check": "~1.0.1"
+            }
+        },
+        "css-what": {
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/css-what/-/css-what-2.1.3.tgz",
+            "integrity": "sha512-a+EPoD+uZiNfh+5fxw2nO9QwFa6nJe2Or35fGY6Ipw1R3R4AGz1d1TEZrCegvw2YTmZ0jXirGYlzxxpYSHwpEg==",
+            "dev": true
+        },
         "dargs": {
             "version": "6.1.0",
             "resolved": "https://registry.npmjs.org/dargs/-/dargs-6.1.0.tgz",
@@ -991,6 +1047,12 @@
             "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
             "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
         },
+        "denodeify": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/denodeify/-/denodeify-1.2.1.tgz",
+            "integrity": "sha1-OjYof1A05pnnV3kBBSwubJQlFjE=",
+            "dev": true
+        },
         "detect-conflict": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/detect-conflict/-/detect-conflict-1.0.1.tgz",
@@ -1028,6 +1090,41 @@
             "requires": {
                 "arrify": "^1.0.1",
                 "path-type": "^3.0.0"
+            }
+        },
+        "dom-serializer": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.1.tgz",
+            "integrity": "sha512-l0IU0pPzLWSHBcieZbpOKgkIn3ts3vAh7ZuFyXNwJxJXk/c4Gwj9xaTJwIDVQCXawWD0qb3IzMGH5rglQaO0XA==",
+            "dev": true,
+            "requires": {
+                "domelementtype": "^1.3.0",
+                "entities": "^1.1.1"
+            }
+        },
+        "domelementtype": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.1.tgz",
+            "integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w==",
+            "dev": true
+        },
+        "domhandler": {
+            "version": "2.4.2",
+            "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.2.tgz",
+            "integrity": "sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==",
+            "dev": true,
+            "requires": {
+                "domelementtype": "1"
+            }
+        },
+        "domutils": {
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
+            "integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
+            "dev": true,
+            "requires": {
+                "dom-serializer": "0",
+                "domelementtype": "1"
             }
         },
         "download-stats": {
@@ -1080,6 +1177,12 @@
             "requires": {
                 "once": "^1.4.0"
             }
+        },
+        "entities": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
+            "integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w==",
+            "dev": true
         },
         "errlop": {
             "version": "2.2.0",
@@ -1296,6 +1399,15 @@
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
             "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
+        },
+        "fd-slicer": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+            "integrity": "sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=",
+            "dev": true,
+            "requires": {
+                "pend": "~1.2.0"
+            }
         },
         "figures": {
             "version": "3.2.0",
@@ -1674,6 +1786,42 @@
             "version": "2.8.8",
             "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
             "integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg=="
+        },
+        "htmlparser2": {
+            "version": "3.10.1",
+            "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.10.1.tgz",
+            "integrity": "sha512-IgieNijUMbkDovyoKObU1DUhm1iwNYE/fuifEoEHfd1oZKZDaONBSkal7Y01shxsM49R4XaMdGez3WnF9UfiCQ==",
+            "dev": true,
+            "requires": {
+                "domelementtype": "^1.3.1",
+                "domhandler": "^2.3.0",
+                "domutils": "^1.5.1",
+                "entities": "^1.1.1",
+                "inherits": "^2.0.1",
+                "readable-stream": "^3.1.1"
+            },
+            "dependencies": {
+                "readable-stream": {
+                    "version": "3.6.0",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+                    "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+                    "dev": true,
+                    "requires": {
+                        "inherits": "^2.0.3",
+                        "string_decoder": "^1.1.1",
+                        "util-deprecate": "^1.0.1"
+                    }
+                },
+                "string_decoder": {
+                    "version": "1.3.0",
+                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+                    "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+                    "dev": true,
+                    "requires": {
+                        "safe-buffer": "~5.2.0"
+                    }
+                }
+            }
         },
         "http-proxy-agent": {
             "version": "4.0.1",
@@ -2161,10 +2309,25 @@
                 "set-getter": "^0.1.0"
             }
         },
+        "leven": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
+            "integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==",
+            "dev": true
+        },
         "lines-and-columns": {
             "version": "1.1.6",
             "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
             "integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA="
+        },
+        "linkify-it": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-2.2.0.tgz",
+            "integrity": "sha512-GnAl/knGn+i1U/wjBz3akz2stz+HrHLsxMwHQGofCDfPvlf+gDKN58UtfmUquTY4/MXeE2x7k19KQmeoZi94Iw==",
+            "dev": true,
+            "requires": {
+                "uc.micro": "^1.0.1"
+            }
         },
         "load-json-file": {
             "version": "4.0.0",
@@ -2252,6 +2415,33 @@
             "requires": {
                 "object-visit": "^1.0.0"
             }
+        },
+        "markdown-it": {
+            "version": "10.0.0",
+            "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-10.0.0.tgz",
+            "integrity": "sha512-YWOP1j7UbDNz+TumYP1kpwnP0aEa711cJjrAQrzd0UXlbJfc5aAq0F/PZHjiioqDC1NKgvIMX+o+9Bk7yuM2dg==",
+            "dev": true,
+            "requires": {
+                "argparse": "^1.0.7",
+                "entities": "~2.0.0",
+                "linkify-it": "^2.0.0",
+                "mdurl": "^1.0.1",
+                "uc.micro": "^1.0.5"
+            },
+            "dependencies": {
+                "entities": {
+                    "version": "2.0.3",
+                    "resolved": "https://registry.npmjs.org/entities/-/entities-2.0.3.tgz",
+                    "integrity": "sha512-MyoZ0jgnLvB2X3Lg5HqpFmn1kybDiIfEQmKzTb5apr51Rb+T3KdmMiqa70T+bhGnyv7bQ6WMj2QMHpGMmlrUYQ==",
+                    "dev": true
+                }
+            }
+        },
+        "mdurl": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
+            "integrity": "sha1-/oWy7HWlkDfyrf7BAP1sYBdhFS4=",
+            "dev": true
         },
         "mem-fs": {
             "version": "1.2.0",
@@ -2350,6 +2540,12 @@
                 "snapdragon": "^0.8.1",
                 "to-regex": "^3.0.2"
             }
+        },
+        "mime": {
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+            "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+            "dev": true
         },
         "mime-db": {
             "version": "1.44.0",
@@ -2630,6 +2826,15 @@
                 "path-key": "^3.0.0"
             }
         },
+        "nth-check": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.2.tgz",
+            "integrity": "sha512-WeBOdju8SnzPN5vTUJYxYUxLeXpCaVP5i5e0LF8fg7WORF2Wd7wFX/pk0tYZk7s8T+J7VLy0Da6J1+wCT0AtHg==",
+            "dev": true,
+            "requires": {
+                "boolbase": "~1.0.0"
+            }
+        },
         "number-is-nan": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
@@ -2700,10 +2905,32 @@
                 "mimic-fn": "^2.1.0"
             }
         },
+        "os": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/os/-/os-0.1.1.tgz",
+            "integrity": "sha1-IIhF6J4ZOtTZcUdLk5R3NqVtE/M=",
+            "dev": true
+        },
+        "os-homedir": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+            "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+            "dev": true
+        },
         "os-tmpdir": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
             "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
+        },
+        "osenv": {
+            "version": "0.1.5",
+            "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
+            "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
+            "dev": true,
+            "requires": {
+                "os-homedir": "^1.0.0",
+                "os-tmpdir": "^1.0.0"
+            }
         },
         "p-cancelable": {
             "version": "0.3.0",
@@ -2768,6 +2995,32 @@
                 "lines-and-columns": "^1.1.6"
             }
         },
+        "parse-semver": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/parse-semver/-/parse-semver-1.1.1.tgz",
+            "integrity": "sha1-mkr9bfBj3Egm+T+6SpnPIj9mbLg=",
+            "dev": true,
+            "requires": {
+                "semver": "^5.1.0"
+            },
+            "dependencies": {
+                "semver": {
+                    "version": "5.7.1",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+                    "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+                    "dev": true
+                }
+            }
+        },
+        "parse5": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/parse5/-/parse5-3.0.3.tgz",
+            "integrity": "sha512-rgO9Zg5LLLkfJF9E6CCmXlSE4UVceloys8JrFqCcHloC3usd/kJCyPDwH2SOlzix2j3xaP9sUX3e8+kvkuleAA==",
+            "dev": true,
+            "requires": {
+                "@types/node": "*"
+            }
+        },
         "pascalcase": {
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
@@ -2814,6 +3067,12 @@
             "requires": {
                 "pify": "^3.0.0"
             }
+        },
+        "pend": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+            "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA=",
+            "dev": true
         },
         "performance-now": {
             "version": "2.1.0",
@@ -2898,6 +3157,15 @@
             "version": "6.5.2",
             "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
             "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
+        },
+        "read": {
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
+            "integrity": "sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ=",
+            "dev": true,
+            "requires": {
+                "mute-stream": "~0.0.4"
+            }
         },
         "read-chunk": {
             "version": "3.2.0",
@@ -3677,6 +3945,12 @@
                 "tslib": "^1.8.1"
             }
         },
+        "tunnel": {
+            "version": "0.0.4",
+            "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.4.tgz",
+            "integrity": "sha1-LTeFoVjBdMmhbcLARuxfxfF0IhM=",
+            "dev": true
+        },
         "tunnel-agent": {
             "version": "0.6.0",
             "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
@@ -3701,10 +3975,32 @@
             "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.11.0.tgz",
             "integrity": "sha512-OdjXJxnCN1AvyLSzeKIgXTXxV+99ZuXl3Hpo9XpJAv9MBcHrrJOQ5kV7ypXOuQie+AmWG25hLbiKdwYTifzcfQ=="
         },
+        "typed-rest-client": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-1.2.0.tgz",
+            "integrity": "sha512-FrUshzZ1yxH8YwGR29PWWnfksLEILbWJydU7zfIRkyH7kAEzB62uMAl2WY6EyolWpLpVHeJGgQm45/MaruaHpw==",
+            "dev": true,
+            "requires": {
+                "tunnel": "0.0.4",
+                "underscore": "1.8.3"
+            }
+        },
         "typescript": {
             "version": "2.9.2",
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.9.2.tgz",
             "integrity": "sha512-Gr4p6nFNaoufRIY4NMdpQRNmgxVIGMs4Fcu/ujdYk3nAZqk7supzBE9idmvfZIlH/Cuj//dvi+019qEue9lV0w==",
+            "dev": true
+        },
+        "uc.micro": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz",
+            "integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==",
+            "dev": true
+        },
+        "underscore": {
+            "version": "1.8.3",
+            "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
+            "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI=",
             "dev": true
         },
         "union-value": {
@@ -3787,6 +4083,12 @@
             "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
             "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI="
         },
+        "url-join": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/url-join/-/url-join-1.1.0.tgz",
+            "integrity": "sha1-dBxsL0WWxIMNZxhGCSDQySIC3Hg=",
+            "dev": true
+        },
         "url-parse-lax": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
@@ -3863,6 +4165,57 @@
                     "version": "2.3.0",
                     "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
                     "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
+                }
+            }
+        },
+        "vsce": {
+            "version": "1.81.1",
+            "resolved": "https://registry.npmjs.org/vsce/-/vsce-1.81.1.tgz",
+            "integrity": "sha512-1yWAYRxTx/PKSFZnuELe7GPyIo70H/XKJqf6wGikofUK3f3TCNGI6F9xkTQFvXKNe0AygUuxN7kITyPIQGMP+w==",
+            "dev": true,
+            "requires": {
+                "azure-devops-node-api": "^7.2.0",
+                "chalk": "^2.4.2",
+                "cheerio": "^1.0.0-rc.1",
+                "commander": "^6.1.0",
+                "denodeify": "^1.2.1",
+                "glob": "^7.0.6",
+                "leven": "^3.1.0",
+                "lodash": "^4.17.15",
+                "markdown-it": "^10.0.0",
+                "mime": "^1.3.4",
+                "minimatch": "^3.0.3",
+                "osenv": "^0.1.3",
+                "parse-semver": "^1.1.1",
+                "read": "^1.0.7",
+                "semver": "^5.1.0",
+                "tmp": "0.0.29",
+                "typed-rest-client": "1.2.0",
+                "url-join": "^1.1.0",
+                "yauzl": "^2.3.1",
+                "yazl": "^2.2.2"
+            },
+            "dependencies": {
+                "commander": {
+                    "version": "6.1.0",
+                    "resolved": "https://registry.npmjs.org/commander/-/commander-6.1.0.tgz",
+                    "integrity": "sha512-wl7PNrYWd2y5mp1OK/LhTlv8Ff4kQJQRXXAvF+uU/TPNiVJUxZLRYGj/B0y/lPGAVcSbJqH2Za/cvHmrPMC8mA==",
+                    "dev": true
+                },
+                "semver": {
+                    "version": "5.7.1",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+                    "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+                    "dev": true
+                },
+                "tmp": {
+                    "version": "0.0.29",
+                    "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.29.tgz",
+                    "integrity": "sha1-8lEl/w3Z2jzLDC3Tce4SiLuRKMA=",
+                    "dev": true,
+                    "requires": {
+                        "os-tmpdir": "~1.0.1"
+                    }
                 }
             }
         },
@@ -4058,6 +4411,25 @@
             "version": "4.0.2",
             "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
             "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
+        },
+        "yauzl": {
+            "version": "2.10.0",
+            "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+            "integrity": "sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=",
+            "dev": true,
+            "requires": {
+                "buffer-crc32": "~0.2.3",
+                "fd-slicer": "~1.1.0"
+            }
+        },
+        "yazl": {
+            "version": "2.5.1",
+            "resolved": "https://registry.npmjs.org/yazl/-/yazl-2.5.1.tgz",
+            "integrity": "sha512-phENi2PLiHnHb6QBVot+dJnaAZ0xosj7p3fWl+znIjBDlnMI2PsZCJZ306BPTFOaHf5qdDEI8x5qFrSOBN5vrw==",
+            "dev": true,
+            "requires": {
+                "buffer-crc32": "~0.2.3"
+            }
         },
         "yeoman-assert": {
             "version": "3.1.1",

--- a/src/VSCodeExtension/package.json.v.template
+++ b/src/VSCodeExtension/package.json.v.template
@@ -120,21 +120,22 @@
         "@types/fs-extra": "^8.0.0"
     },
     "devDependencies": {
-        "vscode": "^1.1.34",
-        "typescript": "^2.6.1",
-        "tslint": "^5.8.0",
-        "mocha": "^5.2.0",
-        "yeoman-test": "^1.7.0",
-        "yeoman-assert": "^3.1.0",
-        "@types/node": "9.6.57",
         "@types/mocha": "^5.2.0",
-        "@types/which": "1.3.1",
-        "@types/tmp": "0.0.33",
-        "@types/semver": "^6.0.0",
+        "@types/node": "9.6.57",
         "@types/request": "^2.48.3",
+        "@types/semver": "^6.0.0",
+        "@types/tmp": "0.0.33",
+        "@types/which": "1.3.1",
         "@types/yeoman-environment": "2.3.3",
         "@types/yeoman-generator": "3.1.4",
-        "@types/yosay": "0.0.29"
+        "@types/yosay": "0.0.29",
+        "mocha": "^5.2.0",
+        "tslint": "^5.8.0",
+        "typescript": "^2.6.1",
+        "vsce": "^1.81.1",
+        "vscode": "^1.1.34",
+        "yeoman-assert": "^3.1.0",
+        "yeoman-test": "^1.7.0"
     },
     "blobs": {
         "win32": {


### PR DESCRIPTION
This pins `vsce` to version `1.81.1` and installs it locally to `node_modules`, instead of using `npm install -g` to install it as a global tool. This prevents `vsce` updates from affecting builds of the QDK extension for VS Code without being tested first.