### PR TITLE
Fixing signing issues.

### DIFF
--- a/build/manifest.ps1
+++ b/build/manifest.ps1
@@ -40,16 +40,16 @@ $artifacts = @{
 
     Assemblies = $VsixAssemblies + @(
         ".\src\Documentation\DocumentationGenerator\bin\$Env:BUILD_CONFIGURATION\netstandard2.1\Microsoft.Quantum.DocumentationGenerator.dll",
+        ".\src\Documentation\DocumentationParser\bin\$Env:BUILD_CONFIGURATION\netstandard2.1\Microsoft.Quantum.QsDocumentationParser.dll",
 
-        ".\src\QsCompiler\Compiler\bin\$Env:BUILD_CONFIGURATION\netstandard2.1\Microsoft.Quantum.QsCompilationManager.dll",
+        ".\src\QsCompiler\CompilationManager\bin\$Env:BUILD_CONFIGURATION\netstandard2.1\Microsoft.Quantum.QsCompilationManager.dll",
         ".\src\QsCompiler\Compiler\bin\$Env:BUILD_CONFIGURATION\netstandard2.1\Microsoft.Quantum.QsCompiler.dll",
-        ".\src\QsCompiler\Compiler\bin\$Env:BUILD_CONFIGURATION\netstandard2.1\Microsoft.Quantum.QsCore.dll",
-        ".\src\QsCompiler\Compiler\bin\$Env:BUILD_CONFIGURATION\netstandard2.1\Microsoft.Quantum.QsDataStructures.dll",
-        ".\src\QsCompiler\Compiler\bin\$Env:BUILD_CONFIGURATION\netstandard2.1\Microsoft.Quantum.QsDocumentationParser.dll",
-        ".\src\QsCompiler\Compiler\bin\$Env:BUILD_CONFIGURATION\netstandard2.1\Microsoft.Quantum.QsOptimizations.dll",
-        ".\src\QsCompiler\Compiler\bin\$Env:BUILD_CONFIGURATION\netstandard2.1\Microsoft.Quantum.QsSyntaxProcessor.dll",
-        ".\src\QsCompiler\Compiler\bin\$Env:BUILD_CONFIGURATION\netstandard2.1\Microsoft.Quantum.QsTextProcessor.dll",
-        ".\src\QsCompiler\Compiler\bin\$Env:BUILD_CONFIGURATION\netstandard2.1\Microsoft.Quantum.QsTransformations.dll"
+        ".\src\QsCompiler\Core\bin\$Env:BUILD_CONFIGURATION\netstandard2.1\Microsoft.Quantum.QsCore.dll",
+        ".\src\QsCompiler\DataStructures\bin\$Env:BUILD_CONFIGURATION\netstandard2.1\Microsoft.Quantum.QsDataStructures.dll",
+        ".\src\QsCompiler\Optimizations\bin\$Env:BUILD_CONFIGURATION\netstandard2.1\Microsoft.Quantum.QsOptimizations.dll",
+        ".\src\QsCompiler\SyntaxProcessor\bin\$Env:BUILD_CONFIGURATION\netstandard2.1\Microsoft.Quantum.QsSyntaxProcessor.dll",
+        ".\src\QsCompiler\TextProcessor\bin\$Env:BUILD_CONFIGURATION\netstandard2.1\Microsoft.Quantum.QsTextProcessor.dll",
+        ".\src\QsCompiler\Transformations\bin\$Env:BUILD_CONFIGURATION\netstandard2.1\Microsoft.Quantum.QsTransformations.dll"
 
         ".\src\QsCompiler\CommandLineTool\bin\$Env:BUILD_CONFIGURATION\netcoreapp3.1\qsc.dll",
 

--- a/build/pack-extensions.ps1
+++ b/build/pack-extensions.ps1
@@ -1,0 +1,174 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+$ErrorActionPreference = 'Stop'
+
+& "$PSScriptRoot/set-env.ps1"
+$all_ok = $True
+
+##
+# Q# Language Server (self-contained)
+##
+$Runtimes = @{
+    "win10-x64" = "win32";
+    "linux-x64" = "linux";
+    "osx-x64" = "darwin";
+};
+
+function New-TemporaryDirectory {
+    $parent = [System.IO.Path]::GetTempPath()
+    $name = [System.IO.Path]::GetRandomFileName()
+    New-Item -ItemType Directory -Path (Join-Path $parent $name)
+}
+
+function Write-Hash() {
+    param(
+        [string]
+        $Path,
+
+        [string]
+        $BlobPlatform,
+
+        [string]
+        $TargetPath
+    );
+
+    "Writing hash of $Path into $TargetPath..." | Write-Host;
+    $packageData = Get-Content $TargetPath | ConvertFrom-Json;
+    $packageData.blobs.$BlobPlatform.sha256 = Get-FileHash $Path | Select-Object -ExpandProperty Hash;
+    # See https://stackoverflow.com/a/23738236 for why this works.
+    $packageData.blobs.$BlobPlatform `
+        | Add-Member `
+            -Force `
+            -MemberType NoteProperty `
+            -Name "size" `
+            -Value (Get-Item $Path | Select-Object -ExpandProperty Length);
+    Write-Host "New blob data: $($packageData."blobs".$BlobPlatform | ConvertTo-Json)";
+    $packageData `
+        | ConvertTo-Json -Depth 32 `
+        | Set-Content `
+            -Path $TargetPath `
+            -Encoding UTF8NoBom;
+}
+function Pack-SelfContained() {
+    param(
+        [string] $Project,
+
+        [string] $PackageData = $null
+    );
+
+    Write-Host "##[info]Packing $Project as a self-contained deployment...";
+    $Runtimes.GetEnumerator() | ForEach-Object {
+        $DotNetRuntimeID = $_.Key;
+        $NodePlatformID = $_.Value;
+        $TargetDir = New-TemporaryDirectory;
+        $BaseName = [System.IO.Path]::GetFileNameWithoutExtension((Join-Path $PSScriptRoot $Project));
+        $ArchiveDir = Join-Path $Env:BLOBS_OUTDIR $BaseName;
+        New-Item -ItemType Directory -Path $ArchiveDir -Force -ErrorAction SilentlyContinue;
+
+        try {
+            if ("" -ne "$Env:ASSEMBLY_CONSTANTS") {
+                $args = @("/property:DefineConstants=$Env:ASSEMBLY_CONSTANTS");
+            }  else {
+                $args = @();
+            }
+            $ArchivePath = Join-Path $ArchiveDir "$BaseName-$DotNetRuntimeID-$Env:SEMVER_VERSION.zip";
+            dotnet publish (Join-Path $PSScriptRoot $Project) `
+                -c $Env:BUILD_CONFIGURATION `
+                -v $Env:BUILD_VERBOSITY `
+                --self-contained `
+                --runtime $DotNetRuntimeID `
+                --output $TargetDir `
+                @args `
+                /property:Version=$Env:ASSEMBLY_VERSION `
+                /property:InformationalVersion=$Env:SEMVER_VERSION
+            Write-Host "##[info]Writing self-contained deployment to $ArchivePath..."
+            Compress-Archive `
+                -Force `
+                -Path (Join-Path $TargetDir *) `
+                -DestinationPath $ArchivePath `
+                -ErrorAction Continue;
+            if ($null -ne $PackageData) {
+                Write-Hash `
+                    -Path $ArchivePath `
+                    -BlobPlatform $NodePlatformID `
+                    -TargetPath (Join-Path $PSScriptRoot $PackageData)
+            }
+        } catch {
+            Write-Host "##vso[task.logissue type=error;]Failed to pack self-contained deployment: $_";
+            $Script:all_ok = $false;
+        } finally {
+            Remove-Item -Recurse $TargetDir -ErrorAction Continue;
+        }
+    };
+}
+
+##
+# VS Code Extension
+##
+function Pack-VSCode() {
+    Write-Host "##[info]Packing VS Code extension..."
+    Push-Location (Join-Path $PSScriptRoot '../src/VSCodeExtension')
+    if (Get-Command npx -ErrorAction SilentlyContinue) {
+        Try {
+            npx vsce package
+    
+            if ($LastExitCode -ne 0) {
+                throw;
+            }
+        } Catch {
+            Write-Host "##vso[task.logissue type=error;]Failed to pack VS Code extension."
+            $Script:all_ok = $False
+        }
+    } else {
+        Write-Host "##vso[task.logissue type=warning;]npx not installed. Will skip creation of VS Code extension package"
+    }
+    Pop-Location
+}
+
+##
+# VisualStudioExtension
+##
+function Pack-VS() {
+    Write-Host "##[info]Packing VisualStudio extension..."
+    Push-Location (Join-Path $PSScriptRoot '..\src\VisualStudioExtension\QsharpVSIX')
+    if (Get-Command msbuild -ErrorAction SilentlyContinue) {
+        Try {
+            msbuild QsharpVSIX.csproj `
+                /t:CreateVsixContainer `
+                /property:Configuration=$Env:BUILD_CONFIGURATION `
+                /property:AssemblyVersion=$Env:ASSEMBLY_VERSION `
+                /property:InformationalVersion=$Env:SEMVER_VERSION
+
+            if  ($LastExitCode -ne 0) {
+                throw
+            }
+        } Catch {
+            Write-Host "##vso[task.logissue type=error;]Failed to pack VS extension."
+            $Script:all_ok = $False
+        }
+    } else {    
+        Write-Host "msbuild not installed. Will skip creation of VisualStudio extension package"
+    }
+    Pop-Location
+}
+
+
+################################
+# Start main execution:
+
+$all_ok = $True
+
+Pack-SelfContained `
+    -Project "../src/QsCompiler/LanguageServer/LanguageServer.csproj" `
+    -PackageData "../src/VSCodeExtension/package.json"
+
+Pack-VSCode
+Pack-VS
+
+if (-not $all_ok) {
+    throw "Packing failed. Check the logs."
+    exit 1
+} else {
+    exit 0
+}

