### PR TITLE
QIR generation bug fixes

### DIFF
--- a/src/QsCompiler/QirGeneration/Context.cs
+++ b/src/QsCompiler/QirGeneration/Context.cs
@@ -261,7 +261,7 @@ namespace Microsoft.Quantum.QsCompiler.QIR
         public void InitializeRuntimeLibrary()
         {
             // int library functions
-            this.runtimeLibrary.AddFunction(RuntimeLibrary.IntPower, this.Types.Int, this.Types.Int, this.Types.Int);
+            this.runtimeLibrary.AddFunction(RuntimeLibrary.IntPower, this.Types.Int, this.Types.Int, this.Context.Int32Type);
 
             // result library functions
             this.runtimeLibrary.AddFunction(RuntimeLibrary.ResultReference, this.Context.VoidType, this.Types.Result);
@@ -1036,7 +1036,15 @@ namespace Microsoft.Quantum.QsCompiler.QIR
                     }
                     else
                     {
-                        funcs[index] = Constant.NullValueFor(funcs[0].NativeType);
+                        try
+                        {
+                            funcs[index] = Constant.NullValueFor(funcs[0].NativeType);
+                        }
+                        catch (NullReferenceException)
+                        {
+                            Console.WriteLine($"null ref exception for {kind} of {callable.FullName}");
+                            throw;
+                        }
                     }
                 }
 

--- a/src/QsCompiler/QirGeneration/Context.cs
+++ b/src/QsCompiler/QirGeneration/Context.cs
@@ -858,7 +858,7 @@ namespace Microsoft.Quantum.QsCompiler.QIR
         /// </summary>
         /// <param name="spec">The Q# specialization for which to register a function.</param>
         /// <param name="argTuple">The specialization's argument tuple.</param>
-        internal void GenerateFunctionHeader(QsSpecialization spec, QsArgumentTuple argTuple) // UDT FAILING HERE - UNRELATED TO WRAPPER GEN
+        internal void GenerateFunctionHeader(QsSpecialization spec, QsArgumentTuple argTuple)
         {
             IEnumerable<string> ArgTupleToNames(QsArgumentTuple arg, Queue<(string, QsArgumentTuple)> tupleQueue)
             {
@@ -882,12 +882,7 @@ namespace Microsoft.Quantum.QsCompiler.QIR
                     : new[] { LocalVarName(arg) };
             }
 
-            this.CurrentFunction = this.RegisterFunction(spec, argTuple); // FIXME: CURRENT FUNCTION HERE IS NULL
-            if (this.CurrentFunction == null)
-            {
-                throw new Exception("null here");
-            }
-
+            this.CurrentFunction = this.RegisterFunction(spec, argTuple);
             this.CurrentBlock = this.CurrentFunction.AppendBasicBlock("entry");
             this.CurrentBuilder = new InstructionBuilder(this.CurrentBlock);
 
@@ -1040,19 +1035,6 @@ namespace Microsoft.Quantum.QsCompiler.QIR
                         var f = this.Module.CreateFunction(FunctionWrapperName(callable.FullName, kind), this.Types.FunctionSignature);
                         funcs[index] = f;
                     }
-                    //else if (callable.IsIntrinsic)
-                    //{
-                    //    if (!this.TryGetWrapper(callable, kind, out var wrapper))
-                    //    {
-                    //        throw new InvalidOperationException("wrapper not found");
-                    //    }
-                    //    funcs[index] = Constant.NullValueFor(wrapper.NativeType);
-                    //
-                    //    //var nativeType = SymbolResolution.TryGetTargetInstructionName(callable.Attributes) is var att && att.IsValue
-                    //    //    ? this.quantumInstructionSet.GetOrCreateFunction(att.Item).NativeType
-                    //    //    : throw new InvalidOperationException("intrinsic callable without a target instruction attribute"); // TODO: PUT INTO PRECONDITION
-                    //    //funcs[index] = Constant.NullValueFor(nativeType);
-                    //}
                     else
                     {
                         funcs[index] = Constant.NullValueFor(funcs[0].NativeType);
@@ -1159,7 +1141,7 @@ namespace Microsoft.Quantum.QsCompiler.QIR
                     // Start with 1 because the 0 element of the LLVM structures is the tuple header
                     for (int i = 1; i <= itemCount; i++)
                     {
-                        // TODO: COMPLETE THE IMPLEMENTATION
+                        // TODO: complete implementation
                     }
                 }
                 else if (!resultType.Resolution.IsUnitType)
@@ -1170,7 +1152,6 @@ namespace Microsoft.Quantum.QsCompiler.QIR
                         outputTuple,
                         new[] { this.Context.CreateConstant(0L), this.Context.CreateConstant(item) });
 
-                    // TODO: MAKE A COMMON HELPER FUNCTION FOR UDT UNWRAPPING...
                     // if the returned value is a udt with a single item then we need to unwrap it first
                     if (resultType.Resolution is QsResolvedTypeKind.UserDefinedType udt
                         && this.TryGetCustomType(udt.Item.GetFullName(), out var udtDecl)

--- a/src/QsCompiler/QirGeneration/Context.cs
+++ b/src/QsCompiler/QirGeneration/Context.cs
@@ -818,7 +818,7 @@ namespace Microsoft.Quantum.QsCompiler.QIR
         }
 
         /// <summary>
-        /// Generates the declaration for a QIR function to the current module.
+        /// Adds the declaration for a QIR function to the current module.
         /// Usually <see cref="GenerateFunctionHeader"/> is used, which generates the start of the actual definition.
         /// This method is primarily useful for Q# specializations with external or intrinsic implementations, which get
         /// generated as declarations with no definition.
@@ -858,7 +858,7 @@ namespace Microsoft.Quantum.QsCompiler.QIR
         /// </summary>
         /// <param name="spec">The Q# specialization for which to register a function.</param>
         /// <param name="argTuple">The specialization's argument tuple.</param>
