### PR TITLE
Fix parsing of ResolvedRuntimeCapabilities project property in language server

### DIFF
--- a/src/QsCompiler/CommandLineTool/Options.cs
+++ b/src/QsCompiler/CommandLineTool/Options.cs
@@ -72,12 +72,7 @@ namespace Microsoft.Quantum.QsCompiler.CommandLineCompiler
             HelpText = "Specifies the classical capabilites of the runtime. Determines what QIR profile to compile to.")]
         public AssemblyConstants.RuntimeCapabilities RuntimeCapabilites { get; set; }
 
-        internal RuntimeCapability RuntimeCapability => this.RuntimeCapabilites switch
-        {
-            AssemblyConstants.RuntimeCapabilities.QPRGen0 => RuntimeCapability.BasicQuantumFunctionality,
-            AssemblyConstants.RuntimeCapabilities.QPRGen1 => RuntimeCapability.BasicMeasurementFeedback,
-            _ => RuntimeCapability.FullComputation
-        };
+        internal RuntimeCapability RuntimeCapability => this.RuntimeCapabilites.ToCapability();
 
         [Option(
             "build-exe",

--- a/src/QsCompiler/DataStructures/RuntimeCapability.fs
+++ b/src/QsCompiler/DataStructures/RuntimeCapability.fs
@@ -1,6 +1,9 @@
 ﻿namespace Microsoft.Quantum.QsCompiler
 
 open Microsoft.Quantum.QsCompiler.DataTypes
+open Microsoft.Quantum.QsCompiler.ReservedKeywords.AssemblyConstants
+open System
+open System.Runtime.CompilerServices
 
 /// The runtime capabilities supported by a quantum processor.
 [<NoComparison>]
@@ -49,3 +52,15 @@ type RuntimeCapability =
         | "BasicMeasurementFeedback" -> Value BasicMeasurementFeedback
         | "FullComputation" -> Value FullComputation
         | _ -> Null
+
+// TODO: RELEASE 2021-04: Remove RuntimeCapabilitiesExtensions.
+[<Extension>]
+[<Obsolete "Use Microsoft.Quantum.QsCompiler.RuntimeCapability.">]
+module RuntimeCapabilitiesExtensions =
+    [<Extension>]
+    [<Obsolete "Use Microsoft.Quantum.QsCompiler.RuntimeCapability.">]
+    let ToCapability capabilities =
+        match capabilities with
+        | RuntimeCapabilities.QPRGen0 -> BasicQuantumFunctionality
+        | RuntimeCapabilities.QPRGen1 -> BasicMeasurementFeedback
+        | _ -> FullComputation

--- a/src/QsCompiler/LanguageServer/EditorState.cs
+++ b/src/QsCompiler/LanguageServer/EditorState.cs
@@ -12,8 +12,8 @@ using Microsoft.Build.Execution;
 using Microsoft.Quantum.QsCompiler;
 using Microsoft.Quantum.QsCompiler.CompilationBuilder;
 using Microsoft.Quantum.QsCompiler.DataTypes;
-using Microsoft.Quantum.QsCompiler.ReservedKeywords;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
+using static Microsoft.Quantum.QsCompiler.ReservedKeywords.AssemblyConstants;
 
 namespace Microsoft.Quantum.QsLanguageServer
 {
@@ -126,8 +126,9 @@ namespace Microsoft.Quantum.QsLanguageServer
 
             var processorArchitecture = projectInstance.GetPropertyValue("ResolvedProcessorArchitecture");
             var resRuntimeCapability = projectInstance.GetPropertyValue("ResolvedRuntimeCapabilities");
-            var runtimeCapabilities = RuntimeCapability.TryParse(resRuntimeCapability)
-                .ValueOr(RuntimeCapability.FullComputation);
+            var runtimeCapability = Enum.TryParse(resRuntimeCapability, out RuntimeCapabilities result)
+                ? result.ToCapability()
+                : RuntimeCapability.FullComputation;
 
             var sourceFiles = GetItemsByType(projectInstance, "QsharpCompile");
             var csharpFiles = GetItemsByType(projectInstance, "Compile").Where(file => !file.EndsWith(".g.cs"));
@@ -147,7 +148,7 @@ namespace Microsoft.Quantum.QsLanguageServer
             info = new ProjectInformation(
                 version,
                 outputPath,
-                runtimeCapabilities,
+                runtimeCapability,
                 isExecutable,
                 NonNullable<string>.New(string.IsNullOrWhiteSpace(processorArchitecture) ? "Unspecified" : processorArchitecture),
                 loadTestNames,


### PR DESCRIPTION
This PR fixes capability verification at design time. Without this change, capability diagnostics only work when the project is built, not when using the language server.