### PR TITLE
Adds ConcreteIntrinsicGen Property

### DIFF
--- a/src/QsCompiler/DataStructures/ReservedKeywords.fs
+++ b/src/QsCompiler/DataStructures/ReservedKeywords.fs
@@ -246,6 +246,7 @@ module AssemblyConstants =
     let ToffoliSimulator = "ToffoliSimulator"
     let ResourcesEstimator = "ResourcesEstimator"
     let ExposeReferencesViaTestNames = "ExposeReferencesViaTestNames"
+    let ConcreteIntrinsicGen = "ConcreteIntrinsicGen"
 
     /// The runtime capabilities supported by an execution target. The names of the capabilities here match the ones
     /// defined by the SDK.

--- a/src/QsCompiler/DataStructures/ReservedKeywords.fs
+++ b/src/QsCompiler/DataStructures/ReservedKeywords.fs
@@ -246,7 +246,7 @@ module AssemblyConstants =
     let ToffoliSimulator = "ToffoliSimulator"
     let ResourcesEstimator = "ResourcesEstimator"
     let ExposeReferencesViaTestNames = "ExposeReferencesViaTestNames"
-    let ConcreteIntrinsicGen = "ConcreteIntrinsicGen"
+    let GenerateConcreteIntrinsic = "GenerateConcreteIntrinsic"
 
     /// The runtime capabilities supported by an execution target. The names of the capabilities here match the ones
     /// defined by the SDK.

--- a/src/QuantumSdk/DefaultItems/DefaultItems.props.v.template
+++ b/src/QuantumSdk/DefaultItems/DefaultItems.props.v.template
@@ -28,18 +28,18 @@
   </PropertyGroup>
 
   <!-- unverified configurable properties -->
-  <PropertyGroup> 
+  <PropertyGroup>
     <QscVerbosity>Normal</QscVerbosity>
     <CsharpGeneration>true</CsharpGeneration> <!-- at some point we may want to make False the default -->
-    <IncludeQsharpCorePackages>true</IncludeQsharpCorePackages> 
-    <IncludeProviderPackages>true</IncludeProviderPackages> 
+    <IncludeQsharpCorePackages>true</IncludeQsharpCorePackages>
+    <IncludeProviderPackages>true</IncludeProviderPackages>
     <QsharpDocsGeneration>false</QsharpDocsGeneration>
     <ExposeReferencesViaTestNames>false</ExposeReferencesViaTestNames> <!-- IMPORTANT: If the name of this property is changed, the property name in the language server needs to be adapted! -->
-    <DefaultQscBuildConfigExe>dotnet "$(MSBuildThisFileDirectory)../tools/utils/Microsoft.Quantum.Sdk.BuildConfiguration.dll"</DefaultQscBuildConfigExe> 
-    <QscBuildConfigExe>$(DefaultQscBuildConfigExe)</QscBuildConfigExe> 
-    <DefaultQscExe>dotnet "$(MSBuildThisFileDirectory)../tools/qsc/qsc.dll"</DefaultQscExe> 
-    <QscExe>$(DefaultQscExe)</QscExe> 
+    <DefaultQscBuildConfigExe>dotnet "$(MSBuildThisFileDirectory)../tools/utils/Microsoft.Quantum.Sdk.BuildConfiguration.dll"</DefaultQscBuildConfigExe>
+    <QscBuildConfigExe>$(DefaultQscBuildConfigExe)</QscBuildConfigExe>
+    <DefaultQscExe>dotnet "$(MSBuildThisFileDirectory)../tools/qsc/qsc.dll"</DefaultQscExe>
+    <QscExe>$(DefaultQscExe)</QscExe>
+    <ConcreteIntrinsicGen>false</ConcreteIntrinsicGen>
   </PropertyGroup>
 
 </Project>
- 

--- a/src/QuantumSdk/DefaultItems/DefaultItems.props.v.template
+++ b/src/QuantumSdk/DefaultItems/DefaultItems.props.v.template
@@ -39,7 +39,7 @@
     <QscBuildConfigExe>$(DefaultQscBuildConfigExe)</QscBuildConfigExe>
     <DefaultQscExe>dotnet "$(MSBuildThisFileDirectory)../tools/qsc/qsc.dll"</DefaultQscExe>
     <QscExe>$(DefaultQscExe)</QscExe>
-    <ConcreteIntrinsicGen>false</ConcreteIntrinsicGen>
+    <GenerateConcreteIntrinsic>false</GenerateConcreteIntrinsic>
   </PropertyGroup>
 
 </Project>

