### PR TITLE
Include name of required runtime capability in diagnostic message

### DIFF
--- a/src/QsCompiler/DataStructures/Diagnostics.fs
+++ b/src/QsCompiler/DataStructures/Diagnostics.fs
@@ -572,7 +572,7 @@ type DiagnosticItem =
             | ErrorCode.SetInResultConditionedBlock               ->
                 "The variable \"{0}\" cannot be reassigned here. " +
                 "In conditional blocks that depend on a measurement result, the target {1} only supports reassigning variables that were declared within the block."
-            | ErrorCode.UnsupportedCapability                     -> "The callable {0} requires runtime capabilities that are not supported by the target {1}."
+            | ErrorCode.UnsupportedCapability                     -> "The callable {0} requires the {1} runtime capability, which is not supported by the target {2}."
 
             | ErrorCode.CallableRedefinition                      -> "Invalid callable declaration. A function or operation with the name \"{0}\" already exists."
             | ErrorCode.CallableOverlapWithTypeConstructor        -> "Invalid callable declaration. A type constructor with the name \"{0}\" already exists."

--- a/src/QsCompiler/SyntaxProcessor/CapabilityInference.fs
+++ b/src/QsCompiler/SyntaxProcessor/CapabilityInference.fs
@@ -223,7 +223,9 @@ let private referenceDiagnostic context (name, range : _ QsNullable) =
         if context.Capability.Implies capability
         then None
         else
-            let error = ErrorCode.UnsupportedCapability, [ name.Name.Value; context.ProcessorArchitecture.Value ]
+            let error =
+                ErrorCode.UnsupportedCapability,
+                [ name.Name.Value; string capability; context.ProcessorArchitecture.Value ]
             range.ValueOr Range.Zero |> QsCompilerDiagnostic.Error error |> Some
     | _ -> None
 


### PR DESCRIPTION
Closes #716.