### PR TITLE
Eliminating tuple headers in QIR

### DIFF
--- a/src/QsCompiler/QirGeneration/QIR/Types.cs
+++ b/src/QsCompiler/QirGeneration/QIR/Types.cs
@@ -101,7 +101,6 @@ namespace Microsoft.Quantum.QIR
 
         // private fields
 
-        private readonly IStructType tupleHeader;
         private readonly Context context;
 
         // constructor
@@ -110,14 +109,13 @@ namespace Microsoft.Quantum.QIR
         {
             this.context = context;
 
-            this.tupleHeader = context.CreateStructType(TypeNames.Tuple, false, context.Int32Type, context.Int32Type); // private
             this.Range = context.CreateStructType(TypeNames.Range, false, context.Int64Type, context.Int64Type, context.Int64Type);
 
             this.Result = context.CreateStructType(TypeNames.Result).CreatePointerType();
             this.Qubit = context.CreateStructType(TypeNames.Qubit).CreatePointerType();
             this.String = context.CreateStructType(TypeNames.String).CreatePointerType();
             this.BigInt = context.CreateStructType(TypeNames.BigInt).CreatePointerType();
-            this.Tuple = this.tupleHeader.CreatePointerType();
+            this.Tuple = context.CreateStructType(TypeNames.Tuple).CreatePointerType();
             this.Array = context.CreateStructType(TypeNames.Array).CreatePointerType();
             this.Callable = context.CreateStructType(TypeNames.Callable).CreatePointerType();
 
@@ -139,7 +137,7 @@ namespace Microsoft.Quantum.QIR
         /// always passed as a pointer to that item.
         /// </summary>
         public IStructType CreateConcreteTupleType(IEnumerable<ITypeRef> items) =>
-            this.context.CreateStructType(false, items.Prepend(this.tupleHeader).ToArray());
+            this.context.CreateStructType(false, items.ToArray());
 
         /// <summary>
         /// Creates the concrete type of a QIR tuple value that contains the given items.
@@ -147,7 +145,7 @@ namespace Microsoft.Quantum.QIR
         /// and are always passed as a pointer to that item.
         /// </summary>
         public IStructType CreateConcreteTupleType(params ITypeRef[] items) =>
-            this.CreateConcreteTupleType((IEnumerable<ITypeRef>)items);
+            this.context.CreateStructType(false, items);
 
         /// <summary>
         /// Determines whether an LLVM type is a pointer to a tuple.
@@ -156,8 +154,8 @@ namespace Microsoft.Quantum.QIR
         public bool IsTupleType(ITypeRef t) =>
             t is IPointerType pt
             && pt.ElementType is IStructType st
-            && st.Members.Count > 0
-            && st.Members[0] == this.tupleHeader;
+            && st.Name == null
+            && st.Members.Count > 0;
     }
 
     /// <summary>
@@ -179,7 +177,7 @@ namespace Microsoft.Quantum.QIR
         public const string BigInt = "BigInt";
         public const string String = "String";
         public const string Array = "Array";
-        public const string Tuple = "TupleHeader";
+        public const string Tuple = "Tuple";
 
         // There is no separate struct type for Tuple,
         // since within QIR, there is not type distinction between tuples with different item types or number of items.

--- a/src/QsCompiler/QirGeneration/ScopeManager.cs
+++ b/src/QsCompiler/QirGeneration/ScopeManager.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Quantum.QsCompiler.QIR
 
         /// <summary>
         /// Is true when there are currently no stack frames tracked.
-        /// Stack frames are added and removed by OpenScope and CloseScope respectively. 
+        /// Stack frames are added and removed by OpenScope and CloseScope respectively.
         /// </summary>
         public bool IsEmpty => !this.releaseStack.Any();
 
@@ -135,17 +135,12 @@ namespace Microsoft.Quantum.QsCompiler.QIR
                 // for tuples we also unreference all inner tuples
                 var elementType = ((IPointerType)value.NativeType).ElementType;
                 var itemTypes = ((IStructType)elementType).Members;
-                for (var i = 1; i < itemTypes.Count; ++i)
+                for (var i = 0; i < itemTypes.Count; ++i)
                 {
                     var itemFuncName = getItemFunc(itemTypes[i]);
                     if (itemFuncName != null)
                     {
-                        var indices = new Value[]
-                        {
-                                this.sharedState.Context.CreateConstant(0L),
-                                this.sharedState.Context.CreateConstant(i)
-                        };
-                        var ptr = builder.GetElementPtr(elementType, value, indices);
+                        var ptr = builder.GetElementPtr(elementType, value, this.sharedState.PointerIndex(i));
                         var item = builder.Load(itemTypes[i], ptr);
                         this.RecursivelyModifyReferences(item, this.sharedState.GetOrCreateRuntimeFunction(itemFuncName), getItemFunc, builder);
                     }
@@ -275,7 +270,7 @@ namespace Microsoft.Quantum.QsCompiler.QIR
         /// Exits the current scope stack by generating all of the pending releases for all open scopes.
         /// Skips any release function for the returned value.
         /// The releases are generated in the current block.
-        /// Exiting the current scope does *not* close the scope. 
+        /// Exiting the current scope does *not* close the scope.
         /// </summary>
         /// <param name="returned">The value that is returned and expected to remain valid after exiting.</param>
         public void ExitScope(Value returned)

--- a/src/QsCompiler/QirGeneration/ScopeManager.cs
+++ b/src/QsCompiler/QirGeneration/ScopeManager.cs
@@ -140,7 +140,7 @@ namespace Microsoft.Quantum.QsCompiler.QIR
                     var itemFuncName = getItemFunc(itemTypes[i]);
                     if (itemFuncName != null)
                     {
-                        var ptr = builder.GetElementPtr(elementType, value, this.sharedState.PointerIndex(i));
+                        var ptr = this.sharedState.GetTupleElementPointer(elementType, value, i, builder);
                         var item = builder.Load(itemTypes[i], ptr);
                         this.RecursivelyModifyReferences(item, this.sharedState.GetOrCreateRuntimeFunction(itemFuncName), getItemFunc, builder);
                     }

--- a/src/QsCompiler/QirGeneration/Subtransformations/ExpressionKindTransformation.cs
+++ b/src/QsCompiler/QirGeneration/Subtransformations/ExpressionKindTransformation.cs
@@ -51,12 +51,7 @@ namespace Microsoft.Quantum.QsCompiler.QIR
 
             public override Value BuildItem(InstructionBuilder builder, ITypeRef captureType, Value capture, ITypeRef parArgsType, Value parArgs)
             {
-                var indices = new Value[]
-                {
-                    builder.Context.CreateConstant(0L),
-                    builder.Context.CreateConstant(this.CaptureIndex)
-                };
-                var srcPtr = builder.GetElementPtr(captureType, capture, indices);
+                var srcPtr = builder.GetElementPtr(captureType, capture, this.SharedState.PointerIndex(this.CaptureIndex));
                 var item = builder.Load(this.ItemType, srcPtr);
                 return item;
             }
@@ -76,12 +71,7 @@ namespace Microsoft.Quantum.QsCompiler.QIR
             {
                 if (this.SharedState.Types.IsTupleType(parArgs.NativeType))
                 {
-                    var indices = new Value[]
-                    {
-                        builder.Context.CreateConstant(0L),
-                        builder.Context.CreateConstant(this.ArgIndex)
-                    };
-                    var srcPtr = builder.GetElementPtr(parArgsType, parArgs, indices);
+                    var srcPtr = builder.GetElementPtr(parArgsType, parArgs, this.SharedState.PointerIndex(this.ArgIndex));
                     var item = builder.Load(this.ItemType, srcPtr);
                     return item;
                 }
@@ -112,8 +102,7 @@ namespace Microsoft.Quantum.QsCompiler.QIR
                 this.SharedState.ScopeMgr.AddValue(typedTuple);
                 for (int i = 0; i < this.Items.Length; i++)
                 {
-                    var indices = new Value[] { builder.Context.CreateConstant(0L), builder.Context.CreateConstant(i + 1) };
-                    var itemDestPtr = builder.GetElementPtr(this.ItemType, typedTuple, indices);
+                    var itemDestPtr = builder.GetElementPtr(this.ItemType, typedTuple, this.SharedState.PointerIndex(i));
                     var item = this.Items[i].BuildItem(builder, captureType, capture, parArgsType, parArgs);
                     if (this.Items[i] is InnerTuple)
                     {
@@ -201,7 +190,7 @@ namespace Microsoft.Quantum.QsCompiler.QIR
                 for (int i = 0; i < elementTypes.Length; i++)
                 {
                     var elementType = elementTypes[i];
-                    var originalElementPointer = this.SharedState.GetTupleElementPointer(originalTypeRef, typedOriginal, i + 1, builder);
+                    var originalElementPointer = this.SharedState.GetTupleElementPointer(originalTypeRef, typedOriginal, i, builder);
                     var originalElement = builder.Load(this.SharedState.LlvmTypeFromQsharpType(elementType), originalElementPointer);
                     Value elementValue = elementType.Resolution switch
                     {
@@ -212,7 +201,7 @@ namespace Microsoft.Quantum.QsCompiler.QIR
                         // FIXME: WHAT ABOUT UDTS?
                         _ => originalElement,
                     };
-                    var copyElementPointer = this.SharedState.GetTupleElementPointer(originalTypeRef, typedCopy, i + 1, builder);
+                    var copyElementPointer = this.SharedState.GetTupleElementPointer(originalTypeRef, typedCopy, i, builder);
                     builder.Store(elementValue, copyElementPointer);
                 }
 
@@ -319,12 +308,7 @@ namespace Microsoft.Quantum.QsCompiler.QIR
             void FillStructSlot(IStructType structType, Value pointerToStruct, Value fillValue, int position)
             {
                 // Generate a store for the value
-                Value[] indices = new Value[]
-                {
-                    this.SharedState.Context.CreateConstant(0L),
-                    this.SharedState.Context.CreateConstant(position)
-                };
-                var elementPointer = this.SharedState.CurrentBuilder.GetElementPtr(structType, pointerToStruct, indices);
+                var elementPointer = this.SharedState.CurrentBuilder.GetElementPtr(structType, pointerToStruct, this.SharedState.PointerIndex(position));
                 var castValue = fillValue.NativeType == this.SharedState.Types.Tuple
                     ? this.SharedState.CurrentBuilder.BitCast(fillValue, structType.Members[position])
                     : fillValue;
@@ -355,18 +339,18 @@ namespace Microsoft.Quantum.QsCompiler.QIR
                             var subTupleTypeRef = ((IPointerType)this.SharedState.LlvmTypeFromQsharpType(items[i].ResolvedType)).ElementType;
                             var subTupleAsTuplePointer = this.SharedState.CreateTupleForType(subTupleTypeRef);
                             var subTupleAsTypedPointer = this.SharedState.CurrentBuilder.BitCast(subTupleAsTuplePointer, subTupleTypeRef.CreatePointerType());
-                            FillStructSlot(tupleTypeRef, tupleToFillPointer, subTupleAsTypedPointer, i + 1);
+                            FillStructSlot(tupleTypeRef, tupleToFillPointer, subTupleAsTypedPointer, i);
                             this.FillTuple(subTupleAsTypedPointer, items[i]);
                             break;
                         default:
-                            FillItem(tupleTypeRef, tupleToFillPointer, items[i], i + 1);
+                            FillItem(tupleTypeRef, tupleToFillPointer, items[i], i);
                             break;
                     }
                 }
             }
             else
             {
-                FillItem(tupleTypeRef, tupleToFillPointer, expr, 1);
+                FillItem(tupleTypeRef, tupleToFillPointer, expr, 0);
             }
         }
 
@@ -464,8 +448,7 @@ namespace Microsoft.Quantum.QsCompiler.QIR
                     {
                         if (this.FindNamedItem(name, list.Item[i], location))
                         {
-                            // +1 to skip the tuple header
-                            location.Add((i + 1, GetTypeItemType(items)));
+                            location.Add((i, GetTypeItemType(items)));
                             return true;
                         }
                     }
@@ -482,7 +465,7 @@ namespace Microsoft.Quantum.QsCompiler.QIR
                 if (arg.Expression.IsMissingExpr)
                 {
                     remainingArgs.Add(argType);
-                    return new InnerArg(this.SharedState, this.SharedState.LlvmTypeFromQsharpType(argType), remainingArgs.Count);
+                    return new InnerArg(this.SharedState, this.SharedState.LlvmTypeFromQsharpType(argType), remainingArgs.Count - 1);
                 }
                 else if (arg.Expression is ResolvedExpression.ValueTuple tuple
                     && argType.Resolution is QsResolvedTypeKind.TupleType types)
@@ -497,7 +480,7 @@ namespace Microsoft.Quantum.QsCompiler.QIR
                     // A value we should capture; remember that the first element in the capture tuple is the inner callable
                     var val = this.SharedState.EvaluateSubexpression(arg);
                     capturedValues.Add((val, argType));
-                    return new InnerCapture(this.SharedState, this.SharedState.LlvmTypeFromQsharpType(arg.ResolvedType), capturedValues.Count + 1);
+                    return new InnerCapture(this.SharedState, this.SharedState.LlvmTypeFromQsharpType(arg.ResolvedType), capturedValues.Count);
                 }
             }
 
@@ -558,56 +541,32 @@ namespace Microsoft.Quantum.QsCompiler.QIR
                     // Deal with the extra control qubit arg for controlled and controlled-adjoint
                     // Note that there's a special case if the base specialization only takes a single parameter,
                     // in which case we don't create the sub-tuple.
-                    if (parArgsStruct.Members.Count > 2)
+                    if (parArgsStruct.Members.Count > 1)
                     {
                         var ctlArgsType = this.SharedState.Types.CreateConcreteTupleType(this.SharedState.Types.Array, this.SharedState.Types.Tuple);
                         var ctlArgsPointer = builder.BitCast(func.Parameters[1], ctlArgsType.CreatePointerType());
-                        var controlsPointer = builder.GetElementPtr(ctlArgsType, ctlArgsPointer, new Value[]
-                        {
-                            this.SharedState.Context.CreateConstant(0L),
-                            this.SharedState.Context.CreateConstant(1)
-                        });
-                        var restPointer = builder.GetElementPtr(ctlArgsType, ctlArgsPointer, new Value[]
-                        {
-                            this.SharedState.Context.CreateConstant(0L),
-                            this.SharedState.Context.CreateConstant(2)
-                        });
+                        var controlsPointer = builder.GetElementPtr(ctlArgsType, ctlArgsPointer, this.SharedState.PointerIndex(0));
+                        var restPointer = builder.GetElementPtr(ctlArgsType, ctlArgsPointer, this.SharedState.PointerIndex(1));
                         var typedRestPointer = builder.BitCast(restPointer, parArgsType.CreatePointerType());
                         var restTuple = rebuild.BuildItem(builder, captureType, capturePointer, parArgsType, typedRestPointer);
                         var size = this.SharedState.ComputeSizeForType(ctlArgsType, builder);
                         innerArgTuple = builder.Call(this.SharedState.GetOrCreateRuntimeFunction(RuntimeLibrary.TupleCreate), size);
                         var typedNewTuple = builder.BitCast(innerArgTuple, ctlArgsType.CreatePointerType());
                         this.SharedState.ScopeMgr.AddValue(typedNewTuple);
-                        var destControlsPointer = builder.GetElementPtr(ctlArgsType, typedNewTuple, new Value[]
-                        {
-                            this.SharedState.Context.CreateConstant(0L),
-                            this.SharedState.Context.CreateConstant(1)
-                        });
+                        var destControlsPointer = builder.GetElementPtr(ctlArgsType, typedNewTuple, this.SharedState.PointerIndex(0));
                         var controls = builder.Load(this.SharedState.Types.Array, controlsPointer);
                         builder.Store(controls, destControlsPointer);
-                        var destArgsPointer = builder.GetElementPtr(ctlArgsType, typedNewTuple, new Value[]
-                        {
-                            this.SharedState.Context.CreateConstant(0L),
-                            this.SharedState.Context.CreateConstant(2)
-                        });
+                        var destArgsPointer = builder.GetElementPtr(ctlArgsType, typedNewTuple, this.SharedState.PointerIndex(1));
                         builder.Store(restTuple, destArgsPointer);
                     }
