### PR TITLE
Fix ClassicallyControlled Rewrite bugs

### DIFF
--- a/src/QsCompiler/Tests.Compiler/ClassicalControlTests.fs
+++ b/src/QsCompiler/Tests.Compiler/ClassicalControlTests.fs
@@ -1384,3 +1384,82 @@ type ClassicalControlTests () =
         [(1, BuiltIn.ApplyIfZero)]
         |> Seq.map ExpandBuiltInQualifiedSymbol
         |> AssertSpecializationHasCalls originalOp
+
+    [<Fact>]
+    [<Trait("Category","Condition API Conversion")>]
+    member this.``Simple NOT condition`` () =
+        let (_, args) = CompileClassicalControlTest 37 |> ApplyIfElseTest
+
+        let SubOp1 = {Namespace = "SubOps"; Name = "SubOp1"}
+        let SubOp2 = {Namespace = "SubOps"; Name = "SubOp2"}
+
+        IsApplyIfElseArgsMatch args "r" SubOp2 SubOp1
+        |> (fun (x, _, _, _, _) -> Assert.True(x, "ApplyIfElse did not have the correct arguments"))
+
+    [<Fact>]
+    [<Trait("Category","Condition API Conversion")>]
+    member this.``Outer NOT condition`` () =
+        let result  = CompileClassicalControlTest 38
+
+        let ifOp = {Namespace = "SubOps"; Name = "SubOp1"}
+        let elseOp = {Namespace = "SubOps"; Name = "SubOp2"}
+        let original = GetCallableWithName result Signatures.ClassicalControlNs "Foo" |> GetBodyFromCallable
+        let generated = GetCallablesWithSuffix result Signatures.ClassicalControlNs "_Foo"
+                        |> (fun x -> Assert.True(1 = Seq.length x); Seq.item 0 x |> GetBodyFromCallable)
+
+        let lines = original |> GetLinesFromSpecialization
+        Assert.True(2 = Seq.length lines, sprintf "Callable %O(%A) did not have the expected number of statements" original.Parent original.Kind)
+        let (success, _, args) = CheckIfLineIsCall BuiltIn.ApplyIfElseR.FullName.Namespace BuiltIn.ApplyIfElseR.FullName.Name lines.[1]
+        Assert.True(success, sprintf "Callable %O(%A) did not have expected content" original.Parent original.Kind)
+
+        let errorMsg = "ApplyIfElse did not have the correct arguments"
+        IsApplyIfElseArgsMatch args "r" elseOp generated.Parent
+        |> (fun (x, _, _, _, _) -> Assert.True(x, errorMsg))
+
+        let lines = generated |> GetLinesFromSpecialization
+        Assert.True(1 = Seq.length lines, sprintf "Callable %O(%A) did not have the expected number of statements" generated.Parent generated.Kind)
+        let (success, _, args) = CheckIfLineIsCall BuiltIn.ApplyIfElseR.FullName.Namespace BuiltIn.ApplyIfElseR.FullName.Name lines.[0]
+        Assert.True(success, sprintf "Callable %O(%A) did not have expected content" generated.Parent generated.Kind)
+
+        IsApplyIfElseArgsMatch args "r" ifOp elseOp
+        |> (fun (x, _, _, _, _) -> Assert.True(x, errorMsg))
+
+    [<Fact>]
+    [<Trait("Category","Condition API Conversion")>]
+    member this.``Nested NOT condition`` () =
+        let result  = CompileClassicalControlTest 39
+
+        let ifOp = {Namespace = "SubOps"; Name = "SubOp1"}
+        let elseOp = {Namespace = "SubOps"; Name = "SubOp2"}
+        let original = GetCallableWithName result Signatures.ClassicalControlNs "Foo" |> GetBodyFromCallable
+        let generated = GetCallablesWithSuffix result Signatures.ClassicalControlNs "_Foo"
+                        |> (fun x -> Assert.True(1 = Seq.length x); Seq.item 0 x |> GetBodyFromCallable)
+
+        let lines = original |> GetLinesFromSpecialization
+        Assert.True(2 = Seq.length lines, sprintf "Callable %O(%A) did not have the expected number of statements" original.Parent original.Kind)
+        let (success, _, args) = CheckIfLineIsCall BuiltIn.ApplyIfElseR.FullName.Namespace BuiltIn.ApplyIfElseR.FullName.Name lines.[1]
+        Assert.True(success, sprintf "Callable %O(%A) did not have expected content" original.Parent original.Kind)
+
+        let errorMsg = "ApplyIfElse did not have the correct arguments"
+        IsApplyIfElseArgsMatch args "r" ifOp generated.Parent
+        |> (fun (x, _, _, _, _) -> Assert.True(x, errorMsg))
+
+        let lines = generated |> GetLinesFromSpecialization
+        Assert.True(1 = Seq.length lines, sprintf "Callable %O(%A) did not have the expected number of statements" generated.Parent generated.Kind)
+        let (success, _, args) = CheckIfLineIsCall BuiltIn.ApplyIfElseR.FullName.Namespace BuiltIn.ApplyIfElseR.FullName.Name lines.[0]
+        Assert.True(success, sprintf "Callable %O(%A) did not have expected content" generated.Parent generated.Kind)
+
+        IsApplyIfElseArgsMatch args "r" ifOp elseOp
+        |> (fun (x, _, _, _, _) -> Assert.True(x, errorMsg))
+
+    [<Fact>]
+    [<Trait("Category","Condition API Conversion")>]
+    member this.``One-sided NOT condition`` () =
+        let (_, args) = CompileClassicalControlTest 40 |> ApplyIfElseTest
+
+        let SubOp1 = {Namespace = "SubOps"; Name = "SubOp1"}
+        let NoOp = {Namespace = "Microsoft.Quantum.Canon"; Name = "NoOp"}
+
+        IsApplyIfElseArgsMatch args "r" SubOp1 NoOp
+        |> (fun (x, _, _, _, _) -> Assert.True(x, "ApplyIfElse did not have the correct arguments"))
+

