### PR TITLE
Detect absence of .NET SDK 3.1 and display error message

### DIFF
--- a/build/init.yml
+++ b/build/init.yml
@@ -16,7 +16,7 @@ steps:
     versionSpec: '5.6.0'
 
 - task: UseDotNet@2
-  displayName: 'Use .NET Core SDK 3.1.300'
+  displayName: 'Use .NET SDK 5.0.101'
   inputs:
     packageType: sdk
-    version: '3.1.300'
+    version: '5.0.101'

--- a/src/QsCompiler/LanguageServer/LanguageServer.cs
+++ b/src/QsCompiler/LanguageServer/LanguageServer.cs
@@ -132,21 +132,21 @@ namespace Microsoft.Quantum.QsLanguageServer
 
         internal async void CheckDotNetSdkVersion()
         {
-            var sdkVersions = DotNetSdkHelper.GetSdkVersions();
-            if (sdkVersions == null)
+            var isDotNet31Installed = DotNetSdkHelper.IsDotNet31Installed();
+            if (isDotNet31Installed == null)
             {
                 this.LogToWindow("Unable to detect .NET SDK versions", MessageType.Error);
             }
             else
             {
-                if (!sdkVersions.HasDotNet31)
+                if (isDotNet31Installed != true)
                 {
                     const string dotnet31Url = "https://dotnet.microsoft.com/download/dotnet-core/3.1";
-                    this.LogToWindow($".NET SDK 3.1 not found. Quantum Development Kit Extension requires .NET Core SDK 3.1 to work properly ({dotnet31Url}).", MessageType.Error);
+                    this.LogToWindow($".NET Core SDK 3.1 not found. Quantum Development Kit Extension requires .NET Core SDK 3.1 to work properly ({dotnet31Url}).", MessageType.Error);
                     var downloadAction = new MessageActionItem { Title = "Download" };
                     var cancelAction = new MessageActionItem { Title = "No, thanks" };
                     var selectedAction = await this.ShowDialogInWindowAsync(
-                        "Quantum Development Kit Extension requires .NET Core SDK 3.1 to work properly. Please install .NET SDK 3.1.",
+                        "Quantum Development Kit Extension requires .NET Core SDK 3.1 to work properly. Please install .NET Core SDK 3.1.",
                         MessageType.Error,
                         new[] { downloadAction, cancelAction });
                     if (selectedAction != null

--- a/src/QsCompiler/LanguageServer/LanguageServer.cs
+++ b/src/QsCompiler/LanguageServer/LanguageServer.cs
@@ -142,11 +142,11 @@ namespace Microsoft.Quantum.QsLanguageServer
                 if (!sdkVersions.HasDotNet31)
                 {
                     const string dotnet31Url = "https://dotnet.microsoft.com/download/dotnet-core/3.1";
-                    this.LogToWindow($".NET SDK 3.1 not found. The Quantum Development Kit Extension requires .NET SDK 3.1 to work properly ({dotnet31Url}).", MessageType.Error);
+                    this.LogToWindow($".NET SDK 3.1 not found. Quantum Development Kit Extension requires .NET Core SDK 3.1 to work properly ({dotnet31Url}).", MessageType.Error);
                     var downloadAction = new MessageActionItem { Title = "Download" };
                     var cancelAction = new MessageActionItem { Title = "No, thanks" };
                     var selectedAction = await this.ShowDialogInWindowAsync(
-                        $"The Quantum Development Kit Extension requires .NET SDK 3.1 to work properly. Please install .NET SDK 3.1.",
+                        $"Quantum Development Kit Extension requires .NET Core SDK 3.1 to work properly. Please install .NET SDK 3.1.",
                         MessageType.Error,
                         new[] { downloadAction, cancelAction });
                     if (selectedAction != null

--- a/src/QsCompiler/LanguageServer/LanguageServer.cs
+++ b/src/QsCompiler/LanguageServer/LanguageServer.cs
@@ -126,6 +126,25 @@ namespace Microsoft.Quantum.QsLanguageServer
         internal Task PublishDiagnosticsAsync(PublishDiagnosticParams diagnostics) =>
             this.NotifyClientAsync(Methods.TextDocumentPublishDiagnosticsName, diagnostics);
 
+        internal void CheckDotNetSDKVersion()
+        {
+            var sdkVersions = DotNetSDKHelper.GetSDKVersions();
+            if (sdkVersions == null)
+            {
+                this.LogToWindow($"Unable to detect .NET SDK versions", MessageType.Error);
+            }
+            else
+            {
+                if (!sdkVersions.HasDotNet31)
+                {
+                    this.LogToWindow($".NET SDK 3.1 not found. QDK requires .NET SDK 3.1 to work properly.", MessageType.Error);
+                    this.ShowInWindow(
+                        $"QDK requires .NET SDK 3.1 to work properly. Please install .NET SDK 3.1 from https://dotnet.microsoft.com/download/dotnet-core/3.1",
+                        MessageType.Error);
+                }
+            }
+        }
+
         /// <summary>
         /// does not actually do anything unless the corresponding flag is defined upon compilation
         /// </summary>

--- a/src/QsCompiler/LanguageServer/LanguageServer.cs
+++ b/src/QsCompiler/LanguageServer/LanguageServer.cs
@@ -146,7 +146,7 @@ namespace Microsoft.Quantum.QsLanguageServer
                     var downloadAction = new MessageActionItem { Title = "Download" };
                     var cancelAction = new MessageActionItem { Title = "No, thanks" };
                     var selectedAction = await this.ShowDialogInWindowAsync(
-                        "Quantum Development Kit Extension requires .NET Core SDK 3.1 to work properly. Please install .NET Core SDK 3.1.",
+                        "Quantum Development Kit Extension requires .NET Core SDK 3.1 to work properly. Please install .NET Core SDK 3.1 and restart Visual Studio.",
                         MessageType.Error,
                         new[] { downloadAction, cancelAction });
                     if (selectedAction != null

--- a/src/QsCompiler/LanguageServer/LanguageServer.cs
+++ b/src/QsCompiler/LanguageServer/LanguageServer.cs
@@ -135,7 +135,7 @@ namespace Microsoft.Quantum.QsLanguageServer
             var sdkVersions = DotNetSdkHelper.GetSdkVersions();
             if (sdkVersions == null)
             {
-                this.LogToWindow($"Unable to detect .NET SDK versions", MessageType.Error);
+                this.LogToWindow("Unable to detect .NET SDK versions", MessageType.Error);
             }
             else
             {

--- a/src/QsCompiler/LanguageServer/LanguageServer.cs
+++ b/src/QsCompiler/LanguageServer/LanguageServer.cs
@@ -155,7 +155,8 @@ namespace Microsoft.Quantum.QsLanguageServer
                         Process.Start(new ProcessStartInfo
                         {
                             FileName = dotnet31Url,
-                            UseShellExecute = true
+                            UseShellExecute = true,
+                            CreateNoWindow = true,
                         });
                     }
                 }

--- a/src/QsCompiler/LanguageServer/LanguageServer.cs
+++ b/src/QsCompiler/LanguageServer/LanguageServer.cs
@@ -146,7 +146,7 @@ namespace Microsoft.Quantum.QsLanguageServer
                     var downloadAction = new MessageActionItem { Title = "Download" };
                     var cancelAction = new MessageActionItem { Title = "No, thanks" };
                     var selectedAction = await this.ShowDialogInWindowAsync(
-                        $"Quantum Development Kit Extension requires .NET Core SDK 3.1 to work properly. Please install .NET SDK 3.1.",
+                        "Quantum Development Kit Extension requires .NET Core SDK 3.1 to work properly. Please install .NET SDK 3.1.",
                         MessageType.Error,
                         new[] { downloadAction, cancelAction });
                     if (selectedAction != null

--- a/src/QsCompiler/LanguageServer/LanguageServer.csproj
+++ b/src/QsCompiler/LanguageServer/LanguageServer.csproj
@@ -13,6 +13,9 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
+    <None Remove="global.json" />
+  </ItemGroup>
+  <ItemGroup>
     <ProjectReference Include="..\CompilationManager\CompilationManager.csproj">
       <Private>true</Private>
     </ProjectReference>
@@ -36,5 +39,10 @@
   </ItemGroup>
   <ItemGroup>
     <AdditionalFiles Include="..\..\Common\stylecop.json" Link="stylecop.json" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="global.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
   </ItemGroup>
 </Project>

--- a/src/QsCompiler/LanguageServer/LanguageServer.csproj
+++ b/src/QsCompiler/LanguageServer/LanguageServer.csproj
@@ -2,12 +2,13 @@
   <Import Project="..\..\Common\AssemblyCommon.props" />
   <PropertyGroup>
     <AssemblyName>Microsoft.Quantum.QsLanguageServer</AssemblyName>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Workaround for https://github.com/dotnet/cli/issues/9514, see https://stackoverflow.com/a/51644988/267841. -->
     <TargetLatestRuntimePatch>true</TargetLatestRuntimePatch>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <DefineConstants>DEBUG;TRACE</DefineConstants>

--- a/src/QsCompiler/LanguageServer/Program.cs
+++ b/src/QsCompiler/LanguageServer/Program.cs
@@ -126,7 +126,6 @@ namespace Microsoft.Quantum.QsLanguageServer
             catch (Exception ex)
             {
                 Log("[ERROR] MsBuildLocator could not register defaults.", options.LogFile);
-                return LogAndExit(ReturnCode.MSBUILD_UNINITIALIZED, options.LogFile, ex.ToString());
             }
 
             QsLanguageServer server;

--- a/src/QsCompiler/LanguageServer/Program.cs
+++ b/src/QsCompiler/LanguageServer/Program.cs
@@ -140,6 +140,7 @@ namespace Microsoft.Quantum.QsLanguageServer
             Log("Listening...", options.LogFile);
             try
             {
+                server.CheckDotNetSDKVersion();
                 server.WaitForShutdown();
             }
             catch (Exception ex)

--- a/src/QsCompiler/LanguageServer/Program.cs
+++ b/src/QsCompiler/LanguageServer/Program.cs
@@ -83,6 +83,11 @@ namespace Microsoft.Quantum.QsLanguageServer
 
         public static int Main(string[] args)
         {
+            // We need to set the current directory to the same directory of
+            // the LanguageServer executable so that it will pick the global.json file
+            // and force the MSBuildLocator to use .NET Core SDK 3.1
+            Directory.SetCurrentDirectory(AppDomain.CurrentDomain.BaseDirectory);
+
             var parser = new Parser(parser => parser.HelpWriter = null); // we want our own custom format for the version info
             var options = parser.ParseArguments<Options>(args);
             return options.MapResult(

--- a/src/QsCompiler/LanguageServer/Program.cs
+++ b/src/QsCompiler/LanguageServer/Program.cs
@@ -140,7 +140,7 @@ namespace Microsoft.Quantum.QsLanguageServer
             Log("Listening...", options.LogFile);
             try
             {
-                server.CheckDotNetSDKVersion();
+                server.CheckDotNetSdkVersion();
                 server.WaitForShutdown();
             }
             catch (Exception ex)

--- a/src/QsCompiler/LanguageServer/Program.cs
+++ b/src/QsCompiler/LanguageServer/Program.cs
@@ -126,6 +126,9 @@ namespace Microsoft.Quantum.QsLanguageServer
             catch (Exception ex)
             {
                 Log("[ERROR] MsBuildLocator could not register defaults.", options.LogFile);
+                // Don't exit here, since exiting without establishing a connection will result in a cryptic failure of the extension. 
+                // Instead, we proceed to create a server instance and establish the connection. 
+                // Any errors can then be properly processed via the standard server-client communication as needed. 
             }
 
             QsLanguageServer server;

--- a/src/QsCompiler/LanguageServer/Utils.cs
+++ b/src/QsCompiler/LanguageServer/Utils.cs
@@ -48,7 +48,6 @@ namespace Microsoft.Quantum.QsLanguageServer
                     MessageType = severity,
                     Actions = actionItems
                 };
-            QsCompilerError.Verify(server != null && message != null, "cannot show message - given server or text was null");
             var action = await server.InvokeAsync<MessageActionItem>(Methods.WindowShowMessageRequestName, message);
             return action;
         }

--- a/src/QsCompiler/LanguageServer/Utils.cs
+++ b/src/QsCompiler/LanguageServer/Utils.cs
@@ -48,8 +48,7 @@ namespace Microsoft.Quantum.QsLanguageServer
                     MessageType = severity,
                     Actions = actionItems
                 };
-            var action = await server.InvokeAsync<MessageActionItem>(Methods.WindowShowMessageRequestName, message);
-            return action;
+            return await server.InvokeAsync<MessageActionItem>(Methods.WindowShowMessageRequestName, message);
         }
 
         /// <summary>

--- a/src/QsCompiler/LanguageServer/Utils.cs
+++ b/src/QsCompiler/LanguageServer/Utils.cs
@@ -145,16 +145,8 @@ namespace Microsoft.Quantum.QsLanguageServer
     internal static class DotNetSdkHelper
     {
         private static readonly Regex DotNet31Regex = new Regex(@"^3\.1\.\d+", RegexOptions.Multiline | RegexOptions.Compiled);
-        private static readonly Regex DotNet50Regex = new Regex(@"^5\.0\.\d+", RegexOptions.Multiline | RegexOptions.Compiled);
 
-        public class DotNetSDKVersions
-        {
-            public bool HasDotNet50 { get; set; }
-
-            public bool HasDotNet31 { get; set; }
-        }
-
-        public static DotNetSDKVersions? GetSdkVersions()
+        public static bool? IsDotNet31Installed()
         {
             var listSdkProcess = Process.Start(
                 new ProcessStartInfo()
@@ -170,11 +162,7 @@ namespace Microsoft.Quantum.QsLanguageServer
                     return null;
                 }
                 var sdks = listSdkProcess.StandardOutput.ReadToEnd();
-                return new DotNetSDKVersions()
-                {
-                    HasDotNet31 = DotNet31Regex.IsMatch(sdks),
-                    HasDotNet50 = DotNet50Regex.IsMatch(sdks),
-                };
+                return DotNet31Regex.IsMatch(sdks);
             }
             return null;
         }

--- a/src/QsCompiler/LanguageServer/global.json
+++ b/src/QsCompiler/LanguageServer/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "3.1.100",
+    "rollForward": "latestFeature"
+  }
+}


### PR DESCRIPTION
This PR mitigates issue #737 by:
1. Adding a global.json in the LanguageServer folder
1. Forcing the Working Directory of the LanguageServer to be the same as the. LanguageServer is (and. therefore using the global.json from step above)
1. Not quitting the LanguageServer if there was an issue with the MSBuildLocator when .NET Core SDK 3.1 is not found
1. Check if .NET Core SDK 3.1 is not installed and display a message to the user with an option to download it (opens the download page) and asking the user to restart VS/Code.