### PR TITLE
Minor fixes to new documentation generation tool

### DIFF
--- a/src/Documentation/DocumentationGenerator/DocumentationWriter.cs
+++ b/src/Documentation/DocumentationGenerator/DocumentationWriter.cs
@@ -59,7 +59,7 @@ namespace Microsoft.Quantum.Documentation
 
             PackageLink = PackageName == null
                 ? ""
-                : $"Package: [{PackageName}](https://nuget.org/packages/{PackageName})\n";
+                : $"\nPackage: [{PackageName}](https://nuget.org/packages/{PackageName})\n";
         }
 
         /// <summary>

--- a/src/Documentation/DocumentationGenerator/Extensions.cs
+++ b/src/Documentation/DocumentationGenerator/Extensions.cs
@@ -287,6 +287,8 @@ namespace Microsoft.Quantum.Documentation
                         tuple.Item.Select(ToMarkdownLink)
                     ) + ")",
                 ResolvedTypeKind.UserDefinedType udt => udt.Item.ToMarkdownLink(),
+                ResolvedTypeKind.TypeParameter typeParam =>
+                    $"'{typeParam.Item.TypeName.Value}",
                 _ => type.Resolution.Tag switch
                     {
                         ResolvedTypeKind.Tags.BigInt => "BigInt",

--- a/src/QuantumSdk/DefaultItems/DefaultItems.props.v.template
+++ b/src/QuantumSdk/DefaultItems/DefaultItems.props.v.template
@@ -34,7 +34,6 @@
     <IncludeQsharpCorePackages>true</IncludeQsharpCorePackages> 
     <IncludeProviderPackages>true</IncludeProviderPackages> 
     <QsharpDocsGeneration>false</QsharpDocsGeneration>
-    <QsharpDocsPackageId>$(PackageId)</QsharpDocsPackageId>
     <ExposeReferencesViaTestNames>false</ExposeReferencesViaTestNames> <!-- IMPORTANT: If the name of this property is changed, the property name in the language server needs to be adapted! -->
     <DefaultQscBuildConfigExe>dotnet "$(MSBuildThisFileDirectory)../tools/utils/Microsoft.Quantum.Sdk.BuildConfiguration.dll"</DefaultQscBuildConfigExe> 
     <QscBuildConfigExe>$(DefaultQscBuildConfigExe)</QscBuildConfigExe> 

--- a/src/QuantumSdk/Sdk/Sdk.targets
+++ b/src/QuantumSdk/Sdk/Sdk.targets
@@ -68,6 +68,11 @@
     </ItemGroup>
     <!-- invoke the Q# command line compiler -->
     <PropertyGroup>
+      <!-- For the package ID that gets displayed in documentation, we default
+           to the actual package ID if it's set, but allow overriding with
+           QsharpDocsPackageId. -->
+      <_QscDocsPackageeId Condition="'$(PackageId)' != ''">$(PackageId)</_QscDocsPackageeId>
+      <_QscDocsPackageeId Condition="'$(QsharpDocsPackageId)' != ''">$(QsharpDocsPackageId)</_QscDocsPackageeId>
       <_QscCommandIsExecutableFlag Condition="'$(ResolvedQsharpOutputType)' == 'QsharpExe'">--build-exe</_QscCommandIsExecutableFlag>
       <_QscCommandOutputFlag>--output "$(GeneratedFilesOutputPath)"</_QscCommandOutputFlag>
       <_QscCommandInputFlag Condition="@(QsharpCompile->Count()) &gt; 0">--input "@(QsharpCompile,'" "')"</_QscCommandInputFlag>
@@ -77,11 +82,11 @@
       <_QscCommandTargetDecompositionsFlag Condition="@(ResolvedTargetSpecificDecompositions->Count()) &gt; 0">--target-specific-decompositions "@(ResolvedTargetSpecificDecompositions,'" "')"</_QscCommandTargetDecompositionsFlag>
       <_QscCommandTestNamesFlag Condition="$(ExposeReferencesViaTestNames)">--load-test-names</_QscCommandTestNamesFlag>
       <_QscCommandPredefinedAssemblyProperties>ProcessorArchitecture:$(ResolvedProcessorArchitecture) QsharpOutputType:$(ResolvedQsharpOutputType)</_QscCommandPredefinedAssemblyProperties>
-      <_QscCommandPredefinedAssemblyProperties Condition="$(DefaultSimulator) != ''">$(_QscCommandPredefinedAssemblyProperties) DefaultSimulator:$(DefaultSimulator)</_QscCommandPredefinedAssemblyProperties>
-      <_QscCommandPredefinedAssemblyProperties Condition="$(ExecutionTarget) != ''">$(_QscCommandPredefinedAssemblyProperties) ExecutionTarget:$(ExecutionTarget)</_QscCommandPredefinedAssemblyProperties>
-      <_QscCommandPredefinedAssemblyProperties Condition="$(ExposeReferencesViaTestNames)">$(_QscCommandPredefinedAssemblyProperties) ExposeReferencesViaTestNames:true</_QscCommandPredefinedAssemblyProperties>
-      <_QscCommandPredefinedAssemblyProperties Condition="$(QsharpDocsPackageId) != ''">$(_QscCommandPredefinedAssemblyProperties) DocsPackageId:$(QsharpDocsPackageId)</_QscCommandPredefinedAssemblyProperties>
-      <_QscCommandPredefinedAssemblyProperties Condition="$(QsharpDocsGeneration)">$(_QscCommandPredefinedAssemblyProperties) DocsOutputPath:$(QsharpDocsOutputPath)</_QscCommandPredefinedAssemblyProperties>
+      <_QscCommandPredefinedAssemblyProperties Condition="'$(DefaultSimulator)' != ''">$(_QscCommandPredefinedAssemblyProperties) DefaultSimulator:$(DefaultSimulator)</_QscCommandPredefinedAssemblyProperties>
+      <_QscCommandPredefinedAssemblyProperties Condition="'$(ExecutionTarget)' != ''">$(_QscCommandPredefinedAssemblyProperties) ExecutionTarget:$(ExecutionTarget)</_QscCommandPredefinedAssemblyProperties>
+      <_QscCommandPredefinedAssemblyProperties Condition="'$(ExposeReferencesViaTestNames)'">$(_QscCommandPredefinedAssemblyProperties) ExposeReferencesViaTestNames:true</_QscCommandPredefinedAssemblyProperties>
+      <_QscCommandPredefinedAssemblyProperties Condition="'$(_QscDocsPackageeId)' != ''">$(_QscCommandPredefinedAssemblyProperties) DocsPackageId:$(_QscDocsPackageeId)</_QscCommandPredefinedAssemblyProperties>
+      <_QscCommandPredefinedAssemblyProperties Condition="'$(QsharpDocsGeneration)'">$(_QscCommandPredefinedAssemblyProperties) DocsOutputPath:$(QsharpDocsOutputPath)</_QscCommandPredefinedAssemblyProperties>
       <_QscCommandAssemblyPropertiesFlag>--assembly-properties $(_QscCommandPredefinedAssemblyProperties) $(QscCommandAssemblyProperties)</_QscCommandAssemblyPropertiesFlag>
       <_QscPackageLoadFallbackFoldersFlag Condition="@(ResolvedPackageLoadFallbackFolders->Count()) &gt; 0">--package-load-fallback-folders "@(ResolvedPackageLoadFallbackFolders,'" "')"</_QscPackageLoadFallbackFoldersFlag>
       <_QscCommandArgs>--proj "$(PathCompatibleAssemblyName)" $(_QscCommandIsExecutableFlag) $(_QscCommandInputFlag) $(_QscCommandOutputFlag) $(_QscCommandReferencesFlag) $(_QscCommandLoadFlag) $(_QscCommandRuntimeFlag) $(_QscCommandTargetDecompositionsFlag) $(_QscPackageLoadFallbackFoldersFlag) $(_QscCommandTestNamesFlag) $(_QscCommandAssemblyPropertiesFlag) $(AdditionalQscArguments)</_QscCommandArgs>


### PR DESCRIPTION
This PR makes a couple fixes to the new documentation generation tool that were discovered using beta packages from the previous PR (#594):

-  Default package ID not being set correctly.
-  Output path not being passed through to assembly constants due to issue with MSBuild conditional attributes.
- ToMarkdownLink falling through to `"__invalid__"` for type parameters as well as for invalid types.