--- a/src/QsCompiler/Tests.Compiler/TestCases/ClassicalControl.qs
+++ b/src/QsCompiler/Tests.Compiler/TestCases/ClassicalControl.qs
@@ -1038,3 +1038,72 @@ namespace Microsoft.Quantum.Testing.ClassicalControl {
         }
     }
 }
+
+// =================================
+
+// Simple NOT condition
+namespace Microsoft.Quantum.Testing.ClassicalControl {
+    open SubOps;
+
+    operation Foo() : Unit {
+        let r = Zero;
+
+        if (not (r == Zero)) {
+            SubOp1();
+        }
+        else {
+            SubOp2();
+        }
+    }
+}
+
+// =================================
+
+// Outer NOT condition
+namespace Microsoft.Quantum.Testing.ClassicalControl {
+    open SubOps;
+
+    operation Foo() : Unit {
+        let r = Zero;
+
+        if (not (r == Zero or r == One)) {
+            SubOp1();
+        }
+        else {
+            SubOp2();
+        }
+    }
+}
+
+// =================================
+
+// Nested NOT condition
+namespace Microsoft.Quantum.Testing.ClassicalControl {
+    open SubOps;
+
+    operation Foo() : Unit {
+        let r = Zero;
+
+        if (r == Zero or not (r == One)) {
+            SubOp1();
+        }
+        else {
+            SubOp2();
+        }
+    }
+}
+
+// =================================
+
+// One-Sided NOT condition
+namespace Microsoft.Quantum.Testing.ClassicalControl {
+    open SubOps;
+
+    operation Foo() : Unit {
+        let r = Zero;
+
+        if (not (r == One)) {
+            SubOp1();
+        }
+    }
+}

--- a/src/QsCompiler/Tests.Compiler/TestUtils/Signatures.fs
+++ b/src/QsCompiler/Tests.Compiler/TestUtils/Signatures.fs
@@ -418,5 +418,19 @@ let public ClassicalControlSignatures =
         (_DefaultTypes, [| // Literal on the Left
             ClassicalControlNs, "Foo", [||], "Unit"
         |])
