### PR TITLE
Warn on invalid names in docgen

### DIFF
--- a/src/Documentation/DocumentationGenerator/DocumentationGeneration.cs
+++ b/src/Documentation/DocumentationGenerator/DocumentationGeneration.cs
@@ -79,13 +79,10 @@ namespace Microsoft.Quantum.Documentation
                 : null
             );
 
-            if (docProcessor.Writer != null)
+            docProcessor.OnDiagnostic += diagnostic =>
             {
-                docProcessor.Writer.OnDiagnostic += diagnostic =>
-                {
-                    this.diagnostics.Add(diagnostic);
-                };
-            }
+                this.diagnostics.Add(diagnostic);
+            };
 
             transformed = docProcessor.OnCompilation(compilation);
             return true;

--- a/src/Documentation/DocumentationGenerator/DocumentationWriter.cs
+++ b/src/Documentation/DocumentationGenerator/DocumentationWriter.cs
@@ -42,6 +42,14 @@ namespace Microsoft.Quantum.Documentation
 
         private readonly string PackageLink;
 
+        private static string AsSeeAlsoLink(string target, string? currentNamespace = null)
+        {
+            var actualTarget = currentNamespace == null || target.Contains(".")
+                ? target
+                : $"{currentNamespace}.{target}";
+            return $"- [{actualTarget}](xref:{actualTarget})";
+        }
+
         private async Task TryWithExceptionsAsDiagnostics(string description, Func<Task> action, DiagnosticSeverity severity = DiagnosticSeverity.Warning)
         {
             try
@@ -66,7 +74,7 @@ namespace Microsoft.Quantum.Documentation
             await this.TryWithExceptionsAsDiagnostics(
                 $"writing output to {filename}",
                 async () => await File.WriteAllTextAsync(
-                    Path.Join(this.OutputPath, $"{filename.ToLowerInvariant()}.md"),
+                    Path.Join(this.OutputPath, filename.ToLowerInvariant()),
                     contents
                 )
             );
@@ -151,11 +159,17 @@ namespace Microsoft.Quantum.Documentation
 
 "
                 .MaybeWithSection("Description", docComment.Description)
+                .MaybeWithSection(
+                    "See Also",
+                    string.Join("\n", docComment.SeeAlso.Select(
+                        seeAlso => AsSeeAlsoLink(seeAlso)
+                    ))
+                )
                 .WithYamlHeader(header);
 
             // Open a file to write the new doc to.
             await this.WriteAllTextAsync(
-                name, document
+                $"{name}.md", document
             );
         }
 
