### PR TITLE
Only initialize Bond protocols when needed

### DIFF
--- a/src/QsCompiler/BondSchemas/Protocols.cs
+++ b/src/QsCompiler/BondSchemas/Protocols.cs
@@ -46,13 +46,24 @@ namespace Microsoft.Quantum.QsCompiler.BondSchemas
         }
 
         /// <summary>
-        /// Starts the creation of Bond serializers and deserializers.
+        /// Starts the creation of a Bond deserializer.
         /// </summary>
-        public static void Initialize()
+        public static void InitializeDeserializer()
         {
             lock (BondSharedDataStructuresLock)
             {
                 simpleBinaryDeserializerInitialization = QueueSimpleBinaryDeserializerInitialization();
+            }
+        }
+
+        /// <summary>
+        /// Starts the creation of a Bond serializer.
+        /// </summary>
+        public static void InitializeSerializer()
+        {
+            lock (BondSharedDataStructuresLock)
+            {
+                
                 simpleBinarySerializerInitialization = QueueSimpleBinarySerializerInitialization();
             }
         }

--- a/src/QsCompiler/BondSchemas/Protocols.cs
+++ b/src/QsCompiler/BondSchemas/Protocols.cs
@@ -46,13 +46,35 @@ namespace Microsoft.Quantum.QsCompiler.BondSchemas
         }
 
         /// <summary>
+        /// Starts the creation of Bond serializers and deserializers.
+        /// </summary>
+        public static void Initialize()
+        {
+            lock (BondSharedDataStructuresLock)
+            {
+                if (simpleBinaryDeserializerInitialization == null)
+                {
+                    simpleBinaryDeserializerInitialization = QueueSimpleBinaryDeserializerInitialization();
+                }
+
+                if (simpleBinarySerializerInitialization == null)
+                {
+                    simpleBinarySerializerInitialization = QueueSimpleBinarySerializerInitialization();
+                }
+            }
+        }
+
+        /// <summary>
         /// Starts the creation of a Bond deserializer.
         /// </summary>
         public static void InitializeDeserializer()
         {
             lock (BondSharedDataStructuresLock)
             {
-                simpleBinaryDeserializerInitialization = QueueSimpleBinaryDeserializerInitialization();
+                if (simpleBinaryDeserializerInitialization == null)
+                {
+                    simpleBinaryDeserializerInitialization = QueueSimpleBinaryDeserializerInitialization();
+                }
             }
         }
 
@@ -63,8 +85,10 @@ namespace Microsoft.Quantum.QsCompiler.BondSchemas
         {
             lock (BondSharedDataStructuresLock)
             {
-                
-                simpleBinarySerializerInitialization = QueueSimpleBinarySerializerInitialization();
+                if (simpleBinarySerializerInitialization == null)
+                {
+                    simpleBinarySerializerInitialization = QueueSimpleBinarySerializerInitialization();
+                }
             }
         }
 

--- a/src/QsCompiler/Compiler/CompilationLoader.cs
+++ b/src/QsCompiler/Compiler/CompilationLoader.cs
@@ -477,10 +477,16 @@ namespace Microsoft.Quantum.QsCompiler
             this.RaiseCompilationTaskStart(null, "OverallCompilation");
 
             // loading the content to compiler
-            BondSchemas.Protocols.Initialize();
             this.logger = logger;
             this.LoadDiagnostics = ImmutableArray<Diagnostic>.Empty;
             this.config = options ?? default;
+
+            // When loading references is done through the generated C# and the syntax tree is not serialized,
+            // Bond protocols are not needed.
+            if (!this.config.LoadReferencesBasedOnGeneratedCsharp && !this.config.SerializeSyntaxTree)
+            {
+                BondSchemas.Protocols.Initialize();
+            }
 
             Status rewriteStepLoading = Status.Succeeded;
             this.externalRewriteSteps = ExternalRewriteStepsManager.Load(this.config, d => this.LogAndUpdateLoadDiagnostics(ref rewriteStepLoading, d), ex => this.LogAndUpdate(ref rewriteStepLoading, ex));

--- a/src/QsCompiler/Compiler/CompilationLoader.cs
+++ b/src/QsCompiler/Compiler/CompilationLoader.cs
@@ -481,11 +481,16 @@ namespace Microsoft.Quantum.QsCompiler
             this.LoadDiagnostics = ImmutableArray<Diagnostic>.Empty;
             this.config = options ?? default;
 
-            // When loading references is done through the generated C# and the syntax tree is not serialized,
-            // Bond protocols are not needed.
-            if (!this.config.LoadReferencesBasedOnGeneratedCsharp && !this.config.SerializeSyntaxTree)
+            // When loading references is done through the generated C# a Bond deserializer is not needed.
+            if (this.config.LoadReferencesBasedOnGeneratedCsharp)
             {
-                BondSchemas.Protocols.Initialize();
+                BondSchemas.Protocols.InitializeDeserializer();
+            }
+
+            // When the syntax tree is not serialized a Bond serializer is not needed.
+            if (this.config.SerializeSyntaxTree)
+            {
+                BondSchemas.Protocols.InitializeSerializer();
             }
 
             Status rewriteStepLoading = Status.Succeeded;

--- a/src/QsCompiler/Compiler/CompilationLoader.cs
+++ b/src/QsCompiler/Compiler/CompilationLoader.cs
@@ -482,7 +482,7 @@ namespace Microsoft.Quantum.QsCompiler
             this.config = options ?? default;
 
             // When loading references is done through the generated C# a Bond deserializer is not needed.
-            if (this.config.LoadReferencesBasedOnGeneratedCsharp)
+            if (!this.config.LoadReferencesBasedOnGeneratedCsharp)
             {
                 BondSchemas.Protocols.InitializeDeserializer();
             }


### PR DESCRIPTION
This change aims to remove impact on Katas' performance by not initializing Bond serializer/deserializer when is not needed (even if it is done asynchronously).