--- a/src/QuantumSdk/Sdk/Sdk.targets
+++ b/src/QuantumSdk/Sdk/Sdk.targets
@@ -93,6 +93,7 @@
       <_QscCommandPredefinedAssemblyProperties Condition="'$(ExposeReferencesViaTestNames)'">$(_QscCommandPredefinedAssemblyProperties)$(_NewLineIndent)ExposeReferencesViaTestNames:true</_QscCommandPredefinedAssemblyProperties>
       <_QscCommandPredefinedAssemblyProperties Condition="'$(_QscDocsPackageId)' != ''">$(_QscCommandPredefinedAssemblyProperties)$(_NewLineIndent)DocsPackageId:$(_QscDocsPackageId)</_QscCommandPredefinedAssemblyProperties>
       <_QscCommandPredefinedAssemblyProperties Condition="'$(QsharpDocsGeneration)'">$(_QscCommandPredefinedAssemblyProperties)$(_NewLineIndent)DocsOutputPath:"$(QsharpDocsOutputPath)"</_QscCommandPredefinedAssemblyProperties>
+      <_QscCommandPredefinedAssemblyProperties Condition="'$(ConcreteIntrinsicGen)'">$(_QscCommandPredefinedAssemblyProperties)$(_NewLineIndent)ConcreteIntrinsicGen:$(ConcreteIntrinsicGen)</_QscCommandPredefinedAssemblyProperties>
       <_QscCommandAssemblyPropertiesFlag>$(_NewLine)--assembly-properties$(_QscCommandPredefinedAssemblyProperties)</_QscCommandAssemblyPropertiesFlag>
       <_QscCommandAssemblyPropertiesFlag Condition="'$(QscCommandAssemblyProperties)' != ''">$(_QscCommandAssemblyPropertiesFlag)$(_NewLineIndent)$(QscCommandAssemblyProperties)</_QscCommandAssemblyPropertiesFlag>
       <AdditionalQscArguments Condition="'$(AdditionalQscArguments)' != ''">$(_NewLine)$(AdditionalQscArguments)</AdditionalQscArguments>

--- a/src/QuantumSdk/Sdk/Sdk.targets
+++ b/src/QuantumSdk/Sdk/Sdk.targets
@@ -93,7 +93,7 @@
       <_QscCommandPredefinedAssemblyProperties Condition="'$(ExposeReferencesViaTestNames)'">$(_QscCommandPredefinedAssemblyProperties)$(_NewLineIndent)ExposeReferencesViaTestNames:true</_QscCommandPredefinedAssemblyProperties>
       <_QscCommandPredefinedAssemblyProperties Condition="'$(_QscDocsPackageId)' != ''">$(_QscCommandPredefinedAssemblyProperties)$(_NewLineIndent)DocsPackageId:$(_QscDocsPackageId)</_QscCommandPredefinedAssemblyProperties>
       <_QscCommandPredefinedAssemblyProperties Condition="'$(QsharpDocsGeneration)'">$(_QscCommandPredefinedAssemblyProperties)$(_NewLineIndent)DocsOutputPath:"$(QsharpDocsOutputPath)"</_QscCommandPredefinedAssemblyProperties>
-      <_QscCommandPredefinedAssemblyProperties Condition="'$(ConcreteIntrinsicGen)'">$(_QscCommandPredefinedAssemblyProperties)$(_NewLineIndent)ConcreteIntrinsicGen:$(ConcreteIntrinsicGen)</_QscCommandPredefinedAssemblyProperties>
+      <_QscCommandPredefinedAssemblyProperties Condition="'$(GenerateConcreteIntrinsic)'">$(_QscCommandPredefinedAssemblyProperties)$(_NewLineIndent)GenerateConcreteIntrinsic:$(GenerateConcreteIntrinsic)</_QscCommandPredefinedAssemblyProperties>
       <_QscCommandAssemblyPropertiesFlag>$(_NewLine)--assembly-properties$(_QscCommandPredefinedAssemblyProperties)</_QscCommandAssemblyPropertiesFlag>
       <_QscCommandAssemblyPropertiesFlag Condition="'$(QscCommandAssemblyProperties)' != ''">$(_QscCommandAssemblyPropertiesFlag)$(_NewLineIndent)$(QscCommandAssemblyProperties)</_QscCommandAssemblyPropertiesFlag>
       <AdditionalQscArguments Condition="'$(AdditionalQscArguments)' != ''">$(_NewLine)$(AdditionalQscArguments)</AdditionalQscArguments>


### PR DESCRIPTION
Adds ConcreteIntrinsicGen Property as an assembly constant and Q# project property. This property will be used by the C# generation rewrite step to determine if an intrinsic operation is generated in C# as an abstract class (original and default behavior) or a concrete class (new behavior from using property). The logic that will utilize this property is found in the runtime repo under the branch 'swernli/decomp-interfaces', specifically here: https://github.com/microsoft/qsharp-runtime/blob/swernli/decomp-interfaces/src/Simulation/CsharpGeneration/SimulationCode.fs