### PR TITLE
Fix pruning of specialization dependencies

### DIFF
--- a/src/QsCompiler/Tests.Compiler/CallGraphTests.fs
+++ b/src/QsCompiler/Tests.Compiler/CallGraphTests.fs
@@ -334,7 +334,7 @@ type CallGraphTests (output:ITestOutputHelper) =
         AssertNotInConcreteGraph graph FooEmpty
         AssertNotInConcreteGraph graph BarEmpty
 
-    [<Fact>]
+    [<Fact(Skip="Workaround for Issue #757 means specialization pruning is disabled.")>]
     [<Trait("Category","Populate Call Graph")>]
     member this.``Concrete Graph Trims Specializations`` () =
         let graph = PopulateCallGraphWithExe 10 |> ConcreteCallGraph

--- a/src/QsCompiler/Tests.Compiler/LinkingTests.fs
+++ b/src/QsCompiler/Tests.Compiler/LinkingTests.fs
@@ -207,7 +207,7 @@ type LinkingTests (output:ITestOutputHelper) =
             "Callables originally public should remain public if all arguments are public.")
 
     
-    [<Fact>]
+    [<Fact(Skip="Workaround for Issue #757 means this test will fail due to unpruned specializations.")>]
     [<Trait("Category","Monomorphization")>]
     member this.``Monomorphization Basic Implementation`` () =
 

--- a/src/QsCompiler/Transformations/CallGraph/ConcreteCallGraphWalker.cs
+++ b/src/QsCompiler/Transformations/CallGraph/ConcreteCallGraphWalker.cs
@@ -198,27 +198,33 @@ namespace Microsoft.Quantum.QsCompiler.Transformations.CallGraphWalker
 
                     void AddEdge(QsSpecializationKind kind) => this.AddEdge(identifier, kind, typeRes, referenceRange);
 
-                    if (this.IsInCall)
-                    {
-                        if (this.HasAdjointDependency && this.HasControlledDependency)
-                        {
-                            AddEdge(QsSpecializationKind.QsControlledAdjoint);
-                        }
-                        else if (this.HasAdjointDependency)
-                        {
-                            AddEdge(QsSpecializationKind.QsAdjoint);
-                        }
-                        else if (this.HasControlledDependency)
-                        {
-                            AddEdge(QsSpecializationKind.QsControlled);
-                        }
-                        else
-                        {
-                            AddEdge(QsSpecializationKind.QsBody);
-                        }
-                    }
-                    else
-                    {
+                    // Work around for Issue #757: Because the below code means specializations that are not explicitly 
+                    // called don't get an edge, any dependencies specific to those specializations don't get included
+                    // in the graph and may end up getting pruned out. This can cause compilation failures,
+                    // because specializations are not pruned but the dependecies are, leaving behind usage
+                    // of types that don't exist.
+                    // if (this.IsInCall)
+                    // {
+                    //     if (this.HasAdjointDependency && this.HasControlledDependency)
+                    //     {
+                    //         AddEdge(QsSpecializationKind.QsControlledAdjoint);
+                    //     }
+                    //     else if (this.HasAdjointDependency)
+                    //     {
+                    //         AddEdge(QsSpecializationKind.QsAdjoint);
+                    //     }
+                    //     else if (this.HasControlledDependency)
+                    //     {
+                    //         AddEdge(QsSpecializationKind.QsControlled);
+                    //     }
+                    //     else
+                    //     {
+                    //         AddEdge(QsSpecializationKind.QsBody);
+                    //     }
+                    // }
+                    // else
+                    // {
+
                         // The callable is being used in a non-call context, such as being
                         // assigned to a variable or passed as an argument to another callable,
                         // which means it could get a functor applied at some later time.
@@ -227,7 +233,8 @@ namespace Microsoft.Quantum.QsCompiler.Transformations.CallGraphWalker
                         {
                             AddEdge(kind);
                         }
-                    }
+
+                    // }
                 }
 
                 /// <summary>


### PR DESCRIPTION
This comments out some code so that any dependency on an operation results in an edge to each specialization of that operation instead of just the specific specialization used. This is a patch to eliminate the issue, but we should consider either eliminating the commented out code and making this design change permanent (never prune dependencies of specializations even if they are unused), or allow for the pruning of both unused dependencies and the unused specialization itself.

Note that this also skips tests that fail due to the given work around.

Works around #757 