### PR TITLE
Fix some nullable reference type errors in Visual Studio 16.8

### DIFF
--- a/src/QsCompiler/LanguageServer/EditorState.cs
+++ b/src/QsCompiler/LanguageServer/EditorState.cs
@@ -36,7 +36,8 @@ namespace Microsoft.Quantum.QsLanguageServer
         /// needed to determine if the reality of a source file that has changed on disk is indeed given by the content on disk,
         /// or whether its current state as it is in the editor needs to be preserved
         /// </summary>
-        private readonly ConcurrentDictionary<Uri, FileContentManager> openFiles;
+        private readonly ConcurrentDictionary<Uri, FileContentManager> openFiles =
+            new ConcurrentDictionary<Uri, FileContentManager>();
 
         private FileContentManager? GetOpenFile(Uri key) => this.openFiles.TryGetValue(key, out var file) ? file : null;
 
@@ -86,7 +87,6 @@ namespace Microsoft.Quantum.QsLanguageServer
 
             this.projectLoader = projectLoader;
             this.projects = new ProjectManager(onException, log, this.publish);
-            this.openFiles = new ConcurrentDictionary<Uri, FileContentManager>();
             this.onTemporaryProjectLoaded = onTemporaryProjectLoaded;
         }
 

--- a/src/QsCompiler/LanguageServer/LanguageServer.cs
+++ b/src/QsCompiler/LanguageServer/LanguageServer.cs
@@ -84,13 +84,14 @@ namespace Microsoft.Quantum.QsLanguageServer
             void ProcessFileEvents(IEnumerable<FileEvent> e) =>
                 this.OnDidChangeWatchedFiles(JToken.Parse(JsonConvert.SerializeObject(
                     new DidChangeWatchedFilesParams { Changes = e.ToArray() })));
+            this.fileWatcher = new FileWatcher(_ =>
+                this.LogToWindow($"FileSystemWatcher encountered and error", MessageType.Error));
             var fileEvents = Observable.FromEvent<FileWatcher.FileEventHandler, FileEvent>(
                     handler => this.fileWatcher.FileEvent += handler,
                     handler => this.fileWatcher.FileEvent -= handler)
                 .Where(e => !e.Uri.LocalPath.EndsWith("tmp", StringComparison.InvariantCultureIgnoreCase) && !e.Uri.LocalPath.EndsWith('~'));
 
             this.projectsInWorkspace = new HashSet<Uri>();
-            this.fileWatcher = new FileWatcher(_ => this.LogToWindow($"FileSystemWatcher encountered and error", MessageType.Error));
             this.fileEvents = new CoalesceingQueue();
             this.fileEvents.Subscribe(fileEvents, observable => ProcessFileEvents(observable));
             this.editorState = new EditorState(

--- a/src/QsCompiler/Tests.Compiler/LinkingTests.fs
+++ b/src/QsCompiler/Tests.Compiler/LinkingTests.fs
@@ -307,7 +307,7 @@ type LinkingTests (output:ITestOutputHelper) =
                     Assert.Equal(0, ex.TypeParameterResolutions.Count)
             | _ -> ()
 
-        let walker = new TypedExpressionWalker<unit>(new Action<_>(onExpr));
+        let walker = TypedExpressionWalker(Action<_> onExpr, ())
         walker.Transformation.OnCompilation compilation |> ignore
         Assert.True(gotLength)
         Assert.True(gotIndexRange)

--- a/src/QsCompiler/Transformations/BasicTransformations.cs
+++ b/src/QsCompiler/Transformations/BasicTransformations.cs
@@ -347,7 +347,7 @@ namespace Microsoft.Quantum.QsCompiler.Transformations.BasicTransformations
         : base(parent, TransformationOptions.NoRebuild) =>
             this.OnExpression = onExpression;
 
-        public TypedExpressionWalker(Action<TypedExpression> onExpression, T internalState = default)
+        public TypedExpressionWalker(Action<TypedExpression> onExpression, T internalState)
         : base(internalState, TransformationOptions.NoRebuild) =>
             this.OnExpression = onExpression;
 


### PR DESCRIPTION
It looks like there were some changes to nullable reference type analysis in Visual Studio 16.8, causing some errors when building the Q# compiler. (This is despite having a global.json that sets the SDK version to 3.1 - `dotnet build` would succeed, but building in VS itself would fail.) The changes needed to fix the errors continue to work in 3.1, and mostly seem reasonable.

There's one (small) breaking change. I removed the default parameter from the `TypedExpressionWalker` constructor:

```csharp
public TypedExpressionWalker(Action<TypedExpression> onExpression, T internalState = default)
```

This could be worked around with nullable attributes or the null-forgiving operator, but having a null transformation state does not seem like a great idea, anyway.