@@ -220,7 +234,7 @@ Namespace: [{type.FullName.Namespace.Value}](xref:{type.FullName.Namespace.Value
             .MaybeWithSection(
                 "See Also",
                 string.Join("\n", docComment.SeeAlso.Select(
-                    seeAlso => $"- {seeAlso}"
+                    seeAlso => AsSeeAlsoLink(seeAlso, type.FullName.Namespace.Value)
                 ))
             )
             .WithYamlHeader(header);
@@ -306,7 +320,7 @@ Namespace: [{callable.FullName.Namespace.Value}](xref:{callable.FullName.Namespa
             .MaybeWithSection(
                 "See Also",
                 string.Join("\n", docComment.SeeAlso.Select(
-                    seeAlso => $"- [{seeAlso}](xref:{seeAlso})"
+                    seeAlso => AsSeeAlsoLink(seeAlso, callable.FullName.Namespace.Value)
                 ))
             )
             .WithYamlHeader(header);

--- a/src/Documentation/DocumentationGenerator/ProcessDocComments.cs
+++ b/src/Documentation/DocumentationGenerator/ProcessDocComments.cs
@@ -32,6 +32,12 @@ namespace Microsoft.Quantum.Documentation
         public class TransformationState
         { }
 
+        /// <summary>
+        ///     An event that is raised on diagnostics about documentation
+        ///     writing (e.g., if an I/O problem prevents writing to disk).
+        /// </summary>
+        public event Action<IRewriteStep.Diagnostic>? OnDiagnostic;
+
         internal readonly DocumentationWriter? Writer;
 
         /// <summary>
@@ -55,6 +61,12 @@ namespace Microsoft.Quantum.Documentation
                           ? null
                           : new DocumentationWriter(outputPath, packageName);
 
+            if (this.Writer != null)
+            {
+                this.Writer.OnDiagnostic += diagnostic =>
+                    this.OnDiagnostic?.Invoke(diagnostic);
+            }
+
             // We provide our own custom namespace transformation, and expression kind transformation.
             this.Namespaces = new ProcessDocComments.NamespaceTransformation(this, this.Writer);
         }
@@ -67,6 +79,33 @@ namespace Microsoft.Quantum.Documentation
             internal NamespaceTransformation(ProcessDocComments parent, DocumentationWriter? writer)
             : base(parent)
             { this.writer = writer; }
+
+            private void ValidateNames(
+                string symbolName,
+                string nameKind,
+                Func<string, bool> isNameValid,
+                IEnumerable<string> actualNames,
+                Range? range = null,
+                string? source = null
+            )
+            {
+                foreach (var name in actualNames)
+                {
+                    if (!isNameValid(name))
+                    {
+                        (this.Transformation as ProcessDocComments)?.OnDiagnostic?.Invoke(
+                            new IRewriteStep.Diagnostic
+                            {
+                                Message = $"When documenting {symbolName}, found documentation for {nameKind} {name}, but no such {nameKind} exists.",
+                                Severity = CodeAnalysis.DiagnosticSeverity.Warning,
+                                Range = range,
+                                Source = source,
+                                Stage = IRewriteStep.Stage.Transformation,
+                            }
+                        );
+                    }
+                }
+            }
 
             public override QsNamespace OnNamespace(QsNamespace ns)
             {
@@ -131,6 +170,31 @@ namespace Microsoft.Quantum.Documentation
                     callable.Documentation, callable.FullName.Name.Value,
                     deprecated: isDeprecated,
                     replacement: replacement
+                );
+                var callableName = 
+                    $"{callable.FullName.Namespace.Value}.{callable.FullName.Name.Value}";
+
+                // Validate input and type parameter names.
+                var inputDeclarations = callable.ArgumentTuple.ToDictionaryOfDeclarations();
+                this.ValidateNames(
+                    callableName,
+                    "input",
+                    name => inputDeclarations.ContainsKey(name),
+                    docComment.Input.Keys,
+                    range: null, // TODO: provide more exact locations once supported by DocParser.
+                    source: callable.SourceFile.Value
+                );
+                this.ValidateNames(
+                    callableName,
+                    "type parameter",
+                    name => callable.Signature.TypeParameters.Any(
+                        typeParam =>
+                            typeParam is QsLocalSymbol.ValidName validName &&
+                            validName.Item.Value == name.TrimStart('\'')
+                    ),
+                    docComment.TypeParameters.Keys,
+                    range: null, // TODO: provide more exact locations once supported by DocParser.
+                    source: callable.SourceFile.Value
                 );
 
                 this.writer?.WriteOutput(callable, docComment)?.Wait();

--- a/src/Documentation/DocumentationGenerator/ProcessDocComments.cs
+++ b/src/Documentation/DocumentationGenerator/ProcessDocComments.cs
@@ -140,6 +140,17 @@ namespace Microsoft.Quantum.Documentation
                     replacement: replacement
                 );
 
+                // Validate named item names.
+                var inputDeclarations = type.TypeItems.ToDictionaryOfDeclarations();
+                this.ValidateNames(
+                    $"{type.FullName.Namespace.Value}.{type.FullName.Name.Value}",
+                    "named item",
+                    name => inputDeclarations.ContainsKey(name),
+                    docComment.Input.Keys,
+                    range: null, // TODO: provide more exact locations once supported by DocParser.
+                    source: type.SourceFile.Value
+                );
+
                 this.writer?.WriteOutput(type, docComment)?.Wait();
 
                 return type

--- a/src/Documentation/DocumentationParser/DocComment.cs
+++ b/src/Documentation/DocumentationParser/DocComment.cs
@@ -221,7 +221,7 @@ namespace Microsoft.Quantum.QsCompiler.Documentation
                                     {
                                         itemText = itemText.Substring(2, itemText.Length - 3);
                                     }
-                                    literal.Content = new Markdig.Helpers.StringSlice(itemText.ToLowerInvariant());
+                                    literal.Content = new Markdig.Helpers.StringSlice(itemText);
                                 }
                                 accum.Add(ToMarkdown(new Block[] { item }));
                             }

--- a/src/QsCompiler/CommandLineTool/Commands/Build.cs
+++ b/src/QsCompiler/CommandLineTool/Commands/Build.cs
@@ -155,7 +155,6 @@ namespace Microsoft.Quantum.QsCompiler.CommandLineCompiler
                 throw new ArgumentNullException(nameof(responseFiles));
             }
             var commandLine = string.Join(" ", responseFiles.Select(File.ReadAllText));
-            System.Diagnostics.Debugger.Launch();
             var args = SplitCommandLineArguments(commandLine);
             var parsed = Parser.Default.ParseArguments<BuildOptions>(args);
             return parsed.MapResult(


### PR DESCRIPTION
Apologies for yet another PR on the docgen feature! In any case, this PR fixes See Also links, and adds warnings when documenting inputs, type parameters, and named items that do not exist.