### PR TITLE
Remove entry point for temporary .csproj creation

### DIFF
--- a/src/QsCompiler/LanguageServer/EditorState.cs
+++ b/src/QsCompiler/LanguageServer/EditorState.cs
@@ -232,43 +232,11 @@ namespace Microsoft.Quantum.QsLanguageServer
             {
                 throw new ArgumentException("invalid text document identifier");
             }
-            // If the file is not associated with a project, we will create a temporary project file for all files in that folder.
-            // We spawn a second query below for the actual processing of the file to ensure that a created project file
-            // is properly registered with the project manager before processing.
-            var createdTemporaryProject = false;
-            this.projects.ManagerTaskAsync(textDocument.Uri, (manager, associatedWithProject) =>
-            {
-                if (this.IgnoreFile(textDocument.Uri))
-                {
-                    return;
-                }
-
-                if (!associatedWithProject && textDocument.Uri.LocalPath.EndsWith(".qs", StringComparison.InvariantCultureIgnoreCase))
-                {
-                    try
-                    {
-                        var projectUri = this.QsTemporaryProjectLoader(textDocument.Uri, sdkVersion: null); // null means the Sdk version will be set to the extension version
-                        this.projects.ProjectChangedOnDiskAsync(projectUri, this.QsProjectLoader, this.GetOpenFile);
-                        this.onTemporaryProjectLoaded?.Invoke(projectUri);
-                        createdTemporaryProject = true;
-                    }
-                    catch (Exception ex)
-                    {
-                        logError?.Invoke($"Failed to create temporary .csproj for {textDocument.Uri.LocalPath}.", MessageType.Info);
-                        manager.LogException(ex);
-                    }
-                }
-            }).Wait(); // needed to ensure that the ProjectChangedOnDiskAsync is queued before the ManagerTaskAsync below
             _ = this.projects.ManagerTaskAsync(textDocument.Uri, (manager, associatedWithProject) =>
             {
                 if (this.IgnoreFile(textDocument.Uri))
                 {
                     return;
-                }
-
-                if (createdTemporaryProject && !associatedWithProject)
-                {
-                    logError?.Invoke($"Failed to load temporary .csproj for {textDocument.Uri.LocalPath}.", MessageType.Info);
                 }
 
                 var newManager = CompilationUnitManager.InitializeFileManager(textDocument.Uri, textDocument.Text, this.publish, ex =>


### PR DESCRIPTION
We are implementing fixes for bugs in temporary .csproj creation (#613 and #720) in PR https://github.com/microsoft/qsharp-compiler/pull/724. In the meantime, we want to merge this change into the `release/v0.13.2010` branch to completely disable the feature there.