--- a/build/pack.ps1
+++ b/build/pack.ps1
@@ -10,7 +10,6 @@ Write-Host "Assembly version: $Env:ASSEMBLY_VERSION"
 ##
 # Q# compiler
 ##
-
 function Publish-One {
     param(
         [string]$project
@@ -78,154 +77,6 @@ function Pack-Dotnet() {
     }
 }
 
-##
-# Q# Language Server (self-contained)
-##
-
-$Runtimes = @{
-    "win10-x64" = "win32";
-    "linux-x64" = "linux";
-    "osx-x64" = "darwin";
-};
-
-function New-TemporaryDirectory {
-    $parent = [System.IO.Path]::GetTempPath()
-    $name = [System.IO.Path]::GetRandomFileName()
-    New-Item -ItemType Directory -Path (Join-Path $parent $name)
-}
-
-function Write-Hash() {
-    param(
-        [string]
-        $Path,
-
-        [string]
-        $BlobPlatform,
-
-        [string]
-        $TargetPath
-    );
-
-    "Writing hash of $Path into $TargetPath..." | Write-Host;
-    $packageData = Get-Content $TargetPath | ConvertFrom-Json;
-    $packageData.blobs.$BlobPlatform.sha256 = Get-FileHash $Path | Select-Object -ExpandProperty Hash;
-    # See https://stackoverflow.com/a/23738236 for why this works.
-    $packageData.blobs.$BlobPlatform `
-        | Add-Member `
-            -Force `
-            -MemberType NoteProperty `
-            -Name "size" `
-            -Value (Get-Item $Path | Select-Object -ExpandProperty Length);
-    Write-Host "New blob data: $($packageData."blobs".$BlobPlatform | ConvertTo-Json)";
-    $packageData `
-        | ConvertTo-Json -Depth 32 `
-        | Set-Content `
-            -Path $TargetPath `
-            -Encoding UTF8NoBom;
-}
-
-function Pack-SelfContained() {
-    param(
-        [string] $Project,
-
-        [string] $PackageData = $null
-    );
-
-    Write-Host "##[info]Packing $Project as a self-contained deployment...";
-    $Runtimes.GetEnumerator() | ForEach-Object {
-        $DotNetRuntimeID = $_.Key;
-        $NodePlatformID = $_.Value;
-        $TargetDir = New-TemporaryDirectory;
-        $BaseName = [System.IO.Path]::GetFileNameWithoutExtension((Join-Path $PSScriptRoot $Project));
-        $ArchiveDir = Join-Path $Env:BLOBS_OUTDIR $BaseName;
-        New-Item -ItemType Directory -Path $ArchiveDir -Force -ErrorAction SilentlyContinue;
-
-        try {
-            if ("" -ne "$Env:ASSEMBLY_CONSTANTS") {
-                $args = @("/property:DefineConstants=$Env:ASSEMBLY_CONSTANTS");
-            }  else {
-                $args = @();
-            }
-            $ArchivePath = Join-Path $ArchiveDir "$BaseName-$DotNetRuntimeID-$Env:SEMVER_VERSION.zip";
-            dotnet publish (Join-Path $PSScriptRoot $Project) `
-                -c $Env:BUILD_CONFIGURATION `
-                -v $Env:BUILD_VERBOSITY `
-                --self-contained `
-                --runtime $DotNetRuntimeID `
-                --output $TargetDir `
-                @args `
-                /property:Version=$Env:ASSEMBLY_VERSION `
-                /property:InformationalVersion=$Env:SEMVER_VERSION
-            Write-Host "##[info]Writing self-contained deployment to $ArchivePath..."
-            Compress-Archive `
-                -Force `
-                -Path (Join-Path $TargetDir *) `
-                -DestinationPath $ArchivePath `
-                -ErrorAction Continue;
-            if ($null -ne $PackageData) {
-                Write-Hash `
-                    -Path $ArchivePath `
-                    -BlobPlatform $NodePlatformID `
-                    -TargetPath (Join-Path $PSScriptRoot $PackageData)
-            }
-        } catch {
-            Write-Host "##vso[task.logissue type=error;]Failed to pack self-contained deployment: $_";
-            $Script:all_ok = $false;
-        } finally {
-            Remove-Item -Recurse $TargetDir -ErrorAction Continue;
-        }
-    };
-}
-
-##
-# VS Code Extension
-##
-function Pack-VSCode() {
-    Write-Host "##[info]Packing VS Code extension..."
-    Push-Location (Join-Path $PSScriptRoot '../src/VSCodeExtension')
-    if (Get-Command npx -ErrorAction SilentlyContinue) {
-        Try {
-            npx vsce package
-    
-            if ($LastExitCode -ne 0) {
-                throw;
-            }
-        } Catch {
-            Write-Host "##vso[task.logissue type=error;]Failed to pack VS Code extension."
-            $Script:all_ok = $False
-        }
-    } else {
-        Write-Host "##vso[task.logissue type=warning;]npx not installed. Will skip creation of VS Code extension package"
-    }
-    Pop-Location
-}
-
-##
-# VisualStudioExtension
-##
-function Pack-VS() {
-    Write-Host "##[info]Packing VisualStudio extension..."
-    Push-Location (Join-Path $PSScriptRoot '..\src\VisualStudioExtension\QsharpVSIX')
-    if (Get-Command msbuild -ErrorAction SilentlyContinue) {
-        Try {
-            msbuild QsharpVSIX.csproj `
-                /t:CreateVsixContainer `
-                /property:Configuration=$Env:BUILD_CONFIGURATION `
-                /property:AssemblyVersion=$Env:ASSEMBLY_VERSION `
-                /property:InformationalVersion=$Env:SEMVER_VERSION
-
-            if  ($LastExitCode -ne 0) {
-                throw
-            }
-        } Catch {
-            Write-Host "##vso[task.logissue type=error;]Failed to pack VS extension."
-            $Script:all_ok = $False
-        }
-    } else {    
-        Write-Host "msbuild not installed. Will skip creation of VisualStudio extension package"
-    }
-    Pop-Location
-}
 
 ################################
 # Start main execution:
