### PR TITLE
Update example to 0.14.2011120240 and addressed the removal of NonNullable

### DIFF
--- a/examples/CompilerExtensions/CustomExtension/CustomExtension.csproj
+++ b/examples/CompilerExtensions/CustomExtension/CustomExtension.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Compiler" Version="0.13.20102604" />
+    <PackageReference Include="Microsoft.Quantum.Compiler" Version="0.14.2011120240" />
   </ItemGroup>
 
 </Project>

--- a/examples/CompilerExtensions/CustomExtension/ListIdentifiers.cs
+++ b/examples/CompilerExtensions/CustomExtension/ListIdentifiers.cs
@@ -121,7 +121,7 @@ namespace Microsoft.Quantum.Demos.CompilerExtensions.Demo
                 (Identifier sym, QsNullable<ImmutableArray<ResolvedType>> tArgs)
             {
                 var name =
-                    sym is Identifier.LocalVariable var ? var.Item.Value :
+                    sym is Identifier.LocalVariable var ? var.Item :
                     sym is Identifier.GlobalCallable global ? global.Item.ToString() :
                     null;
 

--- a/examples/CompilerExtensions/CustomExtension/Utils.cs
+++ b/examples/CompilerExtensions/CustomExtension/Utils.cs
@@ -21,14 +21,14 @@ namespace Microsoft.Quantum.Demos.CompilerExtensions.Demo
     internal class Display
     {
         private readonly QsCompilation Compilation;
-        private readonly ImmutableHashSet<NonNullable<string>> SourceFiles;
-        private readonly ImmutableDictionary<NonNullable<string>, ImmutableArray<(NonNullable<string>, string)>> Imports;
+        private readonly ImmutableHashSet<string> SourceFiles;
+        private readonly ImmutableDictionary<string, ImmutableArray<(string, string)>> Imports;
 
         internal Display(QsCompilation compilation)
         {
             this.Compilation = compilation;
             this.SourceFiles = GetSourceFiles.Apply(compilation.Namespaces);
-            this.Imports = compilation.Namespaces.ToImmutableDictionary(ns => ns.Name, _ => ImmutableArray<(NonNullable<string>, string)>.Empty);
+            this.Imports = compilation.Namespaces.ToImmutableDictionary(ns => ns.Name, _ => ImmutableArray<(string, string)>.Empty);
         }
 
         /// <summary>
@@ -41,13 +41,13 @@ namespace Microsoft.Quantum.Demos.CompilerExtensions.Demo
         public void Show(string sourceFile = null)
         {
             var filesToShow = sourceFile == null
-                ? this.SourceFiles.Where(f => f.Value.EndsWith(".qs")).OrderBy(f => f).Select(f => (f, this.Imports)).ToArray()
-                : new[] { (NonNullable<string>.New(sourceFile), this.Imports) };
+                ? this.SourceFiles.Where(f => f.EndsWith(".qs")).OrderBy(f => f).Select(f => (f, this.Imports)).ToArray()
+                : new[] { (sourceFile, this.Imports) };
 
-            SyntaxTreeToQsharp.Apply(out List<ImmutableDictionary<NonNullable<string>, string>> generated, this.Compilation.Namespaces, filesToShow);
+            SyntaxTreeToQsharp.Apply(out List<ImmutableDictionary<string, string>> generated, this.Compilation.Namespaces, filesToShow);
             var code = generated.SelectMany((namespaces, sourceIndex) =>
                 namespaces.Values
-                .Prepend($"// Compiled Q# code from file \"{filesToShow[sourceIndex].Item1.Value}\":")
+                .Prepend($"// Compiled Q# code from file \"{filesToShow[sourceIndex].Item1}\":")
                 .Select(nsCode => $"{nsCode}{Environment.NewLine}"));
 
             try

--- a/examples/CompilerExtensions/Demo/Demo.csproj
+++ b/examples/CompilerExtensions/Demo/Demo.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.Quantum.Sdk/0.11.2006.2118-beta">
+﻿<Project Sdk="Microsoft.Quantum.Sdk/0.14.2011120240">
 
   <PropertyGroup>
     <QscVerbosity>Detailed</QscVerbosity>

--- a/examples/CompilerExtensions/ExtensionPackage/CustomExtension.Package.nuspec
+++ b/examples/CompilerExtensions/ExtensionPackage/CustomExtension.Package.nuspec
@@ -12,7 +12,7 @@
     <copyright></copyright>
     <tags></tags>
     <dependencies>
-      <dependency id="Microsoft.Quantum.Compiler" version="0.13.20102604" />
+      <dependency id="Microsoft.Quantum.Compiler" version="0.14.2011120240" />
     </dependencies>
     <summary></summary>
   </metadata>


### PR DESCRIPTION
Bumped the example from the old SDK to the latest one and removed the usage of `NonNullable` from it, following https://github.com/microsoft/qsharp-compiler/pull/729