+        (_DefaultTypes, [| // Simple NOT condition
+            ClassicalControlNs, "Foo", [||], "Unit"
+        |])
+        (_DefaultTypes, [| // Outer NOT condition
+            ClassicalControlNs, "Foo", [||], "Unit"
+            ClassicalControlNs, "_Foo", [|"Result"|], "Unit"
+        |])
+        (_DefaultTypes, [| // Nested NOT condition
+            ClassicalControlNs, "Foo", [||], "Unit"
+            ClassicalControlNs, "_Foo", [|"Result"|], "Unit"
+        |])
+        (_DefaultTypes, [| // One-sided NOT condition
+            ClassicalControlNs, "Foo", [||], "Unit"
+        |])
     |]
     |> _MakeSignatures

--- a/src/QsCompiler/Transformations/ClassicallyControlled.cs
+++ b/src/QsCompiler/Transformations/ClassicallyControlled.cs
@@ -932,7 +932,7 @@ namespace Microsoft.Quantum.QsCompiler.Transformations.ClassicallyControlled
                         }
 
                         this.SharedState.GeneratedOpParams = contextParams;
-                        this.SharedState.IsValidScope = this.SharedState.IsValidScope && contextValidScope;
+                        this.SharedState.IsValidScope = contextValidScope;
 
                         if (!this.SharedState.IsConditionLiftable)
                         {
@@ -976,7 +976,7 @@ namespace Microsoft.Quantum.QsCompiler.Transformations.ClassicallyControlled
                         }
 
                         this.SharedState.GeneratedOpParams = contextParams;
-                        this.SharedState.IsValidScope = this.SharedState.IsValidScope && contextValidScope;
+                        this.SharedState.IsValidScope = contextValidScope;
                     }
 
                     if (this.SharedState.IsConditionLiftable)

--- a/src/QsCompiler/Transformations/ClassicallyControlled.cs
+++ b/src/QsCompiler/Transformations/ClassicallyControlled.cs
@@ -172,22 +172,25 @@ namespace Microsoft.Quantum.QsCompiler.Transformations.ClassicallyControlled
 
                     if (condition.Expression is ExpressionKind.NOT notCondition)
                     {
-                        var newConditionalBlock = conditionStatement.Default;
-                        if (newConditionalBlock.IsNull)
+                        if (conditionStatement.Default.IsValue)
+                        {
+                            return (true, new QsConditionalStatement(
+                                ImmutableArray.Create(Tuple.Create(notCondition.Item, conditionStatement.Default.Item)),
+                                QsNullable<QsPositionedBlock>.NewValue(block)));
+                        }
+                        else
                         {
                             var emptyScope = new QsScope(
                                 ImmutableArray<QsStatement>.Empty,
                                 LocalDeclarations.Empty);
-                            newConditionalBlock = QsNullable<QsPositionedBlock>.NewValue(
-                                new QsPositionedBlock(
+                            var newConditionalBlock = new QsPositionedBlock(
                                     emptyScope,
                                     QsNullable<QsLocation>.Null,
-                                    QsComments.Empty));
+                                    QsComments.Empty);
+                            return (true, new QsConditionalStatement(
+                                ImmutableArray.Create(Tuple.Create(notCondition.Item, newConditionalBlock)),
+                                QsNullable<QsPositionedBlock>.NewValue(block)));
                         }
-
-                        return (true, new QsConditionalStatement(
-                            ImmutableArray.Create(Tuple.Create(notCondition.Item, newConditionalBlock.Item)),
-                            QsNullable<QsPositionedBlock>.NewValue(block)));
                     }
                     else
                     {


### PR DESCRIPTION
This change includes 3 fixes/updates to the ClassicallyControlled rewrite step:
1. It adds handling for ExpressionKind.NOT so that those conditions get properly restructured and processed for lifting (fixes #763)
2. If a conditional statement has an empty scope, it gets replaced with a call to `NoOp` instead of being lifted into an empty callable.
3. <s>Updates the propagation of `IsValidScope` through the recursive calls to avoid lifting outer conditional scopes when inner scopes are not valid for lifting.</s> The fix here was incorrect, so it was removed and a separate issue https://github.com/microsoft/qsharp-compiler/issues/768 was filed.

Things left to do before check-in:

- [x] Add test cases for conditional lifting with NOT (top level and nested condition)
- [x] Add test case for lifting an empty scope (becomes `NoOp`)
- [x] <s>Add test case for nested conditionals that cannot be lifted</s>