@@ -242,15 +93,7 @@ Pack-One '../src/ProjectTemplates/Microsoft.Quantum.ProjectTemplates.nuspec'
 Pack-One '../src/QuantumSdk/QuantumSdk.nuspec'
 
 if ($Env:ENABLE_VSIX -ne "false") {
-    Pack-SelfContained `
-        -Project "../src/QsCompiler/LanguageServer/LanguageServer.csproj" `
-        -PackageData "../src/VSCodeExtension/package.json"
-
-    Write-Host "Final package.json:"
-    Get-Content "../src/VSCodeExtension/package.json" | Write-Host
-
-    Pack-VSCode
-    Pack-VS
+    & "$PSScriptRoot/pack-extensions.ps1"
 } else {
     Write-Host "##vso[task.logissue type=warning;]VSIX packing skipped due to ENABLE_VSIX variable."
 }

--- a/build/pack.ps1
+++ b/build/pack.ps1
@@ -24,6 +24,7 @@ function Publish-One {
     dotnet publish (Join-Path $PSScriptRoot $project) `
         -c $Env:BUILD_CONFIGURATION `
         -v $Env:BUILD_VERBOSITY `
+        --no-build `
         @args `
         /property:Version=$Env:ASSEMBLY_VERSION
 
@@ -64,6 +65,7 @@ function Pack-Dotnet() {
         -o $Env:NUGET_OUTDIR `
         -c $Env:BUILD_CONFIGURATION `
         -v detailed `
+        --no-build `
         @args `
         /property:Version=$Env:ASSEMBLY_VERSION `
         /property:PackageVersion=$Env:NUGET_VERSION `


### PR DESCRIPTION
As I am validating the signing on e2e builds I noticed a couple of problems:
* Compiler dlls are distributed unsigned because during the `pack` step they are getting rebuilt. To fix this, I added the `--no-build` flag during packaging.
* The language server is not built on e2e, because it is built only when building the VSIX. Making the packaging of extensions its own script so I can call it from e2e.