-                    else if (parArgsStruct.Members.Count == 2)
+                    else if (parArgsStruct.Members.Count == 1)
                     {
                         // First process the incoming argument. Remember, [0] is the %TupleHeader.
-                        var singleArgType = parArgsStruct.Members[1];
+                        var singleArgType = parArgsStruct.Members[0];
                         var inputArgsType = this.SharedState.Types.CreateConcreteTupleType(this.SharedState.Types.Array, singleArgType);
                         var inputArgsPointer = builder.BitCast(func.Parameters[1], inputArgsType.CreatePointerType());
-                        var controlsPointer = builder.GetElementPtr(inputArgsType, inputArgsPointer, new Value[]
-                        {
-                            this.SharedState.Context.CreateConstant(0L),
-                            this.SharedState.Context.CreateConstant(1)
-                        });
-                        var restPointer = builder.GetElementPtr(inputArgsType, inputArgsPointer, new Value[]
-                        {
-                            this.SharedState.Context.CreateConstant(0L),
-                            this.SharedState.Context.CreateConstant(2)
-                        });
+                        var controlsPointer = builder.GetElementPtr(inputArgsType, inputArgsPointer, this.SharedState.PointerIndex(0));
+                        var restPointer = builder.GetElementPtr(inputArgsType, inputArgsPointer, this.SharedState.PointerIndex(1));
                         var restValue = builder.Load(singleArgType, restPointer);
 
                         // OK, now build the full args for the partially-applied callable, other than the controlled qubits
@@ -618,23 +577,15 @@ namespace Microsoft.Quantum.QsCompiler.QIR
                         innerArgTuple = builder.Call(this.SharedState.GetOrCreateRuntimeFunction(RuntimeLibrary.TupleCreate), size);
                         var typedNewTuple = builder.BitCast(innerArgTuple, innerArgType.CreatePointerType());
                         this.SharedState.ScopeMgr.AddValue(typedNewTuple);
-                        var destControlsPointer = builder.GetElementPtr(innerArgType, typedNewTuple, new Value[]
-                        {
-                            this.SharedState.Context.CreateConstant(0L),
-                            this.SharedState.Context.CreateConstant(1)
-                        });
+                        var destControlsPointer = builder.GetElementPtr(innerArgType, typedNewTuple, this.SharedState.PointerIndex(0));
                         var controls = builder.Load(this.SharedState.Types.Array, controlsPointer);
                         builder.Store(controls, destControlsPointer);
-                        var destArgsPointer = builder.GetElementPtr(innerArgType, typedNewTuple, new Value[]
-                        {
-                            this.SharedState.Context.CreateConstant(0L),
-                            this.SharedState.Context.CreateConstant(2)
-                        });
+                        var destArgsPointer = builder.GetElementPtr(innerArgType, typedNewTuple, this.SharedState.PointerIndex(1));
                         builder.Store(restTuple, destArgsPointer);
                     }
                     else
                     {
-                        throw new InvalidOperationException("argument tuple is expected to have a least one member in addition to the tuple header");
+                        throw new InvalidOperationException("argument tuple is expected to have a least one member");
                     }
                 }
                 else
@@ -643,11 +594,7 @@ namespace Microsoft.Quantum.QsCompiler.QIR
                     innerArgTuple = rebuild.BuildItem(builder, captureType, capturePointer, parArgsType, parArgsPointer);
                 }
 
-                var innerCallablePtr = builder.GetElementPtr(captureType, capturePointer, new Value[]
-                {
-                    this.SharedState.Context.CreateConstant(0L),
-                    this.SharedState.Context.CreateConstant(1)
-                });
+                var innerCallablePtr = builder.GetElementPtr(captureType, capturePointer, this.SharedState.PointerIndex(0));
                 var innerCallable = builder.Load(this.SharedState.Types.Callable, innerCallablePtr);
                 // Depending on the specialization, we may have to get a different specialization of the callable
                 var specToCall = GetSpecializedInnerCallable(innerCallable, kind, builder);
@@ -694,11 +641,7 @@ namespace Microsoft.Quantum.QsCompiler.QIR
             var capType = this.SharedState.Types.CreateConcreteTupleType(capTypeList);
             var cap = this.SharedState.CreateTupleForType(capType);
             var capture = this.SharedState.CurrentBuilder.BitCast(cap, capType.CreatePointerType());
-            var callablePointer = this.SharedState.CurrentBuilder.GetElementPtr(capType, capture, new Value[]
-            {
-                this.SharedState.Context.CreateConstant(0L),
-                this.SharedState.Context.CreateConstant(1)
-            });
+            var callablePointer = this.SharedState.CurrentBuilder.GetElementPtr(capType, capture, this.SharedState.PointerIndex(0));
 
             var innerCallable = this.SharedState.EvaluateSubexpression(method);
             this.SharedState.CurrentBuilder.Store(innerCallable, callablePointer);
@@ -706,11 +649,7 @@ namespace Microsoft.Quantum.QsCompiler.QIR
 
             for (int n = 0; n < caps.Count; n++)
             {
-                var item = this.SharedState.CurrentBuilder.GetElementPtr(capType, capture, new Value[]
-                {
-                    this.SharedState.Context.CreateConstant(0L),
-                    this.SharedState.Context.CreateConstant(n + 2)
-                });
+                var item = this.SharedState.CurrentBuilder.GetElementPtr(capType, capture, this.SharedState.PointerIndex(n + 1));
                 this.SharedState.CurrentBuilder.Store(caps[n].Item1, item);
                 this.SharedState.ScopeMgr.AddReference(caps[n].Item1);
             }
@@ -1204,8 +1143,7 @@ namespace Microsoft.Quantum.QsCompiler.QIR
                     this.SharedState.CurrentBuilder.Call(func, this.SharedState.EvaluateSubexpression(method), argTuple, resultTuple);
 
                     // Now push the result. For now we assume it's a scalar.
-                    var indices = new Value[] { this.SharedState.Context.CreateConstant(0L), this.SharedState.Context.CreateConstant(1) };
-                    Value resultPointer = this.SharedState.CurrentBuilder.GetElementPtr(resultStructType, resultStruct, indices);
+                    Value resultPointer = this.SharedState.CurrentBuilder.GetElementPtr(resultStructType, resultStruct, this.SharedState.PointerIndex(0));
                     ITypeRef resultType = this.SharedState.LlvmTypeFromQsharpType(resultResolvedType);
                     Value result = this.SharedState.CurrentBuilder.Load(resultType, resultPointer);
                     this.SharedState.ValueStack.Push(result);
@@ -1366,12 +1304,10 @@ namespace Microsoft.Quantum.QsCompiler.QIR
                     var current = copy;
                     for (int i = 0; i < location.Count; i++)
                     {
-                        var indices = new Value[]
-                        {
-                            this.SharedState.Context.CreateConstant(0L),
-                            this.SharedState.Context.CreateConstant(location[i].Item1)
-                        };
-                        var ptr = this.SharedState.CurrentBuilder.GetElementPtr(((IPointerType)location[i].Item2).ElementType, current, indices);
+                        var ptr = this.SharedState.CurrentBuilder.GetElementPtr(
+                            ((IPointerType)location[i].Item2).ElementType,
+                            current,
+                            this.SharedState.PointerIndex(location[i].Item1));
                         // For the last item on the list, we store; otherwise, we load the next tuple
                         if (i == location.Count - 1)
                         {
@@ -1844,14 +1780,12 @@ namespace Microsoft.Quantum.QsCompiler.QIR
                     var value = this.SharedState.EvaluateSubexpression(ex);
                     for (int i = 0; i < location.Count; i++)
                     {
-                        var indices = new Value[]
-                        {
-                            this.SharedState.Context.CreateConstant(0L),
-                            this.SharedState.Context.CreateConstant(location[i].Item1)
-                        };
                         var innerTupleType = ((IPointerType)location[i].Item2).ElementType;
                         var elementType = ((IStructType)innerTupleType).Members[location[i].Item1];
-                        var ptr = this.SharedState.CurrentBuilder.GetElementPtr(innerTupleType, value, indices);
+                        var ptr = this.SharedState.CurrentBuilder.GetElementPtr(
+                            innerTupleType,
+                            value,
+                            this.SharedState.PointerIndex(location[i].Item1));
                         value = this.SharedState.CurrentBuilder.Load(elementType, ptr);
                     }
                     this.SharedState.ScopeMgr.AddReference(value);
@@ -2278,7 +2212,7 @@ namespace Microsoft.Quantum.QsCompiler.QIR
             for (int i = 0; i < vs.Length; i++)
             {
                 var itemValue = this.SharedState.EvaluateSubexpression(vs[i]);
-                var itemPointer = this.SharedState.GetTupleElementPointer(tupleType, concreteTuple, i + 1);
+                var itemPointer = this.SharedState.GetTupleElementPointer(tupleType, concreteTuple, i);
                 this.SharedState.CurrentBuilder.Store(itemValue, itemPointer);
                 this.SharedState.ScopeMgr.AddReference(itemValue);
             }
@@ -2303,7 +2237,7 @@ namespace Microsoft.Quantum.QsCompiler.QIR
                 var itemPointer = this.SharedState.CurrentBuilder.GetElementPtr(
                      this.SharedState.Types.CreateConcreteTupleType(itemType),
                      udtTuplePointer,
-                     new[] { this.SharedState.Context.CreateConstant(0L), this.SharedState.Context.CreateConstant(1) });
+                     this.SharedState.PointerIndex(0));
 
                 var element = this.SharedState.CurrentBuilder.Load(itemType, itemPointer);
                 this.SharedState.ScopeMgr.AddReference(element);

--- a/src/QsCompiler/QirGeneration/Subtransformations/StatementKindTransformation.cs
+++ b/src/QsCompiler/QirGeneration/Subtransformations/StatementKindTransformation.cs
@@ -110,7 +110,7 @@ namespace Microsoft.Quantum.QsCompiler.QIR
                     }
                     else
                     {
-                        var itemValuePtr = this.SharedState.GetTupleElementPointer(tupleType, tuplePointer, i + 1);
+                        var itemValuePtr = this.SharedState.GetTupleElementPointer(tupleType, tuplePointer, i);
                         var itemValue = this.SharedState.CurrentBuilder.Load(itemTypes[i], itemValuePtr);
                         BindItem(item, itemValue, types[i]);
                     }
