### PR TITLE
Fix issues with using absolute paths in docgen

### DIFF
--- a/src/Documentation/DocumentationGenerator/DocumentationGeneration.cs
+++ b/src/Documentation/DocumentationGenerator/DocumentationGeneration.cs
@@ -70,14 +70,24 @@ namespace Microsoft.Quantum.Documentation
 
         public bool Transformation(QsCompilation compilation, out QsCompilation transformed)
         {
-            transformed = new ProcessDocComments(
+            var docProcessor = new ProcessDocComments(
                 this.AssemblyConstants.TryGetValue("DocsOutputPath", out var path)
                 ? path
                 : null,
                 this.AssemblyConstants.TryGetValue("DocsPackageId", out var packageName)
                 ? packageName
                 : null
-            ).OnCompilation(compilation);
+            );
+
+            if (docProcessor.Writer != null)
+            {
+                docProcessor.Writer.OnDiagnostic += diagnostic =>
+                {
+                    this.diagnostics.Add(diagnostic);
+                };
+            }
+
+            transformed = docProcessor.OnCompilation(compilation);
             return true;
         }
 

--- a/src/Documentation/DocumentationGenerator/Extensions.cs
+++ b/src/Documentation/DocumentationGenerator/Extensions.cs
@@ -300,7 +300,8 @@ namespace Microsoft.Quantum.Documentation
                         ResolvedTypeKind.Tags.Range => "Range",
                         ResolvedTypeKind.Tags.String => "String",
                         ResolvedTypeKind.Tags.UnitType => "Unit",
-                        _ => "__invalid__",
+                        ResolvedTypeKind.Tags.InvalidType => "__invalid__",
+                        _ => $"__invalid<{type.Resolution.ToString()}>__",
                     },
             };
 
@@ -320,6 +321,19 @@ namespace Microsoft.Quantum.Documentation
 
         internal static bool IsInCompilationUnit(this QsCustomType type) =>
             type.SourceFile.Value.EndsWith(".qs");
+
+        internal static QsCustomType WithoutDocumentationAndComments(this QsCustomType type) =>
+            new QsCustomType(
+                fullName: type.FullName,
+                attributes: type.Attributes,
+                modifiers: type.Modifiers,
+                sourceFile: type.SourceFile,
+                location: type.Location,
+                type: type.Type,
+                typeItems: type.TypeItems,
+                documentation: ImmutableArray<string>.Empty,
+                comments: QsComments.Empty
+            );
     }
 
 }

--- a/src/Documentation/DocumentationGenerator/ProcessDocComments.cs
+++ b/src/Documentation/DocumentationGenerator/ProcessDocComments.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Quantum.Documentation
         public class TransformationState
         { }
 
-        private readonly DocumentationWriter? writer;
+        internal readonly DocumentationWriter? Writer;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ProcessDocComments"/> class.
@@ -51,12 +51,12 @@ namespace Microsoft.Quantum.Documentation
         )
         : base(new TransformationState(), TransformationOptions.Disabled)
         {
-            this.writer = outputPath == null
+            this.Writer = outputPath == null
                           ? null
                           : new DocumentationWriter(outputPath, packageName);
 
             // We provide our own custom namespace transformation, and expression kind transformation.
-            this.Namespaces = new ProcessDocComments.NamespaceTransformation(this, this.writer);
+            this.Namespaces = new ProcessDocComments.NamespaceTransformation(this, this.Writer);
         }
 
         private class NamespaceTransformation

--- a/src/QsCompiler/CommandLineTool/Commands/Build.cs
+++ b/src/QsCompiler/CommandLineTool/Commands/Build.cs
@@ -112,8 +112,14 @@ namespace Microsoft.Quantum.QsCompiler.CommandLineCompiler
         /// </summary>
         private static IEnumerable<string> SplitCommandLineArguments(string commandLine)
         {
+            string TrimQuotes(string s) =>
+                s.StartsWith('"') && s.EndsWith('"')
+                ? s.Substring(1, s.Length - 2)
+                : s;
+
             var parmChars = commandLine?.ToCharArray() ?? Array.Empty<char>();
             var inQuote = false;
+
             for (int index = 0; index < parmChars.Length; index++)
             {
                 var precededByBackslash = index > 0 && parmChars[index - 1] == '\\';
@@ -131,9 +137,10 @@ namespace Microsoft.Quantum.QsCompiler.CommandLineCompiler
                     parmChars[index] = '\n';
                 }
             }
+
             return new string(parmChars)
                 .Split('\n', StringSplitOptions.RemoveEmptyEntries)
-                .Select(arg => arg.Trim('"'));
+                .Select(arg => TrimQuotes(arg));
         }
 
         /// <summary>
@@ -148,6 +155,7 @@ namespace Microsoft.Quantum.QsCompiler.CommandLineCompiler
                 throw new ArgumentNullException(nameof(responseFiles));
             }
             var commandLine = string.Join(" ", responseFiles.Select(File.ReadAllText));
