### PR TITLE
Adding useful links to extension descriptions

### DIFF
--- a/src/VSCodeExtension/README.md
+++ b/src/VSCodeExtension/README.md
@@ -4,11 +4,19 @@ Thank you for your interest in Microsoft's Quantum Development Kit for Visual St
 The Quantum Development Kit contains the tools you'll need to build your own quantum computing programs and experiments. 
 Assuming some experience with Visual Studio Code, beginners can write their first quantum program, and experienced researchers can quickly and efficiently develop new quantum algorithms.
 
+## Getting Started
+
 To jump right in, take a look at our [Getting Started guide](https://docs.microsoft.com/quantum/quickstarts/get-started) to learn about the structure of a Q# project and how to develop a quantum program with Q#.
+
+You can also try our [Quantum Computing Fundamentals](https://docs.microsoft.com/en-us/learn/paths/quantum-computing-fundamentals/) learning path to get familiar with the basic concepts of quantum computing, building quantum programs and identify the kind of problems that can be solved.
 
 **NOTE: The simulator included with the Quantum Development Kit requires a 64-bit operating system to run.**
 
 The source code for this extension can be found on [our GitHub repository](https://github.com/microsoft/qsharp-compiler). 
+
+## Support and Q&A
+
+If you have questions about the Quantum Development Kit and the Q# language, or if you encounter issues while using any of the components of the kit, you can reach out to the quantum team and the community of users in [Stack Overflow](https://stackoverflow.com/questions/tagged/q%23) and [Quantum Computing Stack Exchange](https://quantumcomputing.stackexchange.com/questions/tagged/q%23) tagging your questions with **q#**.
 
 ## Feedback
 

--- a/src/VisualStudioExtension/README.md
+++ b/src/VisualStudioExtension/README.md
@@ -4,11 +4,19 @@ Thank you for your interest in Microsoft's Quantum Development Kit for Visual St
 The Quantum Development Kit contains the tools you'll need to build your own quantum computing programs and experiments. 
 Assuming some experience with Visual Studio, beginners can write their first quantum program, and experienced researchers can quickly and efficiently develop new quantum algorithms.
 
+## Getting Started
+
 To jump right in, take a look at our [Getting Started guide](https://docs.microsoft.com/quantum/quickstarts/get-started) to learn about the structure of a Q# project and how to develop a quantum program with Q#.
+
+You can also try our [Quantum Computing Fundamentals](https://docs.microsoft.com/en-us/learn/paths/quantum-computing-fundamentals/) learning path to get familiar with the basic concepts of quantum computing, building quantum programs and identify the kind of problems that can be solved.
 
 **NOTE: The simulator included with the Quantum Development Kit requires a 64-bit operating system to run.**
 
 The source code for this extension can be found on [our GitHub repository](https://github.com/microsoft/qsharp-compiler). 
+
+## Support and Q&A
+
+If you have questions about the Quantum Development Kit and the Q# language, or if you encounter issues while using any of the components of the kit, you can reach out to the quantum team and the community of users in [Stack Overflow](https://stackoverflow.com/questions/tagged/q%23) and [Quantum Computing Stack Exchange](https://quantumcomputing.stackexchange.com/questions/tagged/q%23) tagging your questions with **q#**.
 
 ## Feedback
 


### PR DESCRIPTION
We're adding information to the description of the Visual Studio and Visual Studio Code extensions.

- A link to the Quantum Computing Foundations learning module.
- Links to the Stack Exchange and Stack Overflow resources for Q# where users of the extensions can find support if they run into issues.

