### PR TITLE
Add nullable settings to AssemblyCommon.props

### DIFF
--- a/src/Common/AssemblyCommon.props
+++ b/src/Common/AssemblyCommon.props
@@ -7,7 +7,12 @@
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
   </PropertyGroup>
 
-  <!-- 
+  <PropertyGroup Condition="'$(MSBuildProjectExtension)' == '.csproj'">
+    <Nullable>enable</Nullable>
+    <WarningsAsErrors>nullable</WarningsAsErrors>
+  </PropertyGroup>
+
+  <!--
     When DefineConstants receives a list with the semicolon escaped (%3B),
     like: SIGNED%3BTELEMETRY
     the F# tasks doesn't break them up using the semicolon, instead it defines one constant

--- a/src/Documentation/DocumentationGenerator/DocumentationGenerator.csproj
+++ b/src/Documentation/DocumentationGenerator/DocumentationGenerator.csproj
@@ -4,9 +4,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
     <AssemblyName>Microsoft.Quantum.DocumentationGenerator</AssemblyName>
-    <Nullable>enable</Nullable>
-    <WarningsAsErrors>nullable</WarningsAsErrors>
-  </PropertyGroup>  
+  </PropertyGroup>
 
   <PropertyGroup>
     <Authors>Microsoft</Authors>
@@ -39,5 +37,4 @@
   <ItemGroup>
     <AdditionalFiles Include="..\..\Common\stylecop.json" Link="stylecop.json" />
   </ItemGroup>
-
 </Project>

--- a/src/Documentation/DocumentationParser/DocumentationParser.csproj
+++ b/src/Documentation/DocumentationParser/DocumentationParser.csproj
@@ -5,8 +5,6 @@
     <TargetFramework>netstandard2.1</TargetFramework>
     <AssemblyName>Microsoft.Quantum.QsDocumentationParser</AssemblyName>
     <RootNamespace>Microsoft.Quantum.QsCompiler.Documentation</RootNamespace>
-    <Nullable>enable</Nullable>
-    <WarningsAsErrors>nullable</WarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>
@@ -28,5 +26,4 @@
   <ItemGroup>
     <AdditionalFiles Include="..\..\Common\stylecop.json" Link="stylecop.json" />
   </ItemGroup>
-
 </Project>

--- a/src/Documentation/Tests.DocGenerator/Tests.DocGenerator.csproj
+++ b/src/Documentation/Tests.DocGenerator/Tests.DocGenerator.csproj
@@ -6,8 +6,6 @@
     <IsPackable>false</IsPackable>
     <RootNamespace>Microsoft.Quantum.QsCompiler.Documentation.Testing</RootNamespace>
     <AssemblyName>Tests.Microsoft.Quantum.QsDocumentationParser</AssemblyName>
-    <Nullable>enable</Nullable>
-    <WarningsAsErrors>nullable</WarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>
@@ -32,5 +30,4 @@
     <ProjectReference Include="..\..\QsCompiler\DataStructures\DataStructures.fsproj" />
     <ProjectReference Include="..\DocumentationParser\DocumentationParser.csproj" />
   </ItemGroup>
-
 </Project>

--- a/src/QsCompiler/BondSchemas/BondSchemas.csproj
+++ b/src/QsCompiler/BondSchemas/BondSchemas.csproj
@@ -6,7 +6,6 @@
     <OutputType>Library</OutputType>
     <TargetFramework>netstandard2.1</TargetFramework>
     <AssemblyName>Microsoft.Quantum.BondSchemas</AssemblyName>
-    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/QsCompiler/CommandLineTool/CommandLineTool.csproj
+++ b/src/QsCompiler/CommandLineTool/CommandLineTool.csproj
@@ -6,8 +6,6 @@
     <AssemblyTitle>Microsoft Q# compiler command line tool.</AssemblyTitle>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <OutputType>Exe</OutputType>
-    <Nullable>enable</Nullable>
-    <WarningsAsErrors>nullable</WarningsAsErrors>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/QsCompiler/CompilationManager/CompilationManager.csproj
+++ b/src/QsCompiler/CompilationManager/CompilationManager.csproj
@@ -7,8 +7,6 @@
     <TargetFramework>netstandard2.1</TargetFramework>
     <AssemblyName>Microsoft.Quantum.QsCompilationManager</AssemblyName>
     <RootNamespace>Microsoft.Quantum.QsCompiler.CompilationBuilder</RootNamespace>