+            System.Diagnostics.Debugger.Launch();
             var args = SplitCommandLineArguments(commandLine);
             var parsed = Parser.Default.ParseArguments<BuildOptions>(args);
             return parsed.MapResult(

--- a/src/QsCompiler/CommandLineTool/Options.cs
+++ b/src/QsCompiler/CommandLineTool/Options.cs
@@ -90,7 +90,8 @@ namespace Microsoft.Quantum.QsCompiler.CommandLineCompiler
             parsed = new Dictionary<string, string>();
             foreach (var keyValue in this.AdditionalAssemblyProperties ?? Array.Empty<string>())
             {
-                var pieces = keyValue?.Split(":");
+                // NB: We use `count: 2` here to ensure that assembly constants can contain colons.
+                var pieces = keyValue?.Split(":", count: 2);
                 var valid = pieces != null && pieces.Length == 2;
                 success = valid && parsed.TryAdd(pieces[0].Trim().Trim('"'), pieces[1].Trim().Trim('"')) && success;
             }

--- a/src/QuantumSdk/Sdk/Sdk.targets
+++ b/src/QuantumSdk/Sdk/Sdk.targets
@@ -71,8 +71,8 @@
       <!-- For the package ID that gets displayed in documentation, we default
            to the actual package ID if it's set, but allow overriding with
            QsharpDocsPackageId. -->
-      <_QscDocsPackageeId Condition="'$(PackageId)' != ''">$(PackageId)</_QscDocsPackageeId>
-      <_QscDocsPackageeId Condition="'$(QsharpDocsPackageId)' != ''">$(QsharpDocsPackageId)</_QscDocsPackageeId>
+      <_QscDocsPackageId Condition="'$(PackageId)' != ''">$(PackageId)</_QscDocsPackageId>
+      <_QscDocsPackageId Condition="'$(QsharpDocsPackageId)' != ''">$(QsharpDocsPackageId)</_QscDocsPackageId>
       <_QscCommandIsExecutableFlag Condition="'$(ResolvedQsharpOutputType)' == 'QsharpExe'">--build-exe</_QscCommandIsExecutableFlag>
       <_QscCommandOutputFlag>--output "$(GeneratedFilesOutputPath)"</_QscCommandOutputFlag>
       <_QscCommandInputFlag Condition="@(QsharpCompile->Count()) &gt; 0">--input "@(QsharpCompile,'" "')"</_QscCommandInputFlag>
@@ -85,8 +85,8 @@
       <_QscCommandPredefinedAssemblyProperties Condition="'$(DefaultSimulator)' != ''">$(_QscCommandPredefinedAssemblyProperties) DefaultSimulator:$(DefaultSimulator)</_QscCommandPredefinedAssemblyProperties>
       <_QscCommandPredefinedAssemblyProperties Condition="'$(ExecutionTarget)' != ''">$(_QscCommandPredefinedAssemblyProperties) ExecutionTarget:$(ExecutionTarget)</_QscCommandPredefinedAssemblyProperties>
       <_QscCommandPredefinedAssemblyProperties Condition="'$(ExposeReferencesViaTestNames)'">$(_QscCommandPredefinedAssemblyProperties) ExposeReferencesViaTestNames:true</_QscCommandPredefinedAssemblyProperties>
-      <_QscCommandPredefinedAssemblyProperties Condition="'$(_QscDocsPackageeId)' != ''">$(_QscCommandPredefinedAssemblyProperties) DocsPackageId:$(_QscDocsPackageeId)</_QscCommandPredefinedAssemblyProperties>
-      <_QscCommandPredefinedAssemblyProperties Condition="'$(QsharpDocsGeneration)'">$(_QscCommandPredefinedAssemblyProperties) DocsOutputPath:$(QsharpDocsOutputPath)</_QscCommandPredefinedAssemblyProperties>
+      <_QscCommandPredefinedAssemblyProperties Condition="'$(_QscDocsPackageId)' != ''">$(_QscCommandPredefinedAssemblyProperties) DocsPackageId:$(_QscDocsPackageeId)</_QscCommandPredefinedAssemblyProperties>
+      <_QscCommandPredefinedAssemblyProperties Condition="'$(QsharpDocsGeneration)'">$(_QscCommandPredefinedAssemblyProperties) DocsOutputPath:"$(QsharpDocsOutputPath)"</_QscCommandPredefinedAssemblyProperties>
       <_QscCommandAssemblyPropertiesFlag>--assembly-properties $(_QscCommandPredefinedAssemblyProperties) $(QscCommandAssemblyProperties)</_QscCommandAssemblyPropertiesFlag>
       <_QscPackageLoadFallbackFoldersFlag Condition="@(ResolvedPackageLoadFallbackFolders->Count()) &gt; 0">--package-load-fallback-folders "@(ResolvedPackageLoadFallbackFolders,'" "')"</_QscPackageLoadFallbackFoldersFlag>
       <_QscCommandArgs>--proj "$(PathCompatibleAssemblyName)" $(_QscCommandIsExecutableFlag) $(_QscCommandInputFlag) $(_QscCommandOutputFlag) $(_QscCommandReferencesFlag) $(_QscCommandLoadFlag) $(_QscCommandRuntimeFlag) $(_QscCommandTargetDecompositionsFlag) $(_QscPackageLoadFallbackFoldersFlag) $(_QscCommandTestNamesFlag) $(_QscCommandAssemblyPropertiesFlag) $(AdditionalQscArguments)</_QscCommandArgs>


### PR DESCRIPTION
The previous version of the new docgen tool works correctly when using relative paths, but fails when using absolute paths on Windows. Upon investigation, this comes down to three distinct issues:

- The docgen path was not properly quoted in MSBuild properties.
- `qsc.dll` was stripping one of the two quotation marks (#679)
- `qsc.dll` was truncating assembly properties at the first colon (#679)

This PR fixes all three issues, and adds more diagnostics to the documentation writer component to help understand future issues.