### PR TITLE
Initialize Bond serializers and deserializers asynchronously

### DIFF
--- a/src/QsCompiler/BondSchemas/Protocols.cs
+++ b/src/QsCompiler/BondSchemas/Protocols.cs
@@ -1,20 +1,30 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System.Diagnostics;
 using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
 using Bond;
 using Bond.IO.Unsafe;
 using Bond.Protocols;
 
 namespace Microsoft.Quantum.QsCompiler.BondSchemas
 {
+    using SimpleBinaryDeserializer = Deserializer<SimpleBinaryReader<InputBuffer>>;
+    using SimpleBinarySerializer = Serializer<SimpleBinaryWriter<OutputBuffer>>;
+
     /// <summary>
     /// This class provides methods for serialization/deserialization of Q# compilation objects.
     /// </summary>
     public static class Protocols
     {
-        private static Deserializer<SimpleBinaryReader<InputBuffer>>? simpleBinaryDeserializer = null;
-        private static Serializer<SimpleBinaryWriter<OutputBuffer>>? simpleBinarySerializer = null;
+        /// <summary>
+        /// Provides thread-safe access to the members and methods of this class.
+        /// </summary>
+        private static readonly object BondSharedDataStructuresLock = new object();
+        private static Task<SimpleBinaryDeserializer>? simpleBinaryDeserializerInitialization = null;
+        private static Task<SimpleBinarySerializer>? simpleBinarySerializerInitialization = null;
 
         /// <summary>
         /// Deserializes a Q# compilation object from its Bond simple binary representation.
@@ -23,11 +33,28 @@ namespace Microsoft.Quantum.QsCompiler.BondSchemas
         public static SyntaxTree.QsCompilation? DeserializeQsCompilationFromSimpleBinary(
             byte[] byteArray)
         {
-            var inputBuffer = new InputBuffer(byteArray);
-            var deserializer = GetSimpleBinaryDeserializer();
-            var reader = new SimpleBinaryReader<InputBuffer>(inputBuffer);
-            var bondCompilation = deserializer.Deserialize<QsCompilation>(reader);
+            QsCompilation? bondCompilation = null;
+            lock(BondSharedDataStructuresLock)
+            {
+                var inputBuffer = new InputBuffer(byteArray);
+                var deserializer = GetSimpleBinaryDeserializer();
+                var reader = new SimpleBinaryReader<InputBuffer>(inputBuffer);
+                bondCompilation = deserializer.Deserialize<QsCompilation>(reader);
+            }
+
             return CompilerObjectTranslator.CreateQsCompilation(bondCompilation);
+        }
+
+        /// <summary>
+        /// Starts the creation of Bond serializers and deserializers.
+        /// </summary>
+        public static void Initialize()
+        {
+            lock (BondSharedDataStructuresLock)
+            {
+                simpleBinaryDeserializerInitialization = QueueSimpleBinaryDeserializerInitialization();
+                simpleBinarySerializerInitialization = QueueSimpleBinarySerializerInitialization();
+            }
         }
 
         /// <summary>
@@ -39,34 +66,52 @@ namespace Microsoft.Quantum.QsCompiler.BondSchemas
             SyntaxTree.QsCompilation qsCompilation,
             Stream stream)
         {
-            var outputBuffer = new OutputBuffer();
-            var serializer = GetSimpleBinarySerializer();
-            var writer = new SimpleBinaryWriter<OutputBuffer>(outputBuffer);
-            var bondCompilation = BondSchemaTranslator.CreateBondCompilation(qsCompilation);
-            serializer.Serialize(bondCompilation, writer);
-            stream.Write(outputBuffer.Data);
+            lock(BondSharedDataStructuresLock)
+            {
+                var outputBuffer = new OutputBuffer();
+                var serializer = GetSimpleBinarySerializer();
+                var writer = new SimpleBinaryWriter<OutputBuffer>(outputBuffer);
+                var bondCompilation = BondSchemaTranslator.CreateBondCompilation(qsCompilation);
+                serializer.Serialize(bondCompilation, writer);
+                stream.Write(outputBuffer.Data);
+            }
+
             stream.Flush();
             stream.Position = 0;
         }
 
-        private static Deserializer<SimpleBinaryReader<InputBuffer>> GetSimpleBinaryDeserializer()
+        private static SimpleBinaryDeserializer GetSimpleBinaryDeserializer()
         {
-            if (simpleBinaryDeserializer == null)
+            Debug.Assert(Monitor.IsEntered(BondSharedDataStructuresLock));
+            if (simpleBinaryDeserializerInitialization == null)
             {
-                simpleBinaryDeserializer = new Deserializer<SimpleBinaryReader<InputBuffer>>(typeof(QsCompilation));
+                simpleBinaryDeserializerInitialization = QueueSimpleBinaryDeserializerInitialization();
             }
 
-            return simpleBinaryDeserializer;
+            simpleBinaryDeserializerInitialization.Wait();
+            return simpleBinaryDeserializerInitialization.Result;
         }
 
-        private static Serializer<SimpleBinaryWriter<OutputBuffer>> GetSimpleBinarySerializer()
+        private static SimpleBinarySerializer GetSimpleBinarySerializer()
         {
-            if (simpleBinarySerializer == null)
+            Debug.Assert(Monitor.IsEntered(BondSharedDataStructuresLock));
+            if (simpleBinarySerializerInitialization == null)
             {
-                simpleBinarySerializer = new Serializer<SimpleBinaryWriter<OutputBuffer>>(typeof(QsCompilation));
+                simpleBinarySerializerInitialization = QueueSimpleBinarySerializerInitialization();
             }
 
-            return simpleBinarySerializer;
+            simpleBinarySerializerInitialization.Wait();
+            return simpleBinarySerializerInitialization.Result;
+        }
+
+        private static Task<SimpleBinaryDeserializer> QueueSimpleBinaryDeserializerInitialization()
+        {
+            return Task.Run(() => new SimpleBinaryDeserializer(typeof(QsCompilation)));
+        }
+
+        private static Task<SimpleBinarySerializer> QueueSimpleBinarySerializerInitialization()
+        {
+            return Task.Run(() => new SimpleBinarySerializer(typeof(QsCompilation)));
         }
     }
 }

--- a/src/QsCompiler/Compiler/CompilationLoader.cs
+++ b/src/QsCompiler/Compiler/CompilationLoader.cs
@@ -477,7 +477,7 @@ namespace Microsoft.Quantum.QsCompiler
             this.RaiseCompilationTaskStart(null, "OverallCompilation");
 
             // loading the content to compiler
-
+            BondSchemas.Protocols.Initialize();
             this.logger = logger;
             this.LoadDiagnostics = ImmutableArray<Diagnostic>.Empty;
             this.config = options ?? default;


### PR DESCRIPTION
This change asynchronously triggers the creation of Bond serializers and deserializers at the beginning of the compilation process in order to speed up syntax tree serialization and deserialization.