-        internal void GenerateFunctionHeader(QsSpecialization spec, QsArgumentTuple argTuple)
+        internal void GenerateFunctionHeader(QsSpecialization spec, QsArgumentTuple argTuple) // UDT FAILING HERE - UNRELATED TO WRAPPER GEN
         {
             IEnumerable<string> ArgTupleToNames(QsArgumentTuple arg, Queue<(string, QsArgumentTuple)> tupleQueue)
             {
@@ -882,7 +882,12 @@ namespace Microsoft.Quantum.QsCompiler.QIR
                     : new[] { LocalVarName(arg) };
             }
 
-            this.CurrentFunction = this.RegisterFunction(spec, argTuple);
+            this.CurrentFunction = this.RegisterFunction(spec, argTuple); // FIXME: CURRENT FUNCTION HERE IS NULL
+            if (this.CurrentFunction == null)
+            {
+                throw new Exception("null here");
+            }
+
             this.CurrentBlock = this.CurrentFunction.AppendBasicBlock("entry");
             this.CurrentBuilder = new InstructionBuilder(this.CurrentBlock);
 
@@ -1015,7 +1020,7 @@ namespace Microsoft.Quantum.QsCompiler.QIR
         /// If a wrapper for the given callable already exists, returns the corresponding global variable.
         /// If no such wrapper exists, queues the generation of the wrapper and returns the corresponding global variable.
         /// </summary>
-        internal GlobalVariable GetWrapperName(QsCallable callable)
+        internal GlobalVariable GetOrCreateWrapper(QsCallable callable)
         {
             var key = $"{FlattenNamespaceName(callable.FullName.Namespace)}__{callable.FullName.Name}";
             if (this.wrapperQueue.TryGetValue(key, out (QsCallable, GlobalVariable) item))
@@ -1029,11 +1034,25 @@ namespace Microsoft.Quantum.QsCompiler.QIR
                 for (var index = 0; index < 4; index++)
                 {
                     QsSpecializationKind kind = FunctionArray[index];
-                    if (callable.Specializations.Any(spec => spec.Kind == kind && spec.Implementation.IsProvided))
+                    if (callable.Specializations.Any(spec => spec.Kind == kind &&
+                        (spec.Implementation.IsProvided || spec.Implementation.IsIntrinsic)))
                     {
                         var f = this.Module.CreateFunction(FunctionWrapperName(callable.FullName, kind), this.Types.FunctionSignature);
                         funcs[index] = f;
                     }
+                    //else if (callable.IsIntrinsic)
+                    //{
+                    //    if (!this.TryGetWrapper(callable, kind, out var wrapper))
+                    //    {
+                    //        throw new InvalidOperationException("wrapper not found");
+                    //    }
+                    //    funcs[index] = Constant.NullValueFor(wrapper.NativeType);
+                    //
+                    //    //var nativeType = SymbolResolution.TryGetTargetInstructionName(callable.Attributes) is var att && att.IsValue
+                    //    //    ? this.quantumInstructionSet.GetOrCreateFunction(att.Item).NativeType
+                    //    //    : throw new InvalidOperationException("intrinsic callable without a target instruction attribute"); // TODO: PUT INTO PRECONDITION
+                    //    //funcs[index] = Constant.NullValueFor(nativeType);
+                    //}
                     else
                     {
                         funcs[index] = Constant.NullValueFor(funcs[0].NativeType);
@@ -1132,7 +1151,7 @@ namespace Microsoft.Quantum.QsCompiler.QIR
 
             void PopulateResultTuple(ResolvedType resultType, Value resultValue, Value resultTuplePointer, int item)
             {
-                var resultTupleTypeRef = this.LlvmStructTypeFromQsharpType(resultType);
+                var resultTupleType = this.LlvmStructTypeFromQsharpType(resultType);
                 if (resultType.Resolution is QsResolvedTypeKind.TupleType tupleType)
                 {
                     // Here we'll step through and recurse
@@ -1140,16 +1159,32 @@ namespace Microsoft.Quantum.QsCompiler.QIR
                     // Start with 1 because the 0 element of the LLVM structures is the tuple header
                     for (int i = 1; i <= itemCount; i++)
                     {
-                        // TODO: complete the implementation
+                        // TODO: COMPLETE THE IMPLEMENTATION
                     }
                 }
                 else if (!resultType.Resolution.IsUnitType)
                 {
-                    Value structPointer = this.CurrentBuilder.BitCast(resultTuplePointer, resultTupleTypeRef.CreatePointerType());
+                    Value outputTuple = this.CurrentBuilder.BitCast(resultTuplePointer, resultTupleType.CreatePointerType());
                     Value resultPointer = this.CurrentBuilder.GetElementPtr(
-                        resultTupleTypeRef,
-                        structPointer,
+                        resultTupleType,
+                        outputTuple,
                         new[] { this.Context.CreateConstant(0L), this.Context.CreateConstant(item) });
+
+                    // TODO: MAKE A COMMON HELPER FUNCTION FOR UDT UNWRAPPING...
+                    // if the returned value is a udt with a single item then we need to unwrap it first
+                    if (resultType.Resolution is QsResolvedTypeKind.UserDefinedType udt
+                        && this.TryGetCustomType(udt.Item.GetFullName(), out var udtDecl)
+                        && !udtDecl.Type.Resolution.IsTupleType)
+                    {
+                        var tuplePointer = this.CurrentBuilder.BitCast(resultValue, resultTupleType.CreatePointerType());
+                        var itemType = this.LlvmTypeFromQsharpType(udtDecl.Type);
+                        var itemPointer = this.CurrentBuilder.GetElementPtr(
+                             resultTupleType,
+                             tuplePointer,
+                             new[] { this.Context.CreateConstant(0L), this.Context.CreateConstant(1) });
+                        resultValue = this.CurrentBuilder.Load(itemType, itemPointer);
+                    }
+
                     this.CurrentBuilder.Store(resultValue, resultPointer);
                 }
             }
@@ -1190,7 +1225,8 @@ namespace Microsoft.Quantum.QsCompiler.QIR
                 var callable = kvp.Value.Item1;
                 foreach (var spec in callable.Specializations)
                 {
-                    if (spec.Implementation.IsProvided && GenerateWrapperHeader(callable, spec) && this.CurrentFunction != null)
+                    if ((spec.Implementation.IsProvided || spec.Implementation.IsIntrinsic)
+                        && GenerateWrapperHeader(callable, spec) && this.CurrentFunction != null)
                     {
                         Value argTupleValue = this.CurrentFunction.Parameters[1];
                         var argList = GenerateArgTupleDecomposition(callable.ArgumentTuple, argTupleValue, spec.Kind);

--- a/src/QsCompiler/QirGeneration/Context.cs
+++ b/src/QsCompiler/QirGeneration/Context.cs
@@ -1036,15 +1036,7 @@ namespace Microsoft.Quantum.QsCompiler.QIR
                     }
                     else
                     {
-                        try
-                        {
-                            funcs[index] = Constant.NullValueFor(funcs[0].NativeType);
-                        }
-                        catch (NullReferenceException)
-                        {
-                            Console.WriteLine($"null ref exception for {kind} of {callable.FullName}");
-                            throw;
-                        }
+                        funcs[index] = Constant.NullValueFor(funcs[0].NativeType);
                     }
                 }
 

--- a/src/QsCompiler/QirGeneration/Subtransformations/ExpressionKindTransformation.cs
+++ b/src/QsCompiler/QirGeneration/Subtransformations/ExpressionKindTransformation.cs
@@ -436,7 +436,6 @@ namespace Microsoft.Quantum.QsCompiler.QIR
 
         private void BuildPartialApplication(TypedExpression method, TypedExpression arg)
         {
-            // FIXME: I SUSPECT THIS ONE IS WRONG HERE
             RebuildItem BuildPartialArgList(ResolvedType argType, TypedExpression arg, List<ResolvedType> remainingArgs, List<(Value, ResolvedType)> capturedValues)
             {
                 // We need argType because _'s -- missing expressions -- have MissingType, rather than the actual type.
@@ -1557,7 +1556,7 @@ namespace Microsoft.Quantum.QsCompiler.QIR
                 string name = local.Item;
                 this.SharedState.PushNamedValue(name);
             }
-            else if (sym is Identifier.GlobalCallable globalCallable) // FIXME: WHAT IF IT IS A TYPE CONSTRUCTOR??
+            else if (sym is Identifier.GlobalCallable globalCallable)
             {
                 if (this.SharedState.TryGetGlobalCallable(globalCallable.Item, out QsCallable? callable))
                 {
@@ -2337,6 +2336,9 @@ namespace Microsoft.Quantum.QsCompiler.QIR
 
         public override ResolvedExpression OnUnwrapApplication(TypedExpression ex)
         {
+            // Since we simply represent user defined types as tuples,
+            // we don't need to do anything unless the tuples contains a single item,
+            // in which case we need to remove the tuple wrapping.
             if (ex.ResolvedType.Resolution is QsResolvedTypeKind.UserDefinedType udt
                 && this.SharedState.TryGetCustomType(udt.Item.GetFullName(), out var udtDecl)
                 && !udtDecl.Type.Resolution.IsTupleType)

--- a/src/QsCompiler/QirGeneration/Subtransformations/ExpressionKindTransformation.cs
+++ b/src/QsCompiler/QirGeneration/Subtransformations/ExpressionKindTransformation.cs
@@ -1496,8 +1496,10 @@ namespace Microsoft.Quantum.QsCompiler.QIR
 
             if (lhs.ResolvedType.Resolution.IsInt)
             {
+                // RHS must be an integer that can fit into an i32
+                var exponent = this.SharedState.CurrentBuilder.IntCast(rhsValue, this.SharedState.Context.Int32Type, true);
                 var powFunc = this.SharedState.GetOrCreateRuntimeFunction(RuntimeLibrary.IntPower);
-                this.SharedState.ValueStack.Push(this.SharedState.CurrentBuilder.Call(powFunc, lhsValue, rhsValue));
+                this.SharedState.ValueStack.Push(this.SharedState.CurrentBuilder.Call(powFunc, lhsValue, exponent));
             }
             else if (lhs.ResolvedType.Resolution.IsDouble)
             {
@@ -1588,7 +1590,7 @@ namespace Microsoft.Quantum.QsCompiler.QIR
                 string name = local.Item;
                 this.SharedState.PushNamedValue(name);
             }
-            else if (sym is Identifier.GlobalCallable globalCallable)
+            else if (sym is Identifier.GlobalCallable globalCallable) // FIXME: WHAT IF IT IS A TYPE CONSTRUCTOR??
             {
                 if (this.SharedState.TryGetGlobalCallable(globalCallable.Item, out QsCallable? callable))
                 {

--- a/src/QsCompiler/Tests.Compiler/QirTests.fs
+++ b/src/QsCompiler/Tests.Compiler/QirTests.fs
@@ -72,7 +72,11 @@ let ``QIR UDT construction`` () =
 [<Fact>]
 let ``QIR UDT accessor`` () =
     qirTest false "TestUdtAccessor"
-    
+
+[<Fact>]
+let ``QIR UDT argument`` () =
+    qirTest false "TestUdtArgument"
+   
 [<Fact>]
 let ``QIR UDT update`` () =
     qirTest false "TestUdtUpdate"

--- a/src/QsCompiler/Tests.Compiler/QirTests.fs
+++ b/src/QsCompiler/Tests.Compiler/QirTests.fs
@@ -72,15 +72,19 @@ let ``QIR UDT construction`` () =
 [<Fact>]
 let ``QIR UDT accessor`` () =
     qirTest false "TestUdtAccessor"
-
-[<Fact>]
-let ``QIR UDT argument`` () =
-    qirTest false "TestUdtArgument"
    
 [<Fact>]
 let ``QIR UDT update`` () =
     qirTest false "TestUdtUpdate"
+
+[<Fact>]
+let ``QIR UDT argument`` () =
+    qirTest false "TestUdtArgument"
     
+[<Fact>]
+let ``QIR operation argument`` () =
+    qirTest true "TestOpArgument"
+
 [<Fact>]
 let ``QIR while loop`` () =
     qirTest false "TestWhile"

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestIntegers.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestIntegers.ll
@@ -6,9 +6,10 @@ entry:
   %2 = udiv i64 %b, 7
   %d = sub i64 %1, %2
   %e = ashr i64 %d, 3
-  %f = call i64 @__quantum__rt__int_power(i64 %d, i64 5)
-  %3 = and i64 %e, %f
-  %g = or i64 %3, 65535
-  %4 = xor i64 %g, -1
-  ret i64 %4
+  %3 = trunc i64 %b to i32
+  %f = call i64 @__quantum__rt__int_power(i64 %d, i32 %3)
+  %4 = and i64 %e, %f
+  %g = or i64 %4, 65535
+  %5 = xor i64 %g, -1
+  ret i64 %5
 }

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestIntegers.qs
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestIntegers.qs
@@ -7,7 +7,7 @@ namespace Microsoft.Quantum.Testing.QIR
         let c = a > b ? a | b;
         let d = c * a - b / 7;
         let e = d >>> 3;
-        let f = d ^ 5;
+        let f = d ^ b;
         let g = (e &&& f) ||| 0xffff;
         return ~~~g;
     }

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestOpArgument.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestOpArgument.ll
@@ -1,0 +1,31 @@
+define i64 @Microsoft__Quantum__Testing__QIR__TestAccessors__body() {
+entry:
+  %0 = call %TupleHeader* @__quantum__rt__tuple_create(i64 ptrtoint ({ %TupleHeader, i2, i64 }* getelementptr ({ %TupleHeader, i2, i64 }, { %TupleHeader, i2, i64 }* null, i32 1) to i64))
+  %1 = bitcast %TupleHeader* %0 to { %TupleHeader, i2, i64 }*
+  %2 = load i2, i2* @PauliX
+  %3 = getelementptr { %TupleHeader, i2, i64 }, { %TupleHeader, i2, i64 }* %1, i64 0, i32 1
+  store i2 %2, i2* %3
+  %4 = getelementptr { %TupleHeader, i2, i64 }, { %TupleHeader, i2, i64 }* %1, i64 0, i32 2
+  store i64 1, i64* %4
+  %x = call { %TupleHeader, { %TupleHeader, i2, i64 }*, double }* @Microsoft__Quantum__Testing__QIR__TestType__body({ %TupleHeader, i2, i64 }* %1, double 2.000000e+00)
+  %5 = getelementptr { %TupleHeader, { %TupleHeader, i2, i64 }*, double }, { %TupleHeader, { %TupleHeader, i2, i64 }*, double }* %x, i64 0, i32 1
+  %6 = load { %TupleHeader, i2, i64 }*, { %TupleHeader, i2, i64 }** %5
+  %7 = getelementptr { %TupleHeader, i2, i64 }, { %TupleHeader, i2, i64 }* %6, i64 0, i32 2
+  %y = load i64, i64* %7
+  %8 = bitcast { %TupleHeader, i2, i64 }* %1 to %TupleHeader*
+  call void @__quantum__rt__tuple_unreference(%TupleHeader* %8)
+  ret i64 %y
+}
+
+define { %TupleHeader, { %TupleHeader, i2, i64 }*, double }* @Microsoft__Quantum__Testing__QIR__TestType__body({ %TupleHeader, i2, i64 }* %arg0, double %arg1) {
+entry:
+  %0 = call %TupleHeader* @__quantum__rt__tuple_create(i64 ptrtoint ({ %TupleHeader, { %TupleHeader, i2, i64 }*, double }* getelementptr ({ %TupleHeader, { %TupleHeader, i2, i64 }*, double }, { %TupleHeader, { %TupleHeader, i2, i64 }*, double }* null, i32 1) to i64))
+  %1 = bitcast %TupleHeader* %0 to { %TupleHeader, { %TupleHeader, i2, i64 }*, double }*
+  %2 = getelementptr { %TupleHeader, { %TupleHeader, i2, i64 }*, double }, { %TupleHeader, { %TupleHeader, i2, i64 }*, double }* %1, i64 0, i32 1
+  store { %TupleHeader, i2, i64 }* %arg0, { %TupleHeader, i2, i64 }** %2
+  %3 = bitcast { %TupleHeader, i2, i64 }* %arg0 to %TupleHeader*
+  call void @__quantum__rt__tuple_reference(%TupleHeader* %3)
+  %4 = getelementptr { %TupleHeader, { %TupleHeader, i2, i64 }*, double }, { %TupleHeader, { %TupleHeader, i2, i64 }*, double }* %1, i64 0, i32 2
+  store double %arg1, double* %4
+  ret { %TupleHeader, { %TupleHeader, i2, i64 }*, double }* %1
+}

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestOpArgument.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestOpArgument.ll
@@ -1,63 +1,3 @@
-
-%Result = type opaque
-%Range = type { i64, i64, i64 }
-%TupleHeader = type { i32, i32 }
-%Qubit = type opaque
-%Array = type opaque
-%Callable = type opaque
-%String = type opaque
-
-@ResultZero = external global %Result*
-@ResultOne = external global %Result*
-@PauliI = constant i2 0
-@PauliX = constant i2 1
-@PauliY = constant i2 -1
-@PauliZ = constant i2 -2
-@EmptyRange = internal constant %Range { i64 0, i64 1, i64 -1 }
-@Microsoft__Quantum__Intrinsic__CNOT = constant [4 x void (%TupleHeader*, %TupleHeader*, %TupleHeader*)*] [void (%TupleHeader*, %TupleHeader*, %TupleHeader*)* @Microsoft__Quantum__Intrinsic__CNOT__body__wrapper, void (%TupleHeader*, %TupleHeader*, %TupleHeader*)* null, void (%TupleHeader*, %TupleHeader*, %TupleHeader*)* null, void (%TupleHeader*, %TupleHeader*, %TupleHeader*)* null]
-@PartialApplication__1 = constant [4 x void (%TupleHeader*, %TupleHeader*, %TupleHeader*)*] [void (%TupleHeader*, %TupleHeader*, %TupleHeader*)* @Lifted__PartialApplication__1__body__wrapper, void (%TupleHeader*, %TupleHeader*, %TupleHeader*)* @Lifted__PartialApplication__1__adj__wrapper, void (%TupleHeader*, %TupleHeader*, %TupleHeader*)* null, void (%TupleHeader*, %TupleHeader*, %TupleHeader*)* null]
-
-@Microsoft_Quantum_Testing_QIR_TestOpArgument = alias void (), void ()* @Microsoft__Quantum__Testing__QIR__TestOpArgument__body
-
-declare void @Microsoft__Quantum__Intrinsic__H____body(%Qubit*)
-
-define void @Microsoft__Quantum__Intrinsic__H__body(%Qubit* %qb) {
-entry:
-  call void @__quantum__qis__h__(%Qubit* %qb)
-  ret void
-}
-
-declare void @__quantum__qis__h__(%Qubit*)
-
-declare void @Microsoft__Quantum__Intrinsic__CNOT____body(%Qubit*, %Qubit*)
-
-define void @Microsoft__Quantum__Intrinsic__CNOT__body(%Qubit* %control, %Qubit* %target) {
-entry:
-  call void @__quantum__qis__cnot__(%Qubit* %control, %Qubit* %target)
-  ret void
-}
-
-declare void @__quantum__qis__cnot__(%Qubit*, %Qubit*)
-
-define %TupleHeader* @Microsoft__Quantum__Core__Attribute__body() {
-entry:
-  ret %TupleHeader* null
-}
-
-define %TupleHeader* @Microsoft__Quantum__Core__EntryPoint__body() {
-entry:
-  ret %TupleHeader* null
-}
-
-define %TupleHeader* @Microsoft__Quantum__Core__Inline__body() {
-entry:
-  ret %TupleHeader* null
-}
-
-declare i64 @Microsoft__Quantum__Core__Length__body(%Array*)
-
-declare %Range @Microsoft__Quantum__Core__RangeReverse__body(%Range)
-
 define void @Microsoft__Quantum__Testing__QIR__TestOpArgument__body() #0 {
 entry:
   %q = call %Qubit* @__quantum__rt__qubit_allocate()
@@ -70,110 +10,17 @@ entry:
   store %Qubit* %q, %Qubit** %4
   %5 = call %Callable* @__quantum__rt__callable_create([4 x void (%TupleHeader*, %TupleHeader*, %TupleHeader*)*]* @PartialApplication__1, %TupleHeader* %0)
   call void @Microsoft__Quantum__Testing__QIR__Apply__body(%Callable* %5)
+  %6 = call %TupleHeader* @__quantum__rt__tuple_create(i64 ptrtoint ({ %TupleHeader, %Callable*, %Qubit* }* getelementptr ({ %TupleHeader, %Callable*, %Qubit* }, { %TupleHeader, %Callable*, %Qubit* }* null, i32 1) to i64))
+  %7 = bitcast %TupleHeader* %6 to { %TupleHeader, %Callable*, %Qubit* }*
+  %8 = getelementptr { %TupleHeader, %Callable*, %Qubit* }, { %TupleHeader, %Callable*, %Qubit* }* %7, i64 0, i32 1
+  %9 = call %Callable* @__quantum__rt__callable_create([4 x void (%TupleHeader*, %TupleHeader*, %TupleHeader*)*]* @Microsoft__Quantum__Testing__QIR___SWAP, %TupleHeader* null)
+  store %Callable* %9, %Callable** %8
+  %10 = getelementptr { %TupleHeader, %Callable*, %Qubit* }, { %TupleHeader, %Callable*, %Qubit* }* %7, i64 0, i32 2
+  store %Qubit* %q, %Qubit** %10
+  %11 = call %Callable* @__quantum__rt__callable_create([4 x void (%TupleHeader*, %TupleHeader*, %TupleHeader*)*]* @PartialApplication__2, %TupleHeader* %6)
+  call void @Microsoft__Quantum__Testing__QIR__Apply__body(%Callable* %11)
   call void @__quantum__rt__qubit_release(%Qubit* %q)
   call void @__quantum__rt__callable_unreference(%Callable* %5)
+  call void @__quantum__rt__callable_unreference(%Callable* %11)
   ret void
 }
-
-declare %Qubit* @__quantum__rt__qubit_allocate()
-
-declare %Array* @__quantum__rt__qubit_allocate_array(i64)
-
-define void @Microsoft__Quantum__Testing__QIR__Apply__body(%Callable* %op) {
-entry:
-  %q = call %Qubit* @__quantum__rt__qubit_allocate()
-  call void @__quantum__qis__h__(%Qubit* %q)
-  %0 = call %TupleHeader* @__quantum__rt__tuple_create(i64 ptrtoint ({ %TupleHeader, %Qubit* }* getelementptr ({ %TupleHeader, %Qubit* }, { %TupleHeader, %Qubit* }* null, i32 1) to i64))
-  %1 = bitcast %TupleHeader* %0 to { %TupleHeader, %Qubit* }*
-  %2 = getelementptr { %TupleHeader, %Qubit* }, { %TupleHeader, %Qubit* }* %1, i64 0, i32 1
-  store %Qubit* %q, %Qubit** %2
-  call void @__quantum__rt__callable_invoke(%Callable* %op, %TupleHeader* %0, %TupleHeader* null)
-  call void @__quantum__rt__qubit_release(%Qubit* %q)
-  ret void
-}
-
-declare %TupleHeader* @__quantum__rt__tuple_create(i64)
-
-define void @Microsoft__Quantum__Intrinsic__CNOT__body__wrapper(%TupleHeader* %capture-tuple, %TupleHeader* %arg-tuple, %TupleHeader* %result-tuple) {
-entry:
-  %0 = bitcast %TupleHeader* %arg-tuple to { %TupleHeader, %Qubit*, %Qubit* }*
-  %1 = getelementptr { %TupleHeader, %Qubit*, %Qubit* }, { %TupleHeader, %Qubit*, %Qubit* }* %0, i64 0, i32 1
-  %2 = load %Qubit*, %Qubit** %1
-  %3 = getelementptr { %TupleHeader, %Qubit*, %Qubit* }, { %TupleHeader, %Qubit*, %Qubit* }* %0, i64 0, i32 2
-  %4 = load %Qubit*, %Qubit** %3
-  call void @Microsoft__Quantum__Intrinsic__CNOT__body(%Qubit* %2, %Qubit* %4)
-  ret void
-}
-
-declare %Callable* @__quantum__rt__callable_create([4 x void (%TupleHeader*, %TupleHeader*, %TupleHeader*)*]*, %TupleHeader*)
-
-define void @Lifted__PartialApplication__1__body__wrapper(%TupleHeader* %capture-tuple, %TupleHeader* %arg-tuple, %TupleHeader* %result-tuple) {
-entry:
-  %0 = bitcast %TupleHeader* %capture-tuple to { %TupleHeader, %Callable*, %Qubit* }*
-  %1 = bitcast %TupleHeader* %arg-tuple to { %TupleHeader, %Qubit* }*
-  %2 = call %TupleHeader* @__quantum__rt__tuple_create(i64 ptrtoint ({ %TupleHeader, %Qubit*, %Qubit* }* getelementptr ({ %TupleHeader, %Qubit*, %Qubit* }, { %TupleHeader, %Qubit*, %Qubit* }* null, i32 1) to i64))
-  %3 = bitcast %TupleHeader* %2 to { %TupleHeader, %Qubit*, %Qubit* }*
-  %4 = getelementptr { %TupleHeader, %Qubit*, %Qubit* }, { %TupleHeader, %Qubit*, %Qubit* }* %3, i64 0, i32 1
-  %5 = getelementptr { %TupleHeader, %Qubit* }, { %TupleHeader, %Qubit* }* %1, i64 0, i32 1
-  %6 = load %Qubit*, %Qubit** %5
-  store %Qubit* %6, %Qubit** %4
-  %7 = getelementptr { %TupleHeader, %Qubit*, %Qubit* }, { %TupleHeader, %Qubit*, %Qubit* }* %3, i64 0, i32 2
-  %8 = getelementptr { %TupleHeader, %Callable*, %Qubit* }, { %TupleHeader, %Callable*, %Qubit* }* %0, i64 0, i32 2
-  %9 = load %Qubit*, %Qubit** %8
-  store %Qubit* %9, %Qubit** %7
-  %10 = getelementptr { %TupleHeader, %Callable*, %Qubit* }, { %TupleHeader, %Callable*, %Qubit* }* %0, i64 0, i32 1
-  %11 = load %Callable*, %Callable** %10
-  call void @__quantum__rt__callable_invoke(%Callable* %11, %TupleHeader* %2, %TupleHeader* %result-tuple)
-  call void @__quantum__rt__tuple_unreference(%TupleHeader* %2)
-  ret void
-}
-
-declare void @__quantum__rt__callable_invoke(%Callable*, %TupleHeader*, %TupleHeader*)
-
-declare void @__quantum__rt__tuple_unreference(%TupleHeader*)
-
-define void @Lifted__PartialApplication__1__adj__wrapper(%TupleHeader* %capture-tuple, %TupleHeader* %arg-tuple, %TupleHeader* %result-tuple) {
-entry:
-  %0 = bitcast %TupleHeader* %capture-tuple to { %TupleHeader, %Callable*, %Qubit* }*
-  %1 = bitcast %TupleHeader* %arg-tuple to { %TupleHeader, %Qubit* }*
-  %2 = call %TupleHeader* @__quantum__rt__tuple_create(i64 ptrtoint ({ %TupleHeader, %Qubit*, %Qubit* }* getelementptr ({ %TupleHeader, %Qubit*, %Qubit* }, { %TupleHeader, %Qubit*, %Qubit* }* null, i32 1) to i64))
-  %3 = bitcast %TupleHeader* %2 to { %TupleHeader, %Qubit*, %Qubit* }*
-  %4 = getelementptr { %TupleHeader, %Qubit*, %Qubit* }, { %TupleHeader, %Qubit*, %Qubit* }* %3, i64 0, i32 1
-  %5 = getelementptr { %TupleHeader, %Qubit* }, { %TupleHeader, %Qubit* }* %1, i64 0, i32 1
-  %6 = load %Qubit*, %Qubit** %5
-  store %Qubit* %6, %Qubit** %4
-  %7 = getelementptr { %TupleHeader, %Qubit*, %Qubit* }, { %TupleHeader, %Qubit*, %Qubit* }* %3, i64 0, i32 2
-  %8 = getelementptr { %TupleHeader, %Callable*, %Qubit* }, { %TupleHeader, %Callable*, %Qubit* }* %0, i64 0, i32 2
-  %9 = load %Qubit*, %Qubit** %8
-  store %Qubit* %9, %Qubit** %7
-  %10 = getelementptr { %TupleHeader, %Callable*, %Qubit* }, { %TupleHeader, %Callable*, %Qubit* }* %0, i64 0, i32 1
-  %11 = load %Callable*, %Callable** %10
-  %12 = call %Callable* @__quantum__rt__callable_copy(%Callable* %11)
-  call void @__quantum__rt__callable_make_adjoint(%Callable* %12)
-  call void @__quantum__rt__callable_invoke(%Callable* %12, %TupleHeader* %2, %TupleHeader* %result-tuple)
-  call void @__quantum__rt__tuple_unreference(%TupleHeader* %2)
-  call void @__quantum__rt__callable_unreference(%Callable* %12)
-  ret void
-}
-
-declare %Callable* @__quantum__rt__callable_copy(%Callable*)
-
-declare void @__quantum__rt__callable_make_adjoint(%Callable*)
-
-declare void @__quantum__rt__callable_unreference(%Callable*)
-
-declare void @__quantum__rt__qubit_release(%Qubit*)
-
-define { %TupleHeader, %String* }* @Microsoft__Quantum__Targeting__TargetInstruction__body(%String* %arg0) {
-entry:
-  %0 = call %TupleHeader* @__quantum__rt__tuple_create(i64 ptrtoint ({ %TupleHeader, %String* }* getelementptr ({ %TupleHeader, %String* }, { %TupleHeader, %String* }* null, i32 1) to i64))
-  %1 = bitcast %TupleHeader* %0 to { %TupleHeader, %String* }*
-  %2 = getelementptr { %TupleHeader, %String* }, { %TupleHeader, %String* }* %1, i64 0, i32 1
-  store %String* %arg0, %String** %2
-  call void @__quantum__rt__string_reference(%String* %arg0)
-  ret { %TupleHeader, %String* }* %1
-}
-
-declare void @__quantum__rt__string_reference(%String*)
-
-attributes #0 = { "EntryPoint" }

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestOpArgument.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestOpArgument.ll
@@ -1,31 +1,179 @@
-define i64 @Microsoft__Quantum__Testing__QIR__TestAccessors__body() {
+
+%Result = type opaque
+%Range = type { i64, i64, i64 }
+%TupleHeader = type { i32, i32 }
+%Qubit = type opaque
+%Array = type opaque
+%Callable = type opaque
+%String = type opaque
+
+@ResultZero = external global %Result*
+@ResultOne = external global %Result*
+@PauliI = constant i2 0
+@PauliX = constant i2 1
+@PauliY = constant i2 -1
+@PauliZ = constant i2 -2
+@EmptyRange = internal constant %Range { i64 0, i64 1, i64 -1 }
+@Microsoft__Quantum__Intrinsic__CNOT = constant [4 x void (%TupleHeader*, %TupleHeader*, %TupleHeader*)*] [void (%TupleHeader*, %TupleHeader*, %TupleHeader*)* @Microsoft__Quantum__Intrinsic__CNOT__body__wrapper, void (%TupleHeader*, %TupleHeader*, %TupleHeader*)* null, void (%TupleHeader*, %TupleHeader*, %TupleHeader*)* null, void (%TupleHeader*, %TupleHeader*, %TupleHeader*)* null]
+@PartialApplication__1 = constant [4 x void (%TupleHeader*, %TupleHeader*, %TupleHeader*)*] [void (%TupleHeader*, %TupleHeader*, %TupleHeader*)* @Lifted__PartialApplication__1__body__wrapper, void (%TupleHeader*, %TupleHeader*, %TupleHeader*)* @Lifted__PartialApplication__1__adj__wrapper, void (%TupleHeader*, %TupleHeader*, %TupleHeader*)* null, void (%TupleHeader*, %TupleHeader*, %TupleHeader*)* null]
+
+@Microsoft_Quantum_Testing_QIR_TestOpArgument = alias void (), void ()* @Microsoft__Quantum__Testing__QIR__TestOpArgument__body
+
+declare void @Microsoft__Quantum__Intrinsic__H____body(%Qubit*)
+
+define void @Microsoft__Quantum__Intrinsic__H__body(%Qubit* %qb) {
 entry:
-  %0 = call %TupleHeader* @__quantum__rt__tuple_create(i64 ptrtoint ({ %TupleHeader, i2, i64 }* getelementptr ({ %TupleHeader, i2, i64 }, { %TupleHeader, i2, i64 }* null, i32 1) to i64))
-  %1 = bitcast %TupleHeader* %0 to { %TupleHeader, i2, i64 }*
-  %2 = load i2, i2* @PauliX
-  %3 = getelementptr { %TupleHeader, i2, i64 }, { %TupleHeader, i2, i64 }* %1, i64 0, i32 1
-  store i2 %2, i2* %3
-  %4 = getelementptr { %TupleHeader, i2, i64 }, { %TupleHeader, i2, i64 }* %1, i64 0, i32 2
-  store i64 1, i64* %4
-  %x = call { %TupleHeader, { %TupleHeader, i2, i64 }*, double }* @Microsoft__Quantum__Testing__QIR__TestType__body({ %TupleHeader, i2, i64 }* %1, double 2.000000e+00)
-  %5 = getelementptr { %TupleHeader, { %TupleHeader, i2, i64 }*, double }, { %TupleHeader, { %TupleHeader, i2, i64 }*, double }* %x, i64 0, i32 1
-  %6 = load { %TupleHeader, i2, i64 }*, { %TupleHeader, i2, i64 }** %5
-  %7 = getelementptr { %TupleHeader, i2, i64 }, { %TupleHeader, i2, i64 }* %6, i64 0, i32 2
-  %y = load i64, i64* %7
-  %8 = bitcast { %TupleHeader, i2, i64 }* %1 to %TupleHeader*
-  call void @__quantum__rt__tuple_unreference(%TupleHeader* %8)
-  ret i64 %y
+  call void @__quantum__qis__h__(%Qubit* %qb)
+  ret void
 }
 
-define { %TupleHeader, { %TupleHeader, i2, i64 }*, double }* @Microsoft__Quantum__Testing__QIR__TestType__body({ %TupleHeader, i2, i64 }* %arg0, double %arg1) {
+declare void @__quantum__qis__h__(%Qubit*)
+
+declare void @Microsoft__Quantum__Intrinsic__CNOT____body(%Qubit*, %Qubit*)
+
+define void @Microsoft__Quantum__Intrinsic__CNOT__body(%Qubit* %control, %Qubit* %target) {
 entry:
-  %0 = call %TupleHeader* @__quantum__rt__tuple_create(i64 ptrtoint ({ %TupleHeader, { %TupleHeader, i2, i64 }*, double }* getelementptr ({ %TupleHeader, { %TupleHeader, i2, i64 }*, double }, { %TupleHeader, { %TupleHeader, i2, i64 }*, double }* null, i32 1) to i64))
-  %1 = bitcast %TupleHeader* %0 to { %TupleHeader, { %TupleHeader, i2, i64 }*, double }*
-  %2 = getelementptr { %TupleHeader, { %TupleHeader, i2, i64 }*, double }, { %TupleHeader, { %TupleHeader, i2, i64 }*, double }* %1, i64 0, i32 1
-  store { %TupleHeader, i2, i64 }* %arg0, { %TupleHeader, i2, i64 }** %2
-  %3 = bitcast { %TupleHeader, i2, i64 }* %arg0 to %TupleHeader*
-  call void @__quantum__rt__tuple_reference(%TupleHeader* %3)
-  %4 = getelementptr { %TupleHeader, { %TupleHeader, i2, i64 }*, double }, { %TupleHeader, { %TupleHeader, i2, i64 }*, double }* %1, i64 0, i32 2
-  store double %arg1, double* %4
-  ret { %TupleHeader, { %TupleHeader, i2, i64 }*, double }* %1
+  call void @__quantum__qis__cnot__(%Qubit* %control, %Qubit* %target)
+  ret void
 }
+
+declare void @__quantum__qis__cnot__(%Qubit*, %Qubit*)
+
+define %TupleHeader* @Microsoft__Quantum__Core__Attribute__body() {
+entry:
+  ret %TupleHeader* null
+}
+
+define %TupleHeader* @Microsoft__Quantum__Core__EntryPoint__body() {
+entry:
+  ret %TupleHeader* null
+}
+
+define %TupleHeader* @Microsoft__Quantum__Core__Inline__body() {
+entry:
+  ret %TupleHeader* null
+}
+
+declare i64 @Microsoft__Quantum__Core__Length__body(%Array*)
+
+declare %Range @Microsoft__Quantum__Core__RangeReverse__body(%Range)
+
+define void @Microsoft__Quantum__Testing__QIR__TestOpArgument__body() #0 {
+entry:
+  %q = call %Qubit* @__quantum__rt__qubit_allocate()
+  %0 = call %TupleHeader* @__quantum__rt__tuple_create(i64 ptrtoint ({ %TupleHeader, %Callable*, %Qubit* }* getelementptr ({ %TupleHeader, %Callable*, %Qubit* }, { %TupleHeader, %Callable*, %Qubit* }* null, i32 1) to i64))
+  %1 = bitcast %TupleHeader* %0 to { %TupleHeader, %Callable*, %Qubit* }*
+  %2 = getelementptr { %TupleHeader, %Callable*, %Qubit* }, { %TupleHeader, %Callable*, %Qubit* }* %1, i64 0, i32 1
+  %3 = call %Callable* @__quantum__rt__callable_create([4 x void (%TupleHeader*, %TupleHeader*, %TupleHeader*)*]* @Microsoft__Quantum__Intrinsic__CNOT, %TupleHeader* null)
+  store %Callable* %3, %Callable** %2
+  %4 = getelementptr { %TupleHeader, %Callable*, %Qubit* }, { %TupleHeader, %Callable*, %Qubit* }* %1, i64 0, i32 2
+  store %Qubit* %q, %Qubit** %4
+  %5 = call %Callable* @__quantum__rt__callable_create([4 x void (%TupleHeader*, %TupleHeader*, %TupleHeader*)*]* @PartialApplication__1, %TupleHeader* %0)
+  call void @Microsoft__Quantum__Testing__QIR__Apply__body(%Callable* %5)
+  call void @__quantum__rt__qubit_release(%Qubit* %q)
+  call void @__quantum__rt__callable_unreference(%Callable* %5)
+  ret void
+}
+
+declare %Qubit* @__quantum__rt__qubit_allocate()
+
+declare %Array* @__quantum__rt__qubit_allocate_array(i64)
+
+define void @Microsoft__Quantum__Testing__QIR__Apply__body(%Callable* %op) {
+entry:
+  %q = call %Qubit* @__quantum__rt__qubit_allocate()
+  call void @__quantum__qis__h__(%Qubit* %q)
+  %0 = call %TupleHeader* @__quantum__rt__tuple_create(i64 ptrtoint ({ %TupleHeader, %Qubit* }* getelementptr ({ %TupleHeader, %Qubit* }, { %TupleHeader, %Qubit* }* null, i32 1) to i64))
+  %1 = bitcast %TupleHeader* %0 to { %TupleHeader, %Qubit* }*
+  %2 = getelementptr { %TupleHeader, %Qubit* }, { %TupleHeader, %Qubit* }* %1, i64 0, i32 1
+  store %Qubit* %q, %Qubit** %2
+  call void @__quantum__rt__callable_invoke(%Callable* %op, %TupleHeader* %0, %TupleHeader* null)
+  call void @__quantum__rt__qubit_release(%Qubit* %q)
+  ret void
+}
+
+declare %TupleHeader* @__quantum__rt__tuple_create(i64)
+
+define void @Microsoft__Quantum__Intrinsic__CNOT__body__wrapper(%TupleHeader* %capture-tuple, %TupleHeader* %arg-tuple, %TupleHeader* %result-tuple) {
+entry:
+  %0 = bitcast %TupleHeader* %arg-tuple to { %TupleHeader, %Qubit*, %Qubit* }*
+  %1 = getelementptr { %TupleHeader, %Qubit*, %Qubit* }, { %TupleHeader, %Qubit*, %Qubit* }* %0, i64 0, i32 1
+  %2 = load %Qubit*, %Qubit** %1
+  %3 = getelementptr { %TupleHeader, %Qubit*, %Qubit* }, { %TupleHeader, %Qubit*, %Qubit* }* %0, i64 0, i32 2
+  %4 = load %Qubit*, %Qubit** %3
+  call void @Microsoft__Quantum__Intrinsic__CNOT__body(%Qubit* %2, %Qubit* %4)
+  ret void
+}
+
+declare %Callable* @__quantum__rt__callable_create([4 x void (%TupleHeader*, %TupleHeader*, %TupleHeader*)*]*, %TupleHeader*)
+
+define void @Lifted__PartialApplication__1__body__wrapper(%TupleHeader* %capture-tuple, %TupleHeader* %arg-tuple, %TupleHeader* %result-tuple) {
+entry:
+  %0 = bitcast %TupleHeader* %capture-tuple to { %TupleHeader, %Callable*, %Qubit* }*
+  %1 = bitcast %TupleHeader* %arg-tuple to { %TupleHeader, %Qubit* }*
+  %2 = call %TupleHeader* @__quantum__rt__tuple_create(i64 ptrtoint ({ %TupleHeader, %Qubit*, %Qubit* }* getelementptr ({ %TupleHeader, %Qubit*, %Qubit* }, { %TupleHeader, %Qubit*, %Qubit* }* null, i32 1) to i64))
+  %3 = bitcast %TupleHeader* %2 to { %TupleHeader, %Qubit*, %Qubit* }*
+  %4 = getelementptr { %TupleHeader, %Qubit*, %Qubit* }, { %TupleHeader, %Qubit*, %Qubit* }* %3, i64 0, i32 1
+  %5 = getelementptr { %TupleHeader, %Qubit* }, { %TupleHeader, %Qubit* }* %1, i64 0, i32 1
+  %6 = load %Qubit*, %Qubit** %5
+  store %Qubit* %6, %Qubit** %4
+  %7 = getelementptr { %TupleHeader, %Qubit*, %Qubit* }, { %TupleHeader, %Qubit*, %Qubit* }* %3, i64 0, i32 2
+  %8 = getelementptr { %TupleHeader, %Callable*, %Qubit* }, { %TupleHeader, %Callable*, %Qubit* }* %0, i64 0, i32 2
+  %9 = load %Qubit*, %Qubit** %8
+  store %Qubit* %9, %Qubit** %7
+  %10 = getelementptr { %TupleHeader, %Callable*, %Qubit* }, { %TupleHeader, %Callable*, %Qubit* }* %0, i64 0, i32 1
+  %11 = load %Callable*, %Callable** %10
+  call void @__quantum__rt__callable_invoke(%Callable* %11, %TupleHeader* %2, %TupleHeader* %result-tuple)
+  call void @__quantum__rt__tuple_unreference(%TupleHeader* %2)
+  ret void
+}
+
+declare void @__quantum__rt__callable_invoke(%Callable*, %TupleHeader*, %TupleHeader*)
+
+declare void @__quantum__rt__tuple_unreference(%TupleHeader*)
+
+define void @Lifted__PartialApplication__1__adj__wrapper(%TupleHeader* %capture-tuple, %TupleHeader* %arg-tuple, %TupleHeader* %result-tuple) {
+entry:
+  %0 = bitcast %TupleHeader* %capture-tuple to { %TupleHeader, %Callable*, %Qubit* }*
+  %1 = bitcast %TupleHeader* %arg-tuple to { %TupleHeader, %Qubit* }*
+  %2 = call %TupleHeader* @__quantum__rt__tuple_create(i64 ptrtoint ({ %TupleHeader, %Qubit*, %Qubit* }* getelementptr ({ %TupleHeader, %Qubit*, %Qubit* }, { %TupleHeader, %Qubit*, %Qubit* }* null, i32 1) to i64))
+  %3 = bitcast %TupleHeader* %2 to { %TupleHeader, %Qubit*, %Qubit* }*
+  %4 = getelementptr { %TupleHeader, %Qubit*, %Qubit* }, { %TupleHeader, %Qubit*, %Qubit* }* %3, i64 0, i32 1
+  %5 = getelementptr { %TupleHeader, %Qubit* }, { %TupleHeader, %Qubit* }* %1, i64 0, i32 1
+  %6 = load %Qubit*, %Qubit** %5
+  store %Qubit* %6, %Qubit** %4
+  %7 = getelementptr { %TupleHeader, %Qubit*, %Qubit* }, { %TupleHeader, %Qubit*, %Qubit* }* %3, i64 0, i32 2
+  %8 = getelementptr { %TupleHeader, %Callable*, %Qubit* }, { %TupleHeader, %Callable*, %Qubit* }* %0, i64 0, i32 2
+  %9 = load %Qubit*, %Qubit** %8
+  store %Qubit* %9, %Qubit** %7
+  %10 = getelementptr { %TupleHeader, %Callable*, %Qubit* }, { %TupleHeader, %Callable*, %Qubit* }* %0, i64 0, i32 1
+  %11 = load %Callable*, %Callable** %10
+  %12 = call %Callable* @__quantum__rt__callable_copy(%Callable* %11)
+  call void @__quantum__rt__callable_make_adjoint(%Callable* %12)
+  call void @__quantum__rt__callable_invoke(%Callable* %12, %TupleHeader* %2, %TupleHeader* %result-tuple)
+  call void @__quantum__rt__tuple_unreference(%TupleHeader* %2)
+  call void @__quantum__rt__callable_unreference(%Callable* %12)
+  ret void
+}
+
+declare %Callable* @__quantum__rt__callable_copy(%Callable*)
+
+declare void @__quantum__rt__callable_make_adjoint(%Callable*)
+
+declare void @__quantum__rt__callable_unreference(%Callable*)
+
+declare void @__quantum__rt__qubit_release(%Qubit*)
+
+define { %TupleHeader, %String* }* @Microsoft__Quantum__Targeting__TargetInstruction__body(%String* %arg0) {
+entry:
+  %0 = call %TupleHeader* @__quantum__rt__tuple_create(i64 ptrtoint ({ %TupleHeader, %String* }* getelementptr ({ %TupleHeader, %String* }, { %TupleHeader, %String* }* null, i32 1) to i64))
+  %1 = bitcast %TupleHeader* %0 to { %TupleHeader, %String* }*
+  %2 = getelementptr { %TupleHeader, %String* }, { %TupleHeader, %String* }* %1, i64 0, i32 1
+  store %String* %arg0, %String** %2
+  call void @__quantum__rt__string_reference(%String* %arg0)
+  ret { %TupleHeader, %String* }* %1
+}
+
+declare void @__quantum__rt__string_reference(%String*)
+
+attributes #0 = { "EntryPoint" }

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestOpArgument.qs
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestOpArgument.qs
@@ -11,6 +11,11 @@ namespace Microsoft.Quantum.Testing.QIR
         body intrinsic;
 	}
 
+    @TargetInstruction("choose")
+    operation _Choose(q1 : Qubit, (q2 : Qubit, q3 : Qubit)) : Unit {
+        body intrinsic;
+	}
+
     operation Apply(op : (Qubit => Unit)) : Unit {
         using (q = Qubit()) {
             H(q);
@@ -19,10 +24,12 @@ namespace Microsoft.Quantum.Testing.QIR
     }
 
     @EntryPoint()
-    operation TestUdtArgument () : Unit {
+    operation TestOpArgument () : Unit {
         using (q = Qubit()) {
             Apply(CNOT(_, q)); 
             Apply(_SWAP(_, q));
+            // Apply(_Choose(q, (_, q))); FIXME: THIS DOESN'T WORK BECAUSE PARTIAL APPLICATION ARGS MAPPING IS WRONG
+            // Apply(_Choose(_,(q,q)));     SAME HERE
         }
     }
 }

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestOpArgument.qs
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestOpArgument.qs
@@ -1,0 +1,28 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace Microsoft.Quantum.Testing.QIR
+{
+    open Microsoft.Quantum.Intrinsic;
+    open Microsoft.Quantum.Targeting;
+
+    @TargetInstruction("swap")
+    operation _SWAP(q1 : Qubit, q2 : Qubit) : Unit {
+        body intrinsic;
+	}
+
+    operation Apply(op : (Qubit => Unit)) : Unit {
+        using (q = Qubit()) {
+            H(q);
+            op(q);
+        }
+    }
+
+    @EntryPoint()
+    operation TestUdtArgument () : Unit {
+        using (q = Qubit()) {
+            Apply(CNOT(_, q)); 
+            Apply(_SWAP(_, q));
+        }
+    }
+}

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestOpArgument.qs
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestOpArgument.qs
@@ -28,8 +28,9 @@ namespace Microsoft.Quantum.Testing.QIR
         using (q = Qubit()) {
             Apply(CNOT(_, q)); 
             Apply(_SWAP(_, q));
-            // Apply(_Choose(q, (_, q))); FIXME: THIS DOESN'T WORK BECAUSE PARTIAL APPLICATION ARGS MAPPING IS WRONG
-            // Apply(_Choose(_,(q,q)));     SAME HERE
+            // TODO: there is currently a bug in the partial application mapping
+            // Apply(_Choose(q, (_, q))); 
+            // Apply(_Choose(_,(q,q)));
         }
     }
 }

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestRepeat.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestRepeat.ll
@@ -5,10 +5,10 @@ entry:
   br label %repeat__1
 
 repeat__1:                                        ; preds = %continue__1, %entry
-  call void @__quantum__qis__t__body(%Qubit* %q)
-  call void @__quantum__qis__x__body(%Qubit* %q)
-  call void @__quantum__qis__t__adj(%Qubit* %q)
-  call void @__quantum__qis__h__body(%Qubit* %q)
+  call void @__quantum__qis__t__(%Qubit* %q)
+  call void @__quantum__qis__x__(%Qubit* %q)
+  call void @__quantum__qis__tadj__(%Qubit* %q)
+  call void @__quantum__qis__h__(%Qubit* %q)
   br label %until__1
 
 until__1:                                         ; preds = %repeat__1

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestUdtArgument.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestUdtArgument.ll
@@ -1,125 +1,21 @@
-
-%Result = type opaque
-%Range = type { i64, i64, i64 }
-%TupleHeader = type { i32, i32 }
-%Callable = type opaque
-%Array = type opaque
-%String = type opaque
-
-@ResultZero = external global %Result*
-@ResultOne = external global %Result*
-@PauliI = constant i2 0
-@PauliX = constant i2 1
-@PauliY = constant i2 -1
-@PauliZ = constant i2 -2
-@EmptyRange = internal constant %Range { i64 0, i64 1, i64 -1 }
-@Microsoft__Quantum__Testing__QIR__TestType1 = constant [4 x void (%TupleHeader*, %TupleHeader*, %TupleHeader*)*] [void (%TupleHeader*, %TupleHeader*, %TupleHeader*)* @Microsoft__Quantum__Testing__QIR__TestType1__body__wrapper, void (%TupleHeader*, %TupleHeader*, %TupleHeader*)* null, void (%TupleHeader*, %TupleHeader*, %TupleHeader*)* null, void (%TupleHeader*, %TupleHeader*, %TupleHeader*)* null]
-
-@Microsoft_Quantum_Testing_QIR_TestUdtArgument = alias { %TupleHeader, i64, { %TupleHeader, { %TupleHeader, i2, i64 }*, double }* }* (), { %TupleHeader, i64, { %TupleHeader, { %TupleHeader, i2, i64 }*, double }* }* ()* @Microsoft__Quantum__Testing__QIR__TestUdtArgument__body
-
-define { %TupleHeader, i64 }* @Microsoft__Quantum__Testing__QIR__TestType1__body(i64 %arg0) {
-entry:
-  %0 = call %TupleHeader* @__quantum__rt__tuple_create(i64 ptrtoint ({ %TupleHeader, i64 }* getelementptr ({ %TupleHeader, i64 }, { %TupleHeader, i64 }* null, i32 1) to i64))
-  %1 = bitcast %TupleHeader* %0 to { %TupleHeader, i64 }*
-  %2 = getelementptr { %TupleHeader, i64 }, { %TupleHeader, i64 }* %1, i64 0, i32 1
-  store i64 %arg0, i64* %2
-  ret { %TupleHeader, i64 }* %1
-}
-
-declare %TupleHeader* @__quantum__rt__tuple_create(i64)
-
-define { %TupleHeader, { %TupleHeader, i2, i64 }*, double }* @Microsoft__Quantum__Testing__QIR__TestType2__body({ %TupleHeader, i2, i64 }* %arg0, double %arg1) {
-entry:
-  %0 = call %TupleHeader* @__quantum__rt__tuple_create(i64 ptrtoint ({ %TupleHeader, { %TupleHeader, i2, i64 }*, double }* getelementptr ({ %TupleHeader, { %TupleHeader, i2, i64 }*, double }, { %TupleHeader, { %TupleHeader, i2, i64 }*, double }* null, i32 1) to i64))
-  %1 = bitcast %TupleHeader* %0 to { %TupleHeader, { %TupleHeader, i2, i64 }*, double }*
-  %2 = getelementptr { %TupleHeader, { %TupleHeader, i2, i64 }*, double }, { %TupleHeader, { %TupleHeader, i2, i64 }*, double }* %1, i64 0, i32 1
-  store { %TupleHeader, i2, i64 }* %arg0, { %TupleHeader, i2, i64 }** %2
-  %3 = bitcast { %TupleHeader, i2, i64 }* %arg0 to %TupleHeader*
-  call void @__quantum__rt__tuple_reference(%TupleHeader* %3)
-  %4 = getelementptr { %TupleHeader, { %TupleHeader, i2, i64 }*, double }, { %TupleHeader, { %TupleHeader, i2, i64 }*, double }* %1, i64 0, i32 2
-  store double %arg1, double* %4
-  ret { %TupleHeader, { %TupleHeader, i2, i64 }*, double }* %1
-}
-
-declare void @__quantum__rt__tuple_reference(%TupleHeader*)
-
-define { %TupleHeader, i64, { %TupleHeader, { %TupleHeader, i2, i64 }*, double }* }* @Microsoft__Quantum__Testing__QIR__TestUdtArgument__body() #0 {
+define i64 @Microsoft__Quantum__Testing__QIR__TestUdtArgument__body() #0 {
 entry:
   %0 = call %Callable* @__quantum__rt__callable_create([4 x void (%TupleHeader*, %TupleHeader*, %TupleHeader*)*]* @Microsoft__Quantum__Testing__QIR__TestType1, %TupleHeader* null)
-  %udt1 = call i64 @Microsoft__Quantum__Testing__QIR__Build__body(%Callable* %0)
-  %1 = call %TupleHeader* @__quantum__rt__tuple_create(i64 ptrtoint ({ %TupleHeader, i2, i64 }* getelementptr ({ %TupleHeader, i2, i64 }, { %TupleHeader, i2, i64 }* null, i32 1) to i64))
-  %2 = bitcast %TupleHeader* %1 to { %TupleHeader, i2, i64 }*
-  %3 = load i2, i2* @PauliX
-  %4 = getelementptr { %TupleHeader, i2, i64 }, { %TupleHeader, i2, i64 }* %2, i64 0, i32 1
-  store i2 %3, i2* %4
-  %5 = getelementptr { %TupleHeader, i2, i64 }, { %TupleHeader, i2, i64 }* %2, i64 0, i32 2
-  store i64 1, i64* %5
-  %udt2 = call { %TupleHeader, { %TupleHeader, i2, i64 }*, double }* @Microsoft__Quantum__Testing__QIR__TestType2__body({ %TupleHeader, i2, i64 }* %2, double 2.000000e+00)
-  %6 = call %TupleHeader* @__quantum__rt__tuple_create(i64 ptrtoint ({ %TupleHeader, i64, { %TupleHeader, { %TupleHeader, i2, i64 }*, double }* }* getelementptr ({ %TupleHeader, i64, { %TupleHeader, { %TupleHeader, i2, i64 }*, double }* }, { %TupleHeader, i64, { %TupleHeader, { %TupleHeader, i2, i64 }*, double }* }* null, i32 1) to i64))
-  %7 = bitcast %TupleHeader* %6 to { %TupleHeader, i64, { %TupleHeader, { %TupleHeader, i2, i64 }*, double }* }*
-  %8 = getelementptr { %TupleHeader, i64, { %TupleHeader, { %TupleHeader, i2, i64 }*, double }* }, { %TupleHeader, i64, { %TupleHeader, { %TupleHeader, i2, i64 }*, double }* }* %7, i64 0, i32 1
-  store i64 %udt1, i64* %8
-  %9 = getelementptr { %TupleHeader, i64, { %TupleHeader, { %TupleHeader, i2, i64 }*, double }* }, { %TupleHeader, i64, { %TupleHeader, { %TupleHeader, i2, i64 }*, double }* }* %7, i64 0, i32 2
-  store { %TupleHeader, { %TupleHeader, i2, i64 }*, double }* %udt2, { %TupleHeader, { %TupleHeader, i2, i64 }*, double }** %9
+  %udt1 = call i64 @Microsoft__Quantum__Testing__QIR__Build1__body(%Callable* %0)
+  %1 = load i2, i2* @PauliX
+  %2 = call %TupleHeader* @__quantum__rt__tuple_create(i64 ptrtoint ({ %TupleHeader, %Callable*, i2 }* getelementptr ({ %TupleHeader, %Callable*, i2 }, { %TupleHeader, %Callable*, i2 }* null, i32 1) to i64))
+  %3 = bitcast %TupleHeader* %2 to { %TupleHeader, %Callable*, i2 }*
+  %4 = getelementptr { %TupleHeader, %Callable*, i2 }, { %TupleHeader, %Callable*, i2 }* %3, i64 0, i32 1
+  %5 = call %Callable* @__quantum__rt__callable_create([4 x void (%TupleHeader*, %TupleHeader*, %TupleHeader*)*]* @Microsoft__Quantum__Testing__QIR__TestType2, %TupleHeader* null)
+  store %Callable* %5, %Callable** %4
+  %6 = getelementptr { %TupleHeader, %Callable*, i2 }, { %TupleHeader, %Callable*, i2 }* %3, i64 0, i32 2
+  store i2 %1, i2* %6
+  %7 = call %Callable* @__quantum__rt__callable_create([4 x void (%TupleHeader*, %TupleHeader*, %TupleHeader*)*]* @PartialApplication__1, %TupleHeader* %2)
+  %udt2 = call { %TupleHeader, i2, i64 }* @Microsoft__Quantum__Testing__QIR__Build2__body(%Callable* %7)
+  %8 = bitcast i64 %udt1 to { %TupleHeader, i64 }*
+  %9 = getelementptr { %TupleHeader, i64 }, { %TupleHeader, i64 }* %8, i64 0, i32 1
+  %10 = load i64, i64* %9
   call void @__quantum__rt__callable_unreference(%Callable* %0)
-  %10 = bitcast { %TupleHeader, i2, i64 }* %2 to %TupleHeader*
-  call void @__quantum__rt__tuple_unreference(%TupleHeader* %10)
-  ret { %TupleHeader, i64, { %TupleHeader, { %TupleHeader, i2, i64 }*, double }* }* %7
+  call void @__quantum__rt__callable_unreference(%Callable* %7)
+  ret i64 %10
 }
-
-define i64 @Microsoft__Quantum__Testing__QIR__Build__body(%Callable* %build) {
-entry:
-  %0 = call %TupleHeader* @__quantum__rt__tuple_create(i64 ptrtoint ({ %TupleHeader, i64 }* getelementptr ({ %TupleHeader, i64 }, { %TupleHeader, i64 }* null, i32 1) to i64))
-  %1 = bitcast %TupleHeader* %0 to { %TupleHeader, i64 }*
-  %2 = getelementptr { %TupleHeader, i64 }, { %TupleHeader, i64 }* %1, i64 0, i32 1
-  store i64 1, i64* %2
-  %3 = call %TupleHeader* @__quantum__rt__tuple_create(i64 ptrtoint ({ %TupleHeader, i64 }* getelementptr ({ %TupleHeader, i64 }, { %TupleHeader, i64 }* null, i32 1) to i64))
-  %4 = bitcast %TupleHeader* %3 to { %TupleHeader, i64 }*
-  call void @__quantum__rt__callable_invoke(%Callable* %build, %TupleHeader* %0, %TupleHeader* %3)
-  %5 = getelementptr { %TupleHeader, i64 }, { %TupleHeader, i64 }* %4, i64 0, i32 1
-  %6 = load i64, i64* %5
-  ret i64 %6
-}
-
-declare void @Microsoft__Quantum__Testing__QIR__TestType1__body__wrapper(%TupleHeader*, %TupleHeader*, %TupleHeader*)
-
-declare %Callable* @__quantum__rt__callable_create([4 x void (%TupleHeader*, %TupleHeader*, %TupleHeader*)*]*, %TupleHeader*)
-
-declare void @__quantum__rt__callable_unreference(%Callable*)
-
-declare void @__quantum__rt__tuple_unreference(%TupleHeader*)
-
-declare void @__quantum__rt__callable_invoke(%Callable*, %TupleHeader*, %TupleHeader*)
-
-define %TupleHeader* @Microsoft__Quantum__Core__Attribute__body() {
-entry:
-  ret %TupleHeader* null
-}
-
-define %TupleHeader* @Microsoft__Quantum__Core__EntryPoint__body() {
-entry:
-  ret %TupleHeader* null
-}
-
-define %TupleHeader* @Microsoft__Quantum__Core__Inline__body() {
-entry:
-  ret %TupleHeader* null
-}
-
-declare i64 @Microsoft__Quantum__Core__Length__body(%Array*)
-
-declare %Range @Microsoft__Quantum__Core__RangeReverse__body(%Range)
-
-define { %TupleHeader, %String* }* @Microsoft__Quantum__Targeting__TargetInstruction__body(%String* %arg0) {
-entry:
-  %0 = call %TupleHeader* @__quantum__rt__tuple_create(i64 ptrtoint ({ %TupleHeader, %String* }* getelementptr ({ %TupleHeader, %String* }, { %TupleHeader, %String* }* null, i32 1) to i64))
-  %1 = bitcast %TupleHeader* %0 to { %TupleHeader, %String* }*
-  %2 = getelementptr { %TupleHeader, %String* }, { %TupleHeader, %String* }* %1, i64 0, i32 1
-  store %String* %arg0, %String** %2
-  call void @__quantum__rt__string_reference(%String* %arg0)
-  ret { %TupleHeader, %String* }* %1
-}
-
-declare void @__quantum__rt__string_reference(%String*)
-
-attributes #0 = { "EntryPoint" }

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestUdtArgument.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestUdtArgument.ll
@@ -1,0 +1,125 @@
+
+%Result = type opaque
+%Range = type { i64, i64, i64 }
+%TupleHeader = type { i32, i32 }
+%Callable = type opaque
+%Array = type opaque
+%String = type opaque
+
+@ResultZero = external global %Result*
+@ResultOne = external global %Result*
+@PauliI = constant i2 0
+@PauliX = constant i2 1
+@PauliY = constant i2 -1
+@PauliZ = constant i2 -2
+@EmptyRange = internal constant %Range { i64 0, i64 1, i64 -1 }
+@Microsoft__Quantum__Testing__QIR__TestType1 = constant [4 x void (%TupleHeader*, %TupleHeader*, %TupleHeader*)*] [void (%TupleHeader*, %TupleHeader*, %TupleHeader*)* @Microsoft__Quantum__Testing__QIR__TestType1__body__wrapper, void (%TupleHeader*, %TupleHeader*, %TupleHeader*)* null, void (%TupleHeader*, %TupleHeader*, %TupleHeader*)* null, void (%TupleHeader*, %TupleHeader*, %TupleHeader*)* null]
+
+@Microsoft_Quantum_Testing_QIR_TestUdtArgument = alias { %TupleHeader, i64, { %TupleHeader, { %TupleHeader, i2, i64 }*, double }* }* (), { %TupleHeader, i64, { %TupleHeader, { %TupleHeader, i2, i64 }*, double }* }* ()* @Microsoft__Quantum__Testing__QIR__TestUdtArgument__body
+
+define { %TupleHeader, i64 }* @Microsoft__Quantum__Testing__QIR__TestType1__body(i64 %arg0) {
+entry:
+  %0 = call %TupleHeader* @__quantum__rt__tuple_create(i64 ptrtoint ({ %TupleHeader, i64 }* getelementptr ({ %TupleHeader, i64 }, { %TupleHeader, i64 }* null, i32 1) to i64))
+  %1 = bitcast %TupleHeader* %0 to { %TupleHeader, i64 }*
+  %2 = getelementptr { %TupleHeader, i64 }, { %TupleHeader, i64 }* %1, i64 0, i32 1
+  store i64 %arg0, i64* %2
+  ret { %TupleHeader, i64 }* %1
+}
+
+declare %TupleHeader* @__quantum__rt__tuple_create(i64)
+
+define { %TupleHeader, { %TupleHeader, i2, i64 }*, double }* @Microsoft__Quantum__Testing__QIR__TestType2__body({ %TupleHeader, i2, i64 }* %arg0, double %arg1) {
+entry:
+  %0 = call %TupleHeader* @__quantum__rt__tuple_create(i64 ptrtoint ({ %TupleHeader, { %TupleHeader, i2, i64 }*, double }* getelementptr ({ %TupleHeader, { %TupleHeader, i2, i64 }*, double }, { %TupleHeader, { %TupleHeader, i2, i64 }*, double }* null, i32 1) to i64))
+  %1 = bitcast %TupleHeader* %0 to { %TupleHeader, { %TupleHeader, i2, i64 }*, double }*
+  %2 = getelementptr { %TupleHeader, { %TupleHeader, i2, i64 }*, double }, { %TupleHeader, { %TupleHeader, i2, i64 }*, double }* %1, i64 0, i32 1
+  store { %TupleHeader, i2, i64 }* %arg0, { %TupleHeader, i2, i64 }** %2
+  %3 = bitcast { %TupleHeader, i2, i64 }* %arg0 to %TupleHeader*
+  call void @__quantum__rt__tuple_reference(%TupleHeader* %3)
+  %4 = getelementptr { %TupleHeader, { %TupleHeader, i2, i64 }*, double }, { %TupleHeader, { %TupleHeader, i2, i64 }*, double }* %1, i64 0, i32 2
+  store double %arg1, double* %4
+  ret { %TupleHeader, { %TupleHeader, i2, i64 }*, double }* %1
+}
+
+declare void @__quantum__rt__tuple_reference(%TupleHeader*)
+
+define { %TupleHeader, i64, { %TupleHeader, { %TupleHeader, i2, i64 }*, double }* }* @Microsoft__Quantum__Testing__QIR__TestUdtArgument__body() #0 {
+entry:
+  %0 = call %Callable* @__quantum__rt__callable_create([4 x void (%TupleHeader*, %TupleHeader*, %TupleHeader*)*]* @Microsoft__Quantum__Testing__QIR__TestType1, %TupleHeader* null)
+  %udt1 = call i64 @Microsoft__Quantum__Testing__QIR__Build__body(%Callable* %0)
+  %1 = call %TupleHeader* @__quantum__rt__tuple_create(i64 ptrtoint ({ %TupleHeader, i2, i64 }* getelementptr ({ %TupleHeader, i2, i64 }, { %TupleHeader, i2, i64 }* null, i32 1) to i64))
+  %2 = bitcast %TupleHeader* %1 to { %TupleHeader, i2, i64 }*
+  %3 = load i2, i2* @PauliX
+  %4 = getelementptr { %TupleHeader, i2, i64 }, { %TupleHeader, i2, i64 }* %2, i64 0, i32 1
+  store i2 %3, i2* %4
+  %5 = getelementptr { %TupleHeader, i2, i64 }, { %TupleHeader, i2, i64 }* %2, i64 0, i32 2
+  store i64 1, i64* %5
+  %udt2 = call { %TupleHeader, { %TupleHeader, i2, i64 }*, double }* @Microsoft__Quantum__Testing__QIR__TestType2__body({ %TupleHeader, i2, i64 }* %2, double 2.000000e+00)
+  %6 = call %TupleHeader* @__quantum__rt__tuple_create(i64 ptrtoint ({ %TupleHeader, i64, { %TupleHeader, { %TupleHeader, i2, i64 }*, double }* }* getelementptr ({ %TupleHeader, i64, { %TupleHeader, { %TupleHeader, i2, i64 }*, double }* }, { %TupleHeader, i64, { %TupleHeader, { %TupleHeader, i2, i64 }*, double }* }* null, i32 1) to i64))
+  %7 = bitcast %TupleHeader* %6 to { %TupleHeader, i64, { %TupleHeader, { %TupleHeader, i2, i64 }*, double }* }*
+  %8 = getelementptr { %TupleHeader, i64, { %TupleHeader, { %TupleHeader, i2, i64 }*, double }* }, { %TupleHeader, i64, { %TupleHeader, { %TupleHeader, i2, i64 }*, double }* }* %7, i64 0, i32 1
+  store i64 %udt1, i64* %8
+  %9 = getelementptr { %TupleHeader, i64, { %TupleHeader, { %TupleHeader, i2, i64 }*, double }* }, { %TupleHeader, i64, { %TupleHeader, { %TupleHeader, i2, i64 }*, double }* }* %7, i64 0, i32 2
+  store { %TupleHeader, { %TupleHeader, i2, i64 }*, double }* %udt2, { %TupleHeader, { %TupleHeader, i2, i64 }*, double }** %9
+  call void @__quantum__rt__callable_unreference(%Callable* %0)
+  %10 = bitcast { %TupleHeader, i2, i64 }* %2 to %TupleHeader*
+  call void @__quantum__rt__tuple_unreference(%TupleHeader* %10)
+  ret { %TupleHeader, i64, { %TupleHeader, { %TupleHeader, i2, i64 }*, double }* }* %7
+}
+
+define i64 @Microsoft__Quantum__Testing__QIR__Build__body(%Callable* %build) {
+entry:
+  %0 = call %TupleHeader* @__quantum__rt__tuple_create(i64 ptrtoint ({ %TupleHeader, i64 }* getelementptr ({ %TupleHeader, i64 }, { %TupleHeader, i64 }* null, i32 1) to i64))
+  %1 = bitcast %TupleHeader* %0 to { %TupleHeader, i64 }*
+  %2 = getelementptr { %TupleHeader, i64 }, { %TupleHeader, i64 }* %1, i64 0, i32 1
+  store i64 1, i64* %2
+  %3 = call %TupleHeader* @__quantum__rt__tuple_create(i64 ptrtoint ({ %TupleHeader, i64 }* getelementptr ({ %TupleHeader, i64 }, { %TupleHeader, i64 }* null, i32 1) to i64))
+  %4 = bitcast %TupleHeader* %3 to { %TupleHeader, i64 }*
+  call void @__quantum__rt__callable_invoke(%Callable* %build, %TupleHeader* %0, %TupleHeader* %3)
+  %5 = getelementptr { %TupleHeader, i64 }, { %TupleHeader, i64 }* %4, i64 0, i32 1
+  %6 = load i64, i64* %5
+  ret i64 %6
+}
+
+declare void @Microsoft__Quantum__Testing__QIR__TestType1__body__wrapper(%TupleHeader*, %TupleHeader*, %TupleHeader*)
+
+declare %Callable* @__quantum__rt__callable_create([4 x void (%TupleHeader*, %TupleHeader*, %TupleHeader*)*]*, %TupleHeader*)
+
+declare void @__quantum__rt__callable_unreference(%Callable*)
+
+declare void @__quantum__rt__tuple_unreference(%TupleHeader*)
+
+declare void @__quantum__rt__callable_invoke(%Callable*, %TupleHeader*, %TupleHeader*)
+
+define %TupleHeader* @Microsoft__Quantum__Core__Attribute__body() {
+entry:
+  ret %TupleHeader* null
+}
+
+define %TupleHeader* @Microsoft__Quantum__Core__EntryPoint__body() {
+entry:
+  ret %TupleHeader* null
+}
+
+define %TupleHeader* @Microsoft__Quantum__Core__Inline__body() {
+entry:
+  ret %TupleHeader* null
+}
+
+declare i64 @Microsoft__Quantum__Core__Length__body(%Array*)
+
+declare %Range @Microsoft__Quantum__Core__RangeReverse__body(%Range)
+
+define { %TupleHeader, %String* }* @Microsoft__Quantum__Targeting__TargetInstruction__body(%String* %arg0) {
+entry:
+  %0 = call %TupleHeader* @__quantum__rt__tuple_create(i64 ptrtoint ({ %TupleHeader, %String* }* getelementptr ({ %TupleHeader, %String* }, { %TupleHeader, %String* }* null, i32 1) to i64))
+  %1 = bitcast %TupleHeader* %0 to { %TupleHeader, %String* }*
+  %2 = getelementptr { %TupleHeader, %String* }, { %TupleHeader, %String* }* %1, i64 0, i32 1
+  store %String* %arg0, %String** %2
+  call void @__quantum__rt__string_reference(%String* %arg0)
+  ret { %TupleHeader, %String* }* %1
+}
+
+declare void @__quantum__rt__string_reference(%String*)
+
+attributes #0 = { "EntryPoint" }

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestUdtArgument.qs
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestUdtArgument.qs
@@ -3,11 +3,11 @@
 
 namespace Microsoft.Quantum.Testing.QIR
 {
-    // FIXME: FOR SOME REASON USING A GENERIC INSTEAD DOESN'T WORK...!
-    //function Build<'T>(build: (Int -> 'T)) : 'T
-    //{
-    //    return build(1);
-    //}
+    // TODO: using the type parameterized version for Build instead current runs into a bug
+    // function Build<'T>(build: (Int -> 'T)) : 'T
+    // {
+    //     return build(1);
+    // }
 
     function Build1(build: (Int -> TestType1)) : TestType1
     {
@@ -30,11 +30,11 @@ namespace Microsoft.Quantum.Testing.QIR
     newtype TestType3 = ((Pauli, I : Int), D : Double);
 
     @EntryPoint()
-    operation TestUdtArgument () : (Int) //, ((Pauli, Int), Double)) // FIXME: IN ORDER TO PROCESS A TUPLE WE ACTUALLY NEED TO FILL IN THE TODO...
+    operation TestUdtArgument () : (Int) //, ((Pauli, Int), Double)) // TODO: returning tuples is not yet implemented
     {
         let udt1 = Build1(TestType1);
         let udt2 = Build2(TestType2(PauliX, _));
-        //let udt3 = (TestType3((PauliX, 1), 2.0)); // FIXME: partial application args...
+        //let udt3 = (TestType3((PauliX, 1), 2.0)); // TODO: there is currently a bug in the partial application mapping
         return (udt1!); //, udt3!);
     }
 }

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestUdtArgument.qs
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestUdtArgument.qs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace Microsoft.Quantum.Testing.QIR
+{
+    function Build<'T>(build: (Int -> 'T)) : 'T
+    {
+        return build(1);
+    }
+
+    newtype TestType1 = Int;
+    newtype TestType2 = ((Pauli, I : Int), D : Double);
+
+    @EntryPoint()
+    operation TestUdtArgument () : (Int, ((Pauli, Int), Double))
+    {
+        let udt1 = Build(TestType1);
+        let udt2 = Build(TestType2((PauliX, _), 2.0));
+        return (udt1!, udt2!);
+    }
+}

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestUdtArgument.qs
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestUdtArgument.qs
@@ -3,19 +3,38 @@
 
 namespace Microsoft.Quantum.Testing.QIR
 {
-    function Build<'T>(build: (Int -> 'T)) : 'T
+    // FIXME: FOR SOME REASON USING A GENERIC INSTEAD DOESN'T WORK...!
+    //function Build<'T>(build: (Int -> 'T)) : 'T
+    //{
+    //    return build(1);
+    //}
+
+    function Build1(build: (Int -> TestType1)) : TestType1
     {
         return build(1);
     }
 
+    function Build2(build: (Int -> TestType2)) : TestType2
+    {
+        return build(1);
+    }
+    
+    function Build3(build: (Int -> TestType3)) : TestType3
+    {
+        return build(1);
+    }
+
+
     newtype TestType1 = Int;
-    newtype TestType2 = ((Pauli, I : Int), D : Double);
+    newtype TestType2 = (Pauli, I : Int);
+    newtype TestType3 = ((Pauli, I : Int), D : Double);
 
     @EntryPoint()
-    operation TestUdtArgument () : (Int, ((Pauli, Int), Double))
+    operation TestUdtArgument () : (Int) //, ((Pauli, Int), Double)) // FIXME: IN ORDER TO PROCESS A TUPLE WE ACTUALLY NEED TO FILL IN THE TODO...
     {
-        let udt1 = Build(TestType1);
-        let udt2 = Build(TestType2((PauliX, _), 2.0));
-        return (udt1!, udt2!);
+        let udt1 = Build1(TestType1);
+        let udt2 = Build2(TestType2(PauliX, _));
+        //let udt3 = (TestType3((PauliX, 1), 2.0)); // FIXME: partial application args...
+        return (udt1!); //, udt3!);
     }
 }

--- a/src/QsCompiler/Tests.Compiler/Tests.Compiler.fsproj
+++ b/src/QsCompiler/Tests.Compiler/Tests.Compiler.fsproj
@@ -153,6 +153,12 @@
     <Content Include="TestCases\QirTests\TestUdtConstruction.qs">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="TestCases\QirTests\TestUdtArgument.ll">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="TestCases\QirTests\TestUdtArgument.qs">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Content Include="TestCases\QirTests\TestUdtUpdate.ll">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>

--- a/src/QsCompiler/Tests.Compiler/Tests.Compiler.fsproj
+++ b/src/QsCompiler/Tests.Compiler/Tests.Compiler.fsproj
@@ -78,6 +78,12 @@
     <Content Include="TestCases\QirTests\TestEntryPoint.qs">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="TestCases\QirTests\TestOpArgument.ll">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="TestCases\QirTests\TestOpArgument.qs">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Content Include="TestCases\QirTests\TestIntegers.ll">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
@@ -147,16 +153,16 @@
     <Content Include="TestCases\QirTests\TestUdtAccessor.qs">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
-    <Content Include="TestCases\QirTests\TestUdtConstruction.ll">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="TestCases\QirTests\TestUdtConstruction.qs">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
     <Content Include="TestCases\QirTests\TestUdtArgument.ll">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="TestCases\QirTests\TestUdtArgument.qs">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="TestCases\QirTests\TestUdtConstruction.ll">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="TestCases\QirTests\TestUdtConstruction.qs">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="TestCases\QirTests\TestUdtUpdate.ll">

--- a/src/QsCompiler/Transformations/TargetInstructionInference.cs
+++ b/src/QsCompiler/Transformations/TargetInstructionInference.cs
@@ -129,12 +129,12 @@ namespace Microsoft.Quantum.QsCompiler.Transformations.Targeting
                             QsQualifiedName GeneratedName(QsSpecializationKind kind)
                             {
                                 var suffix =
-                                    kind.IsQsBody ? "Body" :
+                                    kind.IsQsBody ? "" :
                                     kind.IsQsAdjoint ? "Adj" :
                                     kind.IsQsControlled ? "Ctl" :
                                     kind.IsQsControlledAdjoint ? "CtlAdj" :
                                     kind.ToString();
-                                return new QsQualifiedName(callable.FullName.Namespace, $"{callable.FullName.Name}__{suffix}");
+                                return new QsQualifiedName(callable.FullName.Namespace, $"{callable.FullName.Name}{suffix}__");
                             }
 
                             var specializations = callable.Specializations.Select(spec =>


### PR DESCRIPTION
This PR fixes 
- a bug that made the QIR generation fail when returning a user defined type
- a bug that made the QIR generation fail when passing type constructors as arguments
- a bug that made the QIR generation fail when passing intrinsic callables as arguments
- a bug that made the QIR generation fail when a user defined type with a single item is unwrapped.

Parts of the added tests are still commented out, since the tests cover three more issues that first need to be fixed. 