### PR TITLE
Fix some additional minor nullability issues

### DIFF
--- a/src/QsCompiler/Compiler/ExternalRewriteSteps.cs
+++ b/src/QsCompiler/Compiler/ExternalRewriteSteps.cs
@@ -43,15 +43,21 @@ namespace Microsoft.Quantum.QsCompiler
                 this.InterfaceMethod($"get_{name}")?.Invoke(this.selfAsObject, null);
 
             [return: MaybeNull]
-            private T GetViaReflection<T>(string name) =>
-                (T)this.InterfaceMethod($"get_{name}")?.Invoke(this.selfAsObject, null);
+            private T GetViaReflection<T>(string name)
+            {
+                var result = this.InterfaceMethod($"get_{name}")?.Invoke(this.selfAsObject, null);
+                return result is null ? default : (T)result;
+            }
 
             private void SetViaReflection<T>(string name, T arg) =>
                 this.InterfaceMethod($"set_{name}")?.Invoke(this.selfAsObject, new object?[] { arg });
 
             [return: MaybeNull]
-            private T InvokeViaReflection<T>(string name, params object?[] args) =>
-                (T)this.InterfaceMethod(name)?.Invoke(this.selfAsObject, args);
+            private T InvokeViaReflection<T>(string name, params object?[] args)
+            {
+                var result = this.InterfaceMethod(name)?.Invoke(this.selfAsObject, args);
+                return result is null ? default : (T)result;
+            }
 
             /// <summary>
             /// Attempts to construct a rewrite step via reflection.

--- a/src/QsCompiler/LanguageServer/ProjectLoader.cs
+++ b/src/QsCompiler/LanguageServer/ProjectLoader.cs
@@ -117,7 +117,7 @@ namespace Microsoft.Quantum.QsLanguageServer
                     .Select(item => (item.EvaluatedInclude, GetVersion(item)));
                 var trackedProperties = project.Properties.Where(p =>
                     p?.Name != null && PropertiesToTrack.Contains(p.Name, StringComparer.InvariantCultureIgnoreCase))
-                    .Select(p => (p.Name?.ToLowerInvariant(), p.EvaluatedValue));
+                    .Select(p => (p.Name.ToLowerInvariant(), p.EvaluatedValue));
 
                 var projInfo = new Dictionary<string, string?>();
                 foreach (var (package, version) in packageRefs)

--- a/src/QsCompiler/LanguageServer/Utils.cs
+++ b/src/QsCompiler/LanguageServer/Utils.cs
@@ -73,7 +73,7 @@ namespace Microsoft.Quantum.QsLanguageServer
             }
 
             bool TryMoveNext() => Try(enumerator.MoveNext, false);
-            (bool, TResult) ApplyToCurrent() => Try(() => (true, mapper(enumerator.Current)), (false, default(TResult)));
+            (bool, TResult) ApplyToCurrent() => Try(() => (true, mapper(enumerator.Current)), (false, default!));
 
             var values = ImmutableArray.CreateBuilder<TResult>();
             while (TryMoveNext())


### PR DESCRIPTION
These are a few minor nullability issues that don't seem to be caught by the C# compiler or Visual Studio, but Rider marks them as errors. They seem to be legitimate issues, so here are some fixes:

* ExternalRewriteSteps.cs: `T` could be a value type, in which case unboxing the potentially null result from `?.Invoke` could throw an exception. Using `default` handles both value and reference types without errors.
* ProjectLoader.cs: `p.Name` is known to be not null here, but `p.Name?.ToLowerInvariant()` implies that it could be null, and should convert the type from `string` to `string?`. But the value is used as a dictionary key which must be non-null.
* LanguageServer/Utils.cs: `TResult` may be null, but it is not known to be either a value type or a reference type, so it's not possible to use `TResult?`. A `[MaybeNullWhen(false)]` out parameter can't be easily used either, because local functions don't support attributes until C# 9. The simplest thing here seems to be to use the null-forgiving operator, because the return value is used safely in the code below.