-    <Nullable>enable</Nullable>
-    <WarningsAsErrors>nullable</WarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/QsCompiler/Compiler/Compiler.csproj
+++ b/src/QsCompiler/Compiler/Compiler.csproj
@@ -7,8 +7,6 @@
     <AssemblyName>Microsoft.Quantum.QsCompiler</AssemblyName>
     <RootNamespace>Microsoft.Quantum.QsCompiler</RootNamespace>
     <AssemblyTitle>Microsoft Q# compiler library.</AssemblyTitle>
-    <Nullable>enable</Nullable>
-    <WarningsAsErrors>nullable</WarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/QsCompiler/LanguageServer/LanguageServer.csproj
+++ b/src/QsCompiler/LanguageServer/LanguageServer.csproj
@@ -4,8 +4,6 @@
     <AssemblyName>Microsoft.Quantum.QsLanguageServer</AssemblyName>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <OutputType>Exe</OutputType>
-    <Nullable>enable</Nullable>
-    <WarningsAsErrors>nullable</WarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Workaround for https://github.com/dotnet/cli/issues/9514, see https://stackoverflow.com/a/51644988/267841. -->

--- a/src/QsCompiler/TestTargets/Simulation/Target/Simulation.csproj
+++ b/src/QsCompiler/TestTargets/Simulation/Target/Simulation.csproj
@@ -6,8 +6,6 @@
     <TargetFramework>netstandard2.1</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
-    <Nullable>enable</Nullable>
-    <WarningsAsErrors>nullable</WarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>
@@ -22,6 +20,4 @@
     <PackageReference Include="Microsoft.Quantum.CsharpGeneration" Version="0.12.20071723-beta" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.164" PrivateAssets="All" />
   </ItemGroup>
-
 </Project>
-

--- a/src/QsCompiler/Tests.LanguageServer/Tests.LanguageServer.csproj
+++ b/src/QsCompiler/Tests.LanguageServer/Tests.LanguageServer.csproj
@@ -8,8 +8,6 @@
     <PlatformTarget>x64</PlatformTarget>
     <OutputType>Library</OutputType>
     <NoWarn>NU1701</NoWarn>
-    <Nullable>enable</Nullable>
-    <WarningsAsErrors>nullable</WarningsAsErrors>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/src/QsCompiler/Transformations/Transformations.csproj
+++ b/src/QsCompiler/Transformations/Transformations.csproj
@@ -5,8 +5,6 @@
     <OutputType>Library</OutputType>
     <TargetFramework>netstandard2.1</TargetFramework>
     <AssemblyName>Microsoft.Quantum.QsTransformations</AssemblyName>
-    <Nullable>enable</Nullable>
-    <WarningsAsErrors>nullable</WarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>
@@ -27,5 +25,4 @@
   <ItemGroup>
     <AdditionalFiles Include="..\..\Common\stylecop.json" Link="stylecop.json" />
   </ItemGroup>
-
 </Project>

--- a/src/QuantumSdk/Tools/BuildConfiguration/Generate.cs
+++ b/src/QuantumSdk/Tools/BuildConfiguration/Generate.cs
@@ -58,7 +58,7 @@ namespace Microsoft.Quantum.Sdk.Tools
         /// Work in progress: 
         /// The signature and output of this method will change in the future. 
         /// </summary>
-        private static bool WriteConfigFile(string configFile, string[] qscReferences, bool verbose = false)
+        private static bool WriteConfigFile(string? configFile, string[] qscReferences, bool verbose = false)
         {
             try
             {

--- a/src/QuantumSdk/Tools/BuildConfiguration/Options.cs
+++ b/src/QuantumSdk/Tools/BuildConfiguration/Options.cs
@@ -11,15 +11,15 @@ namespace Microsoft.Quantum.Sdk.Tools
     {
         [Option('v', "verbosity", Required = false, Default = "Normal",
         HelpText = "Specifies the verbosity of the logged output. Valid values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].")]
-        public string Verbosity { get; set; }
+        public string? Verbosity { get; set; }
 
         [Option("QscReferences", Required = false,
         HelpText = ".NET Core assemblies containing rewrite steps to be passed to the Q# compiler. " +
             "Each reference need to be a string of the form \"(pathToDll, priority)\".")]
-        public IEnumerable<string> QscReferences { get; set; }
+        public IEnumerable<string>? QscReferences { get; set; }
 
         [Option('o', "output", Required = false,
         HelpText = "Name of the generated config file.")]
-        public string OutputFile { get; set; }
+        public string? OutputFile { get; set; }
     }
 }


### PR DESCRIPTION
This PR factors out the `<Nullable>enable</Nullable>` and `<WarningsAsErrors>nullable</WarningsAsErrors>` properties into the `AssemblyCommon.props` file that all projects import.