@@ -572,7 +572,7 @@ namespace Microsoft.Quantum.QsCompiler.QIR
                 var tuplePointer = this.SharedState.CurrentBuilder.BitCast(val, tupleType.CreatePointerType());
                 for (int i = 0; i < items.Length; i++)
                 {
-                    var itemValuePtr = this.SharedState.GetTupleElementPointer(tupleType, tuplePointer, i + 1);
+                    var itemValuePtr = this.SharedState.GetTupleElementPointer(tupleType, tuplePointer, i);
                     var itemValue = this.SharedState.CurrentBuilder.Load(itemTypes[i], itemValuePtr);
                     UpdateItem(items[i], itemValue);
                 }

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestArrayLoop.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestArrayLoop.ll
@@ -1,16 +1,16 @@
-define { %TupleHeader, i64, i64 }* @Microsoft__Quantum__Testing__QIR__TestArrayLoop__body(%Array* %a) {
+define { i64, i64 }* @Microsoft__Quantum__Testing__QIR__TestArrayLoop__body(%Array* %a) {
 entry:
-  %0 = call %TupleHeader* @__quantum__rt__tuple_create(i64 ptrtoint ({ %TupleHeader, i64, i64 }* getelementptr ({ %TupleHeader, i64, i64 }, { %TupleHeader, i64, i64 }* null, i32 1) to i64))
-  %1 = bitcast %TupleHeader* %0 to { %TupleHeader, i64, i64 }*
-  %2 = getelementptr { %TupleHeader, i64, i64 }, { %TupleHeader, i64, i64 }* %1, i64 0, i32 1
+  %0 = call %Tuple* @__quantum__rt__tuple_create(i64 mul nuw (i64 ptrtoint (i64* getelementptr (i64, i64* null, i32 1) to i64), i64 2))
+  %1 = bitcast %Tuple* %0 to { i64, i64 }*
+  %2 = getelementptr { i64, i64 }, { i64, i64 }* %1, i64 0, i32 0
   store i64 0, i64* %2
-  %3 = getelementptr { %TupleHeader, i64, i64 }, { %TupleHeader, i64, i64 }* %1, i64 0, i32 2
+  %3 = getelementptr { i64, i64 }, { i64, i64 }* %1, i64 0, i32 1
   store i64 0, i64* %3
-  %4 = getelementptr { %TupleHeader, i64, i64 }, { %TupleHeader, i64, i64 }* %1, i64 0, i32 1
+  %4 = getelementptr { i64, i64 }, { i64, i64 }* %1, i64 0, i32 0
   %5 = load i64, i64* %4
   %x = alloca i64
   store i64 %5, i64* %x
-  %6 = getelementptr { %TupleHeader, i64, i64 }, { %TupleHeader, i64, i64 }* %1, i64 0, i32 2
+  %6 = getelementptr { i64, i64 }, { i64, i64 }* %1, i64 0, i32 1
   %7 = load i64, i64* %6
   %y = alloca i64
   store i64 %7, i64* %y
@@ -30,11 +30,11 @@ header__1:                                        ; preds = %exiting__1, %prehea
 
 body__1:                                          ; preds = %header__1
   %12 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %a, i64 %iter__1)
-  %13 = bitcast i8* %12 to { %TupleHeader, i64, i64 }**
-  %z = load { %TupleHeader, i64, i64 }*, { %TupleHeader, i64, i64 }** %13
-  %14 = getelementptr { %TupleHeader, i64, i64 }, { %TupleHeader, i64, i64 }* %z, i64 0, i32 1
+  %13 = bitcast i8* %12 to { i64, i64 }**
+  %z = load { i64, i64 }*, { i64, i64 }** %13
+  %14 = getelementptr { i64, i64 }, { i64, i64 }* %z, i64 0, i32 0
   %j = load i64, i64* %14
-  %15 = getelementptr { %TupleHeader, i64, i64 }, { %TupleHeader, i64, i64 }* %z, i64 0, i32 2
+  %15 = getelementptr { i64, i64 }, { i64, i64 }* %z, i64 0, i32 1
   %k = load i64, i64* %15
   %16 = load i64, i64* %x
   %17 = add i64 %16, %j
@@ -49,15 +49,15 @@ exiting__1:                                       ; preds = %body__1
   br label %header__1
 
 exit__1:                                          ; preds = %header__1
-  %21 = call %TupleHeader* @__quantum__rt__tuple_create(i64 ptrtoint ({ %TupleHeader, i64, i64 }* getelementptr ({ %TupleHeader, i64, i64 }, { %TupleHeader, i64, i64 }* null, i32 1) to i64))
-  %22 = bitcast %TupleHeader* %21 to { %TupleHeader, i64, i64 }*
+  %21 = call %Tuple* @__quantum__rt__tuple_create(i64 mul nuw (i64 ptrtoint (i64* getelementptr (i64, i64* null, i32 1) to i64), i64 2))
+  %22 = bitcast %Tuple* %21 to { i64, i64 }*
   %23 = load i64, i64* %x
-  %24 = getelementptr { %TupleHeader, i64, i64 }, { %TupleHeader, i64, i64 }* %22, i64 0, i32 1
+  %24 = getelementptr { i64, i64 }, { i64, i64 }* %22, i64 0, i32 0
   store i64 %23, i64* %24
   %25 = load i64, i64* %y
-  %26 = getelementptr { %TupleHeader, i64, i64 }, { %TupleHeader, i64, i64 }* %22, i64 0, i32 2
+  %26 = getelementptr { i64, i64 }, { i64, i64 }* %22, i64 0, i32 1
   store i64 %25, i64* %26
-  %27 = bitcast { %TupleHeader, i64, i64 }* %1 to %TupleHeader*
-  call void @__quantum__rt__tuple_unreference(%TupleHeader* %27)
-  ret { %TupleHeader, i64, i64 }* %22
+  %27 = bitcast { i64, i64 }* %1 to %Tuple*
+  call void @__quantum__rt__tuple_unreference(%Tuple* %27)
+  ret { i64, i64 }* %22
 }

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestControlled1.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestControlled1.ll
@@ -1,37 +1,37 @@
-﻿define void @Lifted__PartialApplication__2__ctl__wrapper(%TupleHeader* %capture-tuple, %TupleHeader* %arg-tuple, %TupleHeader* %result-tuple) {
+﻿define void @Lifted__PartialApplication__2__ctl__wrapper(%Tuple* %capture-tuple, %Tuple* %arg-tuple, %Tuple* %result-tuple) {
 entry:
-  %0 = bitcast %TupleHeader* %capture-tuple to { %TupleHeader, %Callable* }*
-  %1 = bitcast %TupleHeader* %arg-tuple to { %TupleHeader, %Array*, %TupleHeader* }*
-  %2 = getelementptr { %TupleHeader, %Array*, %TupleHeader* }, { %TupleHeader, %Array*, %TupleHeader* }* %1, i64 0, i32 1
-  %3 = getelementptr { %TupleHeader, %Array*, %TupleHeader* }, { %TupleHeader, %Array*, %TupleHeader* }* %1, i64 0, i32 2
-  %4 = bitcast %TupleHeader** %3 to { %TupleHeader, %Qubit*, i64 }*
-  %5 = call %TupleHeader* @__quantum__rt__tuple_create(i64 ptrtoint ({ %TupleHeader, %Qubit*, i64 }* getelementptr ({ %TupleHeader, %Qubit*, i64 }, { %TupleHeader, %Qubit*, i64 }* null, i32 1) to i64))
-  %6 = bitcast %TupleHeader* %5 to { %TupleHeader, %Qubit*, i64 }*
-  %7 = getelementptr { %TupleHeader, %Qubit*, i64 }, { %TupleHeader, %Qubit*, i64 }* %6, i64 0, i32 1
-  %8 = getelementptr { %TupleHeader, %Qubit*, i64 }, { %TupleHeader, %Qubit*, i64 }* %4, i64 0, i32 1
+  %0 = bitcast %Tuple* %capture-tuple to { %Callable* }*
+  %1 = bitcast %Tuple* %arg-tuple to { %Array*, %Tuple* }*
+  %2 = getelementptr { %Array*, %Tuple* }, { %Array*, %Tuple* }* %1, i64 0, i32 0
+  %3 = getelementptr { %Array*, %Tuple* }, { %Array*, %Tuple* }* %1, i64 0, i32 1
+  %4 = bitcast %Tuple** %3 to { %Qubit*, i64 }*
+  %5 = call %Tuple* @__quantum__rt__tuple_create(i64 ptrtoint ({ %Qubit*, i64 }* getelementptr ({ %Qubit*, i64 }, { %Qubit*, i64 }* null, i32 1) to i64))
+  %6 = bitcast %Tuple* %5 to { %Qubit*, i64 }*
+  %7 = getelementptr { %Qubit*, i64 }, { %Qubit*, i64 }* %6, i64 0, i32 0
+  %8 = getelementptr { %Qubit*, i64 }, { %Qubit*, i64 }* %4, i64 0, i32 0
   %9 = load %Qubit*, %Qubit** %8
   store %Qubit* %9, %Qubit** %7
-  %10 = getelementptr { %TupleHeader, %Qubit*, i64 }, { %TupleHeader, %Qubit*, i64 }* %6, i64 0, i32 2
-  %11 = getelementptr { %TupleHeader, %Qubit*, i64 }, { %TupleHeader, %Qubit*, i64 }* %4, i64 0, i32 2
+  %10 = getelementptr { %Qubit*, i64 }, { %Qubit*, i64 }* %6, i64 0, i32 1
+  %11 = getelementptr { %Qubit*, i64 }, { %Qubit*, i64 }* %4, i64 0, i32 1
   %12 = load i64, i64* %11
   store i64 %12, i64* %10
-  %13 = call %TupleHeader* @__quantum__rt__tuple_create(i64 ptrtoint ({ %TupleHeader, %Array*, %TupleHeader* }* getelementptr ({ %TupleHeader, %Array*, %TupleHeader* }, { %TupleHeader, %Array*, %TupleHeader* }* null, i32 1) to i64))
-  %14 = bitcast %TupleHeader* %13 to { %TupleHeader, %Array*, %TupleHeader* }*
-  %15 = getelementptr { %TupleHeader, %Array*, %TupleHeader* }, { %TupleHeader, %Array*, %TupleHeader* }* %14, i64 0, i32 1
+  %13 = call %Tuple* @__quantum__rt__tuple_create(i64 mul nuw (i64 ptrtoint (i1** getelementptr (i1*, i1** null, i32 1) to i64), i64 2))
+  %14 = bitcast %Tuple* %13 to { %Array*, %Tuple* }*
+  %15 = getelementptr { %Array*, %Tuple* }, { %Array*, %Tuple* }* %14, i64 0, i32 0
   %16 = load %Array*, %Array** %2
   store %Array* %16, %Array** %15
-  %17 = getelementptr { %TupleHeader, %Array*, %TupleHeader* }, { %TupleHeader, %Array*, %TupleHeader* }* %14, i64 0, i32 2
-  store %TupleHeader* %5, %TupleHeader** %17
-  %18 = getelementptr { %TupleHeader, %Callable* }, { %TupleHeader, %Callable* }* %0, i64 0, i32 1
+  %17 = getelementptr { %Array*, %Tuple* }, { %Array*, %Tuple* }* %14, i64 0, i32 1
+  store %Tuple* %5, %Tuple** %17
+  %18 = getelementptr { %Callable* }, { %Callable* }* %0, i64 0, i32 0
   %19 = load %Callable*, %Callable** %18
   %20 = call %Callable* @__quantum__rt__callable_copy(%Callable* %19)
   call void @__quantum__rt__callable_make_controlled(%Callable* %20)
-  call void @__quantum__rt__callable_invoke(%Callable* %20, %TupleHeader* %13, %TupleHeader* %result-tuple)
-  %21 = bitcast { %TupleHeader, %Qubit*, i64 }* %6 to %TupleHeader*
-  call void @__quantum__rt__tuple_unreference(%TupleHeader* %21)
-  %22 = bitcast { %TupleHeader, %Array*, %TupleHeader* }* %14 to %TupleHeader*
-  call void @__quantum__rt__tuple_unreference(%TupleHeader* %22)
-  %23 = getelementptr { %TupleHeader, %Array*, %TupleHeader* }, { %TupleHeader, %Array*, %TupleHeader* }* %14, i64 0, i32 1
+  call void @__quantum__rt__callable_invoke(%Callable* %20, %Tuple* %13, %Tuple* %result-tuple)
+  %21 = bitcast { %Qubit*, i64 }* %6 to %Tuple*
+  call void @__quantum__rt__tuple_unreference(%Tuple* %21)
+  %22 = bitcast { %Array*, %Tuple* }* %14 to %Tuple*
+  call void @__quantum__rt__tuple_unreference(%Tuple* %22)
+  %23 = getelementptr { %Array*, %Tuple* }, { %Array*, %Tuple* }* %14, i64 0, i32 0
   %24 = load %Array*, %Array** %23
   call void @__quantum__rt__array_unreference(%Array* %24)
   call void @__quantum__rt__callable_unreference(%Callable* %20)

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestControlled2.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestControlled2.ll
@@ -1,35 +1,35 @@
-﻿define void @Lifted__PartialApplication__1__ctl__wrapper(%TupleHeader* %capture-tuple, %TupleHeader* %arg-tuple, %TupleHeader* %result-tuple) {
+﻿define void @Lifted__PartialApplication__1__ctl__wrapper(%Tuple* %capture-tuple, %Tuple* %arg-tuple, %Tuple* %result-tuple) {
 entry:
-  %0 = bitcast %TupleHeader* %capture-tuple to { %TupleHeader, %Callable*, i64 }*
-  %1 = bitcast %TupleHeader* %arg-tuple to { %TupleHeader, %Array*, %Qubit* }*
-  %2 = getelementptr { %TupleHeader, %Array*, %Qubit* }, { %TupleHeader, %Array*, %Qubit* }* %1, i64 0, i32 1
-  %3 = getelementptr { %TupleHeader, %Array*, %Qubit* }, { %TupleHeader, %Array*, %Qubit* }* %1, i64 0, i32 2
+  %0 = bitcast %Tuple* %capture-tuple to { %Callable*, i64 }*
+  %1 = bitcast %Tuple* %arg-tuple to { %Array*, %Qubit* }*
+  %2 = getelementptr { %Array*, %Qubit* }, { %Array*, %Qubit* }* %1, i64 0, i32 0
+  %3 = getelementptr { %Array*, %Qubit* }, { %Array*, %Qubit* }* %1, i64 0, i32 1
   %4 = load %Qubit*, %Qubit** %3
-  %5 = call %TupleHeader* @__quantum__rt__tuple_create(i64 ptrtoint ({ %TupleHeader, %Qubit*, i64 }* getelementptr ({ %TupleHeader, %Qubit*, i64 }, { %TupleHeader, %Qubit*, i64 }* null, i32 1) to i64))
-  %6 = bitcast %TupleHeader* %5 to { %TupleHeader, %Qubit*, i64 }*
-  %7 = getelementptr { %TupleHeader, %Qubit*, i64 }, { %TupleHeader, %Qubit*, i64 }* %6, i64 0, i32 1
+  %5 = call %Tuple* @__quantum__rt__tuple_create(i64 ptrtoint ({ %Qubit*, i64 }* getelementptr ({ %Qubit*, i64 }, { %Qubit*, i64 }* null, i32 1) to i64))
+  %6 = bitcast %Tuple* %5 to { %Qubit*, i64 }*
+  %7 = getelementptr { %Qubit*, i64 }, { %Qubit*, i64 }* %6, i64 0, i32 0
   store %Qubit* %4, %Qubit** %7
-  %8 = getelementptr { %TupleHeader, %Qubit*, i64 }, { %TupleHeader, %Qubit*, i64 }* %6, i64 0, i32 2
-  %9 = getelementptr { %TupleHeader, %Callable*, i64 }, { %TupleHeader, %Callable*, i64 }* %0, i64 0, i32 2
+  %8 = getelementptr { %Qubit*, i64 }, { %Qubit*, i64 }* %6, i64 0, i32 1
+  %9 = getelementptr { %Callable*, i64 }, { %Callable*, i64 }* %0, i64 0, i32 1
   %10 = load i64, i64* %9
   store i64 %10, i64* %8
-  %11 = call %TupleHeader* @__quantum__rt__tuple_create(i64 ptrtoint ({ %TupleHeader, %Array*, %TupleHeader* }* getelementptr ({ %TupleHeader, %Array*, %TupleHeader* }, { %TupleHeader, %Array*, %TupleHeader* }* null, i32 1) to i64))
-  %12 = bitcast %TupleHeader* %11 to { %TupleHeader, %Array*, %TupleHeader* }*
-  %13 = getelementptr { %TupleHeader, %Array*, %TupleHeader* }, { %TupleHeader, %Array*, %TupleHeader* }* %12, i64 0, i32 1
+  %11 = call %Tuple* @__quantum__rt__tuple_create(i64 mul nuw (i64 ptrtoint (i1** getelementptr (i1*, i1** null, i32 1) to i64), i64 2))
+  %12 = bitcast %Tuple* %11 to { %Array*, %Tuple* }*
+  %13 = getelementptr { %Array*, %Tuple* }, { %Array*, %Tuple* }* %12, i64 0, i32 0
   %14 = load %Array*, %Array** %2
   store %Array* %14, %Array** %13
-  %15 = getelementptr { %TupleHeader, %Array*, %TupleHeader* }, { %TupleHeader, %Array*, %TupleHeader* }* %12, i64 0, i32 2
-  store %TupleHeader* %5, %TupleHeader** %15
-  %16 = getelementptr { %TupleHeader, %Callable*, i64 }, { %TupleHeader, %Callable*, i64 }* %0, i64 0, i32 1
+  %15 = getelementptr { %Array*, %Tuple* }, { %Array*, %Tuple* }* %12, i64 0, i32 1
+  store %Tuple* %5, %Tuple** %15
+  %16 = getelementptr { %Callable*, i64 }, { %Callable*, i64 }* %0, i64 0, i32 0
   %17 = load %Callable*, %Callable** %16
   %18 = call %Callable* @__quantum__rt__callable_copy(%Callable* %17)
   call void @__quantum__rt__callable_make_controlled(%Callable* %18)
-  call void @__quantum__rt__callable_invoke(%Callable* %18, %TupleHeader* %11, %TupleHeader* %result-tuple)
-  %19 = bitcast { %TupleHeader, %Qubit*, i64 }* %6 to %TupleHeader*
-  call void @__quantum__rt__tuple_unreference(%TupleHeader* %19)
-  %20 = bitcast { %TupleHeader, %Array*, %TupleHeader* }* %12 to %TupleHeader*
-  call void @__quantum__rt__tuple_unreference(%TupleHeader* %20)
-  %21 = getelementptr { %TupleHeader, %Array*, %TupleHeader* }, { %TupleHeader, %Array*, %TupleHeader* }* %12, i64 0, i32 1
+  call void @__quantum__rt__callable_invoke(%Callable* %18, %Tuple* %11, %Tuple* %result-tuple)
+  %19 = bitcast { %Qubit*, i64 }* %6 to %Tuple*
+  call void @__quantum__rt__tuple_unreference(%Tuple* %19)
+  %20 = bitcast { %Array*, %Tuple* }* %12 to %Tuple*
+  call void @__quantum__rt__tuple_unreference(%Tuple* %20)
+  %21 = getelementptr { %Array*, %Tuple* }, { %Array*, %Tuple* }* %12, i64 0, i32 0
   %22 = load %Array*, %Array** %21
   call void @__quantum__rt__array_unreference(%Array* %22)
   call void @__quantum__rt__callable_unreference(%Callable* %18)

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestControlled3.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestControlled3.ll
@@ -1,10 +1,10 @@
-﻿define void @Microsoft__Quantum__Intrinsic__K__ctl__wrapper(%TupleHeader* %capture-tuple, %TupleHeader* %arg-tuple, %TupleHeader* %result-tuple) {
+﻿define void @Microsoft__Quantum__Intrinsic__K__ctl__wrapper(%Tuple* %capture-tuple, %Tuple* %arg-tuple, %Tuple* %result-tuple) {
 entry:
-  %0 = bitcast %TupleHeader* %arg-tuple to { %TupleHeader, %Array*, { %TupleHeader, %Qubit*, i64 }* }*
-  %1 = getelementptr { %TupleHeader, %Array*, { %TupleHeader, %Qubit*, i64 }* }, { %TupleHeader, %Array*, { %TupleHeader, %Qubit*, i64 }* }* %0, i64 0, i32 1
+  %0 = bitcast %Tuple* %arg-tuple to { %Array*, { %Qubit*, i64 }* }*
+  %1 = getelementptr { %Array*, { %Qubit*, i64 }* }, { %Array*, { %Qubit*, i64 }* }* %0, i64 0, i32 0
   %2 = load %Array*, %Array** %1
-  %3 = getelementptr { %TupleHeader, %Array*, { %TupleHeader, %Qubit*, i64 }* }, { %TupleHeader, %Array*, { %TupleHeader, %Qubit*, i64 }* }* %0, i64 0, i32 2
-  %4 = load { %TupleHeader, %Qubit*, i64 }*, { %TupleHeader, %Qubit*, i64 }** %3
-  call void @Microsoft__Quantum__Intrinsic__K__ctl(%Array* %2, { %TupleHeader, %Qubit*, i64 }* %4)
+  %3 = getelementptr { %Array*, { %Qubit*, i64 }* }, { %Array*, { %Qubit*, i64 }* }* %0, i64 0, i32 1
+  %4 = load { %Qubit*, i64 }*, { %Qubit*, i64 }** %3
+  call void @Microsoft__Quantum__Intrinsic__K__ctl(%Array* %2, { %Qubit*, i64 }* %4)
   ret void
 }

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestDeconstruct.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestDeconstruct.ll
@@ -1,17 +1,17 @@
-define i64 @Microsoft__Quantum__Testing__QIR__TestDeconstruct__body({ %TupleHeader, i64, { %TupleHeader, i64, i64 }* }* %a) {
+define i64 @Microsoft__Quantum__Testing__QIR__TestDeconstruct__body({ i64, { i64, i64 }* }* %a) {
 entry:
-  %0 = getelementptr { %TupleHeader, i64, { %TupleHeader, i64, i64 }* }, { %TupleHeader, i64, { %TupleHeader, i64, i64 }* }* %a, i64 0, i32 1
+  %0 = getelementptr { i64, { i64, i64 }* }, { i64, { i64, i64 }* }* %a, i64 0, i32 0
   %x = load i64, i64* %0
-  %1 = getelementptr { %TupleHeader, i64, { %TupleHeader, i64, i64 }* }, { %TupleHeader, i64, { %TupleHeader, i64, i64 }* }* %a, i64 0, i32 2
-  %y = load { %TupleHeader, i64, i64 }*, { %TupleHeader, i64, i64 }** %1
+  %1 = getelementptr { i64, { i64, i64 }* }, { i64, { i64, i64 }* }* %a, i64 0, i32 1
+  %y = load { i64, i64 }*, { i64, i64 }** %1
   %b = alloca i64
   store i64 3, i64* %b
   %c = alloca i64
   store i64 5, i64* %c
-  %2 = getelementptr { %TupleHeader, i64, i64 }, { %TupleHeader, i64, i64 }* %y, i64 0, i32 1
+  %2 = getelementptr { i64, i64 }, { i64, i64 }* %y, i64 0, i32 0
   %3 = load i64, i64* %2
   store i64 %3, i64* %b
-  %4 = getelementptr { %TupleHeader, i64, i64 }, { %TupleHeader, i64, i64 }* %y, i64 0, i32 2
+  %4 = getelementptr { i64, i64 }, { i64, i64 }* %y, i64 0, i32 1
   %5 = load i64, i64* %4
   store i64 %5, i64* %c
   %6 = load i64, i64* %b

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestExpressions.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestExpressions.ll
@@ -4,10 +4,10 @@ entry:
   %2 = call i64 @Microsoft__Quantum__Testing__QIR__ReturnFunctionCall__body()
   %3 = call double @Microsoft__Quantum__Testing__QIR__ReturnOperationCall__body()
   %4 = call %Callable* @Microsoft__Quantum__Testing__QIR__ReturnPartialApplication__body()
-  %5 = call { %TupleHeader, { %TupleHeader, i2, i64 }*, double }* @Microsoft__Quantum__Testing__QIR__ReturnUnwrapApplication__body()
+  %5 = call { { i2, i64 }*, double }* @Microsoft__Quantum__Testing__QIR__ReturnUnwrapApplication__body()
   %6 = call %Callable* @Microsoft__Quantum__Testing__QIR__ReturnAdjointApplication__body()
   %7 = call %Callable* @Microsoft__Quantum__Testing__QIR__ReturnControlledApplication__body()
-  %8 = call { %TupleHeader, i64, { %TupleHeader, %Callable*, %String* }* }* @Microsoft__Quantum__Testing__QIR__ReturnTuple__body()
+  %8 = call { i64, { %Callable*, %String* }* }* @Microsoft__Quantum__Testing__QIR__ReturnTuple__body()
   %9 = call %String* @Microsoft__Quantum__Testing__QIR__ReturnArrayItem__body()
   %10 = call i2 @Microsoft__Quantum__Testing__QIR__ReturnNamedItem__body()
   %11 = call %Array* @Microsoft__Quantum__Testing__QIR__ReturnArray__body()
@@ -15,7 +15,7 @@ entry:
   %13 = call %String* @Microsoft__Quantum__Testing__QIR__ReturnString__body()
   %14 = call %Range @Microsoft__Quantum__Testing__QIR__ReturnRange__body()
   %15 = call %Array* @Microsoft__Quantum__Testing__QIR__ReturnCopyAndUpdateArray__body()
-  %16 = call { %TupleHeader, { %TupleHeader, i2, i64 }*, double }* @Microsoft__Quantum__Testing__QIR__ReturnCopyAndUpdateUdt__body()
+  %16 = call { { i2, i64 }*, double }* @Microsoft__Quantum__Testing__QIR__ReturnCopyAndUpdateUdt__body()
   %17 = call %BigInt* @Microsoft__Quantum__Testing__QIR__ReturnConditional__body(i1 false)
   %18 = call i1 @Microsoft__Quantum__Testing__QIR__ReturnEquality__body(i64 4, i64 5)
   %19 = call i1 @Microsoft__Quantum__Testing__QIR__ReturnInequality__body(i64 5, i64 6)
@@ -51,24 +51,24 @@ entry:
   call void @__quantum__rt__callable_unreference(%Callable* %0)
   call void @__quantum__rt__callable_unreference(%Callable* %1)
   call void @__quantum__rt__callable_unreference(%Callable* %4)
-  %48 = bitcast { %TupleHeader, { %TupleHeader, i2, i64 }*, double }* %5 to %TupleHeader*
-  call void @__quantum__rt__tuple_unreference(%TupleHeader* %48)
-  %49 = getelementptr { %TupleHeader, { %TupleHeader, i2, i64 }*, double }, { %TupleHeader, { %TupleHeader, i2, i64 }*, double }* %5, i64 0, i32 1
-  %50 = load { %TupleHeader, i2, i64 }*, { %TupleHeader, i2, i64 }** %49
-  %51 = bitcast { %TupleHeader, i2, i64 }* %50 to %TupleHeader*
-  call void @__quantum__rt__tuple_unreference(%TupleHeader* %51)
+  %48 = bitcast { { i2, i64 }*, double }* %5 to %Tuple*
+  call void @__quantum__rt__tuple_unreference(%Tuple* %48)
+  %49 = getelementptr { { i2, i64 }*, double }, { { i2, i64 }*, double }* %5, i64 0, i32 0
+  %50 = load { i2, i64 }*, { i2, i64 }** %49
+  %51 = bitcast { i2, i64 }* %50 to %Tuple*
+  call void @__quantum__rt__tuple_unreference(%Tuple* %51)
   call void @__quantum__rt__callable_unreference(%Callable* %6)
   call void @__quantum__rt__callable_unreference(%Callable* %7)
-  %52 = bitcast { %TupleHeader, i64, { %TupleHeader, %Callable*, %String* }* }* %8 to %TupleHeader*
-  call void @__quantum__rt__tuple_unreference(%TupleHeader* %52)
-  %53 = getelementptr { %TupleHeader, i64, { %TupleHeader, %Callable*, %String* }* }, { %TupleHeader, i64, { %TupleHeader, %Callable*, %String* }* }* %8, i64 0, i32 2
-  %54 = load { %TupleHeader, %Callable*, %String* }*, { %TupleHeader, %Callable*, %String* }** %53
-  %55 = bitcast { %TupleHeader, %Callable*, %String* }* %54 to %TupleHeader*
-  call void @__quantum__rt__tuple_unreference(%TupleHeader* %55)
-  %56 = getelementptr { %TupleHeader, %Callable*, %String* }, { %TupleHeader, %Callable*, %String* }* %54, i64 0, i32 1
+  %52 = bitcast { i64, { %Callable*, %String* }* }* %8 to %Tuple*
+  call void @__quantum__rt__tuple_unreference(%Tuple* %52)
+  %53 = getelementptr { i64, { %Callable*, %String* }* }, { i64, { %Callable*, %String* }* }* %8, i64 0, i32 1
+  %54 = load { %Callable*, %String* }*, { %Callable*, %String* }** %53
+  %55 = bitcast { %Callable*, %String* }* %54 to %Tuple*
+  call void @__quantum__rt__tuple_unreference(%Tuple* %55)
+  %56 = getelementptr { %Callable*, %String* }, { %Callable*, %String* }* %54, i64 0, i32 0
   %57 = load %Callable*, %Callable** %56
   call void @__quantum__rt__callable_unreference(%Callable* %57)
-  %58 = getelementptr { %TupleHeader, %Callable*, %String* }, { %TupleHeader, %Callable*, %String* }* %54, i64 0, i32 2
+  %58 = getelementptr { %Callable*, %String* }, { %Callable*, %String* }* %54, i64 0, i32 1
   %59 = load %String*, %String** %58
   call void @__quantum__rt__string_unreference(%String* %59)
   call void @__quantum__rt__string_unreference(%String* %9)
@@ -76,12 +76,12 @@ entry:
   call void @__quantum__rt__array_unreference(%Array* %12)
   call void @__quantum__rt__string_unreference(%String* %13)
   call void @__quantum__rt__array_unreference(%Array* %15)
-  %60 = bitcast { %TupleHeader, { %TupleHeader, i2, i64 }*, double }* %16 to %TupleHeader*
-  call void @__quantum__rt__tuple_unreference(%TupleHeader* %60)
-  %61 = getelementptr { %TupleHeader, { %TupleHeader, i2, i64 }*, double }, { %TupleHeader, { %TupleHeader, i2, i64 }*, double }* %16, i64 0, i32 1
-  %62 = load { %TupleHeader, i2, i64 }*, { %TupleHeader, i2, i64 }** %61
-  %63 = bitcast { %TupleHeader, i2, i64 }* %62 to %TupleHeader*
-  call void @__quantum__rt__tuple_unreference(%TupleHeader* %63)
+  %60 = bitcast { { i2, i64 }*, double }* %16 to %Tuple*
+  call void @__quantum__rt__tuple_unreference(%Tuple* %60)
+  %61 = getelementptr { { i2, i64 }*, double }, { { i2, i64 }*, double }* %16, i64 0, i32 0
+  %62 = load { i2, i64 }*, { i2, i64 }** %61
+  %63 = bitcast { i2, i64 }* %62 to %Tuple*
+  call void @__quantum__rt__tuple_unreference(%Tuple* %63)
   call void @__quantum__rt__bigint_unreference(%BigInt* %17)
   call void @__quantum__rt__bigint_unreference(%BigInt* %32)
   call void @__quantum__rt__result_unreference(%Result* %35)

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestExpressions.qs
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestExpressions.qs
@@ -3,6 +3,16 @@
 
 namespace Microsoft.Quantum.Testing.QIR {
 
+    // TODO: WRITE A TEST THAT USES THE RETURNED UDT WITH MORE THAN ONE ITEM
+    // TODO: TEST UDT AS INNER TUPLE ITEM IN RETURN VALUE
+    // TODO: ADD A TEST FOR AN ARGUMENT WITH MULTIPLE ITEMS
+
+    // FIXME: REFERENCE HANDLING IN UDTUPDATE IS NOT ACCURATE
+    // FIXME: SAME FOR ARRAYUPDATE
+    // FIXME: SAME FOR TESTRESULTS (ref counter for passed in result value is not properly increased?)
+    // FIXME: TAKE A LOOK AT GenerateConstructor AND HOW OTHER FUNCTIONS HANDLE ARGUMENTS...
+    // FIXME: GET RID OF BuildArgTupleType AND BuildArgTupleItemType
+
     newtype TestType = ((P : Pauli, I : Int), Double);
 
     // This test makes sure that we properly push a value 

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestExpressions.qs
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestExpressions.qs
@@ -3,16 +3,6 @@
 
 namespace Microsoft.Quantum.Testing.QIR {
 
-    // TODO: WRITE A TEST THAT USES THE RETURNED UDT WITH MORE THAN ONE ITEM
-    // TODO: TEST UDT AS INNER TUPLE ITEM IN RETURN VALUE
-    // TODO: ADD A TEST FOR AN ARGUMENT WITH MULTIPLE ITEMS
-
-    // FIXME: REFERENCE HANDLING IN UDTUPDATE IS NOT ACCURATE
-    // FIXME: SAME FOR ARRAYUPDATE
-    // FIXME: SAME FOR TESTRESULTS (ref counter for passed in result value is not properly increased?)
-    // FIXME: TAKE A LOOK AT GenerateConstructor AND HOW OTHER FUNCTIONS HANDLE ARGUMENTS...
-    // FIXME: GET RID OF BuildArgTupleType AND BuildArgTupleItemType
-
     newtype TestType = ((P : Pauli, I : Int), Double);
 
     // This test makes sure that we properly push a value 

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestOpArgument.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestOpArgument.ll
@@ -1,49 +1,49 @@
 define void @Microsoft__Quantum__Testing__QIR__TestOpArgument__body() #0 {
 entry:
   %q = call %Qubit* @__quantum__rt__qubit_allocate()
-  %0 = call %TupleHeader* @__quantum__rt__tuple_create(i64 ptrtoint ({ %TupleHeader, %Callable*, %Qubit* }* getelementptr ({ %TupleHeader, %Callable*, %Qubit* }, { %TupleHeader, %Callable*, %Qubit* }* null, i32 1) to i64))
-  %1 = bitcast %TupleHeader* %0 to { %TupleHeader, %Callable*, %Qubit* }*
-  %2 = getelementptr { %TupleHeader, %Callable*, %Qubit* }, { %TupleHeader, %Callable*, %Qubit* }* %1, i64 0, i32 1
-  %3 = call %Callable* @__quantum__rt__callable_create([4 x void (%TupleHeader*, %TupleHeader*, %TupleHeader*)*]* @Microsoft__Quantum__Intrinsic__CNOT, %TupleHeader* null)
+  %0 = call %Tuple* @__quantum__rt__tuple_create(i64 mul nuw (i64 ptrtoint (i1** getelementptr (i1*, i1** null, i32 1) to i64), i64 2))
+  %1 = bitcast %Tuple* %0 to { %Callable*, %Qubit* }*
+  %2 = getelementptr { %Callable*, %Qubit* }, { %Callable*, %Qubit* }* %1, i64 0, i32 0
+  %3 = call %Callable* @__quantum__rt__callable_create([4 x void (%Tuple*, %Tuple*, %Tuple*)*]* @Microsoft__Quantum__Intrinsic__CNOT, %Tuple* null)
   store %Callable* %3, %Callable** %2
   call void @__quantum__rt__callable_reference(%Callable* %3)
-  %4 = getelementptr { %TupleHeader, %Callable*, %Qubit* }, { %TupleHeader, %Callable*, %Qubit* }* %1, i64 0, i32 2
+  %4 = getelementptr { %Callable*, %Qubit* }, { %Callable*, %Qubit* }* %1, i64 0, i32 1
   store %Qubit* %q, %Qubit** %4
-  %5 = call %Callable* @__quantum__rt__callable_create([4 x void (%TupleHeader*, %TupleHeader*, %TupleHeader*)*]* @PartialApplication__1, %TupleHeader* %0)
+  %5 = call %Callable* @__quantum__rt__callable_create([4 x void (%Tuple*, %Tuple*, %Tuple*)*]* @PartialApplication__1, %Tuple* %0)
   call void @Microsoft__Quantum__Testing__QIR__Apply__body(%Callable* %5)
-  %6 = call %TupleHeader* @__quantum__rt__tuple_create(i64 ptrtoint ({ %TupleHeader, %Callable*, %Qubit* }* getelementptr ({ %TupleHeader, %Callable*, %Qubit* }, { %TupleHeader, %Callable*, %Qubit* }* null, i32 1) to i64))
-  %7 = bitcast %TupleHeader* %6 to { %TupleHeader, %Callable*, %Qubit* }*
-  %8 = getelementptr { %TupleHeader, %Callable*, %Qubit* }, { %TupleHeader, %Callable*, %Qubit* }* %7, i64 0, i32 1
-  %9 = call %Callable* @__quantum__rt__callable_create([4 x void (%TupleHeader*, %TupleHeader*, %TupleHeader*)*]* @Microsoft__Quantum__Testing__QIR___SWAP, %TupleHeader* null)
+  %6 = call %Tuple* @__quantum__rt__tuple_create(i64 mul nuw (i64 ptrtoint (i1** getelementptr (i1*, i1** null, i32 1) to i64), i64 2))
+  %7 = bitcast %Tuple* %6 to { %Callable*, %Qubit* }*
+  %8 = getelementptr { %Callable*, %Qubit* }, { %Callable*, %Qubit* }* %7, i64 0, i32 0
+  %9 = call %Callable* @__quantum__rt__callable_create([4 x void (%Tuple*, %Tuple*, %Tuple*)*]* @Microsoft__Quantum__Testing__QIR___SWAP, %Tuple* null)
   store %Callable* %9, %Callable** %8
   call void @__quantum__rt__callable_reference(%Callable* %9)
-  %10 = getelementptr { %TupleHeader, %Callable*, %Qubit* }, { %TupleHeader, %Callable*, %Qubit* }* %7, i64 0, i32 2
+  %10 = getelementptr { %Callable*, %Qubit* }, { %Callable*, %Qubit* }* %7, i64 0, i32 1
   store %Qubit* %q, %Qubit** %10
-  %11 = call %Callable* @__quantum__rt__callable_create([4 x void (%TupleHeader*, %TupleHeader*, %TupleHeader*)*]* @PartialApplication__2, %TupleHeader* %6)
+  %11 = call %Callable* @__quantum__rt__callable_create([4 x void (%Tuple*, %Tuple*, %Tuple*)*]* @PartialApplication__2, %Tuple* %6)
   call void @Microsoft__Quantum__Testing__QIR__Apply__body(%Callable* %11)
-  %12 = call %TupleHeader* @__quantum__rt__tuple_create(i64 ptrtoint ({ %TupleHeader, %Callable*, %Qubit*, %Qubit* }* getelementptr ({ %TupleHeader, %Callable*, %Qubit*, %Qubit* }, { %TupleHeader, %Callable*, %Qubit*, %Qubit* }* null, i32 1) to i64))
-  %13 = bitcast %TupleHeader* %12 to { %TupleHeader, %Callable*, %Qubit*, %Qubit* }*
-  %14 = getelementptr { %TupleHeader, %Callable*, %Qubit*, %Qubit* }, { %TupleHeader, %Callable*, %Qubit*, %Qubit* }* %13, i64 0, i32 1
-  %15 = call %Callable* @__quantum__rt__callable_create([4 x void (%TupleHeader*, %TupleHeader*, %TupleHeader*)*]* @Microsoft__Quantum__Testing__QIR___Choose, %TupleHeader* null)
+  %12 = call %Tuple* @__quantum__rt__tuple_create(i64 mul nuw (i64 ptrtoint (i1** getelementptr (i1*, i1** null, i32 1) to i64), i64 3))
+  %13 = bitcast %Tuple* %12 to { %Callable*, %Qubit*, %Qubit* }*
+  %14 = getelementptr { %Callable*, %Qubit*, %Qubit* }, { %Callable*, %Qubit*, %Qubit* }* %13, i64 0, i32 0
+  %15 = call %Callable* @__quantum__rt__callable_create([4 x void (%Tuple*, %Tuple*, %Tuple*)*]* @Microsoft__Quantum__Testing__QIR___Choose, %Tuple* null)
   store %Callable* %15, %Callable** %14
   call void @__quantum__rt__callable_reference(%Callable* %15)
-  %16 = getelementptr { %TupleHeader, %Callable*, %Qubit*, %Qubit* }, { %TupleHeader, %Callable*, %Qubit*, %Qubit* }* %13, i64 0, i32 2
+  %16 = getelementptr { %Callable*, %Qubit*, %Qubit* }, { %Callable*, %Qubit*, %Qubit* }* %13, i64 0, i32 1
   store %Qubit* %q, %Qubit** %16
-  %17 = getelementptr { %TupleHeader, %Callable*, %Qubit*, %Qubit* }, { %TupleHeader, %Callable*, %Qubit*, %Qubit* }* %13, i64 0, i32 3
+  %17 = getelementptr { %Callable*, %Qubit*, %Qubit* }, { %Callable*, %Qubit*, %Qubit* }* %13, i64 0, i32 2
   store %Qubit* %q, %Qubit** %17
-  %18 = call %Callable* @__quantum__rt__callable_create([4 x void (%TupleHeader*, %TupleHeader*, %TupleHeader*)*]* @PartialApplication__3, %TupleHeader* %12)
+  %18 = call %Callable* @__quantum__rt__callable_create([4 x void (%Tuple*, %Tuple*, %Tuple*)*]* @PartialApplication__3, %Tuple* %12)
   call void @Microsoft__Quantum__Testing__QIR__Apply__body(%Callable* %18)
-  %19 = call %TupleHeader* @__quantum__rt__tuple_create(i64 ptrtoint ({ %TupleHeader, %Callable*, %Qubit*, %Qubit* }* getelementptr ({ %TupleHeader, %Callable*, %Qubit*, %Qubit* }, { %TupleHeader, %Callable*, %Qubit*, %Qubit* }* null, i32 1) to i64))
-  %20 = bitcast %TupleHeader* %19 to { %TupleHeader, %Callable*, %Qubit*, %Qubit* }*
-  %21 = getelementptr { %TupleHeader, %Callable*, %Qubit*, %Qubit* }, { %TupleHeader, %Callable*, %Qubit*, %Qubit* }* %20, i64 0, i32 1
-  %22 = call %Callable* @__quantum__rt__callable_create([4 x void (%TupleHeader*, %TupleHeader*, %TupleHeader*)*]* @Microsoft__Quantum__Testing__QIR___Choose, %TupleHeader* null)
+  %19 = call %Tuple* @__quantum__rt__tuple_create(i64 mul nuw (i64 ptrtoint (i1** getelementptr (i1*, i1** null, i32 1) to i64), i64 3))
+  %20 = bitcast %Tuple* %19 to { %Callable*, %Qubit*, %Qubit* }*
+  %21 = getelementptr { %Callable*, %Qubit*, %Qubit* }, { %Callable*, %Qubit*, %Qubit* }* %20, i64 0, i32 0
+  %22 = call %Callable* @__quantum__rt__callable_create([4 x void (%Tuple*, %Tuple*, %Tuple*)*]* @Microsoft__Quantum__Testing__QIR___Choose, %Tuple* null)
   store %Callable* %22, %Callable** %21
   call void @__quantum__rt__callable_reference(%Callable* %22)
-  %23 = getelementptr { %TupleHeader, %Callable*, %Qubit*, %Qubit* }, { %TupleHeader, %Callable*, %Qubit*, %Qubit* }* %20, i64 0, i32 2
+  %23 = getelementptr { %Callable*, %Qubit*, %Qubit* }, { %Callable*, %Qubit*, %Qubit* }* %20, i64 0, i32 1
   store %Qubit* %q, %Qubit** %23
-  %24 = getelementptr { %TupleHeader, %Callable*, %Qubit*, %Qubit* }, { %TupleHeader, %Callable*, %Qubit*, %Qubit* }* %20, i64 0, i32 3
+  %24 = getelementptr { %Callable*, %Qubit*, %Qubit* }, { %Callable*, %Qubit*, %Qubit* }* %20, i64 0, i32 2
   store %Qubit* %q, %Qubit** %24
-  %25 = call %Callable* @__quantum__rt__callable_create([4 x void (%TupleHeader*, %TupleHeader*, %TupleHeader*)*]* @PartialApplication__4, %TupleHeader* %19)
+  %25 = call %Callable* @__quantum__rt__callable_create([4 x void (%Tuple*, %Tuple*, %Tuple*)*]* @PartialApplication__4, %Tuple* %19)
   call void @Microsoft__Quantum__Testing__QIR__Apply__body(%Callable* %25)
   call void @__quantum__rt__qubit_release(%Qubit* %q)
   call void @__quantum__rt__callable_unreference(%Callable* %3)
@@ -54,7 +54,7 @@ entry:
   call void @__quantum__rt__callable_unreference(%Callable* %18)
   call void @__quantum__rt__callable_unreference(%Callable* %22)
   call void @__quantum__rt__callable_unreference(%Callable* %25)
-  %26 = call %Callable* @__quantum__rt__callable_create([4 x void (%TupleHeader*, %TupleHeader*, %TupleHeader*)*]* @Microsoft__Quantum__Testing__QIR__GetNestedTuple, %TupleHeader* null)
+  %26 = call %Callable* @__quantum__rt__callable_create([4 x void (%Tuple*, %Tuple*, %Tuple*)*]* @Microsoft__Quantum__Testing__QIR__GetNestedTuple, %Tuple* null)
   call void @Microsoft__Quantum__Testing__QIR_____GUID___InvokeAndIgnore__body(%Callable* %26)
   call void @__quantum__rt__callable_unreference(%Callable* %26)
   ret void

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestPartials1.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestPartials1.ll
@@ -1,14 +1,14 @@
 ﻿define i1 @Microsoft__Quantum__Testing__QIR__TestPartials__body() #0 {
 entry:
-  %0 = call %TupleHeader* @__quantum__rt__tuple_create(i64 ptrtoint ({ %TupleHeader, %Callable*, double }* getelementptr ({ %TupleHeader, %Callable*, double }, { %TupleHeader, %Callable*, double }* null, i32 1) to i64))
-  %1 = bitcast %TupleHeader* %0 to { %TupleHeader, %Callable*, double }*
-  %2 = getelementptr { %TupleHeader, %Callable*, double }, { %TupleHeader, %Callable*, double }* %1, i64 0, i32 1
-  %3 = call %Callable* @__quantum__rt__callable_create([4 x void (%TupleHeader*, %TupleHeader*, %TupleHeader*)*]* @Microsoft__Quantum__Intrinsic__Rz, %TupleHeader* null)
+  %0 = call %Tuple* @__quantum__rt__tuple_create(i64 ptrtoint ({ %Callable*, double }* getelementptr ({ %Callable*, double }, { %Callable*, double }* null, i32 1) to i64))
+  %1 = bitcast %Tuple* %0 to { %Callable*, double }*
+  %2 = getelementptr { %Callable*, double }, { %Callable*, double }* %1, i64 0, i32 0
+  %3 = call %Callable* @__quantum__rt__callable_create([4 x void (%Tuple*, %Tuple*, %Tuple*)*]* @Microsoft__Quantum__Intrinsic__Rz, %Tuple* null)
   store %Callable* %3, %Callable** %2
   call void @__quantum__rt__callable_reference(%Callable* %3)
-  %4 = getelementptr { %TupleHeader, %Callable*, double }, { %TupleHeader, %Callable*, double }* %1, i64 0, i32 2
+  %4 = getelementptr { %Callable*, double }, { %Callable*, double }* %1, i64 0, i32 1
   store double 2.500000e-01, double* %4
-  %rotate = call %Callable* @__quantum__rt__callable_create([4 x void (%TupleHeader*, %TupleHeader*, %TupleHeader*)*]* @PartialApplication__1, %TupleHeader* %0)
+  %rotate = call %Callable* @__quantum__rt__callable_create([4 x void (%Tuple*, %Tuple*, %Tuple*)*]* @PartialApplication__1, %Tuple* %0)
   %unrotate = call %Callable* @__quantum__rt__callable_copy(%Callable* %rotate)
   call void @__quantum__rt__callable_make_adjoint(%Callable* %unrotate)
   br label %preheader__1
@@ -25,16 +25,16 @@ header__1:                                        ; preds = %exiting__1, %prehea
 
 body__1:                                          ; preds = %header__1
   %qb = call %Qubit* @__quantum__rt__qubit_allocate()
-  %8 = call %TupleHeader* @__quantum__rt__tuple_create(i64 ptrtoint ({ %TupleHeader, %Qubit* }* getelementptr ({ %TupleHeader, %Qubit* }, { %TupleHeader, %Qubit* }* null, i32 1) to i64))
-  %9 = bitcast %TupleHeader* %8 to { %TupleHeader, %Qubit* }*
-  %10 = getelementptr { %TupleHeader, %Qubit* }, { %TupleHeader, %Qubit* }* %9, i64 0, i32 1
+  %8 = call %Tuple* @__quantum__rt__tuple_create(i64 ptrtoint (i1** getelementptr (i1*, i1** null, i32 1) to i64))
+  %9 = bitcast %Tuple* %8 to { %Qubit* }*
+  %10 = getelementptr { %Qubit* }, { %Qubit* }* %9, i64 0, i32 0
   store %Qubit* %qb, %Qubit** %10
-  call void @__quantum__rt__callable_invoke(%Callable* %rotate, %TupleHeader* %8, %TupleHeader* null)
-  %11 = call %TupleHeader* @__quantum__rt__tuple_create(i64 ptrtoint ({ %TupleHeader, %Qubit* }* getelementptr ({ %TupleHeader, %Qubit* }, { %TupleHeader, %Qubit* }* null, i32 1) to i64))
-  %12 = bitcast %TupleHeader* %11 to { %TupleHeader, %Qubit* }*
-  %13 = getelementptr { %TupleHeader, %Qubit* }, { %TupleHeader, %Qubit* }* %12, i64 0, i32 1
+  call void @__quantum__rt__callable_invoke(%Callable* %rotate, %Tuple* %8, %Tuple* null)
+  %11 = call %Tuple* @__quantum__rt__tuple_create(i64 ptrtoint (i1** getelementptr (i1*, i1** null, i32 1) to i64))
+  %12 = bitcast %Tuple* %11 to { %Qubit* }*
+  %13 = getelementptr { %Qubit* }, { %Qubit* }* %12, i64 0, i32 0
   store %Qubit* %qb, %Qubit** %13
-  call void @__quantum__rt__callable_invoke(%Callable* %unrotate, %TupleHeader* %11, %TupleHeader* null)
+  call void @__quantum__rt__callable_invoke(%Callable* %unrotate, %Tuple* %11, %Tuple* null)
   %14 = call %Result* @__quantum__qis__mz(%Qubit* %qb)
   %15 = load %Result*, %Result** @ResultZero
   %16 = call i1 @__quantum__rt__result_equal(%Result* %14, %Result* %15)

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestPartials2.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestPartials2.ll
@@ -1,43 +1,43 @@
-﻿define void @Microsoft__Quantum__Intrinsic__Rz__body__wrapper(%TupleHeader* %capture-tuple, %TupleHeader* %arg-tuple, %TupleHeader* %result-tuple) {
+﻿define void @Microsoft__Quantum__Intrinsic__Rz__body__wrapper(%Tuple* %capture-tuple, %Tuple* %arg-tuple, %Tuple* %result-tuple) {
 entry:
-  %0 = bitcast %TupleHeader* %arg-tuple to { %TupleHeader, double, %Qubit* }*
-  %1 = getelementptr { %TupleHeader, double, %Qubit* }, { %TupleHeader, double, %Qubit* }* %0, i64 0, i32 1
+  %0 = bitcast %Tuple* %arg-tuple to { double, %Qubit* }*
+  %1 = getelementptr { double, %Qubit* }, { double, %Qubit* }* %0, i64 0, i32 0
   %2 = load double, double* %1
-  %3 = getelementptr { %TupleHeader, double, %Qubit* }, { %TupleHeader, double, %Qubit* }* %0, i64 0, i32 2
+  %3 = getelementptr { double, %Qubit* }, { double, %Qubit* }* %0, i64 0, i32 1
   %4 = load %Qubit*, %Qubit** %3
   call void @Microsoft__Quantum__Intrinsic__Rz__body(double %2, %Qubit* %4)
   ret void
 }
 
-define void @Microsoft__Quantum__Intrinsic__Rz__adj__wrapper(%TupleHeader* %capture-tuple, %TupleHeader* %arg-tuple, %TupleHeader* %result-tuple) {
+define void @Microsoft__Quantum__Intrinsic__Rz__adj__wrapper(%Tuple* %capture-tuple, %Tuple* %arg-tuple, %Tuple* %result-tuple) {
 entry:
-  %0 = bitcast %TupleHeader* %arg-tuple to { %TupleHeader, double, %Qubit* }*
-  %1 = getelementptr { %TupleHeader, double, %Qubit* }, { %TupleHeader, double, %Qubit* }* %0, i64 0, i32 1
+  %0 = bitcast %Tuple* %arg-tuple to { double, %Qubit* }*
+  %1 = getelementptr { double, %Qubit* }, { double, %Qubit* }* %0, i64 0, i32 0
   %2 = load double, double* %1
-  %3 = getelementptr { %TupleHeader, double, %Qubit* }, { %TupleHeader, double, %Qubit* }* %0, i64 0, i32 2
+  %3 = getelementptr { double, %Qubit* }, { double, %Qubit* }* %0, i64 0, i32 1
   %4 = load %Qubit*, %Qubit** %3
   call void @Microsoft__Quantum__Intrinsic__Rz__adj(double %2, %Qubit* %4)
   ret void
 }
 
-define void @Microsoft__Quantum__Intrinsic__Rz__ctl__wrapper(%TupleHeader* %capture-tuple, %TupleHeader* %arg-tuple, %TupleHeader* %result-tuple) {
+define void @Microsoft__Quantum__Intrinsic__Rz__ctl__wrapper(%Tuple* %capture-tuple, %Tuple* %arg-tuple, %Tuple* %result-tuple) {
 entry:
-  %0 = bitcast %TupleHeader* %arg-tuple to { %TupleHeader, %Array*, { %TupleHeader, double, %Qubit* }* }*
-  %1 = getelementptr { %TupleHeader, %Array*, { %TupleHeader, double, %Qubit* }* }, { %TupleHeader, %Array*, { %TupleHeader, double, %Qubit* }* }* %0, i64 0, i32 1
+  %0 = bitcast %Tuple* %arg-tuple to { %Array*, { double, %Qubit* }* }*
+  %1 = getelementptr { %Array*, { double, %Qubit* }* }, { %Array*, { double, %Qubit* }* }* %0, i64 0, i32 0
   %2 = load %Array*, %Array** %1
-  %3 = getelementptr { %TupleHeader, %Array*, { %TupleHeader, double, %Qubit* }* }, { %TupleHeader, %Array*, { %TupleHeader, double, %Qubit* }* }* %0, i64 0, i32 2
-  %4 = load { %TupleHeader, double, %Qubit* }*, { %TupleHeader, double, %Qubit* }** %3
-  call void @Microsoft__Quantum__Intrinsic__Rz__ctl(%Array* %2, { %TupleHeader, double, %Qubit* }* %4)
+  %3 = getelementptr { %Array*, { double, %Qubit* }* }, { %Array*, { double, %Qubit* }* }* %0, i64 0, i32 1
+  %4 = load { double, %Qubit* }*, { double, %Qubit* }** %3
+  call void @Microsoft__Quantum__Intrinsic__Rz__ctl(%Array* %2, { double, %Qubit* }* %4)
   ret void
 }
 
-define void @Microsoft__Quantum__Intrinsic__Rz__ctladj__wrapper(%TupleHeader* %capture-tuple, %TupleHeader* %arg-tuple, %TupleHeader* %result-tuple) {
+define void @Microsoft__Quantum__Intrinsic__Rz__ctladj__wrapper(%Tuple* %capture-tuple, %Tuple* %arg-tuple, %Tuple* %result-tuple) {
 entry:
-  %0 = bitcast %TupleHeader* %arg-tuple to { %TupleHeader, %Array*, { %TupleHeader, double, %Qubit* }* }*
-  %1 = getelementptr { %TupleHeader, %Array*, { %TupleHeader, double, %Qubit* }* }, { %TupleHeader, %Array*, { %TupleHeader, double, %Qubit* }* }* %0, i64 0, i32 1
+  %0 = bitcast %Tuple* %arg-tuple to { %Array*, { double, %Qubit* }* }*
+  %1 = getelementptr { %Array*, { double, %Qubit* }* }, { %Array*, { double, %Qubit* }* }* %0, i64 0, i32 0
   %2 = load %Array*, %Array** %1
-  %3 = getelementptr { %TupleHeader, %Array*, { %TupleHeader, double, %Qubit* }* }, { %TupleHeader, %Array*, { %TupleHeader, double, %Qubit* }* }* %0, i64 0, i32 2
-  %4 = load { %TupleHeader, double, %Qubit* }*, { %TupleHeader, double, %Qubit* }** %3
-  call void @Microsoft__Quantum__Intrinsic__Rz__ctladj(%Array* %2, { %TupleHeader, double, %Qubit* }* %4)
+  %3 = getelementptr { %Array*, { double, %Qubit* }* }, { %Array*, { double, %Qubit* }* }* %0, i64 0, i32 1
+  %4 = load { double, %Qubit* }*, { double, %Qubit* }** %3
+  call void @Microsoft__Quantum__Intrinsic__Rz__ctladj(%Array* %2, { double, %Qubit* }* %4)
   ret void
 }

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestPartials3.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestPartials3.ll
@@ -1,21 +1,21 @@
-﻿define void @Lifted__PartialApplication__1__body__wrapper(%TupleHeader* %capture-tuple, %TupleHeader* %arg-tuple, %TupleHeader* %result-tuple) {
+﻿define void @Lifted__PartialApplication__1__body__wrapper(%Tuple* %capture-tuple, %Tuple* %arg-tuple, %Tuple* %result-tuple) {
 entry:
-  %0 = bitcast %TupleHeader* %capture-tuple to { %TupleHeader, %Callable*, double }*
-  %1 = bitcast %TupleHeader* %arg-tuple to { %TupleHeader, %Qubit* }*
-  %2 = call %TupleHeader* @__quantum__rt__tuple_create(i64 ptrtoint ({ %TupleHeader, double, %Qubit* }* getelementptr ({ %TupleHeader, double, %Qubit* }, { %TupleHeader, double, %Qubit* }* null, i32 1) to i64))
-  %3 = bitcast %TupleHeader* %2 to { %TupleHeader, double, %Qubit* }*
-  %4 = getelementptr { %TupleHeader, double, %Qubit* }, { %TupleHeader, double, %Qubit* }* %3, i64 0, i32 1
-  %5 = getelementptr { %TupleHeader, %Callable*, double }, { %TupleHeader, %Callable*, double }* %0, i64 0, i32 2
+  %0 = bitcast %Tuple* %capture-tuple to { %Callable*, double }*
+  %1 = bitcast %Tuple* %arg-tuple to { %Qubit* }*
+  %2 = call %Tuple* @__quantum__rt__tuple_create(i64 ptrtoint ({ double, %Qubit* }* getelementptr ({ double, %Qubit* }, { double, %Qubit* }* null, i32 1) to i64))
+  %3 = bitcast %Tuple* %2 to { double, %Qubit* }*
+  %4 = getelementptr { double, %Qubit* }, { double, %Qubit* }* %3, i64 0, i32 0
+  %5 = getelementptr { %Callable*, double }, { %Callable*, double }* %0, i64 0, i32 1
   %6 = load double, double* %5
   store double %6, double* %4
-  %7 = getelementptr { %TupleHeader, double, %Qubit* }, { %TupleHeader, double, %Qubit* }* %3, i64 0, i32 2
-  %8 = getelementptr { %TupleHeader, %Qubit* }, { %TupleHeader, %Qubit* }* %1, i64 0, i32 1
+  %7 = getelementptr { double, %Qubit* }, { double, %Qubit* }* %3, i64 0, i32 1
+  %8 = getelementptr { %Qubit* }, { %Qubit* }* %1, i64 0, i32 0
   %9 = load %Qubit*, %Qubit** %8
   store %Qubit* %9, %Qubit** %7
-  %10 = getelementptr { %TupleHeader, %Callable*, double }, { %TupleHeader, %Callable*, double }* %0, i64 0, i32 1
+  %10 = getelementptr { %Callable*, double }, { %Callable*, double }* %0, i64 0, i32 0
   %11 = load %Callable*, %Callable** %10
-  call void @__quantum__rt__callable_invoke(%Callable* %11, %TupleHeader* %2, %TupleHeader* %result-tuple)
-  %12 = bitcast { %TupleHeader, double, %Qubit* }* %3 to %TupleHeader*
-  call void @__quantum__rt__tuple_unreference(%TupleHeader* %12)
+  call void @__quantum__rt__callable_invoke(%Callable* %11, %Tuple* %2, %Tuple* %result-tuple)
+  %12 = bitcast { double, %Qubit* }* %3 to %Tuple*
+  call void @__quantum__rt__tuple_unreference(%Tuple* %12)
   ret void
 }

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestPartials4.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestPartials4.ll
@@ -1,24 +1,24 @@
-﻿define void @Lifted__PartialApplication__1__adj__wrapper(%TupleHeader* %capture-tuple, %TupleHeader* %arg-tuple, %TupleHeader* %result-tuple) {
+﻿define void @Lifted__PartialApplication__1__adj__wrapper(%Tuple* %capture-tuple, %Tuple* %arg-tuple, %Tuple* %result-tuple) {
 entry:
-  %0 = bitcast %TupleHeader* %capture-tuple to { %TupleHeader, %Callable*, double }*
-  %1 = bitcast %TupleHeader* %arg-tuple to { %TupleHeader, %Qubit* }*
-  %2 = call %TupleHeader* @__quantum__rt__tuple_create(i64 ptrtoint ({ %TupleHeader, double, %Qubit* }* getelementptr ({ %TupleHeader, double, %Qubit* }, { %TupleHeader, double, %Qubit* }* null, i32 1) to i64))
-  %3 = bitcast %TupleHeader* %2 to { %TupleHeader, double, %Qubit* }*
-  %4 = getelementptr { %TupleHeader, double, %Qubit* }, { %TupleHeader, double, %Qubit* }* %3, i64 0, i32 1
-  %5 = getelementptr { %TupleHeader, %Callable*, double }, { %TupleHeader, %Callable*, double }* %0, i64 0, i32 2
+  %0 = bitcast %Tuple* %capture-tuple to { %Callable*, double }*
+  %1 = bitcast %Tuple* %arg-tuple to { %Qubit* }*
+  %2 = call %Tuple* @__quantum__rt__tuple_create(i64 ptrtoint ({ double, %Qubit* }* getelementptr ({ double, %Qubit* }, { double, %Qubit* }* null, i32 1) to i64))
+  %3 = bitcast %Tuple* %2 to { double, %Qubit* }*
+  %4 = getelementptr { double, %Qubit* }, { double, %Qubit* }* %3, i64 0, i32 0
+  %5 = getelementptr { %Callable*, double }, { %Callable*, double }* %0, i64 0, i32 1
   %6 = load double, double* %5
   store double %6, double* %4
-  %7 = getelementptr { %TupleHeader, double, %Qubit* }, { %TupleHeader, double, %Qubit* }* %3, i64 0, i32 2
-  %8 = getelementptr { %TupleHeader, %Qubit* }, { %TupleHeader, %Qubit* }* %1, i64 0, i32 1
+  %7 = getelementptr { double, %Qubit* }, { double, %Qubit* }* %3, i64 0, i32 1
+  %8 = getelementptr { %Qubit* }, { %Qubit* }* %1, i64 0, i32 0
   %9 = load %Qubit*, %Qubit** %8
   store %Qubit* %9, %Qubit** %7
-  %10 = getelementptr { %TupleHeader, %Callable*, double }, { %TupleHeader, %Callable*, double }* %0, i64 0, i32 1
+  %10 = getelementptr { %Callable*, double }, { %Callable*, double }* %0, i64 0, i32 0
   %11 = load %Callable*, %Callable** %10
   %12 = call %Callable* @__quantum__rt__callable_copy(%Callable* %11)
   call void @__quantum__rt__callable_make_adjoint(%Callable* %12)
-  call void @__quantum__rt__callable_invoke(%Callable* %12, %TupleHeader* %2, %TupleHeader* %result-tuple)
-  %13 = bitcast { %TupleHeader, double, %Qubit* }* %3 to %TupleHeader*
-  call void @__quantum__rt__tuple_unreference(%TupleHeader* %13)
+  call void @__quantum__rt__callable_invoke(%Callable* %12, %Tuple* %2, %Tuple* %result-tuple)
+  %13 = bitcast { double, %Qubit* }* %3 to %Tuple*
+  call void @__quantum__rt__tuple_unreference(%Tuple* %13)
   call void @__quantum__rt__callable_unreference(%Callable* %12)
   ret void
 }

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestUdt.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestUdt.ll
@@ -1,10 +1,10 @@
-define { %TupleHeader, { %TupleHeader, i2, i64 }*, double }* @Microsoft__Quantum__Testing__QIR__TestType__body({ %TupleHeader, i2, i64 }* %arg__1, double %D) {
+define { { i2, i64 }*, double }* @Microsoft__Quantum__Testing__QIR__TestType__body({ i2, i64 }* %arg__1, double %D) {
 entry:
-  %0 = call %TupleHeader* @__quantum__rt__tuple_create(i64 ptrtoint ({ %TupleHeader, { %TupleHeader, i2, i64 }*, double }* getelementptr ({ %TupleHeader, { %TupleHeader, i2, i64 }*, double }, { %TupleHeader, { %TupleHeader, i2, i64 }*, double }* null, i32 1) to i64))
-  %1 = bitcast %TupleHeader* %0 to { %TupleHeader, { %TupleHeader, i2, i64 }*, double }*
-  %2 = getelementptr { %TupleHeader, { %TupleHeader, i2, i64 }*, double }, { %TupleHeader, { %TupleHeader, i2, i64 }*, double }* %1, i64 0, i32 1
-  store { %TupleHeader, i2, i64 }* %arg__1, { %TupleHeader, i2, i64 }** %2
-  %3 = getelementptr { %TupleHeader, { %TupleHeader, i2, i64 }*, double }, { %TupleHeader, { %TupleHeader, i2, i64 }*, double }* %1, i64 0, i32 2
+  %0 = call %Tuple* @__quantum__rt__tuple_create(i64 ptrtoint ({ { i2, i64 }*, double }* getelementptr ({ { i2, i64 }*, double }, { { i2, i64 }*, double }* null, i32 1) to i64))
+  %1 = bitcast %Tuple* %0 to { { i2, i64 }*, double }*
+  %2 = getelementptr { { i2, i64 }*, double }, { { i2, i64 }*, double }* %1, i64 0, i32 0
+  store { i2, i64 }* %arg__1, { i2, i64 }** %2
+  %3 = getelementptr { { i2, i64 }*, double }, { { i2, i64 }*, double }* %1, i64 0, i32 1
   store double %D, double* %3
-  ret { %TupleHeader, { %TupleHeader, i2, i64 }*, double }* %1
+  ret { { i2, i64 }*, double }* %1
 }

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestUdtAccessor.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestUdtAccessor.ll
@@ -1,35 +1,35 @@
 define i64 @Microsoft__Quantum__Testing__QIR__TestAccessors__body() {
 entry:
-  %0 = call %TupleHeader* @__quantum__rt__tuple_create(i64 ptrtoint ({ %TupleHeader, i2, i64 }* getelementptr ({ %TupleHeader, i2, i64 }, { %TupleHeader, i2, i64 }* null, i32 1) to i64))
-  %1 = bitcast %TupleHeader* %0 to { %TupleHeader, i2, i64 }*
+  %0 = call %Tuple* @__quantum__rt__tuple_create(i64 ptrtoint ({ i2, i64 }* getelementptr ({ i2, i64 }, { i2, i64 }* null, i32 1) to i64))
+  %1 = bitcast %Tuple* %0 to { i2, i64 }*
   %2 = load i2, i2* @PauliX
-  %3 = getelementptr { %TupleHeader, i2, i64 }, { %TupleHeader, i2, i64 }* %1, i64 0, i32 1
+  %3 = getelementptr { i2, i64 }, { i2, i64 }* %1, i64 0, i32 0
   store i2 %2, i2* %3
-  %4 = getelementptr { %TupleHeader, i2, i64 }, { %TupleHeader, i2, i64 }* %1, i64 0, i32 2
+  %4 = getelementptr { i2, i64 }, { i2, i64 }* %1, i64 0, i32 1
   store i64 1, i64* %4
-  %x = call { %TupleHeader, { %TupleHeader, i2, i64 }*, double }* @Microsoft__Quantum__Testing__QIR__TestType__body({ %TupleHeader, i2, i64 }* %1, double 2.000000e+00)
-  %5 = getelementptr { %TupleHeader, { %TupleHeader, i2, i64 }*, double }, { %TupleHeader, { %TupleHeader, i2, i64 }*, double }* %x, i64 0, i32 1
-  %6 = load { %TupleHeader, i2, i64 }*, { %TupleHeader, i2, i64 }** %5
-  %7 = getelementptr { %TupleHeader, i2, i64 }, { %TupleHeader, i2, i64 }* %6, i64 0, i32 2
+  %x = call { { i2, i64 }*, double }* @Microsoft__Quantum__Testing__QIR__TestType__body({ i2, i64 }* %1, double 2.000000e+00)
+  %5 = getelementptr { { i2, i64 }*, double }, { { i2, i64 }*, double }* %x, i64 0, i32 0
+  %6 = load { i2, i64 }*, { i2, i64 }** %5
+  %7 = getelementptr { i2, i64 }, { i2, i64 }* %6, i64 0, i32 1
   %y = load i64, i64* %7
-  %8 = bitcast { %TupleHeader, i2, i64 }* %1 to %TupleHeader*
-  call void @__quantum__rt__tuple_unreference(%TupleHeader* %8)
-  %9 = bitcast { %TupleHeader, { %TupleHeader, i2, i64 }*, double }* %x to %TupleHeader*
-  call void @__quantum__rt__tuple_unreference(%TupleHeader* %9)
-  %10 = getelementptr { %TupleHeader, { %TupleHeader, i2, i64 }*, double }, { %TupleHeader, { %TupleHeader, i2, i64 }*, double }* %x, i64 0, i32 1
-  %11 = load { %TupleHeader, i2, i64 }*, { %TupleHeader, i2, i64 }** %10
-  %12 = bitcast { %TupleHeader, i2, i64 }* %11 to %TupleHeader*
-  call void @__quantum__rt__tuple_unreference(%TupleHeader* %12)
+  %8 = bitcast { i2, i64 }* %1 to %Tuple*
+  call void @__quantum__rt__tuple_unreference(%Tuple* %8)
+  %9 = bitcast { { i2, i64 }*, double }* %x to %Tuple*
+  call void @__quantum__rt__tuple_unreference(%Tuple* %9)
+  %10 = getelementptr { { i2, i64 }*, double }, { { i2, i64 }*, double }* %x, i64 0, i32 0
+  %11 = load { i2, i64 }*, { i2, i64 }** %10
+  %12 = bitcast { i2, i64 }* %11 to %Tuple*
+  call void @__quantum__rt__tuple_unreference(%Tuple* %12)
   ret i64 %y
 }
 
-define { %TupleHeader, { %TupleHeader, i2, i64 }*, double }* @Microsoft__Quantum__Testing__QIR__TestType__body({ %TupleHeader, i2, i64 }* %arg__1, double %D) {
+define { { i2, i64 }*, double }* @Microsoft__Quantum__Testing__QIR__TestType__body({ i2, i64 }* %arg__1, double %D) {
 entry:
-  %0 = call %TupleHeader* @__quantum__rt__tuple_create(i64 ptrtoint ({ %TupleHeader, { %TupleHeader, i2, i64 }*, double }* getelementptr ({ %TupleHeader, { %TupleHeader, i2, i64 }*, double }, { %TupleHeader, { %TupleHeader, i2, i64 }*, double }* null, i32 1) to i64))
-  %1 = bitcast %TupleHeader* %0 to { %TupleHeader, { %TupleHeader, i2, i64 }*, double }*
-  %2 = getelementptr { %TupleHeader, { %TupleHeader, i2, i64 }*, double }, { %TupleHeader, { %TupleHeader, i2, i64 }*, double }* %1, i64 0, i32 1
-  store { %TupleHeader, i2, i64 }* %arg__1, { %TupleHeader, i2, i64 }** %2
-  %3 = getelementptr { %TupleHeader, { %TupleHeader, i2, i64 }*, double }, { %TupleHeader, { %TupleHeader, i2, i64 }*, double }* %1, i64 0, i32 2
+  %0 = call %Tuple* @__quantum__rt__tuple_create(i64 ptrtoint ({ { i2, i64 }*, double }* getelementptr ({ { i2, i64 }*, double }, { { i2, i64 }*, double }* null, i32 1) to i64))
+  %1 = bitcast %Tuple* %0 to { { i2, i64 }*, double }*
+  %2 = getelementptr { { i2, i64 }*, double }, { { i2, i64 }*, double }* %1, i64 0, i32 0
+  store { i2, i64 }* %arg__1, { i2, i64 }** %2
+  %3 = getelementptr { { i2, i64 }*, double }, { { i2, i64 }*, double }* %1, i64 0, i32 1
   store double %D, double* %3
-  ret { %TupleHeader, { %TupleHeader, i2, i64 }*, double }* %1
+  ret { { i2, i64 }*, double }* %1
 }

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestUdtArgument.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestUdtArgument.ll
@@ -1,59 +1,59 @@
-define { %TupleHeader, i64, { %TupleHeader, i2, i64 }* }* @Microsoft__Quantum__Testing__QIR__TestUdtArgument__body() #0 {
+define { i64, { i2, i64 }* }* @Microsoft__Quantum__Testing__QIR__TestUdtArgument__body() #0 {
 entry:
-  %0 = call %Callable* @__quantum__rt__callable_create([4 x void (%TupleHeader*, %TupleHeader*, %TupleHeader*)*]* @Microsoft__Quantum__Testing__QIR__TestType1, %TupleHeader* null)
-  %udt1 = call { %TupleHeader, i64 }* @Microsoft__Quantum__Testing__QIR_____GUID___Build__body(%Callable* %0)
+  %0 = call %Callable* @__quantum__rt__callable_create([4 x void (%Tuple*, %Tuple*, %Tuple*)*]* @Microsoft__Quantum__Testing__QIR__TestType1, %Tuple* null)
+  %udt1 = call { i64 }* @Microsoft__Quantum__Testing__QIR_____GUID___Build__body(%Callable* %0)
   %1 = load i2, i2* @PauliX
-  %2 = call %TupleHeader* @__quantum__rt__tuple_create(i64 ptrtoint ({ %TupleHeader, %Callable*, i2 }* getelementptr ({ %TupleHeader, %Callable*, i2 }, { %TupleHeader, %Callable*, i2 }* null, i32 1) to i64))
-  %3 = bitcast %TupleHeader* %2 to { %TupleHeader, %Callable*, i2 }*
-  %4 = getelementptr { %TupleHeader, %Callable*, i2 }, { %TupleHeader, %Callable*, i2 }* %3, i64 0, i32 1
-  %5 = call %Callable* @__quantum__rt__callable_create([4 x void (%TupleHeader*, %TupleHeader*, %TupleHeader*)*]* @Microsoft__Quantum__Testing__QIR__TestType2, %TupleHeader* null)
+  %2 = call %Tuple* @__quantum__rt__tuple_create(i64 ptrtoint ({ %Callable*, i2 }* getelementptr ({ %Callable*, i2 }, { %Callable*, i2 }* null, i32 1) to i64))
+  %3 = bitcast %Tuple* %2 to { %Callable*, i2 }*
+  %4 = getelementptr { %Callable*, i2 }, { %Callable*, i2 }* %3, i64 0, i32 0
+  %5 = call %Callable* @__quantum__rt__callable_create([4 x void (%Tuple*, %Tuple*, %Tuple*)*]* @Microsoft__Quantum__Testing__QIR__TestType2, %Tuple* null)
   store %Callable* %5, %Callable** %4
   call void @__quantum__rt__callable_reference(%Callable* %5)
-  %6 = getelementptr { %TupleHeader, %Callable*, i2 }, { %TupleHeader, %Callable*, i2 }* %3, i64 0, i32 2
+  %6 = getelementptr { %Callable*, i2 }, { %Callable*, i2 }* %3, i64 0, i32 1
   store i2 %1, i2* %6
-  %7 = call %Callable* @__quantum__rt__callable_create([4 x void (%TupleHeader*, %TupleHeader*, %TupleHeader*)*]* @PartialApplication__1, %TupleHeader* %2)
-  %udt2 = call { %TupleHeader, i2, i64 }* @Microsoft__Quantum__Testing__QIR_____GUID___Build__body(%Callable* %7)
+  %7 = call %Callable* @__quantum__rt__callable_create([4 x void (%Tuple*, %Tuple*, %Tuple*)*]* @PartialApplication__1, %Tuple* %2)
+  %udt2 = call { i2, i64 }* @Microsoft__Quantum__Testing__QIR_____GUID___Build__body(%Callable* %7)
   %8 = load i2, i2* @PauliX
-  %9 = call %TupleHeader* @__quantum__rt__tuple_create(i64 ptrtoint ({ %TupleHeader, %Callable*, i2, double }* getelementptr ({ %TupleHeader, %Callable*, i2, double }, { %TupleHeader, %Callable*, i2, double }* null, i32 1) to i64))
-  %10 = bitcast %TupleHeader* %9 to { %TupleHeader, %Callable*, i2, double }*
-  %11 = getelementptr { %TupleHeader, %Callable*, i2, double }, { %TupleHeader, %Callable*, i2, double }* %10, i64 0, i32 1
-  %12 = call %Callable* @__quantum__rt__callable_create([4 x void (%TupleHeader*, %TupleHeader*, %TupleHeader*)*]* @Microsoft__Quantum__Testing__QIR__TestType3, %TupleHeader* null)
+  %9 = call %Tuple* @__quantum__rt__tuple_create(i64 ptrtoint ({ %Callable*, i2, double }* getelementptr ({ %Callable*, i2, double }, { %Callable*, i2, double }* null, i32 1) to i64))
+  %10 = bitcast %Tuple* %9 to { %Callable*, i2, double }*
+  %11 = getelementptr { %Callable*, i2, double }, { %Callable*, i2, double }* %10, i64 0, i32 0
+  %12 = call %Callable* @__quantum__rt__callable_create([4 x void (%Tuple*, %Tuple*, %Tuple*)*]* @Microsoft__Quantum__Testing__QIR__TestType3, %Tuple* null)
   store %Callable* %12, %Callable** %11
   call void @__quantum__rt__callable_reference(%Callable* %12)
-  %13 = getelementptr { %TupleHeader, %Callable*, i2, double }, { %TupleHeader, %Callable*, i2, double }* %10, i64 0, i32 2
+  %13 = getelementptr { %Callable*, i2, double }, { %Callable*, i2, double }* %10, i64 0, i32 1
   store i2 %8, i2* %13
-  %14 = getelementptr { %TupleHeader, %Callable*, i2, double }, { %TupleHeader, %Callable*, i2, double }* %10, i64 0, i32 3
+  %14 = getelementptr { %Callable*, i2, double }, { %Callable*, i2, double }* %10, i64 0, i32 2
   store double 2.000000e+00, double* %14
-  %15 = call %Callable* @__quantum__rt__callable_create([4 x void (%TupleHeader*, %TupleHeader*, %TupleHeader*)*]* @PartialApplication__2, %TupleHeader* %9)
-  %udt3 = call { %TupleHeader, { %TupleHeader, i2, i64 }*, double }* @Microsoft__Quantum__Testing__QIR_____GUID___Build__body(%Callable* %15)
-  %16 = call %TupleHeader* @__quantum__rt__tuple_create(i64 ptrtoint ({ %TupleHeader, i64, { %TupleHeader, i2, i64 }* }* getelementptr ({ %TupleHeader, i64, { %TupleHeader, i2, i64 }* }, { %TupleHeader, i64, { %TupleHeader, i2, i64 }* }* null, i32 1) to i64))
-  %17 = bitcast %TupleHeader* %16 to { %TupleHeader, i64, { %TupleHeader, i2, i64 }* }*
-  %18 = getelementptr { %TupleHeader, i64 }, { %TupleHeader, i64 }* %udt1, i64 0, i32 1
+  %15 = call %Callable* @__quantum__rt__callable_create([4 x void (%Tuple*, %Tuple*, %Tuple*)*]* @PartialApplication__2, %Tuple* %9)
+  %udt3 = call { { i2, i64 }*, double }* @Microsoft__Quantum__Testing__QIR_____GUID___Build__body(%Callable* %15)
+  %16 = call %Tuple* @__quantum__rt__tuple_create(i64 ptrtoint ({ i64, { i2, i64 }* }* getelementptr ({ i64, { i2, i64 }* }, { i64, { i2, i64 }* }* null, i32 1) to i64))
+  %17 = bitcast %Tuple* %16 to { i64, { i2, i64 }* }*
+  %18 = getelementptr { i64 }, { i64 }* %udt1, i64 0, i32 0
   %19 = load i64, i64* %18
-  %20 = getelementptr { %TupleHeader, i64, { %TupleHeader, i2, i64 }* }, { %TupleHeader, i64, { %TupleHeader, i2, i64 }* }* %17, i64 0, i32 1
+  %20 = getelementptr { i64, { i2, i64 }* }, { i64, { i2, i64 }* }* %17, i64 0, i32 0
   store i64 %19, i64* %20
-  %21 = bitcast { %TupleHeader, i2, i64 }* %udt2 to %TupleHeader*
-  call void @__quantum__rt__tuple_reference(%TupleHeader* %21)
-  %22 = getelementptr { %TupleHeader, i64, { %TupleHeader, i2, i64 }* }, { %TupleHeader, i64, { %TupleHeader, i2, i64 }* }* %17, i64 0, i32 2
-  store { %TupleHeader, i2, i64 }* %udt2, { %TupleHeader, i2, i64 }** %22
-  %23 = bitcast { %TupleHeader, i2, i64 }* %udt2 to %TupleHeader*
-  call void @__quantum__rt__tuple_reference(%TupleHeader* %23)
+  %21 = bitcast { i2, i64 }* %udt2 to %Tuple*
+  call void @__quantum__rt__tuple_reference(%Tuple* %21)
+  %22 = getelementptr { i64, { i2, i64 }* }, { i64, { i2, i64 }* }* %17, i64 0, i32 1
+  store { i2, i64 }* %udt2, { i2, i64 }** %22
+  %23 = bitcast { i2, i64 }* %udt2 to %Tuple*
+  call void @__quantum__rt__tuple_reference(%Tuple* %23)
   call void @__quantum__rt__callable_unreference(%Callable* %0)
-  %24 = bitcast { %TupleHeader, i64 }* %udt1 to %TupleHeader*
-  call void @__quantum__rt__tuple_unreference(%TupleHeader* %24)
+  %24 = bitcast { i64 }* %udt1 to %Tuple*
+  call void @__quantum__rt__tuple_unreference(%Tuple* %24)
   call void @__quantum__rt__callable_unreference(%Callable* %5)
   call void @__quantum__rt__callable_unreference(%Callable* %7)
-  %25 = bitcast { %TupleHeader, i2, i64 }* %udt2 to %TupleHeader*
-  call void @__quantum__rt__tuple_unreference(%TupleHeader* %25)
+  %25 = bitcast { i2, i64 }* %udt2 to %Tuple*
+  call void @__quantum__rt__tuple_unreference(%Tuple* %25)
   call void @__quantum__rt__callable_unreference(%Callable* %12)
   call void @__quantum__rt__callable_unreference(%Callable* %15)
-  %26 = bitcast { %TupleHeader, { %TupleHeader, i2, i64 }*, double }* %udt3 to %TupleHeader*
-  call void @__quantum__rt__tuple_unreference(%TupleHeader* %26)
-  %27 = getelementptr { %TupleHeader, { %TupleHeader, i2, i64 }*, double }, { %TupleHeader, { %TupleHeader, i2, i64 }*, double }* %udt3, i64 0, i32 1
-  %28 = load { %TupleHeader, i2, i64 }*, { %TupleHeader, i2, i64 }** %27
-  %29 = bitcast { %TupleHeader, i2, i64 }* %28 to %TupleHeader*
-  call void @__quantum__rt__tuple_unreference(%TupleHeader* %29)
-  %30 = bitcast { %TupleHeader, i2, i64 }* %udt2 to %TupleHeader*
-  call void @__quantum__rt__tuple_unreference(%TupleHeader* %30)
-  ret { %TupleHeader, i64, { %TupleHeader, i2, i64 }* }* %17
+  %26 = bitcast { { i2, i64 }*, double }* %udt3 to %Tuple*
+  call void @__quantum__rt__tuple_unreference(%Tuple* %26)
+  %27 = getelementptr { { i2, i64 }*, double }, { { i2, i64 }*, double }* %udt3, i64 0, i32 0
+  %28 = load { i2, i64 }*, { i2, i64 }** %27
+  %29 = bitcast { i2, i64 }* %28 to %Tuple*
+  call void @__quantum__rt__tuple_unreference(%Tuple* %29)
+  %30 = bitcast { i2, i64 }* %udt2 to %Tuple*
+  call void @__quantum__rt__tuple_unreference(%Tuple* %30)
+  ret { i64, { i2, i64 }* }* %17
 }

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestUdtConstruction.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestUdtConstruction.ll
@@ -1,14 +1,14 @@
-define { %TupleHeader, { %TupleHeader, i2, i64 }*, double }* @Microsoft__Quantum__Testing__QIR__TestUdtConstructor__body() {
+define { { i2, i64 }*, double }* @Microsoft__Quantum__Testing__QIR__TestUdtConstructor__body() {
 entry:
-  %0 = call %TupleHeader* @__quantum__rt__tuple_create(i64 ptrtoint ({ %TupleHeader, i2, i64 }* getelementptr ({ %TupleHeader, i2, i64 }, { %TupleHeader, i2, i64 }* null, i32 1) to i64))
-  %1 = bitcast %TupleHeader* %0 to { %TupleHeader, i2, i64 }*
+  %0 = call %Tuple* @__quantum__rt__tuple_create(i64 ptrtoint ({ i2, i64 }* getelementptr ({ i2, i64 }, { i2, i64 }* null, i32 1) to i64))
+  %1 = bitcast %Tuple* %0 to { i2, i64 }*
   %2 = load i2, i2* @PauliX
-  %3 = getelementptr { %TupleHeader, i2, i64 }, { %TupleHeader, i2, i64 }* %1, i64 0, i32 1
+  %3 = getelementptr { i2, i64 }, { i2, i64 }* %1, i64 0, i32 0
   store i2 %2, i2* %3
-  %4 = getelementptr { %TupleHeader, i2, i64 }, { %TupleHeader, i2, i64 }* %1, i64 0, i32 2
+  %4 = getelementptr { i2, i64 }, { i2, i64 }* %1, i64 0, i32 1
   store i64 1, i64* %4
-  %5 = call { %TupleHeader, { %TupleHeader, i2, i64 }*, double }* @Microsoft__Quantum__Testing__QIR__TestType__body({ %TupleHeader, i2, i64 }* %1, double 2.000000e+00)
-  %6 = bitcast { %TupleHeader, i2, i64 }* %1 to %TupleHeader*
-  call void @__quantum__rt__tuple_unreference(%TupleHeader* %6)
-  ret { %TupleHeader, { %TupleHeader, i2, i64 }*, double }* %5
+  %5 = call { { i2, i64 }*, double }* @Microsoft__Quantum__Testing__QIR__TestType__body({ i2, i64 }* %1, double 2.000000e+00)
+  %6 = bitcast { i2, i64 }* %1 to %Tuple*
+  call void @__quantum__rt__tuple_unreference(%Tuple* %6)
+  ret { { i2, i64 }*, double }* %5
 }

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestUdtUpdate.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestUdtUpdate.ll
@@ -1,67 +1,67 @@
-define { %TupleHeader, { %TupleHeader, double, i64 }*, i64 }* @Microsoft__Quantum__Testing__QIR__TestUdtUpdate__body(i64 %a, i64 %b) {
+define { { double, i64 }*, i64 }* @Microsoft__Quantum__Testing__QIR__TestUdtUpdate__body(i64 %a, i64 %b) {
 entry:
-  %0 = call %TupleHeader* @__quantum__rt__tuple_create(i64 ptrtoint ({ %TupleHeader, double, i64 }* getelementptr ({ %TupleHeader, double, i64 }, { %TupleHeader, double, i64 }* null, i32 1) to i64))
-  %1 = bitcast %TupleHeader* %0 to { %TupleHeader, double, i64 }*
-  %2 = getelementptr { %TupleHeader, double, i64 }, { %TupleHeader, double, i64 }* %1, i64 0, i32 1
+  %0 = call %Tuple* @__quantum__rt__tuple_create(i64 ptrtoint ({ double, i64 }* getelementptr ({ double, i64 }, { double, i64 }* null, i32 1) to i64))
+  %1 = bitcast %Tuple* %0 to { double, i64 }*
+  %2 = getelementptr { double, i64 }, { double, i64 }* %1, i64 0, i32 0
   store double 1.000000e+00, double* %2
-  %3 = getelementptr { %TupleHeader, double, i64 }, { %TupleHeader, double, i64 }* %1, i64 0, i32 2
+  %3 = getelementptr { double, i64 }, { double, i64 }* %1, i64 0, i32 1
   store i64 %a, i64* %3
-  %4 = call { %TupleHeader, { %TupleHeader, double, i64 }*, i64 }* @Microsoft__Quantum__Testing__QIR__TestType__body({ %TupleHeader, double, i64 }* %1, i64 %b)
-  %x = alloca { %TupleHeader, { %TupleHeader, double, i64 }*, i64 }*
-  store { %TupleHeader, { %TupleHeader, double, i64 }*, i64 }* %4, { %TupleHeader, { %TupleHeader, double, i64 }*, i64 }** %x
-  %5 = load { %TupleHeader, { %TupleHeader, double, i64 }*, i64 }*, { %TupleHeader, { %TupleHeader, double, i64 }*, i64 }** %x
-  %6 = call %TupleHeader* @__quantum__rt__tuple_create(i64 ptrtoint ({ %TupleHeader, { %TupleHeader, double, i64 }*, i64 }* getelementptr ({ %TupleHeader, { %TupleHeader, double, i64 }*, i64 }, { %TupleHeader, { %TupleHeader, double, i64 }*, i64 }* null, i32 1) to i64))
-  %7 = bitcast %TupleHeader* %6 to { %TupleHeader, { %TupleHeader, double, i64 }*, i64 }*
-  %8 = getelementptr { %TupleHeader, { %TupleHeader, double, i64 }*, i64 }, { %TupleHeader, { %TupleHeader, double, i64 }*, i64 }* %5, i64 0, i32 1
-  %9 = load { %TupleHeader, double, i64 }*, { %TupleHeader, double, i64 }** %8
-  %10 = call %TupleHeader* @__quantum__rt__tuple_create(i64 ptrtoint ({ %TupleHeader, double, i64 }* getelementptr ({ %TupleHeader, double, i64 }, { %TupleHeader, double, i64 }* null, i32 1) to i64))
-  %11 = bitcast %TupleHeader* %10 to { %TupleHeader, double, i64 }*
-  %12 = getelementptr { %TupleHeader, double, i64 }, { %TupleHeader, double, i64 }* %9, i64 0, i32 1
+  %4 = call { { double, i64 }*, i64 }* @Microsoft__Quantum__Testing__QIR__TestType__body({ double, i64 }* %1, i64 %b)
+  %x = alloca { { double, i64 }*, i64 }*
+  store { { double, i64 }*, i64 }* %4, { { double, i64 }*, i64 }** %x
+  %5 = load { { double, i64 }*, i64 }*, { { double, i64 }*, i64 }** %x
+  %6 = call %Tuple* @__quantum__rt__tuple_create(i64 ptrtoint ({ { double, i64 }*, i64 }* getelementptr ({ { double, i64 }*, i64 }, { { double, i64 }*, i64 }* null, i32 1) to i64))
+  %7 = bitcast %Tuple* %6 to { { double, i64 }*, i64 }*
+  %8 = getelementptr { { double, i64 }*, i64 }, { { double, i64 }*, i64 }* %5, i64 0, i32 0
+  %9 = load { double, i64 }*, { double, i64 }** %8
+  %10 = call %Tuple* @__quantum__rt__tuple_create(i64 ptrtoint ({ double, i64 }* getelementptr ({ double, i64 }, { double, i64 }* null, i32 1) to i64))
+  %11 = bitcast %Tuple* %10 to { double, i64 }*
+  %12 = getelementptr { double, i64 }, { double, i64 }* %9, i64 0, i32 0
   %13 = load double, double* %12
-  %14 = getelementptr { %TupleHeader, double, i64 }, { %TupleHeader, double, i64 }* %11, i64 0, i32 1
+  %14 = getelementptr { double, i64 }, { double, i64 }* %11, i64 0, i32 0
   store double %13, double* %14
-  %15 = getelementptr { %TupleHeader, double, i64 }, { %TupleHeader, double, i64 }* %9, i64 0, i32 2
+  %15 = getelementptr { double, i64 }, { double, i64 }* %9, i64 0, i32 1
   %16 = load i64, i64* %15
-  %17 = getelementptr { %TupleHeader, double, i64 }, { %TupleHeader, double, i64 }* %11, i64 0, i32 2
+  %17 = getelementptr { double, i64 }, { double, i64 }* %11, i64 0, i32 1
   store i64 %16, i64* %17
-  %18 = getelementptr { %TupleHeader, { %TupleHeader, double, i64 }*, i64 }, { %TupleHeader, { %TupleHeader, double, i64 }*, i64 }* %7, i64 0, i32 1
-  store { %TupleHeader, double, i64 }* %11, { %TupleHeader, double, i64 }** %18
-  %19 = getelementptr { %TupleHeader, { %TupleHeader, double, i64 }*, i64 }, { %TupleHeader, { %TupleHeader, double, i64 }*, i64 }* %5, i64 0, i32 2
+  %18 = getelementptr { { double, i64 }*, i64 }, { { double, i64 }*, i64 }* %7, i64 0, i32 0
+  store { double, i64 }* %11, { double, i64 }** %18
+  %19 = getelementptr { { double, i64 }*, i64 }, { { double, i64 }*, i64 }* %5, i64 0, i32 1
   %20 = load i64, i64* %19
-  %21 = getelementptr { %TupleHeader, { %TupleHeader, double, i64 }*, i64 }, { %TupleHeader, { %TupleHeader, double, i64 }*, i64 }* %7, i64 0, i32 2
+  %21 = getelementptr { { double, i64 }*, i64 }, { { double, i64 }*, i64 }* %7, i64 0, i32 1
   store i64 %20, i64* %21
-  %22 = getelementptr { %TupleHeader, { %TupleHeader, double, i64 }*, i64 }, { %TupleHeader, { %TupleHeader, double, i64 }*, i64 }* %7, i64 0, i32 1
-  %23 = load { %TupleHeader, double, i64 }*, { %TupleHeader, double, i64 }** %22
-  %24 = getelementptr { %TupleHeader, double, i64 }, { %TupleHeader, double, i64 }* %23, i64 0, i32 2
+  %22 = getelementptr { { double, i64 }*, i64 }, { { double, i64 }*, i64 }* %7, i64 0, i32 0
+  %23 = load { double, i64 }*, { double, i64 }** %22
+  %24 = getelementptr { double, i64 }, { double, i64 }* %23, i64 0, i32 1
   store i64 2, i64* %24
-  %25 = load { %TupleHeader, { %TupleHeader, double, i64 }*, i64 }*, { %TupleHeader, { %TupleHeader, double, i64 }*, i64 }** %x
-  store { %TupleHeader, { %TupleHeader, double, i64 }*, i64 }* %7, { %TupleHeader, { %TupleHeader, double, i64 }*, i64 }** %x
-  %26 = bitcast { %TupleHeader, { %TupleHeader, double, i64 }*, i64 }* %7 to %TupleHeader*
-  call void @__quantum__rt__tuple_reference(%TupleHeader* %26)
-  %27 = getelementptr { %TupleHeader, { %TupleHeader, double, i64 }*, i64 }, { %TupleHeader, { %TupleHeader, double, i64 }*, i64 }* %7, i64 0, i32 1
-  %28 = load { %TupleHeader, double, i64 }*, { %TupleHeader, double, i64 }** %27
-  %29 = bitcast { %TupleHeader, double, i64 }* %28 to %TupleHeader*
-  call void @__quantum__rt__tuple_reference(%TupleHeader* %29)
-  %30 = load { %TupleHeader, { %TupleHeader, double, i64 }*, i64 }*, { %TupleHeader, { %TupleHeader, double, i64 }*, i64 }** %x
-  %31 = bitcast { %TupleHeader, double, i64 }* %1 to %TupleHeader*
-  call void @__quantum__rt__tuple_unreference(%TupleHeader* %31)
-  %32 = bitcast { %TupleHeader, { %TupleHeader, double, i64 }*, i64 }* %4 to %TupleHeader*
-  call void @__quantum__rt__tuple_unreference(%TupleHeader* %32)
-  %33 = getelementptr { %TupleHeader, { %TupleHeader, double, i64 }*, i64 }, { %TupleHeader, { %TupleHeader, double, i64 }*, i64 }* %4, i64 0, i32 1
-  %34 = load { %TupleHeader, double, i64 }*, { %TupleHeader, double, i64 }** %33
-  %35 = bitcast { %TupleHeader, double, i64 }* %34 to %TupleHeader*
-  call void @__quantum__rt__tuple_unreference(%TupleHeader* %35)
-  %36 = bitcast { %TupleHeader, { %TupleHeader, double, i64 }*, i64 }* %7 to %TupleHeader*
-  call void @__quantum__rt__tuple_unreference(%TupleHeader* %36)
-  %37 = getelementptr { %TupleHeader, { %TupleHeader, double, i64 }*, i64 }, { %TupleHeader, { %TupleHeader, double, i64 }*, i64 }* %7, i64 0, i32 1
-  %38 = load { %TupleHeader, double, i64 }*, { %TupleHeader, double, i64 }** %37
-  %39 = bitcast { %TupleHeader, double, i64 }* %38 to %TupleHeader*
-  call void @__quantum__rt__tuple_unreference(%TupleHeader* %39)
-  %40 = bitcast { %TupleHeader, { %TupleHeader, double, i64 }*, i64 }* %25 to %TupleHeader*
-  call void @__quantum__rt__tuple_unreference(%TupleHeader* %40)
-  %41 = getelementptr { %TupleHeader, { %TupleHeader, double, i64 }*, i64 }, { %TupleHeader, { %TupleHeader, double, i64 }*, i64 }* %25, i64 0, i32 1
-  %42 = load { %TupleHeader, double, i64 }*, { %TupleHeader, double, i64 }** %41
-  %43 = bitcast { %TupleHeader, double, i64 }* %42 to %TupleHeader*
-  call void @__quantum__rt__tuple_unreference(%TupleHeader* %43)
-  ret { %TupleHeader, { %TupleHeader, double, i64 }*, i64 }* %30
+  %25 = load { { double, i64 }*, i64 }*, { { double, i64 }*, i64 }** %x
+  store { { double, i64 }*, i64 }* %7, { { double, i64 }*, i64 }** %x
+  %26 = bitcast { { double, i64 }*, i64 }* %7 to %Tuple*
+  call void @__quantum__rt__tuple_reference(%Tuple* %26)
+  %27 = getelementptr { { double, i64 }*, i64 }, { { double, i64 }*, i64 }* %7, i64 0, i32 0
+  %28 = load { double, i64 }*, { double, i64 }** %27
+  %29 = bitcast { double, i64 }* %28 to %Tuple*
+  call void @__quantum__rt__tuple_reference(%Tuple* %29)
+  %30 = load { { double, i64 }*, i64 }*, { { double, i64 }*, i64 }** %x
+  %31 = bitcast { double, i64 }* %1 to %Tuple*
+  call void @__quantum__rt__tuple_unreference(%Tuple* %31)
+  %32 = bitcast { { double, i64 }*, i64 }* %4 to %Tuple*
+  call void @__quantum__rt__tuple_unreference(%Tuple* %32)
+  %33 = getelementptr { { double, i64 }*, i64 }, { { double, i64 }*, i64 }* %4, i64 0, i32 0
+  %34 = load { double, i64 }*, { double, i64 }** %33
+  %35 = bitcast { double, i64 }* %34 to %Tuple*
+  call void @__quantum__rt__tuple_unreference(%Tuple* %35)
+  %36 = bitcast { { double, i64 }*, i64 }* %7 to %Tuple*
+  call void @__quantum__rt__tuple_unreference(%Tuple* %36)
+  %37 = getelementptr { { double, i64 }*, i64 }, { { double, i64 }*, i64 }* %7, i64 0, i32 0
+  %38 = load { double, i64 }*, { double, i64 }** %37
+  %39 = bitcast { double, i64 }* %38 to %Tuple*
+  call void @__quantum__rt__tuple_unreference(%Tuple* %39)
+  %40 = bitcast { { double, i64 }*, i64 }* %25 to %Tuple*
+  call void @__quantum__rt__tuple_unreference(%Tuple* %40)
+  %41 = getelementptr { { double, i64 }*, i64 }, { { double, i64 }*, i64 }* %25, i64 0, i32 0
+  %42 = load { double, i64 }*, { double, i64 }** %41
+  %43 = bitcast { double, i64 }* %42 to %Tuple*
+  call void @__quantum__rt__tuple_unreference(%Tuple* %43)
+  ret { { double, i64 }*, i64 }* %30
 }


### PR DESCRIPTION
With this PR, QIR would no longer use tuple headers at all. Instead, concrete tuples represented as normal structs are used locally, and an opaque pointer %Tuple is passed around. The bitcasts remain the same. 

The current target branch is just to show a proper diff. I will retarget it once the reference handling is done and merged.