### PR TITLE
Cherry pick of #706: Fix section headings for type parameters

### DIFF
--- a/src/Documentation/DocumentationGenerator/DocumentationWriter.cs
+++ b/src/Documentation/DocumentationGenerator/DocumentationWriter.cs
@@ -330,13 +330,14 @@ Namespace: [{callable.FullName.Namespace.Value}](xref:{callable.FullName.Namespa
             .MaybeWithSection(
                 "Type Parameters",
                 string.Join("\n", callable.Signature.TypeParameters.Select(
-                    typeParam => $@"### {typeParam}\n\n{(
+                    typeParam =>
                         typeParam is QsLocalSymbol.ValidName name
-                        ? docComment.TypeParameters.TryGetValue(name.Item.Value, out var comment)
+                        ? $@"### '{name.Item.Value}{"\n\n"}{(
+                            docComment.TypeParameters.TryGetValue($"'{name.Item.Value}", out var comment)
                             ? comment
                             : string.Empty
+                          )}"
                         : string.Empty
-                    )}"
                 ))
             )
             .MaybeWithSection("Remarks", docComment.Remarks)

--- a/src/Documentation/Summarizer/summarize_documentation.py
+++ b/src/Documentation/Summarizer/summarize_documentation.py
@@ -6,11 +6,15 @@
 from collections import defaultdict
 from dataclasses import dataclass, asdict, field
 from pathlib import Path
+from typing import Set
 import glob
 
 import click
 import frontmatter
-import ruamel.yaml as yaml
+try:
+    import ruamel.yaml as yaml
+except ImportError:
+    import ruamel_yaml as yaml
 
 namespace_comment = "### YamlMime:QSharpNamespace"
 warning_comment = """
@@ -34,7 +38,7 @@ class Namespace:
     name: str = ""
     # NB: We need to set default_factory instead of default, since set is a
     #     mutable type.
-    items = field(default_factory=set)
+    items: Set = field(default_factory=set)
 
 def items_of_kind(items, kind):
     return [


### PR DESCRIPTION
This is a cherry-pick of #706 

* Fix section headings for type parameters.
* Fix type hinting in summarize_documentation.py.