### PR TITLE
Call Graph Clears Type-Parameter Resolutions before Processing a Statement

### DIFF
--- a/src/QsCompiler/Tests.Compiler/TestCases/PopulateCallGraph.qs
+++ b/src/QsCompiler/Tests.Compiler/TestCases/PopulateCallGraph.qs
@@ -285,3 +285,25 @@ namespace Microsoft.Quantum.Testing.PopulateCallGraph {
         }
     }
 }
+
+// =================================
+
+// Concrete Graph Clears Type Param Resolutions After Statements
+namespace Microsoft.Quantum.Testing.PopulateCallGraph {
+    @EntryPoint()
+    operation Main () : Unit {
+        using (qs = Qubit[1]) {
+            Controlled Bar(qs, (Baz, 0));
+        }
+    }
+
+    operation Foo(x : Int) : Unit is Adj + Ctl { }
+
+    operation Bar<'T> (op : ('T => Unit is Adj + Ctl), arg : 'T) : Unit is Adj + Ctl {   
+        op(arg);
+    }
+    
+    operation Baz(x : Int) : Unit is Adj + Ctl {
+        Bar(Foo, x);
+    }
+}

--- a/src/QsCompiler/Transformations/CallGraph/CallGraphWalkerBase.cs
+++ b/src/QsCompiler/Transformations/CallGraph/CallGraphWalkerBase.cs
@@ -54,6 +54,7 @@ namespace Microsoft.Quantum.QsCompiler.Transformations.CallGraphWalker
 
                 public override QsStatement OnStatement(QsStatement stm)
                 {
+                    this.SharedState.ExprTypeParamResolutions.Clear();
                     this.SharedState.CurrentStatementOffset = stm.Location.IsValue
                         ? QsNullable<Position>.NewValue(stm.Location.Item.Offset)
                         : QsNullable<Position>.Null;


### PR DESCRIPTION
Fixes a bug in call graphs where type parameter resolutions from previous statements would be carried over to subsequent statements, causing incorrect type parameter resolutions to occur in the construction of the graph.