### PR TITLE
Update ms.topic value in DocumentationWriter.cs

### DIFF
--- a/src/Documentation/DocumentationGenerator/DocumentationWriter.cs
+++ b/src/Documentation/DocumentationGenerator/DocumentationWriter.cs
@@ -152,7 +152,7 @@ namespace Microsoft.Quantum.Documentation
 
                 // docs.ms metadata
                 ["ms.date"] = DateTime.Today.ToString(),
-                ["ms.topic"] = "article",
+                ["ms.topic"] = "managed-reference",
 
                 // Q# metadata
                 ["qsharp.kind"] = "namespace",


### PR DESCRIPTION
For SEO tracking and statistics, the API topics should have an ms.topic value of 'managed-reference'. While the value 'article' is valid, it's a generic value that doesn't provide granular data.