### PR TITLE
Add octal int parsing test cases

### DIFF
--- a/src/QsCompiler/Tests.Compiler/SyntaxTests.fs
+++ b/src/QsCompiler/Tests.Compiler/SyntaxTests.fs
@@ -259,6 +259,10 @@ let ``Expression literal tests`` () =
         ("0b100",                 true,    toInt 4,                                                               []); 
         ("+0b100",                true,    toInt 4,                                                               []); 
         ("-0b100",                true,    toExpr (NEG (toInt 4)),                                                []);
+        ("0o1",                   true,    toInt 1,                                                               []); 
+        ("0o100",                 true,    toInt 64,                                                              []);
+        ("+0o100",                true,    toInt 64,                                                              []);
+        ("-0o100",                true,    toExpr (NEG (toInt 64)),                                               []);
         (".1",                    true,    toExpr (DoubleLiteral 0.1),                                            []); 
         ("1.0",                   true,    toExpr (DoubleLiteral 1.0),                                            []); 
         ("1.",                    true,    toExpr (DoubleLiteral 1.0),                                            []); 


### PR DESCRIPTION
This change adds octal test cases to the `Expression literal tests` test.