### PR TITLE
Pass around values during QIR emission as IValue and use custom classes

### DIFF
--- a/src/QsCompiler/Core/SyntaxGenerator.fs
+++ b/src/QsCompiler/Core/SyntaxGenerator.fs
@@ -269,7 +269,7 @@ module SyntaxGenerator =
 
     // utils related to building and generating functor specializations
 
-    let private QubitArray = Qubit |> ResolvedType.New |> ArrayType |> ResolvedType.New
+    let QubitArrayType = Qubit |> ResolvedType.New |> ArrayType |> ResolvedType.New
 
     /// Given a QsTuple, recursively extracts and returns all of its items.
     let ExtractItems (this : QsTuple<_>) =
@@ -293,7 +293,7 @@ module SyntaxGenerator =
 
     /// Given the resolved argument type of an operation, returns the argument type of its controlled version.
     let AddControlQubits (argT : ResolvedType) =
-        [QubitArray; argT].ToImmutableArray() |> TupleType |> ResolvedType.New
+        [QubitArrayType; argT].ToImmutableArray() |> TupleType |> ResolvedType.New
 
     /// Given a resolved signature, returns the corresponding signature for the controlled version.
     let BuildControlled (this : ResolvedSignature) =
@@ -304,7 +304,7 @@ module SyntaxGenerator =
     /// Throws an ArgumentException if the given argument tuple is not a QsTuple.
     let WithControlQubits arg offset (name, symRange : QsNullable<_>) =
         let range = symRange.ValueOr Range.Zero
-        let ctlQs = LocalVariableDeclaration.New false ((offset, range), name, QubitArray, false)
+        let ctlQs = LocalVariableDeclaration.New false ((offset, range), name, QubitArrayType, false)
         let unitArg =
             let argName = ValidName InternalUse.UnitArgument
             let unitT = UnitType |> ResolvedType.New
@@ -324,7 +324,7 @@ module SyntaxGenerator =
         let isInvalid = function
             | Tuple _ | Item _ | Missing -> false
             | _ -> true
-        if ctlQs.ResolvedType.Resolution <> QubitArray.Resolution && not (ctlQs.ResolvedType |> isInvalid) then
+        if ctlQs.ResolvedType.Resolution <> QubitArrayType.Resolution && not (ctlQs.ResolvedType |> isInvalid) then
             new ArgumentException "expression for the control qubits is valid but not of type Qubit[]" |> raise
         TupleLiteral [ctlQs; arg]
 

--- a/src/QsCompiler/QirGeneration/Context.cs
+++ b/src/QsCompiler/QirGeneration/Context.cs
@@ -977,7 +977,7 @@ namespace Microsoft.Quantum.QsCompiler.QIR
                 }
                 var tupleItems = this.CurrentFunction.Parameters.Select((v, i) => this.Values.From(v, ts.Item[i])).ToArray();
                 var innerTuple = this.Values.CreateTuple(tupleItems);
-                this.ScopeMgr.RegisterVariable(outerArgItems[0].Item1, innerTuple, false);
+                this.ScopeMgr.RegisterVariable(outerArgItems[0].Item1, innerTuple);
             }
             else
             {
@@ -986,7 +986,7 @@ namespace Microsoft.Quantum.QsCompiler.QIR
                 {
                     this.CurrentFunction.Parameters[i].Name = arg.Item1;
                     var argValue = this.Values.From(this.CurrentFunction.Parameters[i], arg.Item2);
-                    this.ScopeMgr.RegisterVariable(arg.Item1, argValue, false);
+                    this.ScopeMgr.RegisterVariable(arg.Item1, argValue);
                     i++;
                 }
             }
@@ -995,13 +995,13 @@ namespace Microsoft.Quantum.QsCompiler.QIR
             while (deconstuctArgument && innerTuples.TryDequeue(out (string, QsArgumentTuple) tuple))
             {
                 var (tupleArgName, tupleArg) = tuple;
-                var tupleValue = (TupleValue)this.ScopeMgr.GetNamedValue(tupleArgName);
+                var tupleValue = (TupleValue)this.ScopeMgr.GetVariable(tupleArgName);
 
                 int idx = 0;
                 foreach (var arg in ArgTupleToArgItems(tupleArg, innerTuples))
                 {
                     var element = tupleValue.GetTupleElement(idx);
-                    this.ScopeMgr.RegisterVariable(arg.Item1, element, false);
+                    this.ScopeMgr.RegisterVariable(arg.Item1, element);
                     idx++;
                 }
             }

--- a/src/QsCompiler/QirGeneration/Context.cs
+++ b/src/QsCompiler/QirGeneration/Context.cs
@@ -1538,11 +1538,15 @@ namespace Microsoft.Quantum.QsCompiler.QIR
         /// <summary>
         /// Stop inlining a callable invocation.
         /// This pops the top naming scope and decreases the inlining level.
+        /// The reference count of the return value for the inlining scope is increased before closing the scope,
+        /// and the value is registered with the scope manager.
         /// </summary>
         internal IValue StopInlining()
         {
-            this.ScopeMgr.CloseScope(this.CurrentBlock?.Terminator != null);
-            return this.inlineLevels.Pop().Item2;
+            var res = this.inlineLevels.Pop().Item2;
+            this.ScopeMgr.CloseScope(res);
+            this.ScopeMgr.RegisterValue(res);
+            return res;
         }
 
         /// <summary>

--- a/src/QsCompiler/QirGeneration/QIR/DataStructures.cs
+++ b/src/QsCompiler/QirGeneration/QIR/DataStructures.cs
@@ -255,9 +255,9 @@ namespace Microsoft.Quantum.QIR.Emission
         public Value Value => this.OpaquePointer;
 
         public ResolvedType QSharpType =>
-            ResolvedType.New(QsResolvedTypeKind.NewArrayType(this.QSharpElementType));
+            ResolvedType.New(QsResolvedTypeKind.NewArrayType(this.qsElementType));
 
-        internal readonly ResolvedType QSharpElementType; // FIXME: ELIMINATE ELEMENTTYPE AND INSTEAD HAVE THE POINTERS RETURN A POINTER VALUE
+        private readonly ResolvedType qsElementType; // FIXME: ELIMINATE ELEMENTTYPE AND INSTEAD HAVE THE POINTERS RETURN A POINTER VALUE
         public readonly ITypeRef ElementType;
         public readonly uint? Count;
 
@@ -300,7 +300,7 @@ namespace Microsoft.Quantum.QIR.Emission
         internal ArrayValue(uint count, ResolvedType elementType, GenerationContext context)
         {
             this.sharedState = context;
-            this.QSharpElementType = elementType;
+            this.qsElementType = elementType;
             this.ElementType = context.LlvmTypeFromQsharpType(elementType);
             this.Count = count;
             this.length = context.Context.CreateConstant((long)count);
@@ -317,7 +317,7 @@ namespace Microsoft.Quantum.QIR.Emission
         internal ArrayValue(Value length, ResolvedType elementType, GenerationContext context)
         {
             this.sharedState = context;
-            this.QSharpElementType = elementType;
+            this.qsElementType = elementType;
             this.ElementType = context.LlvmTypeFromQsharpType(elementType);
             this.length = length;
         }
@@ -333,7 +333,7 @@ namespace Microsoft.Quantum.QIR.Emission
         internal ArrayValue(Value array, Value? length, ResolvedType elementType, GenerationContext context)
         {
             this.sharedState = context;
-            this.QSharpElementType = elementType;
+            this.qsElementType = elementType;
             this.ElementType = context.LlvmTypeFromQsharpType(elementType);
             this.opaquePointer = Types.IsArray(array.NativeType) ? array : throw new ArgumentException("expecting an opaque array");
             this.length = length;
@@ -360,7 +360,7 @@ namespace Microsoft.Quantum.QIR.Emission
         {
             var elementPtr = this.GetArrayElementPointer(index);
             var element = this.sharedState.CurrentBuilder.Load(this.ElementType, elementPtr);
-            return this.sharedState.Values.From(element, this.QSharpElementType);
+            return this.sharedState.Values.From(element, this.qsElementType);
         }
 
         /// <summary>
@@ -389,7 +389,7 @@ namespace Microsoft.Quantum.QIR.Emission
         {
             var elementPtrs = this.GetArrayElementPointers(indices);
             var elements = elementPtrs.Select(ptr => this.sharedState.CurrentBuilder.Load(this.ElementType, ptr));
-            return elements.Select((element, i) => this.sharedState.Values.From(element, this.QSharpElementType)).ToArray();
+            return elements.Select((element, i) => this.sharedState.Values.From(element, this.qsElementType)).ToArray();
         }
     }
 

--- a/src/QsCompiler/QirGeneration/QIR/DataStructures.cs
+++ b/src/QsCompiler/QirGeneration/QIR/DataStructures.cs
@@ -145,6 +145,7 @@ namespace Microsoft.Quantum.QIR.Emission
         /// <summary>
         /// Creates a new tuple value. The allocation of the value via invokation of the corresponding runtime function
         /// is lazy, and so are the necessary casts. When needed, the instructions are emitted using the current builder.
+        /// Registers the value with the scope manager once it is allocated.
         /// </summary>
         /// <param name="elementTypes">The Q# types of the tuple items</param>
         /// <param name="context">Generation context where constants are defined and generated if needed</param>
@@ -293,6 +294,7 @@ namespace Microsoft.Quantum.QIR.Emission
         /// <summary>
         /// Creates a new array value. The allocation of the value via invokation of the corresponding runtime function
         /// is lazy, and so are other necessary computations. When needed, the instructions are emitted using the current builder.
+        /// Registers the value with the scope manager once it is allocated.
         /// </summary>
         /// <param name="count">The number of elements in the array</param>
         /// <param name="elementType">Q# type of the array elements</param>
@@ -310,6 +312,7 @@ namespace Microsoft.Quantum.QIR.Emission
         /// Creates a new array value of the given length. Expects a value of type i64 for the length of the array.
         /// The allocation of the value via invokation of the corresponding runtime function is lazy, and so are
         /// other necessary computations. When needed, the instructions are emitted using the current builder.
+        /// Registers the value with the scope manager once it is allocated.
         /// </summary>
         /// <param name="length">Value of type i64 indicating the number of elements in the array</param>
         /// <param name="elementType">Q# type of the array elements</param>
@@ -398,8 +401,8 @@ namespace Microsoft.Quantum.QIR.Emission
     /// </summary>
     internal class CallableValue : SimpleValue
     {
-        internal CallableValue(Value callabe, ResolvedType type)
-        : base(callabe, type)
+        internal CallableValue(Value value, ResolvedType type, GenerationContext context)
+        : base(value, type)
         {
         }
     }

--- a/src/QsCompiler/QirGeneration/QIR/DataStructures.cs
+++ b/src/QsCompiler/QirGeneration/QIR/DataStructures.cs
@@ -1,14 +1,41 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
+using System.Collections.Immutable;
+using System.Linq;
 using Microsoft.Quantum.QsCompiler.QIR;
+using Microsoft.Quantum.QsCompiler.SyntaxTokens;
+using Microsoft.Quantum.QsCompiler.SyntaxTree;
 using Ubiquity.NET.Llvm.Instructions;
 using Ubiquity.NET.Llvm.Types;
 using Ubiquity.NET.Llvm.Values;
 
 namespace Microsoft.Quantum.QIR.Emission
 {
-    internal class TupleValue
+    using QsResolvedTypeKind = QsTypeKind<ResolvedType, UserDefinedType, QsTypeParameter, CallableInformation>;
+
+    internal interface IValue
+    {
+        public Value Value { get; }
+
+        public ResolvedType QSharpType { get; }
+    }
+
+    internal class SimpleValue : IValue
+    {
+        public Value Value { get; }
+
+        public ResolvedType QSharpType { get; }
+
+        internal SimpleValue(Value value, ResolvedType type, InstructionBuilder? builder = null)
+        {
+            this.Value = value;
+            this.QSharpType = type;
+        }
+    }
+
+    internal class TupleValue : IValue
     {
         private readonly GenerationContext sharedState;
         private readonly InstructionBuilder? builder;
@@ -19,6 +46,12 @@ namespace Microsoft.Quantum.QIR.Emission
         private Value? opaquePointer;
         private Value? typedPointer;
 
+        public Value Value => this.TypedPointer;
+
+        public ResolvedType QSharpType =>
+            ResolvedType.New(QsResolvedTypeKind.NewTupleType(ImmutableArray.CreateRange(this.ElementTypes)));
+
+        internal readonly ImmutableArray<ResolvedType> ElementTypes;
         public readonly IStructType StructType;
 
         internal Value OpaquePointer
@@ -31,7 +64,7 @@ namespace Microsoft.Quantum.QIR.Emission
                     var constructor = this.sharedState.GetOrCreateRuntimeFunction(RuntimeLibrary.TupleCreate);
                     var size = this.sharedState.ComputeSizeForType(this.StructType, this.builder);
                     this.opaquePointer = this.Builder.Call(constructor, size);
-                    this.sharedState.ScopeMgr.RegisterValue(this.TypedPointer);
+                    this.sharedState.ScopeMgr.RegisterValue(this);
                 }
 
                 this.opaquePointer ??= this.Builder.BitCast(this.TypedPointer, this.sharedState.Types.Tuple);
@@ -49,21 +82,104 @@ namespace Microsoft.Quantum.QIR.Emission
         }
 
         /// <summary>
+        /// Creates a new tuple value. The allocation of the value via invokation of the corresponding runtime function
+        /// is lazy, and so are the necessary casts. When needed, the instructions are emitted using the given builder.
         /// If no builder is specified, the builder defined in the context is used when a pointer is constructed.
-        /// The construction of both pointers is lazy.
         /// </summary>
-        /// <param name="tupleType">Type of the structure that contains the tuple data</param>
+        /// <param name="elementTypes">The Q# types of the tuple items</param>
         /// <param name="context">Generation context where constants are defined and generated if needed</param>
         /// <param name="builder">Builder used to construct the opaque pointer the first time it is requested</param>
-        internal TupleValue(IStructType tupleType, GenerationContext context, InstructionBuilder? builder = null)
+        internal TupleValue(ImmutableArray<ResolvedType> elementTypes, GenerationContext context, InstructionBuilder? builder = null)
         {
             this.sharedState = context;
             this.builder = builder;
-            this.StructType = tupleType;
+            this.ElementTypes = elementTypes;
+            this.StructType = this.sharedState.Types.TypedTuple(elementTypes.Select(context.LlvmTypeFromQsharpType));
+        }
+
+        /// <summary>
+        /// Creates a new tuple value from the given tuple pointer. The casts to get the opaque and typed pointer
+        /// respectively are executed lazily. When needed, the instructions are emitted using the given builder.
+        /// If no builder is specified, the builder defined in the context is used when a pointer is constructed.
+        /// </summary>
+        /// <param name="tuple">Either an opaque or a typed pointer to the tuple data structure</param>
+        /// <param name="elementTypes">The Q# types of the tuple items</param>
+        /// <param name="context">Generation context where constants are defined and generated if needed</param>
+        /// <param name="builder">Builder used to construct the opaque pointer the first time it is requested</param>
+        internal TupleValue(Value tuple, ImmutableArray<ResolvedType> elementTypes, GenerationContext context, InstructionBuilder? builder = null)
+        {
+            var isTypedTuple = Types.IsTypedTuple(tuple.NativeType);
+            var isOpaqueTuple = Types.IsTuple(tuple.NativeType);
+            if (!isTypedTuple && !isOpaqueTuple)
+            {
+                throw new ArgumentException("expecting either an opaque or a typed tuple");
+            }
+
+            this.sharedState = context;
+            this.builder = builder;
+            this.opaquePointer = isOpaqueTuple ? tuple : null;
+            this.typedPointer = isTypedTuple ? tuple : null;
+            this.ElementTypes = elementTypes;
+            this.StructType = this.sharedState.Types.TypedTuple(elementTypes.Select(context.LlvmTypeFromQsharpType));
+        }
+
+        // methods for item access
+
+        /// <summary>
+        /// Creates a suitable array of values to access the item at a given index for a pointer to a struct.
+        /// </summary>
+        private Value[] PointerIndex(int index) => new[]
+        {
+            this.sharedState.Context.CreateConstant(0L),
+            this.sharedState.Context.CreateConstant(index)
+        };
+
+        /// <summary>
+        /// Returns a pointer to a tuple element.
+        /// If no builder is specified, the current builder is used.
+        /// </summary>
+        /// <param name="index">The element's index into the tuple.</param>
+        /// <param name="builder">Optional argument specifying the builder to use to create the instructions</param>
+        internal Value GetTupleElementPointer(int index) =>
+            this.Builder.GetElementPtr(this.StructType, this.TypedPointer, this.PointerIndex(index));
+
+        /// <summary>
+        /// Returns a tuple element.
+        /// If no builder is specified, the current builder is used.
+        /// </summary>
+        /// <param name="index">The element's index into the tuple.</param>
+        /// <param name="builder">Optional argument specifying the builder to use to create the instructions</param>
+        internal IValue GetTupleElement(int index)
+        {
+            var elementPtr = this.GetTupleElementPointer(index);
+            var element = this.Builder.Load(this.StructType.Members[index], elementPtr);
+            return this.sharedState.Values.From(element, this.ElementTypes[index], this.builder);
+        }
+
+        /// <summary>
+        /// Returns an array with all pointers to the tuple elements.
+        /// If no builder is specified, the current builder is used.
+        /// </summary>
+        /// <param name="builder">Optional argument specifying the builder to use to create the instructions</param>
+        internal Value[] GetTupleElementPointers() =>
+            this.StructType.Members
+                .Select((_, i) => this.Builder.GetElementPtr(this.TypedPointer, this.PointerIndex(i)))
+                .ToArray();
+
+        /// <summary>
+        /// Returns an array with all tuple elements.
+        /// If no builder is specified, the current builder is used.
+        /// </summary>
+        /// <param name="builder">Optional argument specifying the builder to use to create the instructions</param>
+        internal IValue[] GetTupleElements()
+        {
+            var elementPtrs = this.GetTupleElementPointers();
+            var elements = this.StructType.Members.Select((itemType, i) => this.Builder.Load(itemType, elementPtrs[i]));
+            return elements.Select((element, i) => this.sharedState.Values.From(element, this.ElementTypes[i], this.builder)).ToArray();
         }
     }
 
-    internal class ArrayValue
+    internal class ArrayValue : IValue
     {
         private readonly GenerationContext sharedState;
         private readonly InstructionBuilder? builder;
@@ -71,11 +187,31 @@ namespace Microsoft.Quantum.QIR.Emission
         private InstructionBuilder Builder =>
             this.builder ?? this.sharedState.CurrentBuilder;
 
+        // Imporant: the constructors must ensure that either length or opaque pointer is not null!
         private Value? opaquePointer;
+        private Value? length;
 
+        public Value Value => this.OpaquePointer;
+
+        public ResolvedType QSharpType =>
+            ResolvedType.New(QsResolvedTypeKind.NewArrayType(this.elementType));
+
+        private readonly ResolvedType elementType;
         public readonly ITypeRef ElementType;
         public readonly uint? Count;
-        public readonly Value Length;
+
+        public Value Length
+        {
+            get
+            {
+                if (this.length == null)
+                {
+                    var getLength = this.sharedState.GetOrCreateRuntimeFunction(RuntimeLibrary.ArrayGetSize1d);
+                    this.length = this.Builder.Call(getLength, this.opaquePointer ?? throw new InvalidOperationException("array has no value"));
+                }
+                return this.length;
+            }
+        }
 
         internal Value OpaquePointer
         {
@@ -87,45 +223,106 @@ namespace Microsoft.Quantum.QIR.Emission
                     var constructor = this.sharedState.GetOrCreateRuntimeFunction(RuntimeLibrary.ArrayCreate1d);
                     var elementSize = this.sharedState.ComputeSizeForType(this.ElementType, this.builder, this.sharedState.Context.Int32Type);
                     this.opaquePointer = this.Builder.Call(constructor, elementSize, this.Length);
-                    this.sharedState.ScopeMgr.RegisterValue(this.opaquePointer);
+                    this.sharedState.ScopeMgr.RegisterValue(this);
                 }
                 return this.opaquePointer;
             }
         }
 
         /// <summary>
-        /// Expects a value of type i64 for the length of the array.
-        /// If no builder is specified, the builder defined in the context is used when the opaque pointer is constructed.
-        /// The construction of the opaque pointer is lazy.
+        /// Creates a new array value. The allocation of the value via invokation of the corresponding runtime function
+        /// is lazy, and so are other necessary computations. When needed, the instructions are emitted using the given builder.
+        /// If no builder is specified, the builder defined in the context is used when a pointer is constructed.
         /// </summary>
         /// <param name="count">The number of elements in the array</param>
-        /// <param name="elementType">Type of the array elements</param>
+        /// <param name="elementType">Q# type of the array elements</param>
         /// <param name="context">Generation context where constants are defined and generated if needed</param>
         /// <param name="builder">Builder used to construct the opaque pointer the first time it is requested</param>
-        internal ArrayValue(uint count, ITypeRef elementType, GenerationContext context, InstructionBuilder? builder = null)
+        internal ArrayValue(uint count, ResolvedType elementType, GenerationContext context, InstructionBuilder? builder = null)
         {
             this.sharedState = context;
             this.builder = builder;
-            this.ElementType = elementType;
+            this.elementType = elementType;
+            this.ElementType = context.LlvmTypeFromQsharpType(elementType);
             this.Count = count;
-            this.Length = context.Context.CreateConstant((long)count);
+            this.length = context.Context.CreateConstant((long)count);
         }
 
         /// <summary>
-        /// Expects a value of type i64 for the length of the array.
-        /// If no builder is specified, the builder defined in the context is used when the opaque pointer is constructed.
-        /// The construction of the opaque pointer is lazy.
+        /// Creates a new array value of the given length. Expects a value of type i64 for the length of the array.
+        /// The allocation of the value via invokation of the corresponding runtime function is lazy, and so are
+        /// other necessary computations. When needed, the instructions are emitted using the given builder.
+        /// If no builder is specified, the builder defined in the context is used when a pointer is constructed.
         /// </summary>
         /// <param name="length">Value of type i64 indicating the number of elements in the array</param>
-        /// <param name="elementType">Type of the array elements</param>
+        /// <param name="elementType">Q# type of the array elements</param>
         /// <param name="context">Generation context where constants are defined and generated if needed</param>
         /// <param name="builder">Builder used to construct the opaque pointer the first time it is requested</param>
-        internal ArrayValue(Value length, ITypeRef elementType, GenerationContext context, InstructionBuilder? builder = null)
+        internal ArrayValue(Value length, ResolvedType elementType, GenerationContext context, InstructionBuilder? builder = null)
         {
             this.sharedState = context;
             this.builder = builder;
-            this.ElementType = elementType;
-            this.Length = length;
+            this.elementType = elementType;
+            this.ElementType = context.LlvmTypeFromQsharpType(elementType);
+            this.length = length;
+        }
+
+        /// <summary>
+        /// Creates a new array value from the given opaque array of elements of the given type. When needed,
+        /// the instructions to compute the length of the array are emitted using the given builder.
+        /// If no builder is specified, the builder defined in the context is used when a pointer is constructed.
+        /// </summary>
+        /// <param name="array">The opaque pointer to the array data structure</param>
+        /// <param name="length">Value of type i64 indicating the number of elements in the array; will be computed on demand if the given value is null</param>
+        /// <param name="elementType">Q# type of the array elements</param>
+        /// <param name="context">Generation context where constants are defined and generated if needed</param>
+        /// <param name="builder">Builder used to construct the opaque pointer the first time it is requested</param>
+        internal ArrayValue(Value array, Value? length, ResolvedType elementType, GenerationContext context, InstructionBuilder? builder = null)
+        {
+            this.sharedState = context;
+            this.builder = builder;
+            this.elementType = elementType;
+            this.ElementType = context.LlvmTypeFromQsharpType(elementType);
+            this.opaquePointer = Types.IsArray(array.NativeType) ? array : throw new ArgumentException("expecting an opaque array");
+            this.length = length;
+        }
+
+        // methods for item access
+
+        /// <summary>
+        /// Returns a pointer to an array element.
+        /// If no builder is specified, the current builder is used.
+        /// </summary>
+        /// <param name="index">The element's index into the array.</param>
+        /// <param name="builder">Optional argument specifying the builder to use to create the instructions</param>
+        internal Value GetArrayElementPointer(Value index)
+        {
+            var getElementPointer = this.sharedState.GetOrCreateRuntimeFunction(RuntimeLibrary.ArrayGetElementPtr1d);
+            var opaqueElementPointer = this.Builder.Call(getElementPointer, this.OpaquePointer, index);
+            return this.Builder.BitCast(opaqueElementPointer, this.ElementType.CreatePointerType());
+        }
+
+        /// <summary>
+        /// Returns an array element.
+        /// If no builder is specified, the current builder is used.
+        /// </summary>
+        /// <param name="elementType">The type of the array element.</param>
+        /// <param name="array">The pointer to the array.</param>
+        /// <param name="index">The element's index into the array.</param>
+        /// <param name="builder">Optional argument specifying the builder to use to create the instructions</param>
+        internal IValue GetArrayElement(Value index)
+        {
+            var elementPtr = this.GetArrayElementPointer(index);
+            var element = this.Builder.Load(this.ElementType, elementPtr);
+            return this.sharedState.Values.From(element, this.elementType, this.builder);
+        }
+    }
+
+    internal class CallableValue : SimpleValue // FIXME
+    {
+        internal CallableValue(Value callabe, ResolvedType type, InstructionBuilder? builder = null)
+        : base(callabe, type, builder)
+        {
         }
     }
 }

--- a/src/QsCompiler/QirGeneration/QIR/Types.cs
+++ b/src/QsCompiler/QirGeneration/QIR/Types.cs
@@ -173,11 +173,35 @@ namespace Microsoft.Quantum.QIR
         /// <summary>
         /// Determines whether an LLVM type is a pointer to a typed tuple.
         /// </summary>
-        public bool IsTypedTuple(ITypeRef t) =>
+        public static bool IsTypedTuple(ITypeRef t) =>
             t is IPointerType pt
             && pt.ElementType is IStructType st
             && st.Name == null
             && st.Members.Count > 0;
+
+        /// <summary>
+        /// Determines whether an LLVM type is a pointer to an opaque tuple.
+        /// </summary>
+        public static bool IsTuple(ITypeRef t) =>
+            t is IPointerType pt
+            && pt.ElementType is IStructType st
+            && st.Name == TypeNames.Tuple;
+
+        /// <summary>
+        /// Determines whether an LLVM type is a pointer to an opaque array.
+        /// </summary>
+        public static bool IsArray(ITypeRef t) =>
+            t is IPointerType pt
+            && pt.ElementType is IStructType st
+            && st.Name == TypeNames.Array;
+
+        /// <summary>
+        /// Determines whether an LLVM type is a pointer to an opaque callable.
+        /// </summary>
+        public static bool IsCallable(ITypeRef t) =>
+            t is IPointerType pt
+            && pt.ElementType is IStructType st
+            && st.Name == TypeNames.Callable;
     }
 
     /// <summary>

--- a/src/QsCompiler/QirGeneration/QIR/Types.cs
+++ b/src/QsCompiler/QirGeneration/QIR/Types.cs
@@ -202,6 +202,38 @@ namespace Microsoft.Quantum.QIR
             t is IPointerType pt
             && pt.ElementType is IStructType st
             && st.Name == TypeNames.Callable;
+
+        /// <summary>
+        /// Determines whether an LLVM type is a qubit pointer.
+        /// </summary>
+        public static bool IsQubit(ITypeRef t) =>
+            t is IPointerType pt
+            && pt.ElementType is IStructType st
+            && st.Name == TypeNames.Qubit;
+
+        /// <summary>
+        /// Determines whether an LLVM type is a measurement result pointer.
+        /// </summary>
+        public static bool IsResult(ITypeRef t) =>
+            t is IPointerType pt
+            && pt.ElementType is IStructType st
+            && st.Name == TypeNames.Result;
+
+        /// <summary>
+        /// Determines whether an LLVM type is a big int pointer.
+        /// </summary>
+        public static bool IsBigInt(ITypeRef t) =>
+            t is IPointerType pt
+            && pt.ElementType is IStructType st
+            && st.Name == TypeNames.BigInt;
+
+        /// <summary>
+        /// Determines whether an LLVM type is a string pointer.
+        /// </summary>
+        public static bool IsString(ITypeRef t) =>
+            t is IPointerType pt
+            && pt.ElementType is IStructType st
+            && st.Name == TypeNames.String;
     }
 
     /// <summary>

--- a/src/QsCompiler/QirGeneration/QIR/Values.cs
+++ b/src/QsCompiler/QirGeneration/QIR/Values.cs
@@ -100,6 +100,16 @@ namespace Microsoft.Quantum.QIR.Emission
             (IValue)new SimpleValue(value, type, builder);
 
         /// <summary>
+        /// Creates a pointer to a value of arbitrary type.
+        /// When needed, the instructions are emitted using the given builder.
+        /// If no builder is specified, the builder defined in the context is used when a pointer is constructed.
+        /// </summary>
+        /// <param name="type">The Q# type of the value that the pointer points to</param>
+        /// <param name="builder">Builder used to construct the opaque pointer the first time it is requested</param>
+        internal PointerValue CreatePointer(ResolvedType type, InstructionBuilder? builder = null) =>
+            new PointerValue(type, this.sharedState, builder);
+
+        /// <summary>
         /// Creates a new tuple value. The allocation of the value via invokation of the corresponding runtime function
         /// is lazy, and so are the necessary casts. When needed, the instructions are emitted using the given builder.
         /// If no builder is specified, the builder defined in the context is used when a pointer is constructed.

--- a/src/QsCompiler/QirGeneration/QIR/Values.cs
+++ b/src/QsCompiler/QirGeneration/QIR/Values.cs
@@ -7,7 +7,6 @@ using System.Linq;
 using Microsoft.Quantum.QsCompiler.QIR;
 using Microsoft.Quantum.QsCompiler.SyntaxTokens;
 using Microsoft.Quantum.QsCompiler.SyntaxTree;
-using Ubiquity.NET.Llvm.Instructions;
 using Ubiquity.NET.Llvm.Values;
 
 namespace Microsoft.Quantum.QIR.Emission
@@ -35,17 +34,15 @@ namespace Microsoft.Quantum.QIR.Emission
         /// </summary>
         /// <param name="value">The LLVM value to store</param>
         /// <param name="type">The Q# of the value</param>
-        /// <param name="builder">The builder to use to generate instructions if needed</param>
-        internal SimpleValue FromSimpleValue(Value value, ResolvedType type, InstructionBuilder? builder = null) =>
-            new SimpleValue(value, type, builder);
+        internal SimpleValue FromSimpleValue(Value value, ResolvedType type) =>
+            new SimpleValue(value, type);
 
         /// <summary>
         /// Creates a tuple value that stores the given LLVM value representing a Q# value of user defined type.
         /// </summary>
         /// <param name="value">The typed tuple representing a value of user defined type</param>
         /// <param name="udt">The Q# type of the value</param>
-        /// <param name="builder">The builder to use to generate instructions if needed</param>
-        internal TupleValue FromCustomType(Value value, UserDefinedType udt, InstructionBuilder? builder = null)
+        internal TupleValue FromCustomType(Value value, UserDefinedType udt)
         {
             if (!this.sharedState.TryGetCustomType(udt.GetFullName(), out var udtDecl))
             {
@@ -53,138 +50,108 @@ namespace Microsoft.Quantum.QIR.Emission
             }
 
             var elementTypes = udtDecl.Type.Resolution is QsResolvedTypeKind.TupleType ts ? ts.Item : ImmutableArray.Create(udtDecl.Type);
-            return new TupleValue(udt, value, elementTypes, this.sharedState, builder);
+            return new TupleValue(udt, value, elementTypes, this.sharedState);
         }
 
         /// <summary>
         /// Creates a new tuple value from the given tuple pointer. The casts to get the opaque and typed pointer
-        /// respectively are executed lazily. When needed, the instructions are emitted using the given builder.
-        /// If no builder is specified, the builder defined in the context is used when a pointer is constructed.
+        /// respectively are executed lazily. When needed, the instructions are emitted using the current builder.
         /// </summary>
         /// <param name="tuple">Either an opaque or a typed pointer to the tuple data structure</param>
         /// <param name="elementTypes">The Q# types of the tuple items</param>
-        /// <param name="builder">Builder used to construct the opaque pointer the first time it is requested</param>
-        internal TupleValue FromTuple(Value tuple, ImmutableArray<ResolvedType> elementTypes, InstructionBuilder? builder = null) =>
-            new TupleValue(tuple, elementTypes, this.sharedState, builder);
+        internal TupleValue FromTuple(Value tuple, ImmutableArray<ResolvedType> elementTypes) =>
+            new TupleValue(tuple, elementTypes, this.sharedState);
 
         /// <summary>
         /// Creates a new array value from the given opaque array of elements of the given type. When needed,
-        /// the instructions to compute the length of the array are emitted using the given builder.
-        /// If no builder is specified, the builder defined in the context is used when a pointer is constructed.
+        /// the instructions to compute the length of the array are emitted using the current builder.
         /// </summary>
         /// <param name="elementType">Q# type of the array elements</param>
-        /// <param name="builder">Builder used to construct the opaque pointer the first time it is requested</param>
-        internal ArrayValue FromArray(Value value, ResolvedType elementType, InstructionBuilder? builder = null) =>
-            new ArrayValue(value, null, elementType, this.sharedState, builder);
+        internal ArrayValue FromArray(Value value, ResolvedType elementType) =>
+            new ArrayValue(value, null, elementType, this.sharedState);
 
         /// <summary>
         /// Creates a callable value that stores the given LLVM value representing a Q# callable.
         /// </summary>
         /// <param name="value">The LLVM value to store</param>
         /// <param name="type">The Q# of the value</param>
-        /// <param name="builder">The builder to use to generate instructions if needed</param>
-        internal CallableValue FromCallable(Value value, ResolvedType type, InstructionBuilder? builder = null) =>
-            new CallableValue(value, type, builder);
+        internal CallableValue FromCallable(Value value, ResolvedType type) =>
+            new CallableValue(value, type);
 
         /// <summary>
         /// Creates a suitable class to pass around a built LLVM value that represents a Q# value of the given type.
         /// </summary>
         /// <param name="value">The LLVM value to store</param>
         /// <param name="type">The Q# of the value</param>
-        /// <param name="builder">The builder to use to generate instructions if needed</param>
-        internal IValue From(Value value, ResolvedType type, InstructionBuilder? builder = null) =>
-            type.Resolution is QsResolvedTypeKind.ArrayType it ? this.sharedState.Values.FromArray(value, it.Item, builder) :
-            type.Resolution is QsResolvedTypeKind.TupleType ts ? this.sharedState.Values.FromTuple(value, ts.Item, builder) :
-            type.Resolution is QsResolvedTypeKind.UserDefinedType udt ? this.sharedState.Values.FromCustomType(value, udt.Item, builder) :
-            (type.Resolution.IsOperation || type.Resolution.IsFunction) ? this.sharedState.Values.FromCallable(value, type, builder) :
-            (IValue)new SimpleValue(value, type, builder);
+        internal IValue From(Value value, ResolvedType type) =>
+            type.Resolution is QsResolvedTypeKind.ArrayType it ? this.sharedState.Values.FromArray(value, it.Item) :
+            type.Resolution is QsResolvedTypeKind.TupleType ts ? this.sharedState.Values.FromTuple(value, ts.Item) :
+            type.Resolution is QsResolvedTypeKind.UserDefinedType udt ? this.sharedState.Values.FromCustomType(value, udt.Item) :
+            (type.Resolution.IsOperation || type.Resolution.IsFunction) ? this.sharedState.Values.FromCallable(value, type) :
+            (IValue)new SimpleValue(value, type);
 
         /// <summary>
         /// Creates a pointer to a value of arbitrary type.
-        /// When needed, the instructions are emitted using the given builder.
-        /// If no builder is specified, the builder defined in the context is used when a pointer is constructed.
+        /// When needed, the instructions are emitted using the current builder.
         /// </summary>
         /// <param name="type">The Q# type of the value that the pointer points to</param>
-        /// <param name="builder">Builder used to construct the opaque pointer the first time it is requested</param>
-        internal PointerValue CreatePointer(ResolvedType type, InstructionBuilder? builder = null) =>
-            new PointerValue(type, this.sharedState, builder);
+        internal PointerValue CreatePointer(ResolvedType type) =>
+            new PointerValue(type, this.sharedState);
 
         /// <summary>
         /// Creates a new tuple value. The allocation of the value via invokation of the corresponding runtime function
-        /// is lazy, and so are the necessary casts. When needed, the instructions are emitted using the given builder.
-        /// If no builder is specified, the builder defined in the context is used when a pointer is constructed.
+        /// is lazy, and so are the necessary casts. When needed, the instructions are emitted using the current builder.
         /// </summary>
         /// <param name="elementTypes">The Q# types of the tuple items</param>
-        /// <param name="builder">Builder used to construct the opaque pointer the first time it is requested</param>
-        internal TupleValue CreateTuple(ImmutableArray<ResolvedType> elementTypes, InstructionBuilder? builder = null) =>
-            new TupleValue(elementTypes, this.sharedState, builder);
+        internal TupleValue CreateTuple(ImmutableArray<ResolvedType> elementTypes) =>
+            new TupleValue(elementTypes, this.sharedState);
 
         /// <summary>
         /// Builds a tuple with the items set to the given tuple elements.
         /// Increases the reference count for the tuple elements.
         /// </summary>
-        /// <param name="builder">The builder to use to create the tuple</param>
         /// <param name="tupleElements">The tuple elements</param>
-        internal TupleValue CreateTuple(InstructionBuilder builder, params IValue[] tupleElements)
+        internal TupleValue CreateTuple(params IValue[] tupleElements)
         {
-            TupleValue tuple = new TupleValue(tupleElements.Select(v => v.QSharpType).ToImmutableArray(), this.sharedState, builder);
+            TupleValue tuple = new TupleValue(tupleElements.Select(v => v.QSharpType).ToImmutableArray(), this.sharedState);
             Value[] itemPointers = tuple.GetTupleElementPointers();
 
             for (var i = 0; i < itemPointers.Length; ++i)
             {
-                builder.Store(tupleElements[i].Value, itemPointers[i]);
-                this.sharedState.ScopeMgr.IncreaseReferenceCount(tupleElements[i], builder);
+                this.sharedState.CurrentBuilder.Store(tupleElements[i].Value, itemPointers[i]);
+                this.sharedState.ScopeMgr.IncreaseReferenceCount(tupleElements[i]);
             }
 
             return tuple;
         }
 
         /// <summary>
-        /// Builds a tuple with the items set to the given tuple elements.
-        /// Increases the reference count for the tuple elements.
-        /// </summary>
-        /// <param name="tupleElements">The tuple elements</param>
-        internal TupleValue CreateTuple(params IValue[] tupleElements) =>
-            this.CreateTuple(this.sharedState.CurrentBuilder, tupleElements);
-
-        /// <summary>
         /// Creates a new array value of the given length. Expects a value of type i64 for the length of the array.
         /// The allocation of the value via invokation of the corresponding runtime function is lazy, and so are
-        /// other necessary computations. When needed, the instructions are emitted using the given builder.
-        /// If no builder is specified, the builder defined in the context is used when a pointer is constructed.
+        /// other necessary computations. When needed, the instructions are emitted using the current builder.
         /// </summary>
         /// <param name="length">Value of type i64 indicating the number of elements in the array</param>
         /// <param name="elementType">Q# type of the array elements</param>
-        /// <param name="builder">Builder used to construct the opaque pointer the first time it is requested</param>
-        internal ArrayValue CreateArray(Value length, ResolvedType elementType, InstructionBuilder? builder = null) =>
-            new ArrayValue(length, elementType, this.sharedState, builder);
+        internal ArrayValue CreateArray(Value length, ResolvedType elementType) =>
+            new ArrayValue(length, elementType, this.sharedState);
 
         /// <summary>
         /// Builds an array that containsthe given array elements.
         /// Increases the reference count for the array elements.
         /// </summary>
-        /// <param name="builder">The builder to use to create the array</param>
         /// <param name="arrayElements">The elements in the array</param>
-        internal ArrayValue CreateArray(ResolvedType elementType, InstructionBuilder builder, params IValue[] arrayElements)
+        internal ArrayValue CreateArray(ResolvedType elementType, params IValue[] arrayElements)
         {
-            var array = new ArrayValue((uint)arrayElements.Length, elementType, this.sharedState, builder);
+            var array = new ArrayValue((uint)arrayElements.Length, elementType, this.sharedState);
             Value[] itemPointers = array.GetArrayElementPointers();
 
             for (var i = 0; i < itemPointers.Length; ++i)
             {
-                builder.Store(arrayElements[i].Value, itemPointers[i]);
-                this.sharedState.ScopeMgr.IncreaseReferenceCount(arrayElements[i], builder);
+                this.sharedState.CurrentBuilder.Store(arrayElements[i].Value, itemPointers[i]);
+                this.sharedState.ScopeMgr.IncreaseReferenceCount(arrayElements[i]);
             }
 
             return array;
         }
-
-        /// <summary>
-        /// Builds an array that containsthe given array elements.
-        /// Increases the reference count for the array elements.
-        /// </summary>
-        /// <param name="arrayElements">The elements in the array</param>
-        internal ArrayValue CreateArray(ResolvedType elementType, params IValue[] arrayElements) =>
-            this.CreateArray(elementType, this.sharedState.CurrentBuilder, arrayElements);
     }
 }

--- a/src/QsCompiler/QirGeneration/QIR/Values.cs
+++ b/src/QsCompiler/QirGeneration/QIR/Values.cs
@@ -1,0 +1,68 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections.Immutable;
+using Microsoft.Quantum.QsCompiler.QIR;
+using Microsoft.Quantum.QsCompiler.SyntaxTokens;
+using Microsoft.Quantum.QsCompiler.SyntaxTree;
+using Ubiquity.NET.Llvm.Instructions;
+using Ubiquity.NET.Llvm.Values;
+
+namespace Microsoft.Quantum.QIR.Emission
+{
+    using QsResolvedTypeKind = QsTypeKind<ResolvedType, UserDefinedType, QsTypeParameter, CallableInformation>;
+
+    /// <summary>
+    /// Each class instance contains permits to construct QIR values for use
+    /// within the compilation unit given upon instantiation.
+    /// </summary>
+    internal class QirValues
+    {
+        private readonly GenerationContext sharedState;
+
+        internal readonly IValue Unit;
+
+        internal QirValues(GenerationContext context, Constants constants)
+        {
+            this.sharedState = context;
+            this.Unit = new SimpleValue(constants.UnitValue, ResolvedType.New(QsResolvedTypeKind.UnitType));
+        }
+
+        internal SimpleValue FromSimpleValue(Value value, ResolvedType type, InstructionBuilder? builder = null) =>
+            new SimpleValue(value, type, builder);
+
+        /// <summary>
+        /// Creates a new tuple value from the given tuple pointer. The casts to get the opaque and typed pointer
+        /// respectively are executed lazily. When needed, the instructions are emitted using the given builder.
+        /// If no builder is specified, the builder defined in the context is used when a pointer is constructed.
+        /// </summary>
+        /// <param name="tuple">Either an opaque or a typed pointer to the tuple data structure</param>
+        /// <param name="elementTypes">The Q# types of the tuple items</param>
+        /// <param name="context">Generation context where constants are defined and generated if needed</param>
+        /// <param name="builder">Builder used to construct the opaque pointer the first time it is requested</param>
+        internal TupleValue FromTuple(Value tuple, ImmutableArray<ResolvedType> elementTypes, InstructionBuilder? builder = null) =>
+            new TupleValue(tuple, elementTypes, this.sharedState, builder);
+
+        /// <summary>
+        /// Creates a new array value from the given opaque array of elements of the given type. When needed,
+        /// the instructions to compute the length of the array are emitted using the given builder.
+        /// If no builder is specified, the builder defined in the context is used when a pointer is constructed.
+        /// </summary>
+        /// <param name="array">The opaque pointer to the array data structure</param>
+        /// <param name="length">Value of type i64 indicating the number of elements in the array; will be computed on demand if the given value is null</param>
+        /// <param name="elementType">Q# type of the array elements</param>
+        /// <param name="context">Generation context where constants are defined and generated if needed</param>
+        /// <param name="builder">Builder used to construct the opaque pointer the first time it is requested</param>
+        internal ArrayValue FromArray(Value value, ResolvedType elementType, InstructionBuilder? builder = null) =>
+            new ArrayValue(value, null, elementType, this.sharedState, builder);
+
+        internal CallableValue FromCallable(Value value, ResolvedType type, InstructionBuilder? builder = null) =>
+            new CallableValue(value, type, builder);
+
+        internal IValue From(Value value, ResolvedType type, InstructionBuilder? builder = null) =>
+            type.Resolution is QsResolvedTypeKind.ArrayType it ? this.sharedState.Values.FromArray(value, it.Item, builder) :
+            type.Resolution is QsResolvedTypeKind.TupleType ts ? this.sharedState.Values.FromTuple(value, ts.Item, builder) :
+            (type.Resolution.IsOperation || type.Resolution.IsFunction) ? this.sharedState.Values.FromCallable(value, type, builder) :
+            (IValue)new SimpleValue(value, type, builder);
+    }
+}

--- a/src/QsCompiler/QirGeneration/QIR/Values.cs
+++ b/src/QsCompiler/QirGeneration/QIR/Values.cs
@@ -76,7 +76,7 @@ namespace Microsoft.Quantum.QIR.Emission
         /// <param name="value">The LLVM value to store</param>
         /// <param name="type">The Q# of the value</param>
         internal CallableValue FromCallable(Value value, ResolvedType type) =>
-            new CallableValue(value, type);
+            new CallableValue(value, type, this.sharedState);
 
         /// <summary>
         /// Creates a suitable class to pass around a built LLVM value that represents a Q# value of the given type.
@@ -101,6 +101,7 @@ namespace Microsoft.Quantum.QIR.Emission
         /// <summary>
         /// Creates a new tuple value. The allocation of the value via invokation of the corresponding runtime function
         /// is lazy, and so are the necessary casts. When needed, the instructions are emitted using the current builder.
+        /// Registers the value with the scope manager once it is allocated.
         /// </summary>
         /// <param name="elementTypes">The Q# types of the tuple items</param>
         internal TupleValue CreateTuple(ImmutableArray<ResolvedType> elementTypes) =>
@@ -108,6 +109,7 @@ namespace Microsoft.Quantum.QIR.Emission
 
         /// <summary>
         /// Builds a tuple with the items set to the given tuple elements.
+        /// Registers the value with the scope manager once it is allocated.
         /// Increases the reference count for the tuple elements.
         /// </summary>
         /// <param name="tupleElements">The tuple elements</param>
@@ -129,6 +131,7 @@ namespace Microsoft.Quantum.QIR.Emission
         /// Creates a new array value of the given length. Expects a value of type i64 for the length of the array.
         /// The allocation of the value via invokation of the corresponding runtime function is lazy, and so are
         /// other necessary computations. When needed, the instructions are emitted using the current builder.
+        /// Registers the value with the scope manager once it is allocated.
         /// </summary>
         /// <param name="length">Value of type i64 indicating the number of elements in the array</param>
         /// <param name="elementType">Q# type of the array elements</param>
@@ -137,6 +140,7 @@ namespace Microsoft.Quantum.QIR.Emission
 
         /// <summary>
         /// Builds an array that containsthe given array elements.
+        /// Registers the value with the scope manager once it is allocated.
         /// Increases the reference count for the array elements.
         /// </summary>
         /// <param name="arrayElements">The elements in the array</param>

--- a/src/QsCompiler/QirGeneration/QIR/Values.cs
+++ b/src/QsCompiler/QirGeneration/QIR/Values.cs
@@ -41,7 +41,7 @@ namespace Microsoft.Quantum.QIR.Emission
             }
 
             var elementTypes = udtDecl.Type.Resolution is QsResolvedTypeKind.TupleType ts ? ts.Item : ImmutableArray.Create(udtDecl.Type);
-            return this.FromTuple(value, elementTypes, builder);
+            return new TupleValue(udt, value, elementTypes, this.sharedState, builder);
         }
 
         /// <summary>

--- a/src/QsCompiler/QirGeneration/ScopeManager.cs
+++ b/src/QsCompiler/QirGeneration/ScopeManager.cs
@@ -293,8 +293,7 @@ namespace Microsoft.Quantum.QsCompiler.QIR
                     var itemFuncName = getFunctionName(array.ElementType);
                     if (itemFuncName != null)
                     {
-                        // FIXME: ENABLE (MODIFIES THE SCOPES STACK, SO LOOP IN EXITFUNCTION IS NOT HAPPY)
-                        //this.sharedState.IterateThroughArray(array, arrItem => this.RecursivelyModifyCounts(getFunctionName, arrItem, builder));
+                        this.sharedState.IterateThroughArray(array, arrItem => ModifyCounts(itemFuncName, arrItem));
                     }
                     builder.Call(func, array.OpaquePointer);
                 }
@@ -506,8 +505,11 @@ namespace Microsoft.Quantum.QsCompiler.QIR
                 this.IncreaseReferenceCount(returned);
             }
 
+            // We need to extract the scopes to iterate over since for loops to release array items
+            // will create new scopes and hence modify the collection.
+            var currentScopes = this.scopes.ToArray();
             var omittedUnreferences = new List<IValue>() { returned };
-            foreach (var scope in this.scopes)
+            foreach (var scope in currentScopes)
             {
                 scope.ExecutePendingCalls(builder, omittedUnreferences);
             }

--- a/src/QsCompiler/QirGeneration/ScopeManager.cs
+++ b/src/QsCompiler/QirGeneration/ScopeManager.cs
@@ -181,6 +181,12 @@ namespace Microsoft.Quantum.QsCompiler.QIR
         }
 
         /// <summary>
+        /// Returns true if access counts are tracked for values of the given LLVM type.
+        /// </summary>
+        internal bool RequiresAccessCount(ITypeRef t) =>
+            this.AddAccessFunctionForType(t) != null;
+
+        /// <summary>
         /// Gets the name of the runtime function to increase the reference count for a given LLVM type.
         /// </summary>
         /// <param name="t">The LLVM type</param>
@@ -253,6 +259,12 @@ namespace Microsoft.Quantum.QsCompiler.QIR
             }
             return null;
         }
+
+        /// <summary>
+        /// Returns true if reference counts are tracked for values of the given LLVM type.
+        /// </summary>
+        internal bool RequiresReferenceCount(ITypeRef t) =>
+            this.ReferenceFunctionForType(t) != null;
 
         /// <summary>
         /// If the given function returns a function name for the given value,

--- a/src/QsCompiler/QirGeneration/ScopeManager.cs
+++ b/src/QsCompiler/QirGeneration/ScopeManager.cs
@@ -301,7 +301,7 @@ namespace Microsoft.Quantum.QsCompiler.QIR
                     var itemFuncName = getFunctionName(array.ElementType);
                     if (itemFuncName != null)
                     {
-                        //this.sharedState.IterateThroughArray(array, arrItem => ModifyCounts(itemFuncName, arrItem));
+                        this.sharedState.IterateThroughArray(array, arrItem => ModifyCounts(itemFuncName, arrItem));
                     }
                     this.sharedState.CurrentBuilder.Call(func, array.OpaquePointer);
                 }

--- a/src/QsCompiler/QirGeneration/Subtransformations/ExpressionKindTransformation.cs
+++ b/src/QsCompiler/QirGeneration/Subtransformations/ExpressionKindTransformation.cs
@@ -174,33 +174,6 @@ namespace Microsoft.Quantum.QsCompiler.QIR
         /// <returns>Returns true if the item was found and false otherwise</returns>
         private bool FindNamedItem(string name, QsTuple<QsTypeItem> typeItems, out List<int> itemLocation)
         {
-            ITypeRef GetTypeItemType(QsTuple<QsTypeItem> item)
-            {
-                switch (item)
-                {
-                    case QsTuple<QsTypeItem>.QsTupleItem leaf:
-                        var leafType = leaf.Item switch
-                        {
-                            QsTypeItem.Anonymous anon => anon.Item,
-                            QsTypeItem.Named named => named.Item.Type,
-                            _ => ResolvedType.New(QsResolvedTypeKind.InvalidType)
-                        };
-                        return this.SharedState.LlvmTypeFromQsharpType(leafType);
-
-                    case QsTuple<QsTypeItem>.QsTuple list:
-                        var types = list.Item.Select(i => i switch
-                        {
-                            QsTuple<QsTypeItem>.QsTuple l => GetTypeItemType(l),
-                            QsTuple<QsTypeItem>.QsTupleItem l => GetTypeItemType(l),
-                            _ => this.SharedState.Context.TokenType
-                        });
-                        return this.SharedState.Types.TypedTuple(types).CreatePointerType();
-
-                    default:
-                        throw new NotImplementedException("unknown item in argument tuple");
-                }
-            }
-
             bool FindNamedItem(QsTuple<QsTypeItem> items, List<int> location)
             {
                 switch (items)

--- a/src/QsCompiler/QirGeneration/Subtransformations/ExpressionKindTransformation.cs
+++ b/src/QsCompiler/QirGeneration/Subtransformations/ExpressionKindTransformation.cs
@@ -1144,7 +1144,10 @@ namespace Microsoft.Quantum.QsCompiler.QIR
             IValue value;
             if (sym is Identifier.LocalVariable local)
             {
-                value = this.SharedState.ScopeMgr.GetNamedValue(local.Item);
+                var variable = this.SharedState.ScopeMgr.GetVariable(local.Item);
+                value = variable is PointerValue pointer
+                    ? pointer.LoadValue()
+                    : variable;
             }
             else if (!(sym is Identifier.GlobalCallable globalCallable))
             {

--- a/src/QsCompiler/QirGeneration/Subtransformations/ExpressionKindTransformation.cs
+++ b/src/QsCompiler/QirGeneration/Subtransformations/ExpressionKindTransformation.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Quantum.QsCompiler.QIR
                 this.SharedState = sharedState;
             }
 
-            public abstract Value BuildItem(InstructionBuilder builder, Value capture, Value parArgs);
+            public abstract IValue BuildItem(InstructionBuilder builder, TupleValue capture, IValue parArgs);
         }
 
         private class InnerCapture : PartialApplicationArgument
@@ -52,11 +52,8 @@ namespace Microsoft.Quantum.QsCompiler.QIR
             /// The given capture is expected to be fully typed.
             /// The parArgs parameter is unused.
             /// </summary>
-            public override Value BuildItem(InstructionBuilder builder, Value capture, Value parArgs)
-            {
-                var captureType = Quantum.QIR.Types.StructFromPointer(capture.NativeType);
-                return this.SharedState.GetTupleElement(captureType, capture, this.CaptureIndex, builder);
-            }
+            public override IValue BuildItem(InstructionBuilder builder, TupleValue capture, IValue parArgs) =>
+                capture.GetTupleElement(this.CaptureIndex);
         }
 
         private class InnerArg : PartialApplicationArgument
@@ -75,19 +72,11 @@ namespace Microsoft.Quantum.QsCompiler.QIR
             /// The given parameter parArgs is expected to contain an argument to a partial application, and is expected to be fully typed.
             /// The given capture is unused.
             /// </summary>
-            public override Value BuildItem(InstructionBuilder builder, Value capture, Value parArgs)
-            {
+            public override IValue BuildItem(InstructionBuilder builder, TupleValue capture, IValue paArgs) =>
                 // parArgs.NativeType == this.ItemType may occur if we have an item of user defined type (represented as a tuple)
-                if (this.SharedState.Types.IsTypedTuple(parArgs.NativeType) && parArgs.NativeType != this.ItemType)
-                {
-                    var parArgsStruct = Quantum.QIR.Types.StructFromPointer(parArgs.NativeType);
-                    return this.SharedState.GetTupleElement(parArgsStruct, parArgs, this.ArgIndex, builder);
-                }
-                else
-                {
-                    return parArgs;
-                }
-            }
+                (paArgs is TupleValue paArgsTuple) && paArgsTuple.StructType.CreatePointerType() != this.ItemType
+                    ? paArgsTuple.GetTupleElement(this.ArgIndex)
+                    : paArgs;
         }
 
         private class InnerTuple : PartialApplicationArgument
@@ -107,11 +96,11 @@ namespace Microsoft.Quantum.QsCompiler.QIR
             /// The given parameter parArgs is expected to contain an argument to a partial application, and is expected to be fully typed.
             /// </summary>
             /// <returns>A fully typed tuple that combines the captured values as well as the arguments to the partial application</returns>
-            public override Value BuildItem(InstructionBuilder builder, Value capture, Value parArgs)
+            public override IValue BuildItem(InstructionBuilder builder, TupleValue capture, IValue parArgs)
             {
                 var items = this.Items.Select(item => item.BuildItem(builder, capture, parArgs)).ToArray();
                 var tuple = this.SharedState.CreateTuple(builder, items);
-                return tuple.TypedPointer;
+                return tuple;
             }
         }
 
@@ -136,40 +125,40 @@ namespace Microsoft.Quantum.QsCompiler.QIR
         // private helpers
 
         /// <param name="sharedState">The generation context in which to emit the instructions</param>
-        /// <param name="range">The range expression for which to create the access functions</param>
+        /// <param name="rangeEx">The range expression for which to create the access functions</param>
         /// <returns>
         /// Three functions to access the start, step, and end of a range.
         /// The function to access the step may return null if the given range does not specify the step.
         /// In that case, the step size defaults to be 1L.
         /// </returns>
-        internal static (Func<Value> GetStart, Func<Value?> GetStep, Func<Value> GetEnd) RangeItems(GenerationContext sharedState, TypedExpression range)
+        internal static (Func<Value> GetStart, Func<Value?> GetStep, Func<Value> GetEnd) RangeItems(GenerationContext sharedState, TypedExpression rangeEx)
         {
             Func<Value> startValue;
             Func<Value?> stepValue;
             Func<Value> endValue;
-            if (range.Expression is ResolvedExpression.RangeLiteral rlit)
+            if (rangeEx.Expression is ResolvedExpression.RangeLiteral rlit)
             {
                 if (rlit.Item1.Expression is ResolvedExpression.RangeLiteral rlitInner)
                 {
-                    startValue = () => sharedState.EvaluateSubexpression(rlitInner.Item1);
-                    stepValue = () => sharedState.EvaluateSubexpression(rlitInner.Item2);
+                    startValue = () => sharedState.EvaluateSubexpression(rlitInner.Item1).Value;
+                    stepValue = () => sharedState.EvaluateSubexpression(rlitInner.Item2).Value;
                 }
                 else
                 {
-                    startValue = () => sharedState.EvaluateSubexpression(rlit.Item1);
+                    startValue = () => sharedState.EvaluateSubexpression(rlit.Item1).Value;
                     stepValue = () => null;
                 }
 
                 // Item2 is always the end. Either Item1 is the start and 1 is the step,
                 // or Item1 is a range expression itself, with Item1 the start and Item2 the step.
-                endValue = () => sharedState.EvaluateSubexpression(rlit.Item2);
+                endValue = () => sharedState.EvaluateSubexpression(rlit.Item2).Value;
             }
             else
             {
-                var rangeValue = sharedState.EvaluateSubexpression(range);
-                startValue = () => sharedState.CurrentBuilder.ExtractValue(rangeValue, 0);
-                stepValue = () => sharedState.CurrentBuilder.ExtractValue(rangeValue, 1);
-                endValue = () => sharedState.CurrentBuilder.ExtractValue(rangeValue, 2);
+                var range = sharedState.EvaluateSubexpression(rangeEx).Value;
+                startValue = () => sharedState.CurrentBuilder.ExtractValue(range, 0);
+                stepValue = () => sharedState.CurrentBuilder.ExtractValue(range, 1);
+                endValue = () => sharedState.CurrentBuilder.ExtractValue(range, 2);
             }
             return (startValue, stepValue, endValue);
         }
@@ -183,7 +172,7 @@ namespace Microsoft.Quantum.QsCompiler.QIR
         /// <param name="typeItems">The tuple defining the items of a custom type</param>
         /// <param name="itemLocation">The location of the item with the given name within the item tuple</param>
         /// <returns>Returns true if the item was found and false otherwise</returns>
-        private bool FindNamedItem(string name, QsTuple<QsTypeItem> typeItems, out List<(int, IStructType)> itemLocation)
+        private bool FindNamedItem(string name, QsTuple<QsTypeItem> typeItems, out List<int> itemLocation)
         {
             ITypeRef GetTypeItemType(QsTuple<QsTypeItem> item)
             {
@@ -212,7 +201,7 @@ namespace Microsoft.Quantum.QsCompiler.QIR
                 }
             }
 
-            bool FindNamedItem(QsTuple<QsTypeItem> items, List<(int, IStructType)> location)
+            bool FindNamedItem(QsTuple<QsTypeItem> items, List<int> location)
             {
                 switch (items)
                 {
@@ -227,8 +216,7 @@ namespace Microsoft.Quantum.QsCompiler.QIR
                         {
                             if (FindNamedItem(list.Item[i], location))
                             {
-                                var tupleStruct = this.SharedState.Types.TypedTuple(list.Item.Select(GetTypeItemType));
-                                location.Add((i, tupleStruct));
+                                location.Add(i);
                                 return true;
                             }
                         }
@@ -237,7 +225,7 @@ namespace Microsoft.Quantum.QsCompiler.QIR
                 return false;
             }
 
-            itemLocation = new List<(int, IStructType)>();
+            itemLocation = new List<int>();
             var found = FindNamedItem(typeItems, itemLocation);
             itemLocation.Reverse();
             return found;
@@ -247,31 +235,34 @@ namespace Microsoft.Quantum.QsCompiler.QIR
         /// The result of the evaluation if the given name matches one of the recognized runtime functions,
         /// and null otherwise.
         /// </returns>
-        private bool TryEvaluateRuntimeFunction(QsQualifiedName name, TypedExpression arg, [MaybeNullWhen(false)] out Value evaluated)
+        private bool TryEvaluateRuntimeFunction(QsQualifiedName name, TypedExpression arg, [MaybeNullWhen(false)] out IValue evaluated)
         {
+            var intType = ResolvedType.New(QsResolvedTypeKind.Int);
+            var rangeType = ResolvedType.New(QsResolvedTypeKind.Range);
+
             if (name.Equals(BuiltIn.Length.FullName))
             {
-                var arrayArg = this.SharedState.EvaluateSubexpression(arg);
-                var lengthFunc = this.SharedState.GetOrCreateRuntimeFunction(RuntimeLibrary.ArrayGetSize1d);
-                evaluated = this.SharedState.CurrentBuilder.Call(lengthFunc, arrayArg);
+                var arrayArg = (ArrayValue)this.SharedState.EvaluateSubexpression(arg);
+                evaluated = this.SharedState.Values.FromSimpleValue(arrayArg.Length, intType);
                 return true;
             }
             else if (name.Equals(BuiltIn.RangeStart.FullName))
             {
                 var (getStart, _, _) = RangeItems(this.SharedState, arg);
-                evaluated = getStart();
+                evaluated = this.SharedState.Values.FromSimpleValue(getStart(), intType);
                 return true;
             }
             else if (name.Equals(BuiltIn.RangeStep.FullName))
             {
                 var (_, getStep, _) = RangeItems(this.SharedState, arg);
-                evaluated = getStep() ?? this.SharedState.Context.CreateConstant(1L);
+                var res = getStep() ?? this.SharedState.Context.CreateConstant(1L);
+                evaluated = this.SharedState.Values.FromSimpleValue(res, intType);
                 return true;
             }
             else if (name.Equals(BuiltIn.RangeEnd))
             {
                 var (_, _, getEnd) = RangeItems(this.SharedState, arg);
-                evaluated = getEnd();
+                evaluated = this.SharedState.Values.FromSimpleValue(getEnd(), intType);
                 return true;
             }
             else if (name.Equals(BuiltIn.RangeReverse.FullName))
@@ -287,12 +278,13 @@ namespace Microsoft.Quantum.QsCompiler.QIR
                         step,
                         this.SharedState.CurrentBuilder.SDiv(
                             this.SharedState.CurrentBuilder.Sub(end, start), step)));
-                evaluated = this.SharedState.CurrentBuilder.Load(
+                Value reversed = this.SharedState.CurrentBuilder.Load(
                     this.SharedState.Types.Range,
                     this.SharedState.Constants.EmptyRange);
-                evaluated = this.SharedState.CurrentBuilder.InsertValue(evaluated, newStart, 0u);
-                evaluated = this.SharedState.CurrentBuilder.InsertValue(evaluated, this.SharedState.CurrentBuilder.Neg(step), 1u);
-                evaluated = this.SharedState.CurrentBuilder.InsertValue(evaluated, start, 2u);
+                reversed = this.SharedState.CurrentBuilder.InsertValue(reversed, newStart, 0u);
+                reversed = this.SharedState.CurrentBuilder.InsertValue(reversed, this.SharedState.CurrentBuilder.Neg(step), 1u);
+                reversed = this.SharedState.CurrentBuilder.InsertValue(reversed, start, 2u);
+                evaluated = this.SharedState.Values.From(reversed, rangeType);
                 return true;
             }
             else
@@ -310,37 +302,36 @@ namespace Microsoft.Quantum.QsCompiler.QIR
         /// <exception cref="InvalidOperationException">
         /// Thrown when no callable with the given name exists, or the corresponding specialization cannot be found.
         /// </exception>
-        private Value InvokeGlobalCallable(QsQualifiedName callableName, QsSpecializationKind kind, TypedExpression arg)
+        private IValue InvokeGlobalCallable(QsQualifiedName callableName, QsSpecializationKind kind, TypedExpression arg)
         {
-            Value CallGlobal(IrFunction func, TypedExpression arg)
+            IValue CallGlobal(IrFunction func, TypedExpression arg, ResolvedType returnType)
             {
-                Value[] argList;
+                IEnumerable<IValue> argList;
                 if (arg.ResolvedType.Resolution.IsUnitType)
                 {
-                    argList = new Value[] { };
+                    argList = Enumerable.Empty<IValue>();
                 }
                 else if (arg.ResolvedType.Resolution.IsTupleType && arg.Expression is ResolvedExpression.ValueTuple vs)
                 {
-                    argList = vs.Item.Select(this.SharedState.EvaluateSubexpression).ToArray();
+                    argList = vs.Item.Select(this.SharedState.EvaluateSubexpression);
                 }
                 else if (arg.ResolvedType.Resolution.IsTupleType && arg.ResolvedType.Resolution is QsResolvedTypeKind.TupleType ts)
                 {
-                    Value evaluatedArg = this.SharedState.EvaluateSubexpression(arg);
-                    IStructType tupleType = this.SharedState.CreateConcreteTupleType(ts.Item);
-                    argList = this.SharedState.GetTupleElements(tupleType, evaluatedArg);
+                    var evaluatedArg = (TupleValue)this.SharedState.EvaluateSubexpression(arg);
+                    argList = evaluatedArg.GetTupleElements();
                 }
                 else
                 {
-                    argList = new Value[] { this.SharedState.EvaluateSubexpression(arg) };
+                    argList = new[] { this.SharedState.EvaluateSubexpression(arg) };
                 }
 
-                var value = this.SharedState.CurrentBuilder.Call(func, argList);
+                var res = this.SharedState.CurrentBuilder.Call(func, argList.Select(a => a.Value).ToArray());
                 return func.Signature.ReturnType.IsVoid
-                    ? this.SharedState.Constants.UnitValue
-                    : value;
+                    ? this.SharedState.Values.Unit
+                    : this.SharedState.Values.From(res, returnType);
             }
 
-            Value InlineSpecialization(QsSpecialization spec, TypedExpression arg)
+            IValue InlineSpecialization(QsSpecialization spec, TypedExpression arg)
             {
                 this.SharedState.StartInlining();
                 if (spec.Implementation is SpecializationImplementation.Provided impl)
@@ -368,7 +359,7 @@ namespace Microsoft.Quantum.QsCompiler.QIR
             {
                 // deal with functions that are part of the target specific instruction set
                 var targetInstruction = this.SharedState.GetOrCreateTargetInstruction(instructionName);
-                return CallGlobal(targetInstruction, arg);
+                return CallGlobal(targetInstruction, arg, callable.Signature.ReturnType);
             }
             else if (callable.Attributes.Any(BuiltIn.MarksInlining))
             {
@@ -380,18 +371,18 @@ namespace Microsoft.Quantum.QsCompiler.QIR
             {
                 // deal with all other global callables
                 var func = this.SharedState.GetFunctionByName(callableName, kind);
-                return CallGlobal(func, arg);
+                return CallGlobal(func, arg, callable.Signature.ReturnType);
             }
         }
 
         /// <summary>
         /// Handles calls to callables that are (only) locally defined, i.e. calls to callable values.
         /// </summary>
-        private Value InvokeLocalCallable(TypedExpression method, TypedExpression arg)
+        private IValue InvokeLocalCallable(TypedExpression method, TypedExpression arg)
         {
             var func = this.SharedState.GetOrCreateRuntimeFunction(RuntimeLibrary.CallableInvoke);
-            Value calledValue = this.SharedState.EvaluateSubexpression(method);
-            Value argValue = this.SharedState.EvaluateSubexpression(arg);
+            var calledValue = this.SharedState.EvaluateSubexpression(method);
+            var argValue = this.SharedState.EvaluateSubexpression(arg);
             if (!arg.ResolvedType.Resolution.IsTupleType &&
                 !arg.ResolvedType.Resolution.IsUserDefinedType &&
                 !arg.ResolvedType.Resolution.IsUnitType)
@@ -399,28 +390,27 @@ namespace Microsoft.Quantum.QsCompiler.QIR
                 // If the argument is not already of a type that results in the creation of a tuple,
                 // then we need to create a tuple to store the (single) argument to be able to pass
                 // it to the callable value.
-                argValue = this.SharedState.CreateTuple(this.SharedState.CurrentBuilder, argValue).OpaquePointer;
-            }
-            else
-            {
-                argValue = this.SharedState.CurrentBuilder.BitCast(argValue, this.SharedState.Types.Tuple);
+                argValue = this.SharedState.CreateTuple(this.SharedState.CurrentBuilder, argValue);
             }
 
+            var argTuple = (TupleValue)argValue;
             var returnType = method.ResolvedType.TryGetReturnType().Item;
             if (returnType.Resolution.IsUnitType)
             {
                 Value resultTuple = this.SharedState.Constants.UnitValue;
-                this.SharedState.CurrentBuilder.Call(func, calledValue, argValue, resultTuple);
-                return this.SharedState.Constants.UnitValue;
+                this.SharedState.CurrentBuilder.Call(func, calledValue.Value, argTuple.OpaquePointer, resultTuple);
+                return this.SharedState.Values.Unit;
             }
             else
             {
-                IStructType resultStructType = this.SharedState.LlvmStructTypeFromQsharpType(returnType);
-                TupleValue resultTuple = new TupleValue(resultStructType, this.SharedState);
-                this.SharedState.CurrentBuilder.Call(func, calledValue, argValue, resultTuple.OpaquePointer);
+                var resElementTypes = returnType.Resolution is QsResolvedTypeKind.TupleType elementTypes
+                    ? elementTypes.Item
+                    : ImmutableArray.Create(returnType);
+                TupleValue resultTuple = new TupleValue(resElementTypes, this.SharedState);
+                this.SharedState.CurrentBuilder.Call(func, calledValue.Value, argTuple.OpaquePointer, resultTuple.OpaquePointer);
                 return returnType.Resolution.IsTupleType
-                    ? resultTuple.TypedPointer
-                    : this.SharedState.GetTupleElements(resultTuple.StructType, resultTuple.TypedPointer).Single();
+                    ? resultTuple
+                    : resultTuple.GetTupleElements().Single();
             }
         }
 
@@ -448,7 +438,7 @@ namespace Microsoft.Quantum.QsCompiler.QIR
             var isPartialApplication = TypedExpression.IsPartialApplication(ex.Expression);
             var isFunctorApplication = ex.Expression.IsAdjointApplication || ex.Expression.IsControlledApplication;
             var safeToModify = isGlobalCallable || isPartialApplication || isFunctorApplication;
-            Value value = this.ApplyFunctor(runtimeFunctionName, callable, safeToModify);
+            var value = this.ApplyFunctor(runtimeFunctionName, callable, safeToModify);
 
             this.SharedState.ValueStack.Push(value);
             return ResolvedExpression.InvalidExpr;
@@ -463,7 +453,7 @@ namespace Microsoft.Quantum.QsCompiler.QIR
         /// <param name="modifyInPlace">If set to true, modifies and returns the given callable</param>
         /// <param name="builder">Builder to use to generate the instructions</param>
         /// <returns>The callable value to which the functor has been applied</returns>
-        private Value ApplyFunctor(string runtimeFunctionName, Value callable, bool modifyInPlace = false, InstructionBuilder? builder = null)
+        private IValue ApplyFunctor(string runtimeFunctionName, IValue callable, bool modifyInPlace = false, InstructionBuilder? builder = null)
         {
             // This method is used when applying functors when building a functor application expression
             // as well as when creating the specializations for a partial application.
@@ -480,53 +470,59 @@ namespace Microsoft.Quantum.QsCompiler.QIR
                 // Since we don't track access counts for callables we need to force the copy.
                 var makeCopy = this.SharedState.GetOrCreateRuntimeFunction(RuntimeLibrary.CallableCopy);
                 var forceCopy = this.SharedState.Context.CreateConstant(true);
-                callable = builder.Call(makeCopy, callable, forceCopy);
+                var modified = builder.Call(makeCopy, callable.Value, forceCopy);
+                callable = this.SharedState.Values.FromCallable(modified, callable.QSharpType);
                 this.SharedState.ScopeMgr.RegisterValue(callable);
             }
 
             // CallableMakeAdjoint and CallableMakeControlled do *not* create a new value
             // but instead modify the given callable in place.
             var applyFunctor = this.SharedState.GetOrCreateRuntimeFunction(runtimeFunctionName);
-            builder.Call(applyFunctor, callable);
+            builder.Call(applyFunctor, callable.Value);
             return callable;
         }
 
         // public overrides
 
-        public override ResolvedExpression OnAddition(TypedExpression lhs, TypedExpression rhs)
+        public override ResolvedExpression OnAddition(TypedExpression lhsEx, TypedExpression rhsEx)
         {
-            Value lhsValue = this.SharedState.EvaluateSubexpression(lhs);
-            Value rhsValue = this.SharedState.EvaluateSubexpression(rhs);
+            var lhs = this.SharedState.EvaluateSubexpression(lhsEx);
+            var rhs = this.SharedState.EvaluateSubexpression(rhsEx);
             var exType = this.SharedState.CurrentExpressionType();
 
-            Value value;
-            if (exType.IsInt)
+            IValue value;
+            if (exType.Resolution.IsInt)
             {
-                value = this.SharedState.CurrentBuilder.Add(lhsValue, rhsValue);
+                var res = this.SharedState.CurrentBuilder.Add(lhs.Value, rhs.Value);
+                value = this.SharedState.Values.FromSimpleValue(res, exType);
             }
-            else if (exType.IsDouble)
+            else if (exType.Resolution.IsDouble)
             {
-                value = this.SharedState.CurrentBuilder.FAdd(lhsValue, rhsValue);
+                var res = this.SharedState.CurrentBuilder.FAdd(lhs.Value, rhs.Value);
+                value = this.SharedState.Values.FromSimpleValue(res, exType);
             }
-            else if (exType.IsBigInt)
+            else if (exType.Resolution.IsBigInt)
             {
                 // The runtime function BigIntAdd creates a new value with reference count 1.
                 var adder = this.SharedState.GetOrCreateRuntimeFunction(RuntimeLibrary.BigIntAdd);
-                value = this.SharedState.CurrentBuilder.Call(adder, lhsValue, rhsValue);
+                var res = this.SharedState.CurrentBuilder.Call(adder, lhs.Value, rhs.Value);
+                value = this.SharedState.Values.From(res, exType);
                 this.SharedState.ScopeMgr.RegisterValue(value);
             }
-            else if (exType.IsString)
+            else if (exType.Resolution.IsString)
             {
                 // The runtime function StringConcatenate creates a new value with reference count 1.
                 var adder = this.SharedState.GetOrCreateRuntimeFunction(RuntimeLibrary.StringConcatenate);
-                value = this.SharedState.CurrentBuilder.Call(adder, lhsValue, rhsValue);
+                var res = this.SharedState.CurrentBuilder.Call(adder, lhs.Value, rhs.Value);
+                value = this.SharedState.Values.From(res, exType);
                 this.SharedState.ScopeMgr.RegisterValue(value);
             }
-            else if (exType.IsArrayType)
+            else if (exType.Resolution.IsArrayType)
             {
                 // The runtime function ArrayConcatenate creates a new value with reference count 1 and access count 0.
                 var adder = this.SharedState.GetOrCreateRuntimeFunction(RuntimeLibrary.ArrayConcatenate);
-                value = this.SharedState.CurrentBuilder.Call(adder, lhsValue, rhsValue);
+                var res = this.SharedState.CurrentBuilder.Call(adder, lhs.Value, rhs.Value);
+                value = this.SharedState.Values.FromArray(res, exType);
                 this.SharedState.ScopeMgr.RegisterValue(value);
             }
             else
@@ -544,14 +540,13 @@ namespace Microsoft.Quantum.QsCompiler.QIR
         public override ResolvedExpression OnArrayItem(TypedExpression arr, TypedExpression idx)
         {
             // TODO: handle multi-dimensional arrays
-            var array = this.SharedState.EvaluateSubexpression(arr);
+            var array = (ArrayValue)this.SharedState.EvaluateSubexpression(arr);
             var index = this.SharedState.EvaluateSubexpression(idx);
 
-            Value value;
+            IValue value;
             if (idx.ResolvedType.Resolution.IsInt)
             {
-                var elementType = this.SharedState.CurrentLlvmExpressionType();
-                value = this.SharedState.GetArrayElement(elementType, array, index);
+                value = array.GetArrayElement(index.Value);
             }
             else if (idx.ResolvedType.Resolution.IsRange)
             {
@@ -562,7 +557,8 @@ namespace Microsoft.Quantum.QsCompiler.QIR
                 // Since we keep track of access counts for arrays, there is no need to force the copy.
                 var forceCopy = this.SharedState.Context.CreateConstant(false);
                 var sliceArray = this.SharedState.GetOrCreateRuntimeFunction(RuntimeLibrary.ArraySlice1d);
-                value = this.SharedState.CurrentBuilder.Call(sliceArray, array, index, forceCopy);
+                var slice = this.SharedState.CurrentBuilder.Call(sliceArray, array.Value, index.Value, forceCopy);
+                value = this.SharedState.Values.FromArray(slice, array.QSharpType);
                 this.SharedState.ScopeMgr.RegisterValue(value);
             }
             else
@@ -576,13 +572,16 @@ namespace Microsoft.Quantum.QsCompiler.QIR
 
         public override ResolvedExpression OnBigIntLiteral(BigInteger b)
         {
-            Value value;
+            var exType = this.SharedState.CurrentExpressionType();
+
+            IValue value;
             if (b <= long.MaxValue && b >= long.MinValue)
             {
                 // The runtime function BigIntCreateI64 creates a value with reference count 1.
                 var createBigInt = this.SharedState.GetOrCreateRuntimeFunction(RuntimeLibrary.BigIntCreateI64);
                 var val = this.SharedState.Context.CreateConstant((long)b);
-                value = this.SharedState.CurrentBuilder.Call(createBigInt, val);
+                var res = this.SharedState.CurrentBuilder.Call(createBigInt, val);
+                value = this.SharedState.Values.From(res, exType);
                 this.SharedState.ScopeMgr.RegisterValue(value);
             }
             else
@@ -597,7 +596,8 @@ namespace Microsoft.Quantum.QsCompiler.QIR
                 var zeroByteArray = this.SharedState.CurrentBuilder.BitCast(
                     byteArray,
                     this.SharedState.Context.Int8Type.CreateArrayType(0));
-                value = this.SharedState.CurrentBuilder.Call(createBigInt, n, zeroByteArray);
+                var res = this.SharedState.CurrentBuilder.Call(createBigInt, n, zeroByteArray);
+                value = this.SharedState.Values.From(res, exType);
                 this.SharedState.ScopeMgr.RegisterValue(value);
             }
 
@@ -605,22 +605,24 @@ namespace Microsoft.Quantum.QsCompiler.QIR
             return ResolvedExpression.InvalidExpr;
         }
 
-        public override ResolvedExpression OnBitwiseAnd(TypedExpression lhs, TypedExpression rhs)
+        public override ResolvedExpression OnBitwiseAnd(TypedExpression lhsEx, TypedExpression rhsEx)
         {
-            Value lhsValue = this.SharedState.EvaluateSubexpression(lhs);
-            Value rhsValue = this.SharedState.EvaluateSubexpression(rhs);
+            var lhs = this.SharedState.EvaluateSubexpression(lhsEx);
+            var rhs = this.SharedState.EvaluateSubexpression(rhsEx);
             var exType = this.SharedState.CurrentExpressionType();
 
-            Value value;
-            if (exType.IsInt)
+            IValue value;
+            if (exType.Resolution.IsInt)
             {
-                value = this.SharedState.CurrentBuilder.And(lhsValue, rhsValue);
+                var res = this.SharedState.CurrentBuilder.And(lhs.Value, rhs.Value);
+                value = this.SharedState.Values.FromSimpleValue(res, exType);
             }
-            else if (exType.IsBigInt)
+            else if (exType.Resolution.IsBigInt)
             {
                 // The runtime function BigIntBitwiseAnd creates a new value with reference count 1.
                 var func = this.SharedState.GetOrCreateRuntimeFunction(RuntimeLibrary.BigIntBitwiseAnd);
-                value = this.SharedState.CurrentBuilder.Call(func, lhsValue, rhsValue);
+                var res = this.SharedState.CurrentBuilder.Call(func, lhs.Value, rhs.Value);
+                value = this.SharedState.Values.From(res, exType);
                 this.SharedState.ScopeMgr.RegisterValue(value);
             }
             else
@@ -632,22 +634,24 @@ namespace Microsoft.Quantum.QsCompiler.QIR
             return ResolvedExpression.InvalidExpr;
         }
 
-        public override ResolvedExpression OnBitwiseExclusiveOr(TypedExpression lhs, TypedExpression rhs)
+        public override ResolvedExpression OnBitwiseExclusiveOr(TypedExpression lhsEx, TypedExpression rhsEx)
         {
-            Value lhsValue = this.SharedState.EvaluateSubexpression(lhs);
-            Value rhsValue = this.SharedState.EvaluateSubexpression(rhs);
+            var lhs = this.SharedState.EvaluateSubexpression(lhsEx);
+            var rhs = this.SharedState.EvaluateSubexpression(rhsEx);
             var exType = this.SharedState.CurrentExpressionType();
 
-            Value value;
-            if (exType.IsInt)
+            IValue value;
+            if (exType.Resolution.IsInt)
             {
-                value = this.SharedState.CurrentBuilder.Xor(lhsValue, rhsValue);
+                var res = this.SharedState.CurrentBuilder.Xor(lhs.Value, rhs.Value);
+                value = this.SharedState.Values.FromSimpleValue(res, exType);
             }
-            else if (exType.IsBigInt)
+            else if (exType.Resolution.IsBigInt)
             {
                 // The runtime function BigIntBitwiseXor creates a new value with reference count 1.
                 var func = this.SharedState.GetOrCreateRuntimeFunction(RuntimeLibrary.BigIntBitwiseXor);
-                value = this.SharedState.CurrentBuilder.Call(func, lhsValue, rhsValue);
+                var res = this.SharedState.CurrentBuilder.Call(func, lhs.Value, rhs.Value);
+                value = this.SharedState.Values.From(res, exType);
                 this.SharedState.ScopeMgr.RegisterValue(value);
             }
             else
@@ -661,20 +665,22 @@ namespace Microsoft.Quantum.QsCompiler.QIR
 
         public override ResolvedExpression OnBitwiseNot(TypedExpression ex)
         {
-            Value exValue = this.SharedState.EvaluateSubexpression(ex);
+            var exValue = this.SharedState.EvaluateSubexpression(ex);
             var exType = this.SharedState.CurrentExpressionType();
 
-            Value value;
-            if (exType.IsInt)
+            IValue value;
+            if (exType.Resolution.IsInt)
             {
                 Value minusOne = this.SharedState.Context.CreateConstant(-1L);
-                value = this.SharedState.CurrentBuilder.Xor(exValue, minusOne);
+                var res = this.SharedState.CurrentBuilder.Xor(exValue.Value, minusOne);
+                value = this.SharedState.Values.FromSimpleValue(res, exType);
             }
-            else if (exType.IsBigInt)
+            else if (exType.Resolution.IsBigInt)
             {
                 // The runtime function BigIntBitwiseNot creates a new value with reference count 1.
                 var func = this.SharedState.GetOrCreateRuntimeFunction(RuntimeLibrary.BigIntBitwiseNot);
-                value = this.SharedState.CurrentBuilder.Call(func, exValue);
+                var res = this.SharedState.CurrentBuilder.Call(func, exValue.Value);
+                value = this.SharedState.Values.From(res, exType);
                 this.SharedState.ScopeMgr.RegisterValue(value);
             }
             else
@@ -686,22 +692,24 @@ namespace Microsoft.Quantum.QsCompiler.QIR
             return ResolvedExpression.InvalidExpr;
         }
 
-        public override ResolvedExpression OnBitwiseOr(TypedExpression lhs, TypedExpression rhs)
+        public override ResolvedExpression OnBitwiseOr(TypedExpression lhsEx, TypedExpression rhsEx)
         {
-            Value lhsValue = this.SharedState.EvaluateSubexpression(lhs);
-            Value rhsValue = this.SharedState.EvaluateSubexpression(rhs);
+            var lhs = this.SharedState.EvaluateSubexpression(lhsEx);
+            var rhs = this.SharedState.EvaluateSubexpression(rhsEx);
             var exType = this.SharedState.CurrentExpressionType();
 
-            Value value;
-            if (exType.IsInt)
+            IValue value;
+            if (exType.Resolution.IsInt)
             {
-                value = this.SharedState.CurrentBuilder.Or(lhsValue, rhsValue);
+                var res = this.SharedState.CurrentBuilder.Or(lhs.Value, rhs.Value);
+                value = this.SharedState.Values.FromSimpleValue(res, exType);
             }
-            else if (exType.IsBigInt)
+            else if (exType.Resolution.IsBigInt)
             {
                 // The runtime function BigIntBitwiseOr creates a new value with reference count 1.
                 var func = this.SharedState.GetOrCreateRuntimeFunction(RuntimeLibrary.BigIntBitwiseOr);
-                value = this.SharedState.CurrentBuilder.Call(func, lhsValue, rhsValue);
+                var res = this.SharedState.CurrentBuilder.Call(func, lhs.Value, rhs.Value);
+                value = this.SharedState.Values.From(res, exType);
                 this.SharedState.ScopeMgr.RegisterValue(value);
             }
             else
@@ -715,28 +723,32 @@ namespace Microsoft.Quantum.QsCompiler.QIR
 
         public override ResolvedExpression OnBoolLiteral(bool b)
         {
-            Value value = this.SharedState.Context.CreateConstant(b);
+            var constant = this.SharedState.Context.CreateConstant(b);
+            var exType = this.SharedState.CurrentExpressionType();
+            var value = this.SharedState.Values.FromSimpleValue(constant, exType);
             this.SharedState.ValueStack.Push(value);
             return ResolvedExpression.InvalidExpr;
         }
 
-        public override ResolvedExpression OnConditionalExpression(TypedExpression cond, TypedExpression ifTrue, TypedExpression ifFalse)
+        public override ResolvedExpression OnConditionalExpression(TypedExpression condEx, TypedExpression ifTrueEx, TypedExpression ifFalseEx)
         {
             static bool ExpressionIsSelfEvaluating(TypedExpression ex) =>
                 ex.Expression.IsIdentifier || ex.Expression.IsBoolLiteral || ex.Expression.IsDoubleLiteral
                     || ex.Expression.IsIntLiteral || ex.Expression.IsPauliLiteral || ex.Expression.IsRangeLiteral
                     || ex.Expression.IsResultLiteral || ex.Expression.IsUnitValue;
 
-            var condValue = this.SharedState.EvaluateSubexpression(cond);
-            Value value;
+            var cond = this.SharedState.EvaluateSubexpression(condEx);
+            var exType = this.SharedState.CurrentExpressionType();
+            IValue value;
 
             // Special case: if both values are self-evaluating (literals or simple identifiers), we can
             // do this with a select.
-            if (ExpressionIsSelfEvaluating(ifTrue) && ExpressionIsSelfEvaluating(ifFalse))
+            if (ExpressionIsSelfEvaluating(ifTrueEx) && ExpressionIsSelfEvaluating(ifFalseEx))
             {
-                var trueValue = this.SharedState.EvaluateSubexpression(ifTrue);
-                var falseValue = this.SharedState.EvaluateSubexpression(ifFalse);
-                value = this.SharedState.CurrentBuilder.Select(condValue, trueValue, falseValue);
+                var ifTrue = this.SharedState.EvaluateSubexpression(ifTrueEx);
+                var ifFalse = this.SharedState.EvaluateSubexpression(ifFalseEx);
+                var res = this.SharedState.CurrentBuilder.Select(cond.Value, ifTrue.Value, ifFalse.Value);
+                value = this.SharedState.Values.From(res, exType);
             }
             else
             {
@@ -747,21 +759,21 @@ namespace Microsoft.Quantum.QsCompiler.QIR
                 var falseBlock = this.SharedState.AddBlockAfterCurrent("condFalse");
                 var trueBlock = this.SharedState.AddBlockAfterCurrent("condTrue");
 
-                this.SharedState.CurrentBuilder.Branch(condValue, trueBlock, falseBlock);
+                this.SharedState.CurrentBuilder.Branch(cond.Value, trueBlock, falseBlock);
 
                 this.SharedState.SetCurrentBlock(trueBlock);
-                var trueValue = this.SharedState.EvaluateSubexpression(ifTrue);
+                var ifTrue = this.SharedState.EvaluateSubexpression(ifTrueEx);
                 this.SharedState.CurrentBuilder.Branch(contBlock);
 
                 this.SharedState.SetCurrentBlock(falseBlock);
-                var falseValue = this.SharedState.EvaluateSubexpression(ifFalse);
+                var ifFalse = this.SharedState.EvaluateSubexpression(ifFalseEx);
                 this.SharedState.CurrentBuilder.Branch(contBlock);
 
                 this.SharedState.SetCurrentBlock(contBlock);
                 var phi = this.SharedState.CurrentBuilder.PhiNode(this.SharedState.CurrentLlvmExpressionType());
-                phi.AddIncoming(trueValue, trueBlock);
-                phi.AddIncoming(falseValue, falseBlock);
-                value = phi;
+                phi.AddIncoming(ifTrue.Value, trueBlock);
+                phi.AddIncoming(ifFalse.Value, falseBlock);
+                value = this.SharedState.Values.From(phi, exType);
             }
 
             this.SharedState.ValueStack.Push(value);
@@ -773,17 +785,18 @@ namespace Microsoft.Quantum.QsCompiler.QIR
 
         public override ResolvedExpression OnCopyAndUpdateExpression(TypedExpression lhs, TypedExpression accEx, TypedExpression rhs)
         {
-            Value CopyAndUpdateArray(ITypeRef elementType)
+            IValue CopyAndUpdateArray(ResolvedType elementType)
             {
-                var originalArray = this.SharedState.EvaluateSubexpression(lhs);
-                var newItemValue = this.SharedState.EvaluateSubexpression(rhs);
+                IValue originalArray = this.SharedState.EvaluateSubexpression(lhs);
+                IValue newItemValue = this.SharedState.EvaluateSubexpression(rhs);
 
                 // Since we keep track of access counts for arrays we always ask the runtime to create a shallow copy
                 // if needed. The runtime function ArrayCopy creates a new value with reference count 1 if the current
                 // access count is larger than 0, and otherwise merely increases the reference count of the array by 1.
                 var createShallowCopy = this.SharedState.GetOrCreateRuntimeFunction(RuntimeLibrary.ArrayCopy);
                 var forceCopy = this.SharedState.Context.CreateConstant(false);
-                var value = this.SharedState.CurrentBuilder.Call(createShallowCopy, originalArray, forceCopy);
+                var copy = this.SharedState.CurrentBuilder.Call(createShallowCopy, originalArray.Value, forceCopy);
+                var array = this.SharedState.Values.FromArray(copy, originalArray.QSharpType);
 
                 // In order to accurately reflect which items are still in use and thus need to remain allocated,
                 // reference counts always need to be modified recursively. However, while the reference count for
@@ -791,32 +804,33 @@ namespace Microsoft.Quantum.QsCompiler.QIR
                 // to increase the reference count of the contained items due to lacking type information.
                 // In the same way that we increase the reference count when we populate an array, we hence need to
                 // manually (recursively) increase the reference counts for all items.
-                this.SharedState.IterateThroughArray(elementType, value, item => this.SharedState.ScopeMgr.IncreaseReferenceCount(item));
-                this.SharedState.ScopeMgr.RegisterValue(value);
+                this.SharedState.IterateThroughArray(array, item => this.SharedState.ScopeMgr.IncreaseReferenceCount(item));
+                this.SharedState.ScopeMgr.RegisterValue(array);
 
-                void UpdateElement(Func<Value, Value> getNewItemForIndex, Value index)
+                void UpdateElement(Func<Value, IValue> getNewItemForIndex, Value index)
                 {
-                    var elementPtr = this.SharedState.GetArrayElementPointer(elementType, value, index);
-                    var originalElement = this.SharedState.CurrentBuilder.Load(elementType, elementPtr);
+                    var elementPtr = array.GetArrayElementPointer(index);
+                    var loadedOrigElement = this.SharedState.CurrentBuilder.Load(array.ElementType, elementPtr);
+                    var originalElement = this.SharedState.Values.From(loadedOrigElement, elementType);
                     var newElement = getNewItemForIndex(index);
 
                     // Remark: Avoiding to increase and then decrease the reference count for the original item
                     // would require generating a pointer comparison that is evaluated at runtime, and I am not sure
                     // whether that would be much better.
                     this.SharedState.ScopeMgr.DecreaseReferenceCount(originalElement);
-                    this.SharedState.CurrentBuilder.Store(newElement, elementPtr);
+                    this.SharedState.CurrentBuilder.Store(newElement.Value, elementPtr);
                     this.SharedState.ScopeMgr.IncreaseReferenceCount(newElement);
                 }
 
                 if (accEx.ResolvedType.Resolution.IsInt)
                 {
                     var index = this.SharedState.EvaluateSubexpression(accEx);
-                    UpdateElement(_ => newItemValue, index);
+                    UpdateElement(_ => newItemValue, index.Value);
                 }
                 else if (accEx.ResolvedType.Resolution.IsRange)
                 {
-                    Value GetNewItemForIndex(Value index) =>
-                        this.SharedState.GetArrayElement(elementType, newItemValue, index);
+                    IValue GetNewItemForIndex(Value index) =>
+                        ((ArrayValue)newItemValue).GetArrayElement(index);
 
                     var (getStart, getStep, getEnd) = RangeItems(this.SharedState, accEx);
                     this.SharedState.IterateThroughRange(getStart(), getStep(), getEnd(), index => UpdateElement(GetNewItemForIndex, index));
@@ -826,27 +840,24 @@ namespace Microsoft.Quantum.QsCompiler.QIR
                     throw new InvalidOperationException("invalid item name in named item access");
                 }
 
-                return value;
+                return array;
             }
 
-            Value CopyAndUpdateUdt(QsQualifiedName udtName)
+            IValue CopyAndUpdateUdt(QsQualifiedName udtName)
             {
                 // Returns the shallow copy as typed tuple.
-                Value GetTupleCopy(Value original)
+                TupleValue GetTupleCopy(TupleValue original)
                 {
                     // Since we keep track of access counts for tuples we always ask the runtime to create a shallow copy
                     // if needed. The runtime function TupleCopy creates a new value with reference count 1 if the current
                     // access count is larger than 0, and otherwise merely increases the reference count of the tuple by 1.
                     var createShallowCopy = this.SharedState.GetOrCreateRuntimeFunction(RuntimeLibrary.TupleCopy);
                     var forceCopy = this.SharedState.Context.CreateConstant(false);
-
-                    // We need to cast the value to the opaque tuple type before passing it to the runtime.
-                    var tuple = this.SharedState.CurrentBuilder.BitCast(original, this.SharedState.Types.Tuple);
-                    var copy = this.SharedState.CurrentBuilder.Call(createShallowCopy, tuple, forceCopy);
-                    return this.SharedState.CurrentBuilder.BitCast(copy, original.NativeType);
+                    var copy = this.SharedState.CurrentBuilder.Call(createShallowCopy, original.OpaquePointer, forceCopy);
+                    return this.SharedState.Values.FromTuple(copy, original.ElementTypes);
                 }
 
-                var originalValue = this.SharedState.EvaluateSubexpression(lhs);
+                var originalValue = (TupleValue)this.SharedState.EvaluateSubexpression(lhs);
                 var newItemValue = this.SharedState.EvaluateSubexpression(rhs);
                 var value = GetTupleCopy(originalValue);
                 this.SharedState.ScopeMgr.RegisterValue(value);
@@ -859,7 +870,7 @@ namespace Microsoft.Quantum.QsCompiler.QIR
                     && id.Item1 is Identifier.LocalVariable name
                     && this.FindNamedItem(name.Item, udtDecl.TypeItems, out var location))
                 {
-                    Value innerTuple = value;
+                    TupleValue innerTuple = value;
                     for (int depth = 0; depth < location.Count; depth++)
                     {
                         // In order to accurately reflect which items are still in use and thus need to remain allocated,
@@ -868,21 +879,22 @@ namespace Microsoft.Quantum.QsCompiler.QIR
                         // to increase the reference count of the contained items due to lacking type information.
                         // In the same way that we increase the reference count when we populate a tuple, we hence need to
                         // manually (recursively) increase the reference counts for all items.
-                        var itemPointers = this.SharedState.GetTupleElementPointers(location[depth].Item2, innerTuple);
-                        var itemIndex = location[depth].Item1;
+                        var itemPointers = innerTuple.GetTupleElementPointers();
+                        var itemIndex = location[depth];
                         for (var i = 0; i < itemPointers.Length; ++i)
                         {
                             if (i != itemIndex)
                             {
                                 var itemType = Quantum.QIR.Types.PointerElementType(itemPointers[i]);
-                                var item = this.SharedState.CurrentBuilder.Load(itemType, itemPointers[i]);
+                                var loadedItem = this.SharedState.CurrentBuilder.Load(itemType, itemPointers[i]);
+                                var item = this.SharedState.Values.From(loadedItem, innerTuple.ElementTypes[i]);
                                 this.SharedState.ScopeMgr.IncreaseReferenceCount(item);
                             }
                         }
 
                         if (depth == location.Count - 1)
                         {
-                            this.SharedState.CurrentBuilder.Store(newItemValue, itemPointers[itemIndex]);
+                            this.SharedState.CurrentBuilder.Store(newItemValue.Value, itemPointers[itemIndex]);
                             this.SharedState.ScopeMgr.IncreaseReferenceCount(newItemValue);
                         }
                         else
@@ -890,11 +902,15 @@ namespace Microsoft.Quantum.QsCompiler.QIR
                             // We load the original item at that location (which is an inner tuple),
                             // and replace it with a copy of it (if a copy is needed),
                             // such that we can then proceed to modify that copy (the next inner tuple).
-                            var originalItem = this.SharedState.CurrentBuilder.Load(
+                            var loadedOriginalItem = this.SharedState.CurrentBuilder.Load(
                                 Quantum.QIR.Types.PointerElementType(itemPointers[itemIndex]),
                                 itemPointers[itemIndex]);
+                            var oritinalItemTypes = innerTuple.ElementTypes[itemIndex].Resolution is QsResolvedTypeKind.TupleType elementTypes
+                                ? elementTypes.Item
+                                : throw new InvalidOperationException("expecting inner tuple in copy-and-update");
+                            var originalItem = this.SharedState.Values.FromTuple(loadedOriginalItem, oritinalItemTypes);
                             innerTuple = GetTupleCopy(originalItem);
-                            this.SharedState.CurrentBuilder.Store(innerTuple, itemPointers[itemIndex]);
+                            this.SharedState.CurrentBuilder.Store(innerTuple.Value, itemPointers[itemIndex]);
                         }
                     }
 
@@ -906,11 +922,10 @@ namespace Microsoft.Quantum.QsCompiler.QIR
                 }
             }
 
-            Value value;
-            if (lhs.ResolvedType.Resolution is QsResolvedTypeKind.ArrayType it)
+            IValue value;
+            if (lhs.ResolvedType.Resolution is QsResolvedTypeKind.ArrayType elementType)
             {
-                var elementType = this.SharedState.LlvmTypeFromQsharpType(it.Item);
-                value = CopyAndUpdateArray(elementType);
+                value = CopyAndUpdateArray(elementType.Item);
             }
             else if (lhs.ResolvedType.Resolution is QsResolvedTypeKind.UserDefinedType udt)
             {
@@ -925,26 +940,29 @@ namespace Microsoft.Quantum.QsCompiler.QIR
             return ResolvedExpression.InvalidExpr;
         }
 
-        public override ResolvedExpression OnDivision(TypedExpression lhs, TypedExpression rhs)
+        public override ResolvedExpression OnDivision(TypedExpression lhsEx, TypedExpression rhsEx)
         {
-            Value lhsValue = this.SharedState.EvaluateSubexpression(lhs);
-            Value rhsValue = this.SharedState.EvaluateSubexpression(rhs);
+            var lhs = this.SharedState.EvaluateSubexpression(lhsEx);
+            var rhs = this.SharedState.EvaluateSubexpression(rhsEx);
             var exType = this.SharedState.CurrentExpressionType();
 
-            Value value;
-            if (exType.IsInt)
+            IValue value;
+            if (exType.Resolution.IsInt)
             {
-                value = this.SharedState.CurrentBuilder.SDiv(lhsValue, rhsValue);
+                var res = this.SharedState.CurrentBuilder.SDiv(lhs.Value, rhs.Value);
+                value = this.SharedState.Values.FromSimpleValue(res, exType);
             }
-            else if (exType.IsDouble)
+            else if (exType.Resolution.IsDouble)
             {
-                value = this.SharedState.CurrentBuilder.FDiv(lhsValue, rhsValue);
+                var res = this.SharedState.CurrentBuilder.FDiv(lhs.Value, rhs.Value);
+                value = this.SharedState.Values.FromSimpleValue(res, exType);
             }
-            else if (exType.IsBigInt)
+            else if (exType.Resolution.IsBigInt)
             {
                 // The runtime function BigIntDivide creates a new value with reference count 1.
                 var func = this.SharedState.GetOrCreateRuntimeFunction(RuntimeLibrary.BigIntDivide);
-                value = this.SharedState.CurrentBuilder.Call(func, lhsValue, rhsValue);
+                var res = this.SharedState.CurrentBuilder.Call(func, lhs.Value, rhs.Value);
+                value = this.SharedState.Values.From(res, exType);
                 this.SharedState.ScopeMgr.RegisterValue(value);
             }
             else
@@ -958,43 +976,52 @@ namespace Microsoft.Quantum.QsCompiler.QIR
 
         public override ResolvedExpression OnDoubleLiteral(double d)
         {
-            Value value = this.SharedState.Context.CreateConstant(d);
+            var res = this.SharedState.Context.CreateConstant(d);
+            var exType = this.SharedState.CurrentExpressionType();
+            var value = this.SharedState.Values.FromSimpleValue(res, exType);
             this.SharedState.ValueStack.Push(value);
             return ResolvedExpression.InvalidExpr;
         }
 
-        public override ResolvedExpression OnEquality(TypedExpression lhs, TypedExpression rhs)
+        public override ResolvedExpression OnEquality(TypedExpression lhsEx, TypedExpression rhsEx)
         {
-            Value lhsValue = this.SharedState.EvaluateSubexpression(lhs);
-            Value rhsValue = this.SharedState.EvaluateSubexpression(rhs);
+            var lhs = this.SharedState.EvaluateSubexpression(lhsEx);
+            var rhs = this.SharedState.EvaluateSubexpression(rhsEx);
+            var exType = this.SharedState.CurrentExpressionType();
 
-            Value value;
-            if (lhs.ResolvedType.Resolution.IsResult)
+            IValue value;
+            if (lhsEx.ResolvedType.Resolution.IsResult)
             {
                 // Generate a call to the result equality testing function
-                value = this.SharedState.CurrentBuilder.Call(this.SharedState.GetOrCreateRuntimeFunction(RuntimeLibrary.ResultEqual), lhsValue, rhsValue);
+                var equals = this.SharedState.GetOrCreateRuntimeFunction(RuntimeLibrary.ResultEqual);
+                var res = this.SharedState.CurrentBuilder.Call(equals, lhs.Value, rhs.Value);
+                value = this.SharedState.Values.FromSimpleValue(res, exType);
             }
-            else if (lhs.ResolvedType.Resolution.IsBool || lhs.ResolvedType.Resolution.IsInt || lhs.ResolvedType.Resolution.IsQubit
-                || lhs.ResolvedType.Resolution.IsPauli)
+            else if (lhsEx.ResolvedType.Resolution.IsBool || lhsEx.ResolvedType.Resolution.IsInt || lhsEx.ResolvedType.Resolution.IsQubit
+                || lhsEx.ResolvedType.Resolution.IsPauli)
             {
                 // Works for pointers as well as integer types
-                value = this.SharedState.CurrentBuilder.Compare(IntPredicate.Equal, lhsValue, rhsValue);
+                var res = this.SharedState.CurrentBuilder.Compare(IntPredicate.Equal, lhs.Value, rhs.Value);
+                value = this.SharedState.Values.FromSimpleValue(res, exType);
             }
-            else if (lhs.ResolvedType.Resolution.IsDouble)
+            else if (lhsEx.ResolvedType.Resolution.IsDouble)
             {
-                value = this.SharedState.CurrentBuilder.Compare(RealPredicate.OrderedAndEqual, lhsValue, rhsValue);
+                var res = this.SharedState.CurrentBuilder.Compare(RealPredicate.OrderedAndEqual, lhs.Value, rhs.Value);
+                value = this.SharedState.Values.FromSimpleValue(res, exType);
             }
-            else if (lhs.ResolvedType.Resolution.IsString)
+            else if (lhsEx.ResolvedType.Resolution.IsString)
             {
                 // Generate a call to the string equality testing function
                 var compareEquality = this.SharedState.GetOrCreateRuntimeFunction(RuntimeLibrary.StringEqual);
-                value = this.SharedState.CurrentBuilder.Call(compareEquality, lhsValue, rhsValue);
+                var res = this.SharedState.CurrentBuilder.Call(compareEquality, lhs.Value, rhs.Value);
+                value = this.SharedState.Values.FromSimpleValue(res, exType);
             }
-            else if (lhs.ResolvedType.Resolution.IsBigInt)
+            else if (lhsEx.ResolvedType.Resolution.IsBigInt)
             {
                 // Generate a call to the bigint equality testing function
                 var compareEquality = this.SharedState.GetOrCreateRuntimeFunction(RuntimeLibrary.BigIntEqual);
-                value = this.SharedState.CurrentBuilder.Call(compareEquality, lhsValue, rhsValue);
+                var res = this.SharedState.CurrentBuilder.Call(compareEquality, lhs.Value, rhs.Value);
+                value = this.SharedState.Values.FromSimpleValue(res, exType);
             }
             else
             {
@@ -1006,32 +1033,35 @@ namespace Microsoft.Quantum.QsCompiler.QIR
             return ResolvedExpression.InvalidExpr;
         }
 
-        public override ResolvedExpression OnExponentiate(TypedExpression lhs, TypedExpression rhs)
+        public override ResolvedExpression OnExponentiate(TypedExpression lhsEx, TypedExpression rhsEx)
         {
-            Value lhsValue = this.SharedState.EvaluateSubexpression(lhs);
-            Value rhsValue = this.SharedState.EvaluateSubexpression(rhs);
+            var lhs = this.SharedState.EvaluateSubexpression(lhsEx);
+            var rhs = this.SharedState.EvaluateSubexpression(rhsEx);
             var exType = this.SharedState.CurrentExpressionType();
 
-            Value value;
-            if (exType.IsInt)
+            IValue value;
+            if (exType.Resolution.IsInt)
             {
                 // The exponent must be an integer that can fit into an i32.
                 var powFunc = this.SharedState.GetOrCreateRuntimeFunction(RuntimeLibrary.IntPower);
-                var exponent = this.SharedState.CurrentBuilder.IntCast(rhsValue, this.SharedState.Context.Int32Type, true);
-                value = this.SharedState.CurrentBuilder.Call(powFunc, lhsValue, exponent);
+                var exponent = this.SharedState.CurrentBuilder.IntCast(rhs.Value, this.SharedState.Context.Int32Type, true);
+                var res = this.SharedState.CurrentBuilder.Call(powFunc, lhs.Value, exponent);
+                value = this.SharedState.Values.FromSimpleValue(res, exType);
             }
-            else if (exType.IsDouble)
+            else if (exType.Resolution.IsDouble)
             {
                 var powFunc = this.SharedState.Module.GetIntrinsicDeclaration("llvm.pow.f", this.SharedState.Types.Double);
-                value = this.SharedState.CurrentBuilder.Call(powFunc, lhsValue, rhsValue);
+                var res = this.SharedState.CurrentBuilder.Call(powFunc, lhs.Value, rhs.Value);
+                value = this.SharedState.Values.FromSimpleValue(res, exType);
             }
-            else if (exType.IsBigInt)
+            else if (exType.Resolution.IsBigInt)
             {
                 // The runtime function BigIntPower creates a new value with reference count 1.
                 // The exponent must be an integer that can fit into an i32.
                 var powFunc = this.SharedState.GetOrCreateRuntimeFunction(RuntimeLibrary.BigIntPower);
-                var exponent = this.SharedState.CurrentBuilder.IntCast(rhsValue, this.SharedState.Context.Int32Type, true);
-                value = this.SharedState.CurrentBuilder.Call(powFunc, lhsValue, exponent);
+                var exponent = this.SharedState.CurrentBuilder.IntCast(rhs.Value, this.SharedState.Context.Int32Type, true);
+                var res = this.SharedState.CurrentBuilder.Call(powFunc, lhs.Value, exponent);
+                value = this.SharedState.Values.From(res, exType);
                 this.SharedState.ScopeMgr.RegisterValue(value);
             }
             else
@@ -1045,7 +1075,7 @@ namespace Microsoft.Quantum.QsCompiler.QIR
 
         public override ResolvedExpression OnFunctionCall(TypedExpression method, TypedExpression arg)
         {
-            Value value;
+            IValue value;
             var callableName = method.TryAsGlobalCallable().ValueOr(null);
             if (callableName == null)
             {
@@ -1067,24 +1097,28 @@ namespace Microsoft.Quantum.QsCompiler.QIR
             return ResolvedExpression.InvalidExpr;
         }
 
-        public override ResolvedExpression OnGreaterThan(TypedExpression lhs, TypedExpression rhs)
+        public override ResolvedExpression OnGreaterThan(TypedExpression lhsEx, TypedExpression rhsEx)
         {
-            Value lhsValue = this.SharedState.EvaluateSubexpression(lhs);
-            Value rhsValue = this.SharedState.EvaluateSubexpression(rhs);
+            var lhs = this.SharedState.EvaluateSubexpression(lhsEx);
+            var rhs = this.SharedState.EvaluateSubexpression(rhsEx);
+            var exType = this.SharedState.CurrentExpressionType();
 
-            Value value;
-            if (lhs.ResolvedType.Resolution.IsInt)
+            IValue value;
+            if (lhsEx.ResolvedType.Resolution.IsInt)
             {
-                value = this.SharedState.CurrentBuilder.Compare(IntPredicate.SignedGreaterThan, lhsValue, rhsValue);
+                var res = this.SharedState.CurrentBuilder.Compare(IntPredicate.SignedGreaterThan, lhs.Value, rhs.Value);
+                value = this.SharedState.Values.FromSimpleValue(res, exType);
             }
-            else if (lhs.ResolvedType.Resolution.IsDouble)
+            else if (lhsEx.ResolvedType.Resolution.IsDouble)
             {
-                value = this.SharedState.CurrentBuilder.Compare(RealPredicate.OrderedAndGreaterThan, lhsValue, rhsValue);
+                var res = this.SharedState.CurrentBuilder.Compare(RealPredicate.OrderedAndGreaterThan, lhs.Value, rhs.Value);
+                value = this.SharedState.Values.FromSimpleValue(res, exType);
             }
-            else if (lhs.ResolvedType.Resolution.IsBigInt)
+            else if (lhsEx.ResolvedType.Resolution.IsBigInt)
             {
                 var func = this.SharedState.GetOrCreateRuntimeFunction(RuntimeLibrary.BigIntGreater);
-                value = this.SharedState.CurrentBuilder.Call(func, lhsValue, rhsValue);
+                var res = this.SharedState.CurrentBuilder.Call(func, lhs.Value, rhs.Value);
+                value = this.SharedState.Values.FromSimpleValue(res, exType);
             }
             else
             {
@@ -1095,24 +1129,28 @@ namespace Microsoft.Quantum.QsCompiler.QIR
             return ResolvedExpression.InvalidExpr;
         }
 
-        public override ResolvedExpression OnGreaterThanOrEqual(TypedExpression lhs, TypedExpression rhs)
+        public override ResolvedExpression OnGreaterThanOrEqual(TypedExpression lhsEx, TypedExpression rhsEx)
         {
-            Value lhsValue = this.SharedState.EvaluateSubexpression(lhs);
-            Value rhsValue = this.SharedState.EvaluateSubexpression(rhs);
+            var lhs = this.SharedState.EvaluateSubexpression(lhsEx);
+            var rhs = this.SharedState.EvaluateSubexpression(rhsEx);
+            var exType = this.SharedState.CurrentExpressionType();
 
-            Value value;
-            if (lhs.ResolvedType.Resolution.IsInt)
+            IValue value;
+            if (lhsEx.ResolvedType.Resolution.IsInt)
             {
-                value = this.SharedState.CurrentBuilder.Compare(IntPredicate.SignedGreaterThanOrEqual, lhsValue, rhsValue);
+                var res = this.SharedState.CurrentBuilder.Compare(IntPredicate.SignedGreaterThanOrEqual, lhs.Value, rhs.Value);
+                value = this.SharedState.Values.FromSimpleValue(res, exType);
             }
-            else if (lhs.ResolvedType.Resolution.IsDouble)
+            else if (lhsEx.ResolvedType.Resolution.IsDouble)
             {
-                value = this.SharedState.CurrentBuilder.Compare(RealPredicate.OrderedAndGreaterThanOrEqual, lhsValue, rhsValue);
+                var res = this.SharedState.CurrentBuilder.Compare(RealPredicate.OrderedAndGreaterThanOrEqual, lhs.Value, rhs.Value);
+                value = this.SharedState.Values.FromSimpleValue(res, exType);
             }
-            else if (lhs.ResolvedType.Resolution.IsBigInt)
+            else if (lhsEx.ResolvedType.Resolution.IsBigInt)
             {
                 var func = this.SharedState.GetOrCreateRuntimeFunction(RuntimeLibrary.BigIntGreaterEq);
-                value = this.SharedState.CurrentBuilder.Call(func, lhsValue, rhsValue);
+                var res = this.SharedState.CurrentBuilder.Call(func, lhs.Value, rhs.Value);
+                value = this.SharedState.Values.FromSimpleValue(res, exType);
             }
             else
             {
@@ -1125,7 +1163,9 @@ namespace Microsoft.Quantum.QsCompiler.QIR
 
         public override ResolvedExpression OnIdentifier(Identifier sym, QsNullable<ImmutableArray<ResolvedType>> tArgs)
         {
-            Value value;
+            var exType = this.SharedState.CurrentExpressionType();
+
+            IValue value;
             if (sym is Identifier.LocalVariable local)
             {
                 value = this.SharedState.ScopeMgr.GetNamedValue(local.Item);
@@ -1140,7 +1180,8 @@ namespace Microsoft.Quantum.QsCompiler.QIR
                 var createCallable = this.SharedState.GetOrCreateRuntimeFunction(RuntimeLibrary.CallableCreate);
                 var wrapper = this.SharedState.GetOrCreateCallableTable(callable);
                 var capture = this.SharedState.Constants.UnitValue; // nothing to capture
-                value = this.SharedState.CurrentBuilder.Call(createCallable, wrapper, capture);
+                var res = this.SharedState.CurrentBuilder.Call(createCallable, wrapper, capture);
+                value = this.SharedState.Values.FromCallable(res, exType);
                 this.SharedState.ScopeMgr.RegisterValue(value);
             }
             else
@@ -1152,39 +1193,45 @@ namespace Microsoft.Quantum.QsCompiler.QIR
             return ResolvedExpression.InvalidExpr;
         }
 
-        public override ResolvedExpression OnInequality(TypedExpression lhs, TypedExpression rhs)
+        public override ResolvedExpression OnInequality(TypedExpression lhsEx, TypedExpression rhsEx)
         {
-            Value lhsValue = this.SharedState.EvaluateSubexpression(lhs);
-            Value rhsValue = this.SharedState.EvaluateSubexpression(rhs);
+            var lhs = this.SharedState.EvaluateSubexpression(lhsEx);
+            var rhs = this.SharedState.EvaluateSubexpression(rhsEx);
+            var exType = this.SharedState.CurrentExpressionType();
 
-            Value value;
-            if (lhs.ResolvedType.Resolution.IsResult)
+            IValue value;
+            if (lhsEx.ResolvedType.Resolution.IsResult)
             {
                 // Generate a call to the result equality testing function
                 var compareEquality = this.SharedState.GetOrCreateRuntimeFunction(RuntimeLibrary.ResultEqual);
-                value = this.SharedState.CurrentBuilder.Not(this.SharedState.CurrentBuilder.Call(compareEquality, lhsValue, rhsValue));
+                var res = this.SharedState.CurrentBuilder.Not(this.SharedState.CurrentBuilder.Call(compareEquality, lhs.Value, rhs.Value));
+                value = this.SharedState.Values.FromSimpleValue(res, exType);
             }
-            else if (lhs.ResolvedType.Resolution.IsBool || lhs.ResolvedType.Resolution.IsInt || lhs.ResolvedType.Resolution.IsQubit
-                || lhs.ResolvedType.Resolution.IsPauli)
+            else if (lhsEx.ResolvedType.Resolution.IsBool || lhsEx.ResolvedType.Resolution.IsInt || lhsEx.ResolvedType.Resolution.IsQubit
+                || lhsEx.ResolvedType.Resolution.IsPauli)
             {
                 // Works for pointers as well as integer types
-                value = this.SharedState.CurrentBuilder.Compare(IntPredicate.NotEqual, lhsValue, rhsValue);
+                var res = this.SharedState.CurrentBuilder.Compare(IntPredicate.NotEqual, lhs.Value, rhs.Value);
+                value = this.SharedState.Values.FromSimpleValue(res, exType);
             }
-            else if (lhs.ResolvedType.Resolution.IsDouble)
+            else if (lhsEx.ResolvedType.Resolution.IsDouble)
             {
-                value = this.SharedState.CurrentBuilder.Compare(RealPredicate.OrderedAndNotEqual, lhsValue, rhsValue);
+                var res = this.SharedState.CurrentBuilder.Compare(RealPredicate.OrderedAndNotEqual, lhs.Value, rhs.Value);
+                value = this.SharedState.Values.FromSimpleValue(res, exType);
             }
-            else if (lhs.ResolvedType.Resolution.IsString)
+            else if (lhsEx.ResolvedType.Resolution.IsString)
             {
                 // Generate a call to the string equality testing function
                 var compareEquality = this.SharedState.GetOrCreateRuntimeFunction(RuntimeLibrary.StringEqual);
-                value = this.SharedState.CurrentBuilder.Not(this.SharedState.CurrentBuilder.Call(compareEquality, lhsValue, rhsValue));
+                var res = this.SharedState.CurrentBuilder.Not(this.SharedState.CurrentBuilder.Call(compareEquality, lhs.Value, rhs.Value));
+                value = this.SharedState.Values.FromSimpleValue(res, exType);
             }
-            else if (lhs.ResolvedType.Resolution.IsBigInt)
+            else if (lhsEx.ResolvedType.Resolution.IsBigInt)
             {
                 // Generate a call to the bigint equality testing function
                 var compareEquality = this.SharedState.GetOrCreateRuntimeFunction(RuntimeLibrary.BigIntEqual);
-                value = this.SharedState.CurrentBuilder.Not(this.SharedState.CurrentBuilder.Call(compareEquality, lhsValue, rhsValue));
+                var res = this.SharedState.CurrentBuilder.Not(this.SharedState.CurrentBuilder.Call(compareEquality, lhs.Value, rhs.Value));
+                value = this.SharedState.Values.FromSimpleValue(res, exType);
             }
             else
             {
@@ -1198,27 +1245,31 @@ namespace Microsoft.Quantum.QsCompiler.QIR
 
         public override ResolvedExpression OnIntLiteral(long i)
         {
-            Value value = this.SharedState.Context.CreateConstant(i);
+            var constant = this.SharedState.Context.CreateConstant(i);
+            var exType = this.SharedState.CurrentExpressionType();
+            var value = this.SharedState.Values.FromSimpleValue(constant, exType);
             this.SharedState.ValueStack.Push(value);
             return ResolvedExpression.InvalidExpr;
         }
 
-        public override ResolvedExpression OnLeftShift(TypedExpression lhs, TypedExpression rhs)
+        public override ResolvedExpression OnLeftShift(TypedExpression lhsEx, TypedExpression rhsEx)
         {
-            Value lhsValue = this.SharedState.EvaluateSubexpression(lhs);
-            Value rhsValue = this.SharedState.EvaluateSubexpression(rhs);
+            var lhs = this.SharedState.EvaluateSubexpression(lhsEx);
+            var rhs = this.SharedState.EvaluateSubexpression(rhsEx);
             var exType = this.SharedState.CurrentExpressionType();
 
-            Value value;
-            if (exType.IsInt)
+            IValue value;
+            if (exType.Resolution.IsInt)
             {
-                value = this.SharedState.CurrentBuilder.ShiftLeft(lhsValue, rhsValue);
+                var res = this.SharedState.CurrentBuilder.ShiftLeft(lhs.Value, rhs.Value);
+                value = this.SharedState.Values.FromSimpleValue(res, exType);
             }
-            else if (exType.IsBigInt)
+            else if (exType.Resolution.IsBigInt)
             {
                 // The runtime function BigIntLeftShift creates a new value with reference count 1.
                 var func = this.SharedState.GetOrCreateRuntimeFunction(RuntimeLibrary.BigIntShiftLeft);
-                value = this.SharedState.CurrentBuilder.Call(func, lhsValue, rhsValue);
+                var res = this.SharedState.CurrentBuilder.Call(func, lhs.Value, rhs.Value);
+                value = this.SharedState.Values.From(res, exType);
                 this.SharedState.ScopeMgr.RegisterValue(value);
             }
             else
@@ -1230,24 +1281,28 @@ namespace Microsoft.Quantum.QsCompiler.QIR
             return ResolvedExpression.InvalidExpr;
         }
 
-        public override ResolvedExpression OnLessThan(TypedExpression lhs, TypedExpression rhs)
+        public override ResolvedExpression OnLessThan(TypedExpression lhsEx, TypedExpression rhsEx)
         {
-            Value lhsValue = this.SharedState.EvaluateSubexpression(lhs);
-            Value rhsValue = this.SharedState.EvaluateSubexpression(rhs);
+            var lhs = this.SharedState.EvaluateSubexpression(lhsEx);
+            var rhs = this.SharedState.EvaluateSubexpression(rhsEx);
+            var exType = this.SharedState.CurrentExpressionType();
 
-            Value value;
-            if (lhs.ResolvedType.Resolution.IsInt)
+            IValue value;
+            if (lhsEx.ResolvedType.Resolution.IsInt)
             {
-                value = this.SharedState.CurrentBuilder.Compare(IntPredicate.SignedLessThan, lhsValue, rhsValue);
+                var res = this.SharedState.CurrentBuilder.Compare(IntPredicate.SignedLessThan, lhs.Value, rhs.Value);
+                value = this.SharedState.Values.FromSimpleValue(res, exType);
             }
-            else if (lhs.ResolvedType.Resolution.IsDouble)
+            else if (lhsEx.ResolvedType.Resolution.IsDouble)
             {
-                value = this.SharedState.CurrentBuilder.Compare(RealPredicate.OrderedAndLessThan, lhsValue, rhsValue);
+                var res = this.SharedState.CurrentBuilder.Compare(RealPredicate.OrderedAndLessThan, lhs.Value, rhs.Value);
+                value = this.SharedState.Values.FromSimpleValue(res, exType);
             }
-            else if (lhs.ResolvedType.Resolution.IsBigInt)
+            else if (lhsEx.ResolvedType.Resolution.IsBigInt)
             {
                 var func = this.SharedState.GetOrCreateRuntimeFunction(RuntimeLibrary.BigIntGreaterEq);
-                value = this.SharedState.CurrentBuilder.Not(this.SharedState.CurrentBuilder.Call(func, lhsValue, rhsValue));
+                var res = this.SharedState.CurrentBuilder.Not(this.SharedState.CurrentBuilder.Call(func, lhs.Value, rhs.Value));
+                value = this.SharedState.Values.FromSimpleValue(res, exType);
             }
             else
             {
@@ -1258,24 +1313,28 @@ namespace Microsoft.Quantum.QsCompiler.QIR
             return ResolvedExpression.InvalidExpr;
         }
 
-        public override ResolvedExpression OnLessThanOrEqual(TypedExpression lhs, TypedExpression rhs)
+        public override ResolvedExpression OnLessThanOrEqual(TypedExpression lhsEx, TypedExpression rhsEx)
         {
-            Value lhsValue = this.SharedState.EvaluateSubexpression(lhs);
-            Value rhsValue = this.SharedState.EvaluateSubexpression(rhs);
+            var lhs = this.SharedState.EvaluateSubexpression(lhsEx);
+            var rhs = this.SharedState.EvaluateSubexpression(rhsEx);
+            var exType = this.SharedState.CurrentExpressionType();
 
-            Value value;
-            if (lhs.ResolvedType.Resolution.IsInt)
+            IValue value;
+            if (lhsEx.ResolvedType.Resolution.IsInt)
             {
-                value = this.SharedState.CurrentBuilder.Compare(IntPredicate.SignedLessThanOrEqual, lhsValue, rhsValue);
+                var res = this.SharedState.CurrentBuilder.Compare(IntPredicate.SignedLessThanOrEqual, lhs.Value, rhs.Value);
+                value = this.SharedState.Values.FromSimpleValue(res, exType);
             }
-            else if (lhs.ResolvedType.Resolution.IsDouble)
+            else if (lhsEx.ResolvedType.Resolution.IsDouble)
             {
-                value = this.SharedState.CurrentBuilder.Compare(RealPredicate.OrderedAndLessThanOrEqual, lhsValue, rhsValue);
+                var res = this.SharedState.CurrentBuilder.Compare(RealPredicate.OrderedAndLessThanOrEqual, lhs.Value, rhs.Value);
+                value = this.SharedState.Values.FromSimpleValue(res, exType);
             }
-            else if (lhs.ResolvedType.Resolution.IsBigInt)
+            else if (lhsEx.ResolvedType.Resolution.IsBigInt)
             {
                 var func = this.SharedState.GetOrCreateRuntimeFunction(RuntimeLibrary.BigIntGreater);
-                value = this.SharedState.CurrentBuilder.Not(this.SharedState.CurrentBuilder.Call(func, lhsValue, rhsValue));
+                var res = this.SharedState.CurrentBuilder.Not(this.SharedState.CurrentBuilder.Call(func, lhs.Value, rhs.Value));
+                value = this.SharedState.Values.FromSimpleValue(res, exType);
             }
             else
             {
@@ -1286,11 +1345,13 @@ namespace Microsoft.Quantum.QsCompiler.QIR
             return ResolvedExpression.InvalidExpr;
         }
 
-        public override ResolvedExpression OnLogicalAnd(TypedExpression lhs, TypedExpression rhs)
+        public override ResolvedExpression OnLogicalAnd(TypedExpression lhsEx, TypedExpression rhsEx)
         {
-            Value lhsValue = this.SharedState.EvaluateSubexpression(lhs);
-            Value rhsValue = this.SharedState.EvaluateSubexpression(rhs);
-            Value value = this.SharedState.CurrentBuilder.And(lhsValue, rhsValue);
+            var lhs = this.SharedState.EvaluateSubexpression(lhsEx);
+            var rhs = this.SharedState.EvaluateSubexpression(rhsEx);
+            var exType = this.SharedState.CurrentExpressionType();
+            var res = this.SharedState.CurrentBuilder.And(lhs.Value, rhs.Value);
+            var value = this.SharedState.Values.FromSimpleValue(res, exType);
             this.SharedState.ValueStack.Push(value);
             return ResolvedExpression.InvalidExpr;
         }
@@ -1298,37 +1359,43 @@ namespace Microsoft.Quantum.QsCompiler.QIR
         public override ResolvedExpression OnLogicalNot(TypedExpression ex)
         {
             // Get the Value for the expression
-            Value exValue = this.SharedState.EvaluateSubexpression(ex);
-            Value value = this.SharedState.CurrentBuilder.Not(exValue);
+            var arg = this.SharedState.EvaluateSubexpression(ex);
+            var res = this.SharedState.CurrentBuilder.Not(arg.Value);
+            var exType = this.SharedState.CurrentExpressionType();
+            var value = this.SharedState.Values.FromSimpleValue(res, exType);
             this.SharedState.ValueStack.Push(value);
             return ResolvedExpression.InvalidExpr;
         }
 
-        public override ResolvedExpression OnLogicalOr(TypedExpression lhs, TypedExpression rhs)
+        public override ResolvedExpression OnLogicalOr(TypedExpression lhsEx, TypedExpression rhsEx)
         {
-            Value lhsValue = this.SharedState.EvaluateSubexpression(lhs);
-            Value rhsValue = this.SharedState.EvaluateSubexpression(rhs);
-            Value value = this.SharedState.CurrentBuilder.Or(lhsValue, rhsValue);
+            var lhs = this.SharedState.EvaluateSubexpression(lhsEx);
+            var rhs = this.SharedState.EvaluateSubexpression(rhsEx);
+            var exType = this.SharedState.CurrentExpressionType();
+            var res = this.SharedState.CurrentBuilder.Or(lhs.Value, rhs.Value);
+            var value = this.SharedState.Values.FromSimpleValue(res, exType);
             this.SharedState.ValueStack.Push(value);
             return ResolvedExpression.InvalidExpr;
         }
 
-        public override ResolvedExpression OnModulo(TypedExpression lhs, TypedExpression rhs)
+        public override ResolvedExpression OnModulo(TypedExpression lhsEx, TypedExpression rhsEx)
         {
-            Value lhsValue = this.SharedState.EvaluateSubexpression(lhs);
-            Value rhsValue = this.SharedState.EvaluateSubexpression(rhs);
+            var lhs = this.SharedState.EvaluateSubexpression(lhsEx);
+            var rhs = this.SharedState.EvaluateSubexpression(rhsEx);
             var exType = this.SharedState.CurrentExpressionType();
 
-            Value value;
-            if (exType.IsInt)
+            IValue value;
+            if (exType.Resolution.IsInt)
             {
-                value = this.SharedState.CurrentBuilder.SRem(lhsValue, rhsValue);
+                var res = this.SharedState.CurrentBuilder.SRem(lhs.Value, rhs.Value);
+                value = this.SharedState.Values.FromSimpleValue(res, exType);
             }
-            else if (exType.IsBigInt)
+            else if (exType.Resolution.IsBigInt)
             {
                 // The runtime function BigIntModulus creates a new value with reference count 1.
                 var func = this.SharedState.GetOrCreateRuntimeFunction(RuntimeLibrary.BigIntModulus);
-                value = this.SharedState.CurrentBuilder.Call(func, lhsValue, rhsValue);
+                var res = this.SharedState.CurrentBuilder.Call(func, lhs.Value, rhs.Value);
+                value = this.SharedState.Values.From(res, exType);
                 this.SharedState.ScopeMgr.RegisterValue(value);
             }
             else
@@ -1340,26 +1407,29 @@ namespace Microsoft.Quantum.QsCompiler.QIR
             return ResolvedExpression.InvalidExpr;
         }
 
-        public override ResolvedExpression OnMultiplication(TypedExpression lhs, TypedExpression rhs)
+        public override ResolvedExpression OnMultiplication(TypedExpression lhsEx, TypedExpression rhsEx)
         {
-            Value lhsValue = this.SharedState.EvaluateSubexpression(lhs);
-            Value rhsValue = this.SharedState.EvaluateSubexpression(rhs);
+            var lhs = this.SharedState.EvaluateSubexpression(lhsEx);
+            var rhs = this.SharedState.EvaluateSubexpression(rhsEx);
             var exType = this.SharedState.CurrentExpressionType();
 
-            Value value;
-            if (exType.IsInt)
+            IValue value;
+            if (exType.Resolution.IsInt)
             {
-                value = this.SharedState.CurrentBuilder.Mul(lhsValue, rhsValue);
+                var res = this.SharedState.CurrentBuilder.Mul(lhs.Value, rhs.Value);
+                value = this.SharedState.Values.FromSimpleValue(res, exType);
             }
-            else if (exType.IsDouble)
+            else if (exType.Resolution.IsDouble)
             {
-                value = this.SharedState.CurrentBuilder.FMul(lhsValue, rhsValue);
+                var res = this.SharedState.CurrentBuilder.FMul(lhs.Value, rhs.Value);
+                value = this.SharedState.Values.FromSimpleValue(res, exType);
             }
-            else if (exType.IsBigInt)
+            else if (exType.Resolution.IsBigInt)
             {
                 // The runtime function BigIntMultiply creates a new value with reference count 1.
                 var func = this.SharedState.GetOrCreateRuntimeFunction(RuntimeLibrary.BigIntMultiply);
-                value = this.SharedState.CurrentBuilder.Call(func, lhsValue, rhsValue);
+                var res = this.SharedState.CurrentBuilder.Call(func, lhs.Value, rhs.Value);
+                value = this.SharedState.Values.From(res, exType);
                 this.SharedState.ScopeMgr.RegisterValue(value);
             }
             else
@@ -1373,7 +1443,7 @@ namespace Microsoft.Quantum.QsCompiler.QIR
 
         public override ResolvedExpression OnNamedItem(TypedExpression ex, Identifier acc)
         {
-            Value value;
+            IValue value;
             if (!(ex.ResolvedType.Resolution is QsResolvedTypeKind.UserDefinedType udt))
             {
                 throw new NotSupportedException("invalid type for named item access");
@@ -1387,7 +1457,7 @@ namespace Microsoft.Quantum.QsCompiler.QIR
                 value = this.SharedState.EvaluateSubexpression(ex);
                 for (int i = 0; i < location.Count; i++)
                 {
-                    value = this.SharedState.GetTupleElement(location[i].Item2, value, location[i].Item1);
+                    value = ((TupleValue)value).GetTupleElement(location[i]);
                 }
 
                 this.SharedState.ScopeMgr.IncreaseReferenceCount(value);
@@ -1404,23 +1474,26 @@ namespace Microsoft.Quantum.QsCompiler.QIR
 
         public override ResolvedExpression OnNegative(TypedExpression ex)
         {
-            Value exValue = this.SharedState.EvaluateSubexpression(ex);
+            var exValue = this.SharedState.EvaluateSubexpression(ex);
             var exType = this.SharedState.CurrentExpressionType();
 
-            Value value;
-            if (exType.IsInt)
+            IValue value;
+            if (exType.Resolution.IsInt)
             {
-                value = this.SharedState.CurrentBuilder.Neg(exValue);
+                var res = this.SharedState.CurrentBuilder.Neg(exValue.Value);
+                value = this.SharedState.Values.FromSimpleValue(res, exType);
             }
-            else if (exType.IsDouble)
+            else if (exType.Resolution.IsDouble)
             {
-                value = this.SharedState.CurrentBuilder.FNeg(exValue);
+                var res = this.SharedState.CurrentBuilder.FNeg(exValue.Value);
+                value = this.SharedState.Values.FromSimpleValue(res, exType);
             }
-            else if (exType.IsBigInt)
+            else if (exType.Resolution.IsBigInt)
             {
                 // The runtime function BigIntNegative creates a new value with reference count 1.
                 var func = this.SharedState.GetOrCreateRuntimeFunction(RuntimeLibrary.BigIntNegate);
-                value = this.SharedState.CurrentBuilder.Call(func, exValue);
+                var res = this.SharedState.CurrentBuilder.Call(func, exValue.Value);
+                value = this.SharedState.Values.From(res, exType);
                 this.SharedState.ScopeMgr.RegisterValue(value);
             }
             else
@@ -1432,15 +1505,12 @@ namespace Microsoft.Quantum.QsCompiler.QIR
             return ResolvedExpression.InvalidExpr;
         }
 
-        public override ResolvedExpression OnNewArray(ResolvedType elementType, TypedExpression idx)
+        public override ResolvedExpression OnNewArray(ResolvedType elementType, TypedExpression lengthEx)
         {
             // TODO: new multi-dimensional arrays
-            var array = new ArrayValue(
-                this.SharedState.EvaluateSubexpression(idx),
-                this.SharedState.LlvmTypeFromQsharpType(elementType),
-                this.SharedState);
-
-            this.SharedState.ValueStack.Push(array.OpaquePointer);
+            var length = this.SharedState.EvaluateSubexpression(lengthEx);
+            var array = new ArrayValue(length.Value, elementType, this.SharedState);
+            this.SharedState.ValueStack.Push(array);
             return ResolvedExpression.InvalidExpr;
         }
 
@@ -1490,7 +1560,7 @@ namespace Microsoft.Quantum.QsCompiler.QIR
             // We avoid constructing a callable value when functors are applied to global callables.
             var (innerCallable, isAdjoint, controlledCount) = StripModifiers(method, false, 0);
 
-            Value value;
+            IValue value;
             var callableName = innerCallable.TryAsGlobalCallable().ValueOr(null);
             if (callableName == null)
             {
@@ -1511,7 +1581,7 @@ namespace Microsoft.Quantum.QsCompiler.QIR
 
         public override ResolvedExpression OnPartialApplication(TypedExpression method, TypedExpression arg)
         {
-            PartialApplicationArgument BuildPartialArgList(ResolvedType argType, TypedExpression arg, List<ResolvedType> remainingArgs, List<Value> capturedValues)
+            PartialApplicationArgument BuildPartialArgList(ResolvedType argType, TypedExpression arg, List<ResolvedType> remainingArgs, List<IValue> capturedValues)
             {
                 // We need argType because missing argument items have MissingType, rather than the actual type.
                 if (arg.Expression.IsMissingExpr)
@@ -1533,9 +1603,9 @@ namespace Microsoft.Quantum.QsCompiler.QIR
                 }
             }
 
-            IrFunction BuildLiftedSpecialization(string name, QsSpecializationKind kind, IStructType captureType, IStructType parArgsStruct, PartialApplicationArgument partialArgs)
+            IrFunction BuildLiftedSpecialization(string name, QsSpecializationKind kind, ImmutableArray<ResolvedType> captureType, ImmutableArray<ResolvedType> paArgsTypes, PartialApplicationArgument partialArgs)
             {
-                Value ApplyFunctors(Value innerCallable, InstructionBuilder builder)
+                IValue ApplyFunctors(IValue innerCallable, InstructionBuilder builder)
                 {
                     if (kind == QsSpecializationKind.QsBody)
                     {
@@ -1571,45 +1641,44 @@ namespace Microsoft.Quantum.QsCompiler.QIR
                 this.SharedState.ScopeMgr.OpenScope();
                 InstructionBuilder builder = new InstructionBuilder(entry);
 
-                Value capturePointer = builder.BitCast(func.Parameters[0], captureType.CreatePointerType());
-                TupleValue BuildControlledInnerArgument(ITypeRef paArgType)
+                var captureTuple = this.SharedState.Values.FromTuple(func.Parameters[0], captureType, builder);
+                TupleValue BuildControlledInnerArgument(ResolvedType paArgType)
                 {
                     // The argument tuple given to the controlled version of the partial application consists of the array of control qubits
                     // as well as a tuple with the remaining arguments for the partial application.
                     // We need to cast the corresponding function parameter to the appropriate type and load both of these items.
-                    var ctlPaArgsStruct = this.SharedState.Types.TypedTuple(this.SharedState.Types.Array, paArgType);
-                    var ctlPaArgs = builder.BitCast(func.Parameters[1], ctlPaArgsStruct.CreatePointerType());
-                    var ctlPaArgItems = this.SharedState.GetTupleElements(ctlPaArgsStruct, ctlPaArgs, builder);
+                    var ctlPaArgsTypes = ImmutableArray.Create(SyntaxGenerator.QubitArrayType, paArgType);
+                    var ctlPaArgsTuple = this.SharedState.Values.FromTuple(func.Parameters[1], ctlPaArgsTypes, builder);
+                    var ctlPaArgItems = ctlPaArgsTuple.GetTupleElements();
 
                     // We then create and populate the complete argument tuple for the controlled specialization of the inner callable.
                     // The tuple consists of the control qubits and the combined tuple of captured values and the arguments given to the partial application.
-                    var innerArgs = partialArgs.BuildItem(builder, capturePointer, ctlPaArgItems[1]);
+                    var innerArgs = partialArgs.BuildItem(builder, captureTuple, ctlPaArgItems[1]);
                     return this.SharedState.CreateTuple(builder, ctlPaArgItems[0], innerArgs);
                 }
 
-                Value innerArg;
+                TupleValue innerArg;
                 if (kind == QsSpecializationKind.QsControlled || kind == QsSpecializationKind.QsControlledAdjoint)
                 {
                     // Deal with the extra control qubit arg for controlled and controlled-adjoint
                     // We special case if the base specialization only takes a single parameter and don't create the sub-tuple in this case.
                     innerArg = BuildControlledInnerArgument(
-                        parArgsStruct.Members.Count == 1
-                        ? parArgsStruct.Members[0]
-                        : parArgsStruct.CreatePointerType())
-                    .OpaquePointer;
+                        paArgsTypes.Length == 1
+                        ? paArgsTypes[0]
+                        : ResolvedType.New(QsResolvedTypeKind.NewTupleType(paArgsTypes)));
                 }
                 else
                 {
-                    var parArgsPointer = builder.BitCast(func.Parameters[1], parArgsStruct.CreatePointerType());
-                    var typedInnerArg = partialArgs.BuildItem(builder, capturePointer, parArgsPointer);
-                    innerArg = this.SharedState.Types.IsTypedTuple(typedInnerArg.NativeType)
-                        ? builder.BitCast(typedInnerArg, this.SharedState.Types.Tuple)
-                        : this.SharedState.CreateTuple(builder, typedInnerArg).OpaquePointer;
+                    var parArgsTuple = this.SharedState.Values.FromTuple(func.Parameters[1], paArgsTypes, builder);
+                    var typedInnerArg = partialArgs.BuildItem(builder, captureTuple, parArgsTuple);
+                    innerArg = typedInnerArg is TupleValue innerArgTuple
+                        ? innerArgTuple
+                        : this.SharedState.CreateTuple(builder, typedInnerArg);
                 }
 
                 var invokeCallable = this.SharedState.GetOrCreateRuntimeFunction(RuntimeLibrary.CallableInvoke);
-                var innerCallable = this.SharedState.GetTupleElement(captureType, capturePointer, 0, builder);
-                builder.Call(invokeCallable, ApplyFunctors(innerCallable, builder), innerArg, func.Parameters[2]);
+                var innerCallable = captureTuple.GetTupleElement(0);
+                builder.Call(invokeCallable, ApplyFunctors(innerCallable, builder).Value, innerArg.OpaquePointer, func.Parameters[2]);
 
                 builder.Return();
                 this.SharedState.ScopeMgr.CloseScope(isTerminated: false, builder);
@@ -1626,15 +1695,18 @@ namespace Microsoft.Quantum.QsCompiler.QIR
             };
 
             // Figure out the inputs to the resulting callable based on the signature of the partial application expression
-            var partialArgType = this.SharedState.LlvmStructTypeFromQsharpType(
-                CallableArgumentType(this.SharedState.ExpressionTypeStack.Peek()));
+            var exType = this.SharedState.CurrentExpressionType();
+            var callableArgType = CallableArgumentType(exType);
+            var paArgsTypes = callableArgType.Resolution is QsResolvedTypeKind.TupleType itemTypes
+                ? itemTypes.Item
+                : ImmutableArray.Create(callableArgType);
 
             // Argument type of the callable that is partially applied
             var innerArgType = CallableArgumentType(method.ResolvedType);
 
             // Create the capture tuple, which contains the inner callable as the first item and
             // construct the mapping to compine captured arguments with the arguments for the partial application
-            var captured = new List<Value>();
+            var captured = new List<IValue>();
             captured.Add(this.SharedState.EvaluateSubexpression(method));
             var rebuild = BuildPartialArgList(innerArgType, arg, new List<ResolvedType>(), captured);
             var capture = this.SharedState.CreateTuple(this.SharedState.CurrentBuilder, captured.ToArray());
@@ -1670,7 +1742,7 @@ namespace Microsoft.Quantum.QsCompiler.QIR
                 var kind = GenerationContext.FunctionArray[index];
                 if (kinds.Contains(kind))
                 {
-                    specializations[index] = BuildLiftedSpecialization(liftedName, kind, capture.StructType, partialArgType, rebuild);
+                    specializations[index] = BuildLiftedSpecialization(liftedName, kind, capture.ElementTypes, paArgsTypes, rebuild);
                 }
                 else
                 {
@@ -1684,8 +1756,9 @@ namespace Microsoft.Quantum.QsCompiler.QIR
 
             // Create the callable and make sure we inject/queue the functions to manage the reference counts
             var createCallable = this.SharedState.GetOrCreateRuntimeFunction(RuntimeLibrary.CallableCreate);
-            var value = this.SharedState.CurrentBuilder.Call(createCallable, table, capture.OpaquePointer);
-            this.SharedState.ScopeMgr.IncreaseReferenceCount(capture.OpaquePointer);
+            var callable = this.SharedState.CurrentBuilder.Call(createCallable, table, capture.OpaquePointer);
+            var value = this.SharedState.Values.FromCallable(callable, exType);
+            this.SharedState.ScopeMgr.IncreaseReferenceCount(capture);
             this.SharedState.ScopeMgr.RegisterValue(value);
 
             this.SharedState.ValueStack.Push(value);
@@ -1694,10 +1767,14 @@ namespace Microsoft.Quantum.QsCompiler.QIR
 
         public override ResolvedExpression OnPauliLiteral(QsPauli p)
         {
-            Value LoadPauli(Value pauli) =>
-                this.SharedState.CurrentBuilder.Load(this.SharedState.Types.Pauli, pauli);
+            IValue LoadPauli(Value pauli)
+            {
+                var constant = this.SharedState.CurrentBuilder.Load(this.SharedState.Types.Pauli, pauli);
+                var exType = this.SharedState.CurrentExpressionType();
+                return this.SharedState.Values.From(constant, exType);
+            }
 
-            Value value;
+            IValue value;
             if (p.IsPauliI)
             {
                 value = LoadPauli(this.SharedState.Constants.PauliI);
@@ -1730,21 +1807,24 @@ namespace Microsoft.Quantum.QsCompiler.QIR
             switch (lhs.Expression)
             {
                 case ResolvedExpression.RangeLiteral lit:
-                    start = this.SharedState.EvaluateSubexpression(lit.Item1);
-                    step = this.SharedState.EvaluateSubexpression(lit.Item2);
+                    start = this.SharedState.EvaluateSubexpression(lit.Item1).Value;
+                    step = this.SharedState.EvaluateSubexpression(lit.Item2).Value;
                     break;
                 default:
-                    start = this.SharedState.EvaluateSubexpression(lhs);
+                    start = this.SharedState.EvaluateSubexpression(lhs).Value;
                     step = this.SharedState.Context.CreateConstant(1L);
                     break;
             }
-            Value end = this.SharedState.EvaluateSubexpression(rhs);
+            Value end = this.SharedState.EvaluateSubexpression(rhs).Value;
 
             Value rangePtr = this.SharedState.Constants.EmptyRange;
-            Value value = this.SharedState.CurrentBuilder.Load(this.SharedState.Types.Range, rangePtr);
-            value = this.SharedState.CurrentBuilder.InsertValue(value, start, 0);
-            value = this.SharedState.CurrentBuilder.InsertValue(value, step, 1);
-            value = this.SharedState.CurrentBuilder.InsertValue(value, end, 2);
+            Value constant = this.SharedState.CurrentBuilder.Load(this.SharedState.Types.Range, rangePtr);
+            constant = this.SharedState.CurrentBuilder.InsertValue(constant, start, 0);
+            constant = this.SharedState.CurrentBuilder.InsertValue(constant, step, 1);
+            constant = this.SharedState.CurrentBuilder.InsertValue(constant, end, 2);
+
+            var exType = this.SharedState.CurrentExpressionType();
+            var value = this.SharedState.Values.From(constant, exType);
 
             this.SharedState.ValueStack.Push(value);
             return ResolvedExpression.InvalidExpr;
@@ -1753,27 +1833,31 @@ namespace Microsoft.Quantum.QsCompiler.QIR
         public override ResolvedExpression OnResultLiteral(QsResult r)
         {
             var valuePtr = r.IsOne ? this.SharedState.Constants.ResultOne : this.SharedState.Constants.ResultZero;
-            var value = this.SharedState.CurrentBuilder.Load(this.SharedState.Types.Result, valuePtr);
+            var constant = this.SharedState.CurrentBuilder.Load(this.SharedState.Types.Result, valuePtr);
+            var exType = this.SharedState.CurrentExpressionType();
+            var value = this.SharedState.Values.From(constant, exType);
             this.SharedState.ValueStack.Push(value);
             return ResolvedExpression.InvalidExpr;
         }
 
-        public override ResolvedExpression OnRightShift(TypedExpression lhs, TypedExpression rhs)
+        public override ResolvedExpression OnRightShift(TypedExpression lhsEx, TypedExpression rhsEx)
         {
-            Value lhsValue = this.SharedState.EvaluateSubexpression(lhs);
-            Value rhsValue = this.SharedState.EvaluateSubexpression(rhs);
+            var lhs = this.SharedState.EvaluateSubexpression(lhsEx);
+            var rhs = this.SharedState.EvaluateSubexpression(rhsEx);
             var exType = this.SharedState.CurrentExpressionType();
 
-            Value value;
-            if (exType.IsInt)
+            IValue value;
+            if (exType.Resolution.IsInt)
             {
-                value = this.SharedState.CurrentBuilder.ArithmeticShiftRight(lhsValue, rhsValue);
+                var res = this.SharedState.CurrentBuilder.ArithmeticShiftRight(lhs.Value, rhs.Value);
+                value = this.SharedState.Values.FromSimpleValue(res, exType);
             }
-            else if (exType.IsBigInt)
+            else if (exType.Resolution.IsBigInt)
             {
                 // The runtime function BigIntRightShift creates a new value with reference count 1.
                 var func = this.SharedState.GetOrCreateRuntimeFunction(RuntimeLibrary.BigIntShiftRight);
-                value = this.SharedState.CurrentBuilder.Call(func, lhsValue, rhsValue);
+                var res = this.SharedState.CurrentBuilder.Call(func, lhs.Value, rhs.Value);
+                value = this.SharedState.Values.From(res, exType);
                 this.SharedState.ScopeMgr.RegisterValue(value);
             }
             else
@@ -1834,7 +1918,7 @@ namespace Microsoft.Quantum.QsCompiler.QIR
                 // Creates a string value that needs to be queued for unreferencing.
                 Value SimpleToString(TypedExpression ex, string rtFuncName)
                 {
-                    var exValue = this.SharedState.EvaluateSubexpression(ex);
+                    var exValue = this.SharedState.EvaluateSubexpression(ex).Value;
                     var createString = this.SharedState.GetOrCreateRuntimeFunction(rtFuncName);
                     return this.SharedState.CurrentBuilder.Call(createString, exValue);
                 }
@@ -1843,7 +1927,7 @@ namespace Microsoft.Quantum.QsCompiler.QIR
                 if (ty.IsString)
                 {
                     var addReference = this.SharedState.GetOrCreateRuntimeFunction(RuntimeLibrary.StringReference);
-                    var value = this.SharedState.EvaluateSubexpression(ex);
+                    var value = this.SharedState.EvaluateSubexpression(ex).Value;
                     this.SharedState.CurrentBuilder.Call(addReference, value);
                     return value;
                 }
@@ -1931,13 +2015,8 @@ namespace Microsoft.Quantum.QsCompiler.QIR
                 return app;
             }
 
-            Value value;
-            if (exs.IsEmpty)
-            {
-                value = CreateConstantString(str);
-                this.SharedState.ScopeMgr.RegisterValue(value);
-            }
-            else
+            Value? current = null;
+            if (!exs.IsEmpty)
             {
                 // Compiled interpolated strings look like <text>{<int>}<text>...
                 // Our basic pattern is to scan for the next '{', append the intervening text if any
@@ -1945,7 +2024,6 @@ namespace Microsoft.Quantum.QsCompiler.QIR
                 // evaluate the corresponding expression, append it, and keep going.
                 // We do have to be a little careful because we can't just look for '{', we have to
                 // make sure we skip escaped braces -- "\{".
-                Value? current = null;
                 var offset = 0;
                 while (offset < str.Length)
                 {
@@ -1972,35 +2050,40 @@ namespace Microsoft.Quantum.QsCompiler.QIR
                         offset = next;
                     }
                 }
-
-                value = current ?? CreateConstantString("");
-                this.SharedState.ScopeMgr.RegisterValue(value);
             }
+
+            current ??= CreateConstantString(str);
+            var exType = this.SharedState.CurrentExpressionType();
+            var value = this.SharedState.Values.From(current, exType);
+            this.SharedState.ScopeMgr.RegisterValue(value);
 
             this.SharedState.ValueStack.Push(value);
             return ResolvedExpression.InvalidExpr;
         }
 
-        public override ResolvedExpression OnSubtraction(TypedExpression lhs, TypedExpression rhs)
+        public override ResolvedExpression OnSubtraction(TypedExpression lhsEx, TypedExpression rhsEx)
         {
-            Value lhsValue = this.SharedState.EvaluateSubexpression(lhs);
-            Value rhsValue = this.SharedState.EvaluateSubexpression(rhs);
+            var lhs = this.SharedState.EvaluateSubexpression(lhsEx);
+            var rhs = this.SharedState.EvaluateSubexpression(rhsEx);
             var exType = this.SharedState.CurrentExpressionType();
 
-            Value value;
-            if (exType.IsInt)
+            IValue value;
+            if (exType.Resolution.IsInt)
             {
-                value = this.SharedState.CurrentBuilder.Sub(lhsValue, rhsValue);
+                var res = this.SharedState.CurrentBuilder.Sub(lhs.Value, rhs.Value);
+                value = this.SharedState.Values.FromSimpleValue(res, exType);
             }
-            else if (exType.IsDouble)
+            else if (exType.Resolution.IsDouble)
             {
-                value = this.SharedState.CurrentBuilder.FSub(lhsValue, rhsValue);
+                var res = this.SharedState.CurrentBuilder.FSub(lhs.Value, rhs.Value);
+                value = this.SharedState.Values.FromSimpleValue(res, exType);
             }
-            else if (exType.IsBigInt)
+            else if (exType.Resolution.IsBigInt)
             {
                 // The runtime function BigIntSubtract creates a new value with reference count 1.
                 var func = this.SharedState.GetOrCreateRuntimeFunction(RuntimeLibrary.BigIntSubtract);
-                value = this.SharedState.CurrentBuilder.Call(func, lhsValue, rhsValue);
+                var res = this.SharedState.CurrentBuilder.Call(func, lhs.Value, rhs.Value);
+                value = this.SharedState.Values.From(res, exType);
                 this.SharedState.ScopeMgr.RegisterValue(value);
             }
             else
@@ -2014,7 +2097,7 @@ namespace Microsoft.Quantum.QsCompiler.QIR
 
         public override ResolvedExpression OnUnitValue()
         {
-            Value value = this.SharedState.Constants.UnitValue;
+            var value = this.SharedState.Values.Unit;
             this.SharedState.ValueStack.Push(value);
             return ResolvedExpression.InvalidExpr;
         }
@@ -2022,17 +2105,19 @@ namespace Microsoft.Quantum.QsCompiler.QIR
         public override ResolvedExpression OnValueArray(ImmutableArray<TypedExpression> vs)
         {
             // TODO: handle multi-dimensional arrays
-            var elementType = this.SharedState.LlvmTypeFromQsharpType(vs[0].ResolvedType);
-            var value = new ArrayValue((uint)vs.Length, elementType, this.SharedState).OpaquePointer;
+            var elementType = this.SharedState.CurrentExpressionType().Resolution is QsResolvedTypeKind.ArrayType arrItemType
+                ? arrItemType.Item
+                : throw new InvalidOperationException("current expression is not of type array");
+            var value = new ArrayValue((uint)vs.Length, elementType, this.SharedState);
 
             long idx = 0;
-            foreach (var element in vs)
+            foreach (var v in vs)
             {
                 var index = this.SharedState.Context.CreateConstant(idx);
-                var elementPointer = this.SharedState.GetArrayElementPointer(elementType, value, index);
-                var elementValue = this.SharedState.EvaluateSubexpression(element);
-                this.SharedState.CurrentBuilder.Store(elementValue, elementPointer);
-                this.SharedState.ScopeMgr.IncreaseReferenceCount(elementValue);
+                var elementPointer = value.GetArrayElementPointer(index);
+                var element = this.SharedState.EvaluateSubexpression(v);
+                this.SharedState.CurrentBuilder.Store(element.Value, elementPointer);
+                this.SharedState.ScopeMgr.IncreaseReferenceCount(element);
                 idx++;
             }
 
@@ -2044,7 +2129,7 @@ namespace Microsoft.Quantum.QsCompiler.QIR
         {
             var items = vs.Select(v => this.SharedState.EvaluateSubexpression(v)).ToArray();
             var tuple = this.SharedState.CreateTuple(this.SharedState.CurrentBuilder, items);
-            this.SharedState.ValueStack.Push(tuple.TypedPointer);
+            this.SharedState.ValueStack.Push(tuple);
             return ResolvedExpression.InvalidExpr;
         }
 
@@ -2053,7 +2138,7 @@ namespace Microsoft.Quantum.QsCompiler.QIR
             // Since we simply represent user defined types as tuples, we don't need to do anything
             // except pushing the value on the value stack unless the tuples contains a single item,
             // in which case we need to remove the tuple wrapping.
-            Value value = this.SharedState.EvaluateSubexpression(ex);
+            var value = this.SharedState.EvaluateSubexpression(ex);
             var udt = ex.ResolvedType.Resolution as QsResolvedTypeKind.UserDefinedType;
             if (udt == null)
             {
@@ -2065,11 +2150,7 @@ namespace Microsoft.Quantum.QsCompiler.QIR
             }
             else if (!udtDecl.Type.Resolution.IsTupleType)
             {
-                var elementType = this.SharedState.LlvmTypeFromQsharpType(udtDecl.Type);
-                value = this.SharedState.GetTupleElement(
-                     this.SharedState.Types.TypedTuple(elementType),
-                     value,
-                     0);
+                value = ((TupleValue)value).GetTupleElement(0);
             }
 
             this.SharedState.ScopeMgr.IncreaseReferenceCount(value);

--- a/src/QsCompiler/QirGeneration/Subtransformations/StatementKindTransformation.cs
+++ b/src/QsCompiler/QirGeneration/Subtransformations/StatementKindTransformation.cs
@@ -137,7 +137,7 @@ namespace Microsoft.Quantum.QsCompiler.QIR
                     else if (init.Resolution is ResolvedInitializerKind.QubitTupleAllocation inits)
                     {
                         var items = inits.Item.Select(Allocate).ToArray();
-                        return this.SharedState.CreateTuple(this.SharedState.CurrentBuilder, items);
+                        return this.SharedState.Values.CreateTuple(items);
                     }
                     else
                     {

--- a/src/QsCompiler/QirGeneration/Subtransformations/StatementKindTransformation.cs
+++ b/src/QsCompiler/QirGeneration/Subtransformations/StatementKindTransformation.cs
@@ -52,14 +52,13 @@ namespace Microsoft.Quantum.QsCompiler.QIR
             {
                 if (mutable)
                 {
-                    var ptr = this.SharedState.CurrentBuilder.Alloca(this.SharedState.LlvmTypeFromQsharpType(type));
-                    var ptrValue = this.SharedState.Values.FromSimpleValue(ptr, type); // FIXME: THIS IS PRETTY HORRIBLE
-                    this.SharedState.ScopeMgr.RegisterVariable(varName.Item, ptrValue, true);
-                    this.SharedState.CurrentBuilder.Store(ex.Value, ptr);
+                    var ptr = this.SharedState.Values.CreatePointer(type);
+                    this.SharedState.ScopeMgr.RegisterVariable(varName.Item, ptr);
+                    this.SharedState.CurrentBuilder.Store(ex.Value, ptr.Pointer);
                 }
                 else
                 {
-                    this.SharedState.ScopeMgr.RegisterVariable(varName.Item, ex, false);
+                    this.SharedState.ScopeMgr.RegisterVariable(varName.Item, ex);
                 }
             }
             else if (symbols is SymbolTuple.VariableNameTuple syms)
@@ -372,11 +371,9 @@ namespace Microsoft.Quantum.QsCompiler.QIR
             {
                 if (symbols.Expression is ResolvedExpression.Identifier id && id.Item1 is Identifier.LocalVariable varName)
                 {
-                    Value ptr = this.SharedState.ScopeMgr.GetNamedPointer(varName.Item).Value;
-                    var loadedOriginal = this.SharedState.CurrentBuilder.Load(rhs.Value.NativeType, ptr);
-                    var originalValue = this.SharedState.Values.From(loadedOriginal, rhs.QSharpType);
+                    var originalValue = (PointerValue)this.SharedState.ScopeMgr.GetVariable(varName.Item);
                     this.SharedState.ScopeMgr.DecreaseAccessCount(originalValue);
-                    this.SharedState.CurrentBuilder.Store(rhs.Value, ptr);
+                    this.SharedState.CurrentBuilder.Store(rhs.Value, originalValue.Pointer);
                     this.SharedState.ScopeMgr.IncreaseAccessCount(rhs);
                 }
                 else if (symbols.Expression is ResolvedExpression.ValueTuple ids)

--- a/src/QsCompiler/QirGeneration/Subtransformations/StatementKindTransformation.cs
+++ b/src/QsCompiler/QirGeneration/Subtransformations/StatementKindTransformation.cs
@@ -53,8 +53,8 @@ namespace Microsoft.Quantum.QsCompiler.QIR
                 if (mutable)
                 {
                     var ptr = this.SharedState.Values.CreatePointer(type);
-                    this.SharedState.ScopeMgr.RegisterVariable(varName.Item, ptr);
                     this.SharedState.CurrentBuilder.Store(ex.Value, ptr.Pointer);
+                    this.SharedState.ScopeMgr.RegisterVariable(varName.Item, ptr);
                 }
                 else
                 {
@@ -123,15 +123,17 @@ namespace Microsoft.Quantum.QsCompiler.QIR
                     if (init.Resolution.IsSingleQubitAllocation)
                     {
                         Value allocation = this.SharedState.CurrentBuilder.Call(allocateOne);
-                        this.SharedState.ScopeMgr.RegisterAllocatedQubits(allocation);
-                        return this.SharedState.Values.From(allocation, init.Type);
+                        var value = this.SharedState.Values.From(allocation, init.Type);
+                        this.SharedState.ScopeMgr.RegisterAllocatedQubits(value);
+                        return value;
                     }
                     else if (init.Resolution is ResolvedInitializerKind.QubitRegisterAllocation reg)
                     {
                         Value countValue = this.SharedState.EvaluateSubexpression(reg.Item).Value;
                         Value allocation = this.SharedState.CurrentBuilder.Call(allocateArray, countValue);
-                        this.SharedState.ScopeMgr.RegisterAllocatedQubits(allocation);
-                        return this.SharedState.Values.From(allocation, init.Type);
+                        var value = this.SharedState.Values.From(allocation, init.Type);
+                        this.SharedState.ScopeMgr.RegisterAllocatedQubits(value);
+                        return value;
                     }
                     else if (init.Resolution is ResolvedInitializerKind.QubitTupleAllocation inits)
                     {

--- a/src/QsCompiler/QirGeneration/Subtransformations/StatementKindTransformation.cs
+++ b/src/QsCompiler/QirGeneration/Subtransformations/StatementKindTransformation.cs
@@ -53,7 +53,7 @@ namespace Microsoft.Quantum.QsCompiler.QIR
                 if (mutable)
                 {
                     var ptr = this.SharedState.CurrentBuilder.Alloca(this.SharedState.LlvmTypeFromQsharpType(type));
-                    var ptrValue = this.SharedState.Values.FromSimpleValue(ptr, ResolvedType.New(QsResolvedTypeKind.InvalidType));
+                    var ptrValue = this.SharedState.Values.FromSimpleValue(ptr, type); // FIXME: THIS IS PRETTY HORRIBLE
                     this.SharedState.ScopeMgr.RegisterVariable(varName.Item, ptrValue, true);
                     this.SharedState.CurrentBuilder.Store(ex.Value, ptr);
                 }
@@ -79,7 +79,7 @@ namespace Microsoft.Quantum.QsCompiler.QIR
                     }
                 }
             }
-            else
+            else if (!symbols.IsDiscardedItem)
             {
                 throw new NotImplementedException("unknown item in symbol tuple");
             }
@@ -372,7 +372,7 @@ namespace Microsoft.Quantum.QsCompiler.QIR
             {
                 if (symbols.Expression is ResolvedExpression.Identifier id && id.Item1 is Identifier.LocalVariable varName)
                 {
-                    Value ptr = this.SharedState.ScopeMgr.GetNamedPointer(varName.Item);
+                    Value ptr = this.SharedState.ScopeMgr.GetNamedPointer(varName.Item).Value;
                     var loadedOriginal = this.SharedState.CurrentBuilder.Load(rhs.Value.NativeType, ptr);
                     var originalValue = this.SharedState.Values.From(loadedOriginal, rhs.QSharpType);
                     this.SharedState.ScopeMgr.DecreaseAccessCount(originalValue);

--- a/src/QsCompiler/QirGeneration/Subtransformations/StatementKindTransformation.cs
+++ b/src/QsCompiler/QirGeneration/Subtransformations/StatementKindTransformation.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Linq;
 using Microsoft.Quantum.QIR;
+using Microsoft.Quantum.QIR.Emission;
 using Microsoft.Quantum.QsCompiler.SyntaxTokens;
 using Microsoft.Quantum.QsCompiler.SyntaxTree;
 using Microsoft.Quantum.QsCompiler.Transformations.Core;
@@ -45,19 +46,20 @@ namespace Microsoft.Quantum.QsCompiler.QIR
         /// <param name="symbolValue">The Value to bind to</param>
         /// <param name="symbolType">The Q# type of the SymbolTuple</param>
         /// <param name="isImmutable">true if the binding is immutable, false if mutable</param>
-        private void BindSymbolTuple(SymbolTuple symbols, Value value, ResolvedType type, bool mutable = false)
+        private void BindSymbolTuple(SymbolTuple symbols, IValue ex, ResolvedType type, bool mutable = false)
         {
             if (symbols is SymbolTuple.VariableName varName)
             {
                 if (mutable)
                 {
                     var ptr = this.SharedState.CurrentBuilder.Alloca(this.SharedState.LlvmTypeFromQsharpType(type));
-                    this.SharedState.ScopeMgr.RegisterVariable(varName.Item, ptr, true);
-                    this.SharedState.CurrentBuilder.Store(value, ptr);
+                    var ptrValue = this.SharedState.Values.FromSimpleValue(ptr, ResolvedType.New(QsResolvedTypeKind.InvalidType));
+                    this.SharedState.ScopeMgr.RegisterVariable(varName.Item, ptrValue, true);
+                    this.SharedState.CurrentBuilder.Store(ex.Value, ptr);
                 }
                 else
                 {
-                    this.SharedState.ScopeMgr.RegisterVariable(varName.Item, value, false);
+                    this.SharedState.ScopeMgr.RegisterVariable(varName.Item, ex, false);
                 }
             }
             else if (symbols is SymbolTuple.VariableNameTuple syms)
@@ -67,15 +69,12 @@ namespace Microsoft.Quantum.QsCompiler.QIR
                     throw new InvalidOperationException("shape mismatch in symbol binding");
                 }
 
-                var itemTypes = types.Item.Select(this.SharedState.LlvmTypeFromQsharpType).ToArray();
-                var tupleType = this.SharedState.Types.TypedTuple(itemTypes);
-                var itemPointers = this.SharedState.GetTupleElementPointers(tupleType, value);
-
+                var tuple = (TupleValue)ex;
                 for (int i = 0; i < syms.Item.Length; i++)
                 {
                     if (!syms.Item[i].IsDiscardedItem && !syms.Item[i].IsInvalidItem)
                     {
-                        var itemValue = this.SharedState.CurrentBuilder.Load(itemTypes[i], itemPointers[i]);
+                        var itemValue = tuple.GetTupleElement(i);
                         this.BindSymbolTuple(syms.Item[i], itemValue, types.Item[i], mutable);
                     }
                 }
@@ -120,25 +119,25 @@ namespace Microsoft.Quantum.QsCompiler.QIR
                 IrFunction allocateOne = this.SharedState.GetOrCreateRuntimeFunction(RuntimeLibrary.QubitAllocate);
                 IrFunction allocateArray = this.SharedState.GetOrCreateRuntimeFunction(RuntimeLibrary.QubitAllocateArray);
 
-                Value Allocate(ResolvedInitializer init)
+                IValue Allocate(ResolvedInitializer init)
                 {
                     if (init.Resolution.IsSingleQubitAllocation)
                     {
                         Value allocation = this.SharedState.CurrentBuilder.Call(allocateOne);
                         this.SharedState.ScopeMgr.RegisterAllocatedQubits(allocation);
-                        return allocation;
+                        return this.SharedState.Values.From(allocation, init.Type);
                     }
                     else if (init.Resolution is ResolvedInitializerKind.QubitRegisterAllocation reg)
                     {
-                        Value countValue = this.SharedState.EvaluateSubexpression(reg.Item);
+                        Value countValue = this.SharedState.EvaluateSubexpression(reg.Item).Value;
                         Value allocation = this.SharedState.CurrentBuilder.Call(allocateArray, countValue);
                         this.SharedState.ScopeMgr.RegisterAllocatedQubits(allocation);
-                        return allocation;
+                        return this.SharedState.Values.From(allocation, init.Type);
                     }
                     else if (init.Resolution is ResolvedInitializerKind.QubitTupleAllocation inits)
                     {
                         var items = inits.Item.Select(Allocate).ToArray();
-                        return this.SharedState.CreateTuple(this.SharedState.CurrentBuilder, items).TypedPointer;
+                        return this.SharedState.CreateTuple(this.SharedState.CurrentBuilder, items);
                     }
                     else
                     {
@@ -203,7 +202,7 @@ namespace Microsoft.Quantum.QsCompiler.QIR
             {
                 // Evaluate the test, which should be a Boolean at this point
                 var test = clauses[n].Item1;
-                var testValue = this.SharedState.EvaluateSubexpression(test);
+                var testValue = this.SharedState.EvaluateSubexpression(test).Value;
                 var conditionalBlock = this.SharedState.CurrentFunction.InsertBasicBlock(
                             this.SharedState.GenerateUniqueName($"then{n}"), contBlock);
 
@@ -251,7 +250,8 @@ namespace Microsoft.Quantum.QsCompiler.QIR
 
             // Release any resources (qubits or memory) before we fail.
             this.SharedState.ScopeMgr.ExitFunction(message);
-            this.SharedState.CurrentBuilder.Call(this.SharedState.GetOrCreateRuntimeFunction(RuntimeLibrary.Fail), message);
+            var fail = this.SharedState.GetOrCreateRuntimeFunction(RuntimeLibrary.Fail);
+            this.SharedState.CurrentBuilder.Call(fail, message.Value);
             this.SharedState.CurrentBuilder.Unreachable();
 
             return QsStatementKind.EmptyStatement;
@@ -276,7 +276,8 @@ namespace Microsoft.Quantum.QsCompiler.QIR
                     var loopVarName = stm.LoopItem.Item1 is SymbolTuple.VariableName name
                         ? name.Item
                         : throw new ArgumentException("invalid loop variable name");
-                    this.SharedState.ScopeMgr.RegisterVariable(loopVarName, loopVariable);
+                    var variableValue = this.SharedState.Values.From(loopVariable, ResolvedType.New(QsResolvedTypeKind.Int));
+                    this.SharedState.ScopeMgr.RegisterVariable(loopVarName, variableValue);
                     this.Transformation.Statements.OnScope(stm.Body);
                 }
 
@@ -285,16 +286,15 @@ namespace Microsoft.Quantum.QsCompiler.QIR
             }
             else if (stm.IterationValues.ResolvedType.Resolution.IsArrayType)
             {
-                void ExecuteBody(Value arrayItem)
+                void ExecuteBody(IValue arrayItem)
                 {
                     // If we iterate through an array, we inject a binding at the beginning of the body.
                     this.BindSymbolTuple(stm.LoopItem.Item1, arrayItem, stm.LoopItem.Item2);
                     this.Transformation.Statements.OnScope(stm.Body);
                 }
 
-                var itemType = this.SharedState.LlvmTypeFromQsharpType(stm.LoopItem.Item2);
-                var array = this.SharedState.EvaluateSubexpression(stm.IterationValues);
-                this.SharedState.IterateThroughArray(itemType, array, ExecuteBody);
+                var array = (ArrayValue)this.SharedState.EvaluateSubexpression(stm.IterationValues);
+                this.SharedState.IterateThroughArray(array, ExecuteBody);
             }
             else
             {
@@ -341,7 +341,7 @@ namespace Microsoft.Quantum.QsCompiler.QIR
             }
 
             this.SharedState.SetCurrentBlock(testBlock);
-            var test = this.SharedState.EvaluateSubexpression(stm.SuccessCondition);
+            var test = this.SharedState.EvaluateSubexpression(stm.SuccessCondition).Value;
             this.SharedState.CurrentBuilder.Branch(test, contBlock, fixupBlock);
 
             this.SharedState.SetCurrentBlock(fixupBlock);
@@ -360,7 +360,7 @@ namespace Microsoft.Quantum.QsCompiler.QIR
 
         public override QsStatementKind OnReturnStatement(TypedExpression ex)
         {
-            Value result = this.SharedState.EvaluateSubexpression(ex);
+            var result = this.SharedState.EvaluateSubexpression(ex);
             this.SharedState.AddReturn(result, ex.ResolvedType.Resolution.IsUnitType);
             return QsStatementKind.EmptyStatement;
         }
@@ -368,23 +368,29 @@ namespace Microsoft.Quantum.QsCompiler.QIR
         public override QsStatementKind OnValueUpdate(QsValueUpdate stm)
         {
             // Update an item, which might be a single symbol or a tuple, to a new Value
-            void UpdateItem(TypedExpression symbols, Value value)
+            void UpdateItem(TypedExpression symbols, IValue rhs)
             {
                 if (symbols.Expression is ResolvedExpression.Identifier id && id.Item1 is Identifier.LocalVariable varName)
                 {
                     Value ptr = this.SharedState.ScopeMgr.GetNamedPointer(varName.Item);
-                    this.SharedState.ScopeMgr.DecreaseAccessCount(ptr);
-                    this.SharedState.CurrentBuilder.Store(value, ptr);
-                    this.SharedState.ScopeMgr.IncreaseAccessCount(value);
+                    var loadedOriginal = this.SharedState.CurrentBuilder.Load(rhs.Value.NativeType, ptr);
+                    var originalValue = this.SharedState.Values.From(loadedOriginal, rhs.QSharpType);
+                    this.SharedState.ScopeMgr.DecreaseAccessCount(originalValue);
+                    this.SharedState.CurrentBuilder.Store(rhs.Value, ptr);
+                    this.SharedState.ScopeMgr.IncreaseAccessCount(rhs);
                 }
-                else if (symbols.Expression is ResolvedExpression.ValueTuple tuple)
+                else if (symbols.Expression is ResolvedExpression.ValueTuple ids)
                 {
-                    var itemTypes = tuple.Item.Select(i => this.SharedState.LlvmTypeFromQsharpType(i.ResolvedType)).ToArray();
-                    var tupleType = this.SharedState.Types.TypedTuple(itemTypes);
-                    var tupleItems = this.SharedState.GetTupleElements(tupleType, value);
+                    var tuple = (TupleValue)rhs;
+                    var tupleItems = tuple.GetTupleElements();
+                    if (tupleItems.Length != ids.Item.Length)
+                    {
+                        throw new InvalidOperationException("shape mismatch in value update");
+                    }
+
                     for (int i = 0; i < tupleItems.Length; i++)
                     {
-                        UpdateItem(tuple.Item[i], tupleItems[i]);
+                        UpdateItem(ids.Item[i], tupleItems[i]);
                     }
                 }
                 else
@@ -425,7 +431,7 @@ namespace Microsoft.Quantum.QsCompiler.QIR
             // The OpenScope is almost certainly unnecessary, but it is technically possible for the condition
             // expression to perform an allocation that needs to get cleaned up, so...
             this.SharedState.ScopeMgr.OpenScope();
-            var test = this.SharedState.EvaluateSubexpression(stm.Condition);
+            var test = this.SharedState.EvaluateSubexpression(stm.Condition).Value;
             this.SharedState.ScopeMgr.CloseScope(this.SharedState.CurrentBlock?.Terminator != null);
             this.SharedState.CurrentBuilder.Branch(test, bodyBlock, contBlock);
 

--- a/src/QsCompiler/QirGeneration/Subtransformations/TypeTransformation.cs
+++ b/src/QsCompiler/QirGeneration/Subtransformations/TypeTransformation.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Immutable;
-using System.Linq;
 using Microsoft.Quantum.QsCompiler.SyntaxTokens;
 using Microsoft.Quantum.QsCompiler.SyntaxTree;
 using Microsoft.Quantum.QsCompiler.Transformations.Core;

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestArrayLoop.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestArrayLoop.ll
@@ -1,62 +1,104 @@
 define { i64, i64 }* @Microsoft__Quantum__Testing__QIR__TestArrayLoop__body(%Array* %a) {
 entry:
-  call void @__quantum__rt__array_add_access(%Array* %a)
-  %0 = call %Tuple* @__quantum__rt__tuple_create(i64 mul nuw (i64 ptrtoint (i64* getelementptr (i64, i64* null, i32 1) to i64), i64 2))
-  %1 = bitcast %Tuple* %0 to { i64, i64 }*
-  %2 = getelementptr { i64, i64 }, { i64, i64 }* %1, i64 0, i32 0
-  %3 = getelementptr { i64, i64 }, { i64, i64 }* %1, i64 0, i32 1
-  store i64 0, i64* %2
-  store i64 0, i64* %3
-  %4 = getelementptr { i64, i64 }, { i64, i64 }* %1, i64 0, i32 0
-  %5 = load i64, i64* %4
-  %x = alloca i64
-  store i64 %5, i64* %x
-  %6 = getelementptr { i64, i64 }, { i64, i64 }* %1, i64 0, i32 1
-  %7 = load i64, i64* %6
-  %y = alloca i64
-  store i64 %7, i64* %y
-  %8 = call i64 @__quantum__rt__array_get_size_1d(%Array* %a)
-  %9 = sub i64 %8, 1
+  %0 = call i64 @__quantum__rt__array_get_size_1d(%Array* %a)
+  %1 = sub i64 %0, 1
   br label %header__1
 
 header__1:                                        ; preds = %exiting__1, %entry
-  %10 = phi i64 [ 0, %entry ], [ %21, %exiting__1 ]
-  %11 = icmp sle i64 %10, %9
-  br i1 %11, label %body__1, label %exit__1
+  %2 = phi i64 [ 0, %entry ], [ %8, %exiting__1 ]
+  %3 = icmp sle i64 %2, %1
+  br i1 %3, label %body__1, label %exit__1
 
 body__1:                                          ; preds = %header__1
-  %12 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %a, i64 %10)
-  %13 = bitcast i8* %12 to { i64, i64 }**
-  %z = load { i64, i64 }*, { i64, i64 }** %13
-  %14 = bitcast { i64, i64 }* %z to %Tuple*
-  call void @__quantum__rt__tuple_add_access(%Tuple* %14)
-  %15 = getelementptr { i64, i64 }, { i64, i64 }* %z, i64 0, i32 0
-  %j = load i64, i64* %15
-  %16 = getelementptr { i64, i64 }, { i64, i64 }* %z, i64 0, i32 1
-  %k = load i64, i64* %16
-  %17 = load i64, i64* %x
-  %18 = add i64 %17, %j
-  store i64 %18, i64* %x
-  %19 = load i64, i64* %y
-  %20 = add i64 %19, %k
-  store i64 %20, i64* %y
-  call void @__quantum__rt__tuple_remove_access(%Tuple* %14)
+  %4 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %a, i64 %2)
+  %5 = bitcast i8* %4 to { i64, i64 }**
+  %6 = load { i64, i64 }*, { i64, i64 }** %5
+  %7 = bitcast { i64, i64 }* %6 to %Tuple*
+  call void @__quantum__rt__tuple_add_access(%Tuple* %7)
   br label %exiting__1
 
 exiting__1:                                       ; preds = %body__1
-  %21 = add i64 %10, 1
+  %8 = add i64 %2, 1
   br label %header__1
 
 exit__1:                                          ; preds = %header__1
-  %22 = load i64, i64* %x
-  %23 = load i64, i64* %y
-  %24 = call %Tuple* @__quantum__rt__tuple_create(i64 mul nuw (i64 ptrtoint (i64* getelementptr (i64, i64* null, i32 1) to i64), i64 2))
-  %25 = bitcast %Tuple* %24 to { i64, i64 }*
-  %26 = getelementptr { i64, i64 }, { i64, i64 }* %25, i64 0, i32 0
-  %27 = getelementptr { i64, i64 }, { i64, i64 }* %25, i64 0, i32 1
-  store i64 %22, i64* %26
-  store i64 %23, i64* %27
+  call void @__quantum__rt__array_add_access(%Array* %a)
+  %9 = call %Tuple* @__quantum__rt__tuple_create(i64 mul nuw (i64 ptrtoint (i64* getelementptr (i64, i64* null, i32 1) to i64), i64 2))
+  %10 = bitcast %Tuple* %9 to { i64, i64 }*
+  %11 = getelementptr { i64, i64 }, { i64, i64 }* %10, i64 0, i32 0
+  %12 = getelementptr { i64, i64 }, { i64, i64 }* %10, i64 0, i32 1
+  store i64 0, i64* %11
+  store i64 0, i64* %12
+  %13 = getelementptr { i64, i64 }, { i64, i64 }* %10, i64 0, i32 0
+  %14 = load i64, i64* %13
+  %x = alloca i64
+  store i64 %14, i64* %x
+  %15 = getelementptr { i64, i64 }, { i64, i64 }* %10, i64 0, i32 1
+  %16 = load i64, i64* %15
+  %y = alloca i64
+  store i64 %16, i64* %y
+  %17 = sub i64 %0, 1
+  br label %header__2
+
+header__2:                                        ; preds = %exiting__2, %exit__1
+  %18 = phi i64 [ 0, %exit__1 ], [ %29, %exiting__2 ]
+  %19 = icmp sle i64 %18, %17
+  br i1 %19, label %body__2, label %exit__2
+
+body__2:                                          ; preds = %header__2
+  %20 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %a, i64 %18)
+  %21 = bitcast i8* %20 to { i64, i64 }**
+  %z = load { i64, i64 }*, { i64, i64 }** %21
+  %22 = bitcast { i64, i64 }* %z to %Tuple*
+  call void @__quantum__rt__tuple_add_access(%Tuple* %22)
+  %23 = getelementptr { i64, i64 }, { i64, i64 }* %z, i64 0, i32 0
+  %j = load i64, i64* %23
+  %24 = getelementptr { i64, i64 }, { i64, i64 }* %z, i64 0, i32 1
+  %k = load i64, i64* %24
+  %25 = load i64, i64* %x
+  %26 = add i64 %25, %j
+  store i64 %26, i64* %x
+  %27 = load i64, i64* %y
+  %28 = add i64 %27, %k
+  store i64 %28, i64* %y
+  call void @__quantum__rt__tuple_remove_access(%Tuple* %22)
+  br label %exiting__2
+
+exiting__2:                                       ; preds = %body__2
+  %29 = add i64 %18, 1
+  br label %header__2
+
+exit__2:                                          ; preds = %header__2
+  %30 = load i64, i64* %x
+  %31 = load i64, i64* %y
+  %32 = call %Tuple* @__quantum__rt__tuple_create(i64 mul nuw (i64 ptrtoint (i64* getelementptr (i64, i64* null, i32 1) to i64), i64 2))
+  %33 = bitcast %Tuple* %32 to { i64, i64 }*
+  %34 = getelementptr { i64, i64 }, { i64, i64 }* %33, i64 0, i32 0
+  %35 = getelementptr { i64, i64 }, { i64, i64 }* %33, i64 0, i32 1
+  store i64 %30, i64* %34
+  store i64 %31, i64* %35
+  %36 = sub i64 %0, 1
+  br label %header__3
+
+header__3:                                        ; preds = %exiting__3, %exit__2
+  %37 = phi i64 [ 0, %exit__2 ], [ %43, %exiting__3 ]
+  %38 = icmp sle i64 %37, %36
+  br i1 %38, label %body__3, label %exit__3
+
+body__3:                                          ; preds = %header__3
+  %39 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %a, i64 %37)
+  %40 = bitcast i8* %39 to { i64, i64 }**
+  %41 = load { i64, i64 }*, { i64, i64 }** %40
+  %42 = bitcast { i64, i64 }* %41 to %Tuple*
+  call void @__quantum__rt__tuple_remove_access(%Tuple* %42)
+  br label %exiting__3
+
+exiting__3:                                       ; preds = %body__3
+  %43 = add i64 %37, 1
+  br label %header__3
+
+exit__3:                                          ; preds = %header__3
   call void @__quantum__rt__array_remove_access(%Array* %a)
-  call void @__quantum__rt__tuple_unreference(%Tuple* %0)
-  ret { i64, i64 }* %25
+  call void @__quantum__rt__tuple_unreference(%Tuple* %9)
+  ret { i64, i64 }* %33
 }

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestArrayLoop.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestArrayLoop.ll
@@ -1,5 +1,6 @@
 define { i64, i64 }* @Microsoft__Quantum__Testing__QIR__TestArrayLoop__body(%Array* %a) {
 entry:
+  call void @__quantum__rt__array_add_access(%Array* %a)
   %0 = call %Tuple* @__quantum__rt__tuple_create(i64 mul nuw (i64 ptrtoint (i64* getelementptr (i64, i64* null, i32 1) to i64), i64 2))
   %1 = bitcast %Tuple* %0 to { i64, i64 }*
   %2 = getelementptr { i64, i64 }, { i64, i64 }* %1, i64 0, i32 0
@@ -7,11 +8,11 @@ entry:
   store i64 0, i64* %2
   store i64 0, i64* %3
   %4 = getelementptr { i64, i64 }, { i64, i64 }* %1, i64 0, i32 0
-  %5 = getelementptr { i64, i64 }, { i64, i64 }* %1, i64 0, i32 1
-  %6 = load i64, i64* %4
+  %5 = load i64, i64* %4
   %x = alloca i64
-  store i64 %6, i64* %x
-  %7 = load i64, i64* %5
+  store i64 %5, i64* %x
+  %6 = getelementptr { i64, i64 }, { i64, i64 }* %1, i64 0, i32 1
+  %7 = load i64, i64* %6
   %y = alloca i64
   store i64 %7, i64* %y
   %8 = call i64 @__quantum__rt__array_get_size_1d(%Array* %a)
@@ -19,7 +20,7 @@ entry:
   br label %header__1
 
 header__1:                                        ; preds = %exiting__1, %entry
-  %10 = phi i64 [ 0, %entry ], [ %20, %exiting__1 ]
+  %10 = phi i64 [ 0, %entry ], [ %21, %exiting__1 ]
   %11 = icmp sle i64 %10, %9
   br i1 %11, label %body__1, label %exit__1
 
@@ -27,32 +28,35 @@ body__1:                                          ; preds = %header__1
   %12 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %a, i64 %10)
   %13 = bitcast i8* %12 to { i64, i64 }**
   %z = load { i64, i64 }*, { i64, i64 }** %13
-  %14 = getelementptr { i64, i64 }, { i64, i64 }* %z, i64 0, i32 0
-  %15 = getelementptr { i64, i64 }, { i64, i64 }* %z, i64 0, i32 1
-  %j = load i64, i64* %14
-  %k = load i64, i64* %15
-  %16 = load i64, i64* %x
-  %17 = add i64 %16, %j
-  store i64 %17, i64* %x
-  %18 = load i64, i64* %y
-  %19 = add i64 %18, %k
-  store i64 %19, i64* %y
+  %14 = bitcast { i64, i64 }* %z to %Tuple*
+  call void @__quantum__rt__tuple_add_access(%Tuple* %14)
+  %15 = getelementptr { i64, i64 }, { i64, i64 }* %z, i64 0, i32 0
+  %j = load i64, i64* %15
+  %16 = getelementptr { i64, i64 }, { i64, i64 }* %z, i64 0, i32 1
+  %k = load i64, i64* %16
+  %17 = load i64, i64* %x
+  %18 = add i64 %17, %j
+  store i64 %18, i64* %x
+  %19 = load i64, i64* %y
+  %20 = add i64 %19, %k
+  store i64 %20, i64* %y
+  call void @__quantum__rt__tuple_remove_access(%Tuple* %14)
   br label %exiting__1
 
 exiting__1:                                       ; preds = %body__1
-  %20 = add i64 %10, 1
+  %21 = add i64 %10, 1
   br label %header__1
 
 exit__1:                                          ; preds = %header__1
-  %21 = load i64, i64* %x
-  %22 = load i64, i64* %y
-  %23 = call %Tuple* @__quantum__rt__tuple_create(i64 mul nuw (i64 ptrtoint (i64* getelementptr (i64, i64* null, i32 1) to i64), i64 2))
-  %24 = bitcast %Tuple* %23 to { i64, i64 }*
-  %25 = getelementptr { i64, i64 }, { i64, i64 }* %24, i64 0, i32 0
-  %26 = getelementptr { i64, i64 }, { i64, i64 }* %24, i64 0, i32 1
-  store i64 %21, i64* %25
+  %22 = load i64, i64* %x
+  %23 = load i64, i64* %y
+  %24 = call %Tuple* @__quantum__rt__tuple_create(i64 mul nuw (i64 ptrtoint (i64* getelementptr (i64, i64* null, i32 1) to i64), i64 2))
+  %25 = bitcast %Tuple* %24 to { i64, i64 }*
+  %26 = getelementptr { i64, i64 }, { i64, i64 }* %25, i64 0, i32 0
+  %27 = getelementptr { i64, i64 }, { i64, i64 }* %25, i64 0, i32 1
   store i64 %22, i64* %26
-  %27 = bitcast { i64, i64 }* %1 to %Tuple*
-  call void @__quantum__rt__tuple_unreference(%Tuple* %27)
-  ret { i64, i64 }* %24
+  store i64 %23, i64* %27
+  call void @__quantum__rt__array_remove_access(%Array* %a)
+  call void @__quantum__rt__tuple_unreference(%Tuple* %0)
+  ret { i64, i64 }* %25
 }

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestArrayUpdate.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestArrayUpdate.ll
@@ -1,17 +1,25 @@
 define %Array* @Microsoft__Quantum__Testing__QIR__TestArrayUpdate__body(%Array* %y, i64 %a, i64 %b) {
 entry:
+  call void @__quantum__rt__array_add_access(%Array* %y)
   %x = alloca %Array*
   store %Array* %y, %Array** %x
   %0 = load %Array*, %Array** %x
-  %1 = call %Array* @__quantum__rt__array_copy(%Array* %0)
-  %2 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %1, i64 %a)
-  %3 = bitcast i8* %2 to i64*
-  store i64 %b, i64* %3
-  %4 = load %Array*, %Array** %x
-  store %Array* %1, %Array** %x
-  call void @__quantum__rt__array_reference(%Array* %1)
-  %5 = load %Array*, %Array** %x
-  call void @__quantum__rt__array_unreference(%Array* %1)
-  call void @__quantum__rt__array_unreference(%Array* %4)
-  ret %Array* %5
+  call void @__quantum__rt__array_add_access(%Array* %0)
+  %1 = load %Array*, %Array** %x
+  %2 = call %Array* @__quantum__rt__array_copy(%Array* %1, i1 false)
+  %3 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %2, i64 %a)
+  %4 = bitcast i8* %3 to i64*
+  %5 = load i64, i64* %4
+  store i64 %b, i64* %4
+  %6 = load %Array*, %Array** %x
+  call void @__quantum__rt__array_remove_access(%Array* %6)
+  store %Array* %2, %Array** %x
+  call void @__quantum__rt__array_add_access(%Array* %2)
+  %7 = load %Array*, %Array** %x
+  call void @__quantum__rt__array_reference(%Array* %7)
+  call void @__quantum__rt__array_remove_access(%Array* %y)
+  %8 = load %Array*, %Array** %x
+  call void @__quantum__rt__array_remove_access(%Array* %8)
+  call void @__quantum__rt__array_unreference(%Array* %2)
+  ret %Array* %7
 }

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestBigInts.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestBigInts.ll
@@ -17,6 +17,7 @@ entry:
   call void @__quantum__rt__bigint_unreference(%BigInt* %3)
   call void @__quantum__rt__bigint_unreference(%BigInt* %d)
   call void @__quantum__rt__bigint_unreference(%BigInt* %e)
+  call void @__quantum__rt__bigint_unreference(%BigInt* %f)
   call void @__quantum__rt__bigint_unreference(%BigInt* %4)
   call void @__quantum__rt__bigint_unreference(%BigInt* %5)
   call void @__quantum__rt__bigint_unreference(%BigInt* %g)

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestConditional.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestConditional.ll
@@ -1,17 +1,29 @@
 ﻿define i64 @Microsoft__Quantum__Testing__QIR__ReturnInt__body({ %Array* }* %arg) {
 entry:
   %0 = getelementptr { %Array* }, { %Array* }* %arg, i64 0, i32 0
-  %.arg = load %Array*, %Array** %0
-  call void @__quantum__rt__array_reference(%Array* %.arg)
-  %1 = call i64 @__quantum__qis__drawrandom__body(%Array* %.arg)
-  %2 = icmp slt i64 %1, 0
-  br i1 %2, label %then0__1, label %else__1
+  %1 = load %Array*, %Array** %0
+  call void @__quantum__rt__array_add_access(%Array* %1)
+  %2 = bitcast { %Array* }* %arg to %Tuple*
+  call void @__quantum__rt__tuple_add_access(%Tuple* %2)
+  %3 = getelementptr { %Array* }, { %Array* }* %arg, i64 0, i32 0
+  %arg__inline__1 = load %Array*, %Array** %3
+  call void @__quantum__rt__array_add_access(%Array* %arg__inline__1)
+  %4 = call i64 @__quantum__qis__drawrandom__body(%Array* %arg__inline__1)
+  call void @__quantum__rt__array_remove_access(%Array* %arg__inline__1)
+  %5 = icmp slt i64 %4, 0
+  br i1 %5, label %then0__1, label %else__1
 
 then0__1:                                         ; preds = %entry
-  call void @__quantum__rt__array_unreference(%Array* %.arg)
+  %6 = getelementptr { %Array* }, { %Array* }* %arg, i64 0, i32 0
+  %7 = load %Array*, %Array** %6
+  call void @__quantum__rt__array_remove_access(%Array* %7)
+  call void @__quantum__rt__tuple_remove_access(%Tuple* %2)
   ret i64 1
 
 else__1:                                          ; preds = %entry
-  call void @__quantum__rt__array_unreference(%Array* %.arg)
+  %8 = getelementptr { %Array* }, { %Array* }* %arg, i64 0, i32 0
+  %9 = load %Array*, %Array** %8
+  call void @__quantum__rt__array_remove_access(%Array* %9)
+  call void @__quantum__rt__tuple_remove_access(%Tuple* %2)
   ret i64 0
 }

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestControlled1.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestControlled1.ll
@@ -1,44 +1,41 @@
 ﻿define void @Lifted__PartialApplication__1__ctl__wrapper(%Tuple* %capture-tuple, %Tuple* %arg-tuple, %Tuple* %result-tuple) {
 entry:
-  %0 = bitcast %Tuple* %capture-tuple to { %Callable*, i64 }*
-  %1 = bitcast %Tuple* %arg-tuple to { %Array*, %Qubit* }*
-  %2 = getelementptr { %Array*, %Qubit* }, { %Array*, %Qubit* }* %1, i64 0, i32 0
-  %3 = getelementptr { %Array*, %Qubit* }, { %Array*, %Qubit* }* %1, i64 0, i32 1
-  %4 = load %Array*, %Array** %2
-  %5 = load %Qubit*, %Qubit** %3
-  %6 = getelementptr { %Callable*, i64 }, { %Callable*, i64 }* %0, i64 0, i32 1
+  %0 = bitcast %Tuple* %arg-tuple to { %Array*, %Qubit* }*
+  %1 = getelementptr { %Array*, %Qubit* }, { %Array*, %Qubit* }* %0, i64 0, i32 0
+  %2 = getelementptr { %Array*, %Qubit* }, { %Array*, %Qubit* }* %0, i64 0, i32 1
+  %3 = load %Array*, %Array** %1
+  %4 = load %Qubit*, %Qubit** %2
+  %5 = bitcast %Tuple* %capture-tuple to { %Callable*, i64 }*
+  %6 = getelementptr { %Callable*, i64 }, { %Callable*, i64 }* %5, i64 0, i32 1
   %7 = load i64, i64* %6
   %8 = call %Tuple* @__quantum__rt__tuple_create(i64 ptrtoint ({ %Qubit*, i64 }* getelementptr ({ %Qubit*, i64 }, { %Qubit*, i64 }* null, i32 1) to i64))
   %9 = bitcast %Tuple* %8 to { %Qubit*, i64 }*
   %10 = getelementptr { %Qubit*, i64 }, { %Qubit*, i64 }* %9, i64 0, i32 0
   %11 = getelementptr { %Qubit*, i64 }, { %Qubit*, i64 }* %9, i64 0, i32 1
-  store %Qubit* %5, %Qubit** %10
+  store %Qubit* %4, %Qubit** %10
   store i64 %7, i64* %11
   %12 = call %Tuple* @__quantum__rt__tuple_create(i64 mul nuw (i64 ptrtoint (i1** getelementptr (i1*, i1** null, i32 1) to i64), i64 2))
   %13 = bitcast %Tuple* %12 to { %Array*, { %Qubit*, i64 }* }*
   %14 = getelementptr { %Array*, { %Qubit*, i64 }* }, { %Array*, { %Qubit*, i64 }* }* %13, i64 0, i32 0
   %15 = getelementptr { %Array*, { %Qubit*, i64 }* }, { %Array*, { %Qubit*, i64 }* }* %13, i64 0, i32 1
-  store %Array* %4, %Array** %14
-  call void @__quantum__rt__array_reference(%Array* %4)
+  store %Array* %3, %Array** %14
+  call void @__quantum__rt__array_reference(%Array* %3)
   store { %Qubit*, i64 }* %9, { %Qubit*, i64 }** %15
-  %16 = bitcast { %Qubit*, i64 }* %9 to %Tuple*
-  call void @__quantum__rt__tuple_reference(%Tuple* %16)
-  %17 = getelementptr { %Callable*, i64 }, { %Callable*, i64 }* %0, i64 0, i32 0
-  %18 = load %Callable*, %Callable** %17
-  %19 = call %Callable* @__quantum__rt__callable_copy(%Callable* %18)
-  call void @__quantum__rt__callable_make_controlled(%Callable* %19)
-  call void @__quantum__rt__callable_invoke(%Callable* %19, %Tuple* %12, %Tuple* %result-tuple)
-  %20 = bitcast { %Qubit*, i64 }* %9 to %Tuple*
-  call void @__quantum__rt__tuple_unreference(%Tuple* %20)
-  %21 = getelementptr { %Array*, { %Qubit*, i64 }* }, { %Array*, { %Qubit*, i64 }* }* %13, i64 0, i32 0
-  %22 = load %Array*, %Array** %21
-  call void @__quantum__rt__array_unreference(%Array* %22)
-  %23 = getelementptr { %Array*, { %Qubit*, i64 }* }, { %Array*, { %Qubit*, i64 }* }* %13, i64 0, i32 1
-  %24 = load { %Qubit*, i64 }*, { %Qubit*, i64 }** %23
-  %25 = bitcast { %Qubit*, i64 }* %24 to %Tuple*
-  call void @__quantum__rt__tuple_unreference(%Tuple* %25)
-  %26 = bitcast { %Array*, { %Qubit*, i64 }* }* %13 to %Tuple*
-  call void @__quantum__rt__tuple_unreference(%Tuple* %26)
-  call void @__quantum__rt__callable_unreference(%Callable* %19)
+  call void @__quantum__rt__tuple_reference(%Tuple* %8)
+  %16 = getelementptr { %Callable*, i64 }, { %Callable*, i64 }* %5, i64 0, i32 0
+  %17 = load %Callable*, %Callable** %16
+  %18 = call %Callable* @__quantum__rt__callable_copy(%Callable* %17, i1 true)
+  call void @__quantum__rt__callable_make_controlled(%Callable* %18)
+  call void @__quantum__rt__callable_invoke(%Callable* %18, %Tuple* %12, %Tuple* %result-tuple)
+  call void @__quantum__rt__tuple_unreference(%Tuple* %8)
+  %19 = getelementptr { %Array*, { %Qubit*, i64 }* }, { %Array*, { %Qubit*, i64 }* }* %13, i64 0, i32 0
+  %20 = load %Array*, %Array** %19
+  call void @__quantum__rt__array_unreference(%Array* %20)
+  %21 = getelementptr { %Array*, { %Qubit*, i64 }* }, { %Array*, { %Qubit*, i64 }* }* %13, i64 0, i32 1
+  %22 = load { %Qubit*, i64 }*, { %Qubit*, i64 }** %21
+  %23 = bitcast { %Qubit*, i64 }* %22 to %Tuple*
+  call void @__quantum__rt__tuple_unreference(%Tuple* %23)
+  call void @__quantum__rt__tuple_unreference(%Tuple* %12)
+  call void @__quantum__rt__callable_unreference(%Callable* %18)
   ret void
 }

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestControlled2.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestControlled2.ll
@@ -1,46 +1,43 @@
 ﻿define void @Lifted__PartialApplication__2__ctl__wrapper(%Tuple* %capture-tuple, %Tuple* %arg-tuple, %Tuple* %result-tuple) {
 entry:
-  %0 = bitcast %Tuple* %capture-tuple to { %Callable* }*
-  %1 = bitcast %Tuple* %arg-tuple to { %Array*, { %Qubit*, i64 }* }*
-  %2 = getelementptr { %Array*, { %Qubit*, i64 }* }, { %Array*, { %Qubit*, i64 }* }* %1, i64 0, i32 0
-  %3 = getelementptr { %Array*, { %Qubit*, i64 }* }, { %Array*, { %Qubit*, i64 }* }* %1, i64 0, i32 1
-  %4 = load %Array*, %Array** %2
-  %5 = load { %Qubit*, i64 }*, { %Qubit*, i64 }** %3
-  %6 = getelementptr { %Qubit*, i64 }, { %Qubit*, i64 }* %5, i64 0, i32 0
-  %7 = load %Qubit*, %Qubit** %6
-  %8 = getelementptr { %Qubit*, i64 }, { %Qubit*, i64 }* %5, i64 0, i32 1
-  %9 = load i64, i64* %8
-  %10 = call %Tuple* @__quantum__rt__tuple_create(i64 ptrtoint ({ %Qubit*, i64 }* getelementptr ({ %Qubit*, i64 }, { %Qubit*, i64 }* null, i32 1) to i64))
-  %11 = bitcast %Tuple* %10 to { %Qubit*, i64 }*
-  %12 = getelementptr { %Qubit*, i64 }, { %Qubit*, i64 }* %11, i64 0, i32 0
-  %13 = getelementptr { %Qubit*, i64 }, { %Qubit*, i64 }* %11, i64 0, i32 1
-  store %Qubit* %7, %Qubit** %12
-  store i64 %9, i64* %13
-  %14 = call %Tuple* @__quantum__rt__tuple_create(i64 mul nuw (i64 ptrtoint (i1** getelementptr (i1*, i1** null, i32 1) to i64), i64 2))
-  %15 = bitcast %Tuple* %14 to { %Array*, { %Qubit*, i64 }* }*
-  %16 = getelementptr { %Array*, { %Qubit*, i64 }* }, { %Array*, { %Qubit*, i64 }* }* %15, i64 0, i32 0
-  %17 = getelementptr { %Array*, { %Qubit*, i64 }* }, { %Array*, { %Qubit*, i64 }* }* %15, i64 0, i32 1
-  store %Array* %4, %Array** %16
-  call void @__quantum__rt__array_reference(%Array* %4)
-  store { %Qubit*, i64 }* %11, { %Qubit*, i64 }** %17
-  %18 = bitcast { %Qubit*, i64 }* %11 to %Tuple*
-  call void @__quantum__rt__tuple_reference(%Tuple* %18)
-  %19 = getelementptr { %Callable* }, { %Callable* }* %0, i64 0, i32 0
-  %20 = load %Callable*, %Callable** %19
-  %21 = call %Callable* @__quantum__rt__callable_copy(%Callable* %20)
-  call void @__quantum__rt__callable_make_controlled(%Callable* %21)
-  call void @__quantum__rt__callable_invoke(%Callable* %21, %Tuple* %14, %Tuple* %result-tuple)
-  %22 = bitcast { %Qubit*, i64 }* %11 to %Tuple*
-  call void @__quantum__rt__tuple_unreference(%Tuple* %22)
-  %23 = getelementptr { %Array*, { %Qubit*, i64 }* }, { %Array*, { %Qubit*, i64 }* }* %15, i64 0, i32 0
-  %24 = load %Array*, %Array** %23
-  call void @__quantum__rt__array_unreference(%Array* %24)
-  %25 = getelementptr { %Array*, { %Qubit*, i64 }* }, { %Array*, { %Qubit*, i64 }* }* %15, i64 0, i32 1
-  %26 = load { %Qubit*, i64 }*, { %Qubit*, i64 }** %25
-  %27 = bitcast { %Qubit*, i64 }* %26 to %Tuple*
-  call void @__quantum__rt__tuple_unreference(%Tuple* %27)
-  %28 = bitcast { %Array*, { %Qubit*, i64 }* }* %15 to %Tuple*
-  call void @__quantum__rt__tuple_unreference(%Tuple* %28)
-  call void @__quantum__rt__callable_unreference(%Callable* %21)
+  %0 = bitcast %Tuple* %arg-tuple to { %Array*, { %Qubit*, i64 }* }*
+  %1 = getelementptr { %Array*, { %Qubit*, i64 }* }, { %Array*, { %Qubit*, i64 }* }* %0, i64 0, i32 0
+  %2 = getelementptr { %Array*, { %Qubit*, i64 }* }, { %Array*, { %Qubit*, i64 }* }* %0, i64 0, i32 1
+  %3 = load %Array*, %Array** %1
+  %4 = load { %Qubit*, i64 }*, { %Qubit*, i64 }** %2
+  %5 = getelementptr { %Qubit*, i64 }, { %Qubit*, i64 }* %4, i64 0, i32 0
+  %6 = load %Qubit*, %Qubit** %5
+  %7 = getelementptr { %Qubit*, i64 }, { %Qubit*, i64 }* %4, i64 0, i32 1
+  %8 = load i64, i64* %7
+  %9 = call %Tuple* @__quantum__rt__tuple_create(i64 ptrtoint ({ %Qubit*, i64 }* getelementptr ({ %Qubit*, i64 }, { %Qubit*, i64 }* null, i32 1) to i64))
+  %10 = bitcast %Tuple* %9 to { %Qubit*, i64 }*
+  %11 = getelementptr { %Qubit*, i64 }, { %Qubit*, i64 }* %10, i64 0, i32 0
+  %12 = getelementptr { %Qubit*, i64 }, { %Qubit*, i64 }* %10, i64 0, i32 1
+  store %Qubit* %6, %Qubit** %11
+  store i64 %8, i64* %12
+  %13 = call %Tuple* @__quantum__rt__tuple_create(i64 mul nuw (i64 ptrtoint (i1** getelementptr (i1*, i1** null, i32 1) to i64), i64 2))
+  %14 = bitcast %Tuple* %13 to { %Array*, { %Qubit*, i64 }* }*
+  %15 = getelementptr { %Array*, { %Qubit*, i64 }* }, { %Array*, { %Qubit*, i64 }* }* %14, i64 0, i32 0
+  %16 = getelementptr { %Array*, { %Qubit*, i64 }* }, { %Array*, { %Qubit*, i64 }* }* %14, i64 0, i32 1
+  store %Array* %3, %Array** %15
+  call void @__quantum__rt__array_reference(%Array* %3)
+  store { %Qubit*, i64 }* %10, { %Qubit*, i64 }** %16
+  call void @__quantum__rt__tuple_reference(%Tuple* %9)
+  %17 = bitcast %Tuple* %capture-tuple to { %Callable* }*
+  %18 = getelementptr { %Callable* }, { %Callable* }* %17, i64 0, i32 0
+  %19 = load %Callable*, %Callable** %18
+  %20 = call %Callable* @__quantum__rt__callable_copy(%Callable* %19, i1 true)
+  call void @__quantum__rt__callable_make_controlled(%Callable* %20)
+  call void @__quantum__rt__callable_invoke(%Callable* %20, %Tuple* %13, %Tuple* %result-tuple)
+  call void @__quantum__rt__tuple_unreference(%Tuple* %9)
+  %21 = getelementptr { %Array*, { %Qubit*, i64 }* }, { %Array*, { %Qubit*, i64 }* }* %14, i64 0, i32 0
+  %22 = load %Array*, %Array** %21
+  call void @__quantum__rt__array_unreference(%Array* %22)
+  %23 = getelementptr { %Array*, { %Qubit*, i64 }* }, { %Array*, { %Qubit*, i64 }* }* %14, i64 0, i32 1
+  %24 = load { %Qubit*, i64 }*, { %Qubit*, i64 }** %23
+  %25 = bitcast { %Qubit*, i64 }* %24 to %Tuple*
+  call void @__quantum__rt__tuple_unreference(%Tuple* %25)
+  call void @__quantum__rt__tuple_unreference(%Tuple* %13)
+  call void @__quantum__rt__callable_unreference(%Callable* %20)
   ret void
 }

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestDeclarations1.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestDeclarations1.ll
@@ -6,6 +6,8 @@ entry:
 
 define void @Microsoft__Quantum__Testing__QIR__SelfAdjointIntrinsic__ctl(%Array* %__controlQubits__, %Tuple* %__unitArg__) {
 entry:
+  call void @__quantum__rt__array_add_access(%Array* %__controlQubits__)
   call void @__quantum__qis__selfadjointintrinsic__ctl(%Array* %__controlQubits__, %Tuple* %__unitArg__)
+  call void @__quantum__rt__array_remove_access(%Array* %__controlQubits__)
   ret void
 }

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestDeclarations2.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestDeclarations2.ll
@@ -1,5 +1,7 @@
 define void @Microsoft__Quantum__Testing__QIR__SelfAdjointIntrinsic__ctladj(%Array* %__controlQubits__, %Tuple* %__unitArg__) {
 entry:
+  call void @__quantum__rt__array_add_access(%Array* %__controlQubits__)
   call void @__quantum__qis__selfadjointintrinsic__ctl(%Array* %__controlQubits__, %Tuple* %__unitArg__)
+  call void @__quantum__rt__array_remove_access(%Array* %__controlQubits__)
   ret void
 }

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestDeclarations5.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestDeclarations5.ll
@@ -1,4 +1,6 @@
 define void @Microsoft__Quantum__Testing__QIR__SelfAdjointOp__ctl(%Array* %__controlQubits__, %Tuple* %__unitArg__) {
 entry:
+  call void @__quantum__rt__array_add_access(%Array* %__controlQubits__)
+  call void @__quantum__rt__array_remove_access(%Array* %__controlQubits__)
   ret void
 }

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestDeclarations6.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestDeclarations6.ll
@@ -1,5 +1,7 @@
 define void @Microsoft__Quantum__Testing__QIR__SelfAdjointOp__ctladj(%Array* %__controlQubits__, %Tuple* %__unitArg__) {
 entry:
+  call void @__quantum__rt__array_add_access(%Array* %__controlQubits__)
   call void @Microsoft__Quantum__Testing__QIR__SelfAdjointOp__ctl(%Array* %__controlQubits__, %Tuple* %__unitArg__)
+  call void @__quantum__rt__array_remove_access(%Array* %__controlQubits__)
   ret void
 }

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestDeconstruct.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestDeconstruct.ll
@@ -8,29 +8,41 @@ entry:
   store { i64, i64 }* %1, { i64, i64 }** %4
   %5 = bitcast { i64, i64 }* %1 to %Tuple*
   call void @__quantum__rt__tuple_reference(%Tuple* %5)
-  %6 = getelementptr { i64, { i64, i64 }* }, { i64, { i64, i64 }* }* %a, i64 0, i32 0
-  %7 = getelementptr { i64, { i64, i64 }* }, { i64, { i64, i64 }* }* %a, i64 0, i32 1
-  %x = load i64, i64* %6
-  %y = load { i64, i64 }*, { i64, i64 }** %7
+  %6 = getelementptr { i64, { i64, i64 }* }, { i64, { i64, i64 }* }* %a, i64 0, i32 1
+  %7 = load { i64, i64 }*, { i64, i64 }** %6
+  %8 = bitcast { i64, i64 }* %7 to %Tuple*
+  call void @__quantum__rt__tuple_add_access(%Tuple* %8)
+  call void @__quantum__rt__tuple_add_access(%Tuple* %2)
+  %9 = getelementptr { i64, { i64, i64 }* }, { i64, { i64, i64 }* }* %a, i64 0, i32 0
+  %x = load i64, i64* %9
+  %10 = getelementptr { i64, { i64, i64 }* }, { i64, { i64, i64 }* }* %a, i64 0, i32 1
+  %y = load { i64, i64 }*, { i64, i64 }** %10
+  %11 = bitcast { i64, i64 }* %y to %Tuple*
+  call void @__quantum__rt__tuple_add_access(%Tuple* %11)
   %b = alloca i64
   store i64 3, i64* %b
   %c = alloca i64
   store i64 5, i64* %c
-  %8 = getelementptr { i64, i64 }, { i64, i64 }* %y, i64 0, i32 0
-  %9 = getelementptr { i64, i64 }, { i64, i64 }* %y, i64 0, i32 1
-  %10 = load i64, i64* %8
-  %11 = load i64, i64* %9
-  store i64 %10, i64* %b
-  store i64 %11, i64* %c
-  %12 = load i64, i64* %b
-  %13 = load i64, i64* %c
-  %14 = mul i64 %12, %13
-  %15 = add i64 %x, %14
-  %16 = getelementptr { i64, { i64, i64 }* }, { i64, { i64, i64 }* }* %a, i64 0, i32 1
-  %17 = load { i64, i64 }*, { i64, i64 }** %16
-  %18 = bitcast { i64, i64 }* %17 to %Tuple*
-  call void @__quantum__rt__tuple_unreference(%Tuple* %18)
-  %19 = bitcast { i64, { i64, i64 }* }* %a to %Tuple*
-  call void @__quantum__rt__tuple_unreference(%Tuple* %19)
-  ret i64 %15
+  %12 = getelementptr { i64, i64 }, { i64, i64 }* %y, i64 0, i32 0
+  %13 = getelementptr { i64, i64 }, { i64, i64 }* %y, i64 0, i32 1
+  %14 = load i64, i64* %12
+  %15 = load i64, i64* %13
+  store i64 %14, i64* %b
+  store i64 %15, i64* %c
+  %16 = load i64, i64* %b
+  %17 = load i64, i64* %c
+  %18 = mul i64 %16, %17
+  %19 = add i64 %x, %18
+  %20 = getelementptr { i64, { i64, i64 }* }, { i64, { i64, i64 }* }* %a, i64 0, i32 1
+  %21 = load { i64, i64 }*, { i64, i64 }** %20
+  %22 = bitcast { i64, i64 }* %21 to %Tuple*
+  call void @__quantum__rt__tuple_remove_access(%Tuple* %22)
+  call void @__quantum__rt__tuple_remove_access(%Tuple* %2)
+  call void @__quantum__rt__tuple_remove_access(%Tuple* %11)
+  %23 = getelementptr { i64, { i64, i64 }* }, { i64, { i64, i64 }* }* %a, i64 0, i32 1
+  %24 = load { i64, i64 }*, { i64, i64 }** %23
+  %25 = bitcast { i64, i64 }* %24 to %Tuple*
+  call void @__quantum__rt__tuple_unreference(%Tuple* %25)
+  call void @__quantum__rt__tuple_unreference(%Tuple* %2)
+  ret i64 %19
 }

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestExpressions.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestExpressions.ll
@@ -72,16 +72,79 @@ entry:
   %59 = bitcast { i64, { %Callable*, %String* }* }* %8 to %Tuple*
   call void @__quantum__rt__tuple_unreference(%Tuple* %59)
   call void @__quantum__rt__string_unreference(%String* %9)
+  %60 = call i64 @__quantum__rt__array_get_size_1d(%Array* %11)
+  %61 = sub i64 %60, 1
+  br label %header__1
+
+header__1:                                        ; preds = %exiting__1, %entry
+  %62 = phi i64 [ 0, %entry ], [ %67, %exiting__1 ]
+  %63 = icmp sle i64 %62, %61
+  br i1 %63, label %body__1, label %exit__1
+
+body__1:                                          ; preds = %header__1
+  %64 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %11, i64 %62)
+  %65 = bitcast i8* %64 to %String**
+  %66 = load %String*, %String** %65
+  call void @__quantum__rt__string_unreference(%String* %66)
+  br label %exiting__1
+
+exiting__1:                                       ; preds = %body__1
+  %67 = add i64 %62, 1
+  br label %header__1
+
+exit__1:                                          ; preds = %header__1
   call void @__quantum__rt__array_unreference(%Array* %11)
+  %68 = call i64 @__quantum__rt__array_get_size_1d(%Array* %12)
+  %69 = sub i64 %68, 1
+  br label %header__2
+
+header__2:                                        ; preds = %exiting__2, %exit__1
+  %70 = phi i64 [ 0, %exit__1 ], [ %75, %exiting__2 ]
+  %71 = icmp sle i64 %70, %69
+  br i1 %71, label %body__2, label %exit__2
+
+body__2:                                          ; preds = %header__2
+  %72 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %12, i64 %70)
+  %73 = bitcast i8* %72 to %Result**
+  %74 = load %Result*, %Result** %73
+  call void @__quantum__rt__result_unreference(%Result* %74)
+  br label %exiting__2
+
+exiting__2:                                       ; preds = %body__2
+  %75 = add i64 %70, 1
+  br label %header__2
+
+exit__2:                                          ; preds = %header__2
   call void @__quantum__rt__array_unreference(%Array* %12)
   call void @__quantum__rt__string_unreference(%String* %13)
+  %76 = call i64 @__quantum__rt__array_get_size_1d(%Array* %15)
+  %77 = sub i64 %76, 1
+  br label %header__3
+
+header__3:                                        ; preds = %exiting__3, %exit__2
+  %78 = phi i64 [ 0, %exit__2 ], [ %83, %exiting__3 ]
+  %79 = icmp sle i64 %78, %77
+  br i1 %79, label %body__3, label %exit__3
+
+body__3:                                          ; preds = %header__3
+  %80 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %15, i64 %78)
+  %81 = bitcast i8* %80 to %Result**
+  %82 = load %Result*, %Result** %81
+  call void @__quantum__rt__result_unreference(%Result* %82)
+  br label %exiting__3
+
+exiting__3:                                       ; preds = %body__3
+  %83 = add i64 %78, 1
+  br label %header__3
+
+exit__3:                                          ; preds = %header__3
   call void @__quantum__rt__array_unreference(%Array* %15)
-  %60 = getelementptr { { i2, i64 }*, double }, { { i2, i64 }*, double }* %16, i64 0, i32 0
-  %61 = load { i2, i64 }*, { i2, i64 }** %60
-  %62 = bitcast { i2, i64 }* %61 to %Tuple*
-  call void @__quantum__rt__tuple_unreference(%Tuple* %62)
-  %63 = bitcast { { i2, i64 }*, double }* %16 to %Tuple*
-  call void @__quantum__rt__tuple_unreference(%Tuple* %63)
+  %84 = getelementptr { { i2, i64 }*, double }, { { i2, i64 }*, double }* %16, i64 0, i32 0
+  %85 = load { i2, i64 }*, { i2, i64 }** %84
+  %86 = bitcast { i2, i64 }* %85 to %Tuple*
+  call void @__quantum__rt__tuple_unreference(%Tuple* %86)
+  %87 = bitcast { { i2, i64 }*, double }* %16 to %Tuple*
+  call void @__quantum__rt__tuple_unreference(%Tuple* %87)
   call void @__quantum__rt__bigint_unreference(%BigInt* %17)
   call void @__quantum__rt__bigint_unreference(%BigInt* %32)
   call void @__quantum__rt__result_unreference(%Result* %35)

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestFunctors.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestFunctors.ll
@@ -9,89 +9,91 @@ entry:
   call void @__quantum__rt__callable_reference(%Callable* %0)
   store i64 1, i64* %4
   %qop = call %Callable* @__quantum__rt__callable_create([4 x void (%Tuple*, %Tuple*, %Tuple*)*]* @PartialApplication__1, %Tuple* %1)
-  %adj_qop = call %Callable* @__quantum__rt__callable_copy(%Callable* %qop)
+  %5 = getelementptr { %Callable*, i64 }, { %Callable*, i64 }* %2, i64 0, i32 0
+  %6 = load %Callable*, %Callable** %5
+  call void @__quantum__rt__callable_reference(%Callable* %6)
+  call void @__quantum__rt__tuple_reference(%Tuple* %1)
+  %adj_qop = call %Callable* @__quantum__rt__callable_copy(%Callable* %qop, i1 true)
   call void @__quantum__rt__callable_make_adjoint(%Callable* %adj_qop)
-  %ctl_qop = call %Callable* @__quantum__rt__callable_copy(%Callable* %qop)
+  %ctl_qop = call %Callable* @__quantum__rt__callable_copy(%Callable* %qop, i1 true)
   call void @__quantum__rt__callable_make_controlled(%Callable* %ctl_qop)
-  %adj_ctl_qop = call %Callable* @__quantum__rt__callable_copy(%Callable* %qop)
+  %adj_ctl_qop = call %Callable* @__quantum__rt__callable_copy(%Callable* %qop, i1 true)
   call void @__quantum__rt__callable_make_controlled(%Callable* %adj_ctl_qop)
   call void @__quantum__rt__callable_make_adjoint(%Callable* %adj_ctl_qop)
-  %ctl_ctl_qop = call %Callable* @__quantum__rt__callable_copy(%Callable* %ctl_qop)
+  %ctl_ctl_qop = call %Callable* @__quantum__rt__callable_copy(%Callable* %ctl_qop, i1 true)
   call void @__quantum__rt__callable_make_controlled(%Callable* %ctl_ctl_qop)
   %error_code = alloca i64
   store i64 0, i64* %error_code
   %q1 = call %Qubit* @__quantum__rt__qubit_allocate()
   %q2 = call %Qubit* @__quantum__rt__qubit_allocate()
   %q3 = call %Qubit* @__quantum__rt__qubit_allocate()
-  %5 = call %Tuple* @__quantum__rt__tuple_create(i64 ptrtoint (i1** getelementptr (i1*, i1** null, i32 1) to i64))
-  %6 = bitcast %Tuple* %5 to { %Qubit* }*
-  %7 = getelementptr { %Qubit* }, { %Qubit* }* %6, i64 0, i32 0
-  store %Qubit* %q1, %Qubit** %7
-  call void @__quantum__rt__callable_invoke(%Callable* %qop, %Tuple* %5, %Tuple* null)
-  %8 = call %Result* @__quantum__qis__mz(%Qubit* %q1)
-  %9 = load %Result*, %Result** @ResultOne
-  %10 = call i1 @__quantum__rt__result_equal(%Result* %8, %Result* %9)
-  %11 = xor i1 %10, true
-  br i1 %11, label %then0__1, label %else__1
+  %7 = call %Tuple* @__quantum__rt__tuple_create(i64 ptrtoint (i1** getelementptr (i1*, i1** null, i32 1) to i64))
+  %8 = bitcast %Tuple* %7 to { %Qubit* }*
+  %9 = getelementptr { %Qubit* }, { %Qubit* }* %8, i64 0, i32 0
+  store %Qubit* %q1, %Qubit** %9
+  call void @__quantum__rt__callable_invoke(%Callable* %qop, %Tuple* %7, %Tuple* null)
+  %10 = call %Result* @__quantum__qis__mz(%Qubit* %q1)
+  %11 = load %Result*, %Result** @ResultOne
+  %12 = call i1 @__quantum__rt__result_equal(%Result* %10, %Result* %11)
+  %13 = xor i1 %12, true
+  br i1 %13, label %then0__1, label %else__1
 
 then0__1:                                         ; preds = %entry
   store i64 1, i64* %error_code
   br label %continue__1
 
 else__1:                                          ; preds = %entry
-  %12 = call %Tuple* @__quantum__rt__tuple_create(i64 ptrtoint (i1** getelementptr (i1*, i1** null, i32 1) to i64))
-  %13 = bitcast %Tuple* %12 to { %Qubit* }*
-  %14 = getelementptr { %Qubit* }, { %Qubit* }* %13, i64 0, i32 0
-  store %Qubit* %q2, %Qubit** %14
-  call void @__quantum__rt__callable_invoke(%Callable* %adj_qop, %Tuple* %12, %Tuple* null)
-  %15 = call %Result* @__quantum__qis__mz(%Qubit* %q2)
-  %16 = load %Result*, %Result** @ResultOne
-  %17 = call i1 @__quantum__rt__result_equal(%Result* %15, %Result* %16)
-  %18 = xor i1 %17, true
-  br i1 %18, label %then0__2, label %else__2
+  %14 = call %Tuple* @__quantum__rt__tuple_create(i64 ptrtoint (i1** getelementptr (i1*, i1** null, i32 1) to i64))
+  %15 = bitcast %Tuple* %14 to { %Qubit* }*
+  %16 = getelementptr { %Qubit* }, { %Qubit* }* %15, i64 0, i32 0
+  store %Qubit* %q2, %Qubit** %16
+  call void @__quantum__rt__callable_invoke(%Callable* %adj_qop, %Tuple* %14, %Tuple* null)
+  %17 = call %Result* @__quantum__qis__mz(%Qubit* %q2)
+  %18 = load %Result*, %Result** @ResultOne
+  %19 = call i1 @__quantum__rt__result_equal(%Result* %17, %Result* %18)
+  %20 = xor i1 %19, true
+  br i1 %20, label %then0__2, label %else__2
 
 then0__2:                                         ; preds = %else__1
   store i64 2, i64* %error_code
   br label %continue__2
 
 else__2:                                          ; preds = %else__1
-  %19 = call %Array* @__quantum__rt__array_create_1d(i32 8, i64 1)
-  %20 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %19, i64 0)
-  %21 = bitcast i8* %20 to %Qubit**
-  store %Qubit* %q1, %Qubit** %21
-  %22 = call %Tuple* @__quantum__rt__tuple_create(i64 mul nuw (i64 ptrtoint (i1** getelementptr (i1*, i1** null, i32 1) to i64), i64 2))
-  %23 = bitcast %Tuple* %22 to { %Array*, %Qubit* }*
-  %24 = getelementptr { %Array*, %Qubit* }, { %Array*, %Qubit* }* %23, i64 0, i32 0
-  %25 = getelementptr { %Array*, %Qubit* }, { %Array*, %Qubit* }* %23, i64 0, i32 1
-  store %Array* %19, %Array** %24
-  call void @__quantum__rt__array_reference(%Array* %19)
-  store %Qubit* %q3, %Qubit** %25
-  %26 = bitcast { %Array*, %Qubit* }* %23 to %Tuple*
-  call void @__quantum__rt__callable_invoke(%Callable* %ctl_qop, %Tuple* %26, %Tuple* null)
-  %27 = call %Result* @__quantum__qis__mz(%Qubit* %q3)
-  %28 = load %Result*, %Result** @ResultOne
-  %29 = call i1 @__quantum__rt__result_equal(%Result* %27, %Result* %28)
-  %30 = xor i1 %29, true
-  br i1 %30, label %then0__3, label %else__3
+  %21 = call %Array* @__quantum__rt__array_create_1d(i32 8, i64 1)
+  %22 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %21, i64 0)
+  %23 = bitcast i8* %22 to %Qubit**
+  store %Qubit* %q1, %Qubit** %23
+  %24 = call %Tuple* @__quantum__rt__tuple_create(i64 mul nuw (i64 ptrtoint (i1** getelementptr (i1*, i1** null, i32 1) to i64), i64 2))
+  %25 = bitcast %Tuple* %24 to { %Array*, %Qubit* }*
+  %26 = getelementptr { %Array*, %Qubit* }, { %Array*, %Qubit* }* %25, i64 0, i32 0
+  %27 = getelementptr { %Array*, %Qubit* }, { %Array*, %Qubit* }* %25, i64 0, i32 1
+  store %Array* %21, %Array** %26
+  call void @__quantum__rt__array_reference(%Array* %21)
+  store %Qubit* %q3, %Qubit** %27
+  call void @__quantum__rt__callable_invoke(%Callable* %ctl_qop, %Tuple* %24, %Tuple* null)
+  %28 = call %Result* @__quantum__qis__mz(%Qubit* %q3)
+  %29 = load %Result*, %Result** @ResultOne
+  %30 = call i1 @__quantum__rt__result_equal(%Result* %28, %Result* %29)
+  %31 = xor i1 %30, true
+  br i1 %31, label %then0__3, label %else__3
 
 then0__3:                                         ; preds = %else__2
   store i64 3, i64* %error_code
   br label %continue__3
 
 else__3:                                          ; preds = %else__2
-  %31 = call %Array* @__quantum__rt__array_create_1d(i32 8, i64 1)
-  %32 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %31, i64 0)
-  %33 = bitcast i8* %32 to %Qubit**
-  store %Qubit* %q2, %Qubit** %33
-  %34 = call %Tuple* @__quantum__rt__tuple_create(i64 mul nuw (i64 ptrtoint (i1** getelementptr (i1*, i1** null, i32 1) to i64), i64 2))
-  %35 = bitcast %Tuple* %34 to { %Array*, %Qubit* }*
-  %36 = getelementptr { %Array*, %Qubit* }, { %Array*, %Qubit* }* %35, i64 0, i32 0
-  %37 = getelementptr { %Array*, %Qubit* }, { %Array*, %Qubit* }* %35, i64 0, i32 1
-  store %Array* %31, %Array** %36
-  call void @__quantum__rt__array_reference(%Array* %31)
-  store %Qubit* %q3, %Qubit** %37
-  %38 = bitcast { %Array*, %Qubit* }* %35 to %Tuple*
-  call void @__quantum__rt__callable_invoke(%Callable* %adj_ctl_qop, %Tuple* %38, %Tuple* null)
+  %32 = call %Array* @__quantum__rt__array_create_1d(i32 8, i64 1)
+  %33 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %32, i64 0)
+  %34 = bitcast i8* %33 to %Qubit**
+  store %Qubit* %q2, %Qubit** %34
+  %35 = call %Tuple* @__quantum__rt__tuple_create(i64 mul nuw (i64 ptrtoint (i1** getelementptr (i1*, i1** null, i32 1) to i64), i64 2))
+  %36 = bitcast %Tuple* %35 to { %Array*, %Qubit* }*
+  %37 = getelementptr { %Array*, %Qubit* }, { %Array*, %Qubit* }* %36, i64 0, i32 0
+  %38 = getelementptr { %Array*, %Qubit* }, { %Array*, %Qubit* }* %36, i64 0, i32 1
+  store %Array* %32, %Array** %37
+  call void @__quantum__rt__array_reference(%Array* %32)
+  store %Qubit* %q3, %Qubit** %38
+  call void @__quantum__rt__callable_invoke(%Callable* %adj_ctl_qop, %Tuple* %35, %Tuple* null)
   %39 = call %Result* @__quantum__qis__mz(%Qubit* %q3)
   %40 = load %Result*, %Result** @ResultZero
   %41 = call i1 @__quantum__rt__result_equal(%Result* %39, %Result* %40)
@@ -128,44 +130,41 @@ else__4:                                          ; preds = %else__3
   %57 = getelementptr { %Array*, %Qubit* }, { %Array*, %Qubit* }* %50, i64 0, i32 0
   %58 = load %Array*, %Array** %57
   call void @__quantum__rt__array_reference(%Array* %58)
-  %59 = bitcast { %Array*, %Qubit* }* %50 to %Tuple*
-  call void @__quantum__rt__tuple_reference(%Tuple* %59)
-  %60 = bitcast { %Array*, { %Array*, %Qubit* }* }* %54 to %Tuple*
-  call void @__quantum__rt__callable_invoke(%Callable* %ctl_ctl_qop, %Tuple* %60, %Tuple* null)
-  %61 = call %Result* @__quantum__qis__mz(%Qubit* %q3)
-  %62 = load %Result*, %Result** @ResultOne
-  %63 = call i1 @__quantum__rt__result_equal(%Result* %61, %Result* %62)
-  %64 = xor i1 %63, true
-  br i1 %64, label %then0__5, label %else__5
+  call void @__quantum__rt__tuple_reference(%Tuple* %49)
+  call void @__quantum__rt__callable_invoke(%Callable* %ctl_ctl_qop, %Tuple* %53, %Tuple* null)
+  %59 = call %Result* @__quantum__qis__mz(%Qubit* %q3)
+  %60 = load %Result*, %Result** @ResultOne
+  %61 = call i1 @__quantum__rt__result_equal(%Result* %59, %Result* %60)
+  %62 = xor i1 %61, true
+  br i1 %62, label %then0__5, label %else__5
 
 then0__5:                                         ; preds = %else__4
   store i64 5, i64* %error_code
   br label %continue__5
 
 else__5:                                          ; preds = %else__4
-  %65 = call %Callable* @__quantum__rt__callable_copy(%Callable* %qop)
-  call void @__quantum__rt__callable_make_controlled(%Callable* %65)
-  %66 = call %Array* @__quantum__rt__array_create_1d(i32 8, i64 2)
-  %67 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %66, i64 0)
+  %63 = call %Callable* @__quantum__rt__callable_copy(%Callable* %qop, i1 true)
+  call void @__quantum__rt__callable_make_controlled(%Callable* %63)
+  %64 = call %Array* @__quantum__rt__array_create_1d(i32 8, i64 2)
+  %65 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %64, i64 0)
+  %66 = bitcast i8* %65 to %Qubit**
+  %67 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %64, i64 1)
   %68 = bitcast i8* %67 to %Qubit**
-  store %Qubit* %q1, %Qubit** %68
-  %69 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %66, i64 1)
-  %70 = bitcast i8* %69 to %Qubit**
-  store %Qubit* %q2, %Qubit** %70
-  %71 = call %Tuple* @__quantum__rt__tuple_create(i64 mul nuw (i64 ptrtoint (i1** getelementptr (i1*, i1** null, i32 1) to i64), i64 2))
-  %72 = bitcast %Tuple* %71 to { %Array*, %Qubit* }*
-  %73 = getelementptr { %Array*, %Qubit* }, { %Array*, %Qubit* }* %72, i64 0, i32 0
-  %74 = getelementptr { %Array*, %Qubit* }, { %Array*, %Qubit* }* %72, i64 0, i32 1
-  store %Array* %66, %Array** %73
-  call void @__quantum__rt__array_reference(%Array* %66)
-  store %Qubit* %q3, %Qubit** %74
-  %75 = bitcast { %Array*, %Qubit* }* %72 to %Tuple*
-  call void @__quantum__rt__callable_invoke(%Callable* %65, %Tuple* %75, %Tuple* null)
-  %76 = call %Result* @__quantum__qis__mz(%Qubit* %q3)
-  %77 = load %Result*, %Result** @ResultZero
-  %78 = call i1 @__quantum__rt__result_equal(%Result* %76, %Result* %77)
-  %79 = xor i1 %78, true
-  br i1 %79, label %then0__6, label %else__6
+  store %Qubit* %q1, %Qubit** %66
+  store %Qubit* %q2, %Qubit** %68
+  %69 = call %Tuple* @__quantum__rt__tuple_create(i64 mul nuw (i64 ptrtoint (i1** getelementptr (i1*, i1** null, i32 1) to i64), i64 2))
+  %70 = bitcast %Tuple* %69 to { %Array*, %Qubit* }*
+  %71 = getelementptr { %Array*, %Qubit* }, { %Array*, %Qubit* }* %70, i64 0, i32 0
+  %72 = getelementptr { %Array*, %Qubit* }, { %Array*, %Qubit* }* %70, i64 0, i32 1
+  store %Array* %64, %Array** %71
+  call void @__quantum__rt__array_reference(%Array* %64)
+  store %Qubit* %q3, %Qubit** %72
+  call void @__quantum__rt__callable_invoke(%Callable* %63, %Tuple* %69, %Tuple* null)
+  %73 = call %Result* @__quantum__qis__mz(%Qubit* %q3)
+  %74 = load %Result*, %Result** @ResultZero
+  %75 = call i1 @__quantum__rt__result_equal(%Result* %73, %Result* %74)
+  %76 = xor i1 %75, true
+  br i1 %76, label %then0__6, label %else__6
 
 then0__6:                                         ; preds = %else__5
   store i64 6, i64* %error_code
@@ -173,73 +172,70 @@ then0__6:                                         ; preds = %else__5
 
 else__6:                                          ; preds = %else__5
   %q4 = call %Qubit* @__quantum__rt__qubit_allocate()
-  %80 = call %Callable* @__quantum__rt__callable_copy(%Callable* %qop)
-  call void @__quantum__rt__callable_make_adjoint(%Callable* %80)
-  %81 = call %Tuple* @__quantum__rt__tuple_create(i64 ptrtoint (i1** getelementptr (i1*, i1** null, i32 1) to i64))
-  %82 = bitcast %Tuple* %81 to { %Qubit* }*
-  %83 = getelementptr { %Qubit* }, { %Qubit* }* %82, i64 0, i32 0
-  store %Qubit* %q3, %Qubit** %83
-  call void @__quantum__rt__callable_invoke(%Callable* %80, %Tuple* %81, %Tuple* null)
-  %84 = call %Callable* @__quantum__rt__callable_copy(%Callable* %ctl_ctl_qop)
-  call void @__quantum__rt__callable_make_controlled(%Callable* %84)
-  call void @__quantum__rt__callable_make_adjoint(%Callable* %84)
+  %77 = call %Callable* @__quantum__rt__callable_copy(%Callable* %qop, i1 true)
+  call void @__quantum__rt__callable_make_adjoint(%Callable* %77)
+  %78 = call %Tuple* @__quantum__rt__tuple_create(i64 ptrtoint (i1** getelementptr (i1*, i1** null, i32 1) to i64))
+  %79 = bitcast %Tuple* %78 to { %Qubit* }*
+  %80 = getelementptr { %Qubit* }, { %Qubit* }* %79, i64 0, i32 0
+  store %Qubit* %q3, %Qubit** %80
+  call void @__quantum__rt__callable_invoke(%Callable* %77, %Tuple* %78, %Tuple* null)
+  %81 = call %Callable* @__quantum__rt__callable_copy(%Callable* %ctl_ctl_qop, i1 true)
+  call void @__quantum__rt__callable_make_controlled(%Callable* %81)
+  call void @__quantum__rt__callable_make_adjoint(%Callable* %81)
+  %82 = call %Array* @__quantum__rt__array_create_1d(i32 8, i64 1)
+  %83 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %82, i64 0)
+  %84 = bitcast i8* %83 to %Qubit**
+  store %Qubit* %q1, %Qubit** %84
   %85 = call %Array* @__quantum__rt__array_create_1d(i32 8, i64 1)
   %86 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %85, i64 0)
   %87 = bitcast i8* %86 to %Qubit**
-  store %Qubit* %q1, %Qubit** %87
+  store %Qubit* %q2, %Qubit** %87
   %88 = call %Array* @__quantum__rt__array_create_1d(i32 8, i64 1)
   %89 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %88, i64 0)
   %90 = bitcast i8* %89 to %Qubit**
-  store %Qubit* %q2, %Qubit** %90
-  %91 = call %Array* @__quantum__rt__array_create_1d(i32 8, i64 1)
-  %92 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %91, i64 0)
-  %93 = bitcast i8* %92 to %Qubit**
-  store %Qubit* %q3, %Qubit** %93
-  %94 = call %Tuple* @__quantum__rt__tuple_create(i64 mul nuw (i64 ptrtoint (i1** getelementptr (i1*, i1** null, i32 1) to i64), i64 2))
-  %95 = bitcast %Tuple* %94 to { %Array*, %Qubit* }*
-  %96 = getelementptr { %Array*, %Qubit* }, { %Array*, %Qubit* }* %95, i64 0, i32 0
-  %97 = getelementptr { %Array*, %Qubit* }, { %Array*, %Qubit* }* %95, i64 0, i32 1
-  store %Array* %91, %Array** %96
-  call void @__quantum__rt__array_reference(%Array* %91)
-  store %Qubit* %q4, %Qubit** %97
-  %98 = call %Tuple* @__quantum__rt__tuple_create(i64 mul nuw (i64 ptrtoint (i1** getelementptr (i1*, i1** null, i32 1) to i64), i64 2))
-  %99 = bitcast %Tuple* %98 to { %Array*, { %Array*, %Qubit* }* }*
-  %100 = getelementptr { %Array*, { %Array*, %Qubit* }* }, { %Array*, { %Array*, %Qubit* }* }* %99, i64 0, i32 0
-  %101 = getelementptr { %Array*, { %Array*, %Qubit* }* }, { %Array*, { %Array*, %Qubit* }* }* %99, i64 0, i32 1
-  store %Array* %88, %Array** %100
+  store %Qubit* %q3, %Qubit** %90
+  %91 = call %Tuple* @__quantum__rt__tuple_create(i64 mul nuw (i64 ptrtoint (i1** getelementptr (i1*, i1** null, i32 1) to i64), i64 2))
+  %92 = bitcast %Tuple* %91 to { %Array*, %Qubit* }*
+  %93 = getelementptr { %Array*, %Qubit* }, { %Array*, %Qubit* }* %92, i64 0, i32 0
+  %94 = getelementptr { %Array*, %Qubit* }, { %Array*, %Qubit* }* %92, i64 0, i32 1
+  store %Array* %88, %Array** %93
   call void @__quantum__rt__array_reference(%Array* %88)
-  store { %Array*, %Qubit* }* %95, { %Array*, %Qubit* }** %101
-  %102 = getelementptr { %Array*, %Qubit* }, { %Array*, %Qubit* }* %95, i64 0, i32 0
-  %103 = load %Array*, %Array** %102
-  call void @__quantum__rt__array_reference(%Array* %103)
-  %104 = bitcast { %Array*, %Qubit* }* %95 to %Tuple*
-  call void @__quantum__rt__tuple_reference(%Tuple* %104)
-  %105 = call %Tuple* @__quantum__rt__tuple_create(i64 mul nuw (i64 ptrtoint (i1** getelementptr (i1*, i1** null, i32 1) to i64), i64 2))
-  %106 = bitcast %Tuple* %105 to { %Array*, { %Array*, { %Array*, %Qubit* }* }* }*
-  %107 = getelementptr { %Array*, { %Array*, { %Array*, %Qubit* }* }* }, { %Array*, { %Array*, { %Array*, %Qubit* }* }* }* %106, i64 0, i32 0
-  %108 = getelementptr { %Array*, { %Array*, { %Array*, %Qubit* }* }* }, { %Array*, { %Array*, { %Array*, %Qubit* }* }* }* %106, i64 0, i32 1
-  store %Array* %85, %Array** %107
+  store %Qubit* %q4, %Qubit** %94
+  %95 = call %Tuple* @__quantum__rt__tuple_create(i64 mul nuw (i64 ptrtoint (i1** getelementptr (i1*, i1** null, i32 1) to i64), i64 2))
+  %96 = bitcast %Tuple* %95 to { %Array*, { %Array*, %Qubit* }* }*
+  %97 = getelementptr { %Array*, { %Array*, %Qubit* }* }, { %Array*, { %Array*, %Qubit* }* }* %96, i64 0, i32 0
+  %98 = getelementptr { %Array*, { %Array*, %Qubit* }* }, { %Array*, { %Array*, %Qubit* }* }* %96, i64 0, i32 1
+  store %Array* %85, %Array** %97
   call void @__quantum__rt__array_reference(%Array* %85)
-  store { %Array*, { %Array*, %Qubit* }* }* %99, { %Array*, { %Array*, %Qubit* }* }** %108
-  %109 = getelementptr { %Array*, { %Array*, %Qubit* }* }, { %Array*, { %Array*, %Qubit* }* }* %99, i64 0, i32 0
+  store { %Array*, %Qubit* }* %92, { %Array*, %Qubit* }** %98
+  %99 = getelementptr { %Array*, %Qubit* }, { %Array*, %Qubit* }* %92, i64 0, i32 0
+  %100 = load %Array*, %Array** %99
+  call void @__quantum__rt__array_reference(%Array* %100)
+  call void @__quantum__rt__tuple_reference(%Tuple* %91)
+  %101 = call %Tuple* @__quantum__rt__tuple_create(i64 mul nuw (i64 ptrtoint (i1** getelementptr (i1*, i1** null, i32 1) to i64), i64 2))
+  %102 = bitcast %Tuple* %101 to { %Array*, { %Array*, { %Array*, %Qubit* }* }* }*
+  %103 = getelementptr { %Array*, { %Array*, { %Array*, %Qubit* }* }* }, { %Array*, { %Array*, { %Array*, %Qubit* }* }* }* %102, i64 0, i32 0
+  %104 = getelementptr { %Array*, { %Array*, { %Array*, %Qubit* }* }* }, { %Array*, { %Array*, { %Array*, %Qubit* }* }* }* %102, i64 0, i32 1
+  store %Array* %82, %Array** %103
+  call void @__quantum__rt__array_reference(%Array* %82)
+  store { %Array*, { %Array*, %Qubit* }* }* %96, { %Array*, { %Array*, %Qubit* }* }** %104
+  %105 = getelementptr { %Array*, { %Array*, %Qubit* }* }, { %Array*, { %Array*, %Qubit* }* }* %96, i64 0, i32 0
+  %106 = load %Array*, %Array** %105
+  call void @__quantum__rt__array_reference(%Array* %106)
+  %107 = getelementptr { %Array*, { %Array*, %Qubit* }* }, { %Array*, { %Array*, %Qubit* }* }* %96, i64 0, i32 1
+  %108 = load { %Array*, %Qubit* }*, { %Array*, %Qubit* }** %107
+  %109 = getelementptr { %Array*, %Qubit* }, { %Array*, %Qubit* }* %108, i64 0, i32 0
   %110 = load %Array*, %Array** %109
   call void @__quantum__rt__array_reference(%Array* %110)
-  %111 = getelementptr { %Array*, { %Array*, %Qubit* }* }, { %Array*, { %Array*, %Qubit* }* }* %99, i64 0, i32 1
-  %112 = load { %Array*, %Qubit* }*, { %Array*, %Qubit* }** %111
-  %113 = getelementptr { %Array*, %Qubit* }, { %Array*, %Qubit* }* %112, i64 0, i32 0
-  %114 = load %Array*, %Array** %113
-  call void @__quantum__rt__array_reference(%Array* %114)
-  %115 = bitcast { %Array*, %Qubit* }* %112 to %Tuple*
-  call void @__quantum__rt__tuple_reference(%Tuple* %115)
-  %116 = bitcast { %Array*, { %Array*, %Qubit* }* }* %99 to %Tuple*
-  call void @__quantum__rt__tuple_reference(%Tuple* %116)
-  %117 = bitcast { %Array*, { %Array*, { %Array*, %Qubit* }* }* }* %106 to %Tuple*
-  call void @__quantum__rt__callable_invoke(%Callable* %84, %Tuple* %117, %Tuple* null)
-  %118 = call %Result* @__quantum__qis__mz(%Qubit* %q4)
-  %119 = load %Result*, %Result** @ResultOne
-  %120 = call i1 @__quantum__rt__result_equal(%Result* %118, %Result* %119)
-  %121 = xor i1 %120, true
-  br i1 %121, label %then0__7, label %continue__7
+  %111 = bitcast { %Array*, %Qubit* }* %108 to %Tuple*
+  call void @__quantum__rt__tuple_reference(%Tuple* %111)
+  call void @__quantum__rt__tuple_reference(%Tuple* %95)
+  call void @__quantum__rt__callable_invoke(%Callable* %81, %Tuple* %101, %Tuple* null)
+  %112 = call %Result* @__quantum__qis__mz(%Qubit* %q4)
+  %113 = load %Result*, %Result** @ResultOne
+  %114 = call i1 @__quantum__rt__result_equal(%Result* %112, %Result* %113)
+  %115 = xor i1 %114, true
+  br i1 %115, label %then0__7, label %continue__7
 
 then0__7:                                         ; preds = %else__6
   store i64 7, i64* %error_code
@@ -247,137 +243,118 @@ then0__7:                                         ; preds = %else__6
 
 continue__7:                                      ; preds = %then0__7, %else__6
   call void @__quantum__rt__qubit_release(%Qubit* %q4)
-  call void @__quantum__rt__callable_unreference(%Callable* %80)
-  %122 = bitcast { %Qubit* }* %82 to %Tuple*
-  call void @__quantum__rt__tuple_unreference(%Tuple* %122)
-  call void @__quantum__rt__callable_unreference(%Callable* %84)
+  call void @__quantum__rt__callable_unreference(%Callable* %77)
+  call void @__quantum__rt__tuple_unreference(%Tuple* %78)
+  call void @__quantum__rt__callable_unreference(%Callable* %81)
+  call void @__quantum__rt__array_unreference(%Array* %82)
   call void @__quantum__rt__array_unreference(%Array* %85)
   call void @__quantum__rt__array_unreference(%Array* %88)
-  call void @__quantum__rt__array_unreference(%Array* %91)
-  %123 = getelementptr { %Array*, %Qubit* }, { %Array*, %Qubit* }* %95, i64 0, i32 0
-  %124 = load %Array*, %Array** %123
-  call void @__quantum__rt__array_unreference(%Array* %124)
-  %125 = bitcast { %Array*, %Qubit* }* %95 to %Tuple*
-  call void @__quantum__rt__tuple_unreference(%Tuple* %125)
-  %126 = getelementptr { %Array*, { %Array*, %Qubit* }* }, { %Array*, { %Array*, %Qubit* }* }* %99, i64 0, i32 0
-  %127 = load %Array*, %Array** %126
-  call void @__quantum__rt__array_unreference(%Array* %127)
-  %128 = getelementptr { %Array*, { %Array*, %Qubit* }* }, { %Array*, { %Array*, %Qubit* }* }* %99, i64 0, i32 1
-  %129 = load { %Array*, %Qubit* }*, { %Array*, %Qubit* }** %128
-  %130 = getelementptr { %Array*, %Qubit* }, { %Array*, %Qubit* }* %129, i64 0, i32 0
-  %131 = load %Array*, %Array** %130
-  call void @__quantum__rt__array_unreference(%Array* %131)
-  %132 = bitcast { %Array*, %Qubit* }* %129 to %Tuple*
-  call void @__quantum__rt__tuple_unreference(%Tuple* %132)
-  %133 = bitcast { %Array*, { %Array*, %Qubit* }* }* %99 to %Tuple*
-  call void @__quantum__rt__tuple_unreference(%Tuple* %133)
-  %134 = getelementptr { %Array*, { %Array*, { %Array*, %Qubit* }* }* }, { %Array*, { %Array*, { %Array*, %Qubit* }* }* }* %106, i64 0, i32 0
-  %135 = load %Array*, %Array** %134
-  call void @__quantum__rt__array_unreference(%Array* %135)
-  %136 = getelementptr { %Array*, { %Array*, { %Array*, %Qubit* }* }* }, { %Array*, { %Array*, { %Array*, %Qubit* }* }* }* %106, i64 0, i32 1
-  %137 = load { %Array*, { %Array*, %Qubit* }* }*, { %Array*, { %Array*, %Qubit* }* }** %136
-  %138 = getelementptr { %Array*, { %Array*, %Qubit* }* }, { %Array*, { %Array*, %Qubit* }* }* %137, i64 0, i32 0
-  %139 = load %Array*, %Array** %138
-  call void @__quantum__rt__array_unreference(%Array* %139)
-  %140 = getelementptr { %Array*, { %Array*, %Qubit* }* }, { %Array*, { %Array*, %Qubit* }* }* %137, i64 0, i32 1
-  %141 = load { %Array*, %Qubit* }*, { %Array*, %Qubit* }** %140
-  %142 = getelementptr { %Array*, %Qubit* }, { %Array*, %Qubit* }* %141, i64 0, i32 0
-  %143 = load %Array*, %Array** %142
-  call void @__quantum__rt__array_unreference(%Array* %143)
-  %144 = bitcast { %Array*, %Qubit* }* %141 to %Tuple*
-  call void @__quantum__rt__tuple_unreference(%Tuple* %144)
-  %145 = bitcast { %Array*, { %Array*, %Qubit* }* }* %137 to %Tuple*
-  call void @__quantum__rt__tuple_unreference(%Tuple* %145)
-  %146 = bitcast { %Array*, { %Array*, { %Array*, %Qubit* }* }* }* %106 to %Tuple*
-  call void @__quantum__rt__tuple_unreference(%Tuple* %146)
-  call void @__quantum__rt__result_unreference(%Result* %118)
-  call void @__quantum__rt__result_unreference(%Result* %119)
+  %116 = getelementptr { %Array*, %Qubit* }, { %Array*, %Qubit* }* %92, i64 0, i32 0
+  %117 = load %Array*, %Array** %116
+  call void @__quantum__rt__array_unreference(%Array* %117)
+  call void @__quantum__rt__tuple_unreference(%Tuple* %91)
+  %118 = getelementptr { %Array*, { %Array*, %Qubit* }* }, { %Array*, { %Array*, %Qubit* }* }* %96, i64 0, i32 0
+  %119 = load %Array*, %Array** %118
+  call void @__quantum__rt__array_unreference(%Array* %119)
+  %120 = getelementptr { %Array*, { %Array*, %Qubit* }* }, { %Array*, { %Array*, %Qubit* }* }* %96, i64 0, i32 1
+  %121 = load { %Array*, %Qubit* }*, { %Array*, %Qubit* }** %120
+  %122 = getelementptr { %Array*, %Qubit* }, { %Array*, %Qubit* }* %121, i64 0, i32 0
+  %123 = load %Array*, %Array** %122
+  call void @__quantum__rt__array_unreference(%Array* %123)
+  %124 = bitcast { %Array*, %Qubit* }* %121 to %Tuple*
+  call void @__quantum__rt__tuple_unreference(%Tuple* %124)
+  call void @__quantum__rt__tuple_unreference(%Tuple* %95)
+  %125 = getelementptr { %Array*, { %Array*, { %Array*, %Qubit* }* }* }, { %Array*, { %Array*, { %Array*, %Qubit* }* }* }* %102, i64 0, i32 0
+  %126 = load %Array*, %Array** %125
+  call void @__quantum__rt__array_unreference(%Array* %126)
+  %127 = getelementptr { %Array*, { %Array*, { %Array*, %Qubit* }* }* }, { %Array*, { %Array*, { %Array*, %Qubit* }* }* }* %102, i64 0, i32 1
+  %128 = load { %Array*, { %Array*, %Qubit* }* }*, { %Array*, { %Array*, %Qubit* }* }** %127
+  %129 = getelementptr { %Array*, { %Array*, %Qubit* }* }, { %Array*, { %Array*, %Qubit* }* }* %128, i64 0, i32 0
+  %130 = load %Array*, %Array** %129
+  call void @__quantum__rt__array_unreference(%Array* %130)
+  %131 = getelementptr { %Array*, { %Array*, %Qubit* }* }, { %Array*, { %Array*, %Qubit* }* }* %128, i64 0, i32 1
+  %132 = load { %Array*, %Qubit* }*, { %Array*, %Qubit* }** %131
+  %133 = getelementptr { %Array*, %Qubit* }, { %Array*, %Qubit* }* %132, i64 0, i32 0
+  %134 = load %Array*, %Array** %133
+  call void @__quantum__rt__array_unreference(%Array* %134)
+  %135 = bitcast { %Array*, %Qubit* }* %132 to %Tuple*
+  call void @__quantum__rt__tuple_unreference(%Tuple* %135)
+  %136 = bitcast { %Array*, { %Array*, %Qubit* }* }* %128 to %Tuple*
+  call void @__quantum__rt__tuple_unreference(%Tuple* %136)
+  call void @__quantum__rt__tuple_unreference(%Tuple* %101)
+  call void @__quantum__rt__result_unreference(%Result* %112)
   br label %continue__6
 
 continue__6:                                      ; preds = %continue__7, %then0__6
-  call void @__quantum__rt__callable_unreference(%Callable* %65)
-  call void @__quantum__rt__array_unreference(%Array* %66)
-  %147 = getelementptr { %Array*, %Qubit* }, { %Array*, %Qubit* }* %72, i64 0, i32 0
-  %148 = load %Array*, %Array** %147
-  call void @__quantum__rt__array_unreference(%Array* %148)
-  %149 = bitcast { %Array*, %Qubit* }* %72 to %Tuple*
-  call void @__quantum__rt__tuple_unreference(%Tuple* %149)
-  call void @__quantum__rt__result_unreference(%Result* %76)
-  call void @__quantum__rt__result_unreference(%Result* %77)
+  call void @__quantum__rt__callable_unreference(%Callable* %63)
+  call void @__quantum__rt__array_unreference(%Array* %64)
+  %137 = getelementptr { %Array*, %Qubit* }, { %Array*, %Qubit* }* %70, i64 0, i32 0
+  %138 = load %Array*, %Array** %137
+  call void @__quantum__rt__array_unreference(%Array* %138)
+  call void @__quantum__rt__tuple_unreference(%Tuple* %69)
+  call void @__quantum__rt__result_unreference(%Result* %73)
   br label %continue__5
 
 continue__5:                                      ; preds = %continue__6, %then0__5
   call void @__quantum__rt__array_unreference(%Array* %43)
   call void @__quantum__rt__array_unreference(%Array* %46)
-  %150 = getelementptr { %Array*, %Qubit* }, { %Array*, %Qubit* }* %50, i64 0, i32 0
-  %151 = load %Array*, %Array** %150
-  call void @__quantum__rt__array_unreference(%Array* %151)
-  %152 = bitcast { %Array*, %Qubit* }* %50 to %Tuple*
-  call void @__quantum__rt__tuple_unreference(%Tuple* %152)
-  %153 = getelementptr { %Array*, { %Array*, %Qubit* }* }, { %Array*, { %Array*, %Qubit* }* }* %54, i64 0, i32 0
-  %154 = load %Array*, %Array** %153
-  call void @__quantum__rt__array_unreference(%Array* %154)
-  %155 = getelementptr { %Array*, { %Array*, %Qubit* }* }, { %Array*, { %Array*, %Qubit* }* }* %54, i64 0, i32 1
-  %156 = load { %Array*, %Qubit* }*, { %Array*, %Qubit* }** %155
-  %157 = getelementptr { %Array*, %Qubit* }, { %Array*, %Qubit* }* %156, i64 0, i32 0
-  %158 = load %Array*, %Array** %157
-  call void @__quantum__rt__array_unreference(%Array* %158)
-  %159 = bitcast { %Array*, %Qubit* }* %156 to %Tuple*
-  call void @__quantum__rt__tuple_unreference(%Tuple* %159)
-  %160 = bitcast { %Array*, { %Array*, %Qubit* }* }* %54 to %Tuple*
-  call void @__quantum__rt__tuple_unreference(%Tuple* %160)
-  call void @__quantum__rt__result_unreference(%Result* %61)
-  call void @__quantum__rt__result_unreference(%Result* %62)
+  %139 = getelementptr { %Array*, %Qubit* }, { %Array*, %Qubit* }* %50, i64 0, i32 0
+  %140 = load %Array*, %Array** %139
+  call void @__quantum__rt__array_unreference(%Array* %140)
+  call void @__quantum__rt__tuple_unreference(%Tuple* %49)
+  %141 = getelementptr { %Array*, { %Array*, %Qubit* }* }, { %Array*, { %Array*, %Qubit* }* }* %54, i64 0, i32 0
+  %142 = load %Array*, %Array** %141
+  call void @__quantum__rt__array_unreference(%Array* %142)
+  %143 = getelementptr { %Array*, { %Array*, %Qubit* }* }, { %Array*, { %Array*, %Qubit* }* }* %54, i64 0, i32 1
+  %144 = load { %Array*, %Qubit* }*, { %Array*, %Qubit* }** %143
+  %145 = getelementptr { %Array*, %Qubit* }, { %Array*, %Qubit* }* %144, i64 0, i32 0
+  %146 = load %Array*, %Array** %145
+  call void @__quantum__rt__array_unreference(%Array* %146)
+  %147 = bitcast { %Array*, %Qubit* }* %144 to %Tuple*
+  call void @__quantum__rt__tuple_unreference(%Tuple* %147)
+  call void @__quantum__rt__tuple_unreference(%Tuple* %53)
+  call void @__quantum__rt__result_unreference(%Result* %59)
   br label %continue__4
 
 continue__4:                                      ; preds = %continue__5, %then0__4
-  call void @__quantum__rt__array_unreference(%Array* %31)
-  %161 = getelementptr { %Array*, %Qubit* }, { %Array*, %Qubit* }* %35, i64 0, i32 0
-  %162 = load %Array*, %Array** %161
-  call void @__quantum__rt__array_unreference(%Array* %162)
-  %163 = bitcast { %Array*, %Qubit* }* %35 to %Tuple*
-  call void @__quantum__rt__tuple_unreference(%Tuple* %163)
+  call void @__quantum__rt__array_unreference(%Array* %32)
+  %148 = getelementptr { %Array*, %Qubit* }, { %Array*, %Qubit* }* %36, i64 0, i32 0
+  %149 = load %Array*, %Array** %148
+  call void @__quantum__rt__array_unreference(%Array* %149)
+  call void @__quantum__rt__tuple_unreference(%Tuple* %35)
   call void @__quantum__rt__result_unreference(%Result* %39)
-  call void @__quantum__rt__result_unreference(%Result* %40)
   br label %continue__3
 
 continue__3:                                      ; preds = %continue__4, %then0__3
-  call void @__quantum__rt__array_unreference(%Array* %19)
-  %164 = getelementptr { %Array*, %Qubit* }, { %Array*, %Qubit* }* %23, i64 0, i32 0
-  %165 = load %Array*, %Array** %164
-  call void @__quantum__rt__array_unreference(%Array* %165)
-  %166 = bitcast { %Array*, %Qubit* }* %23 to %Tuple*
-  call void @__quantum__rt__tuple_unreference(%Tuple* %166)
-  call void @__quantum__rt__result_unreference(%Result* %27)
+  call void @__quantum__rt__array_unreference(%Array* %21)
+  %150 = getelementptr { %Array*, %Qubit* }, { %Array*, %Qubit* }* %25, i64 0, i32 0
+  %151 = load %Array*, %Array** %150
+  call void @__quantum__rt__array_unreference(%Array* %151)
+  call void @__quantum__rt__tuple_unreference(%Tuple* %24)
   call void @__quantum__rt__result_unreference(%Result* %28)
   br label %continue__2
 
 continue__2:                                      ; preds = %continue__3, %then0__2
-  %167 = bitcast { %Qubit* }* %13 to %Tuple*
-  call void @__quantum__rt__tuple_unreference(%Tuple* %167)
-  call void @__quantum__rt__result_unreference(%Result* %15)
-  call void @__quantum__rt__result_unreference(%Result* %16)
+  call void @__quantum__rt__tuple_unreference(%Tuple* %14)
+  call void @__quantum__rt__result_unreference(%Result* %17)
   br label %continue__1
 
 continue__1:                                      ; preds = %continue__2, %then0__1
   call void @__quantum__rt__qubit_release(%Qubit* %q1)
   call void @__quantum__rt__qubit_release(%Qubit* %q2)
   call void @__quantum__rt__qubit_release(%Qubit* %q3)
-  %168 = bitcast { %Qubit* }* %6 to %Tuple*
-  call void @__quantum__rt__tuple_unreference(%Tuple* %168)
-  call void @__quantum__rt__result_unreference(%Result* %8)
-  call void @__quantum__rt__result_unreference(%Result* %9)
-  %169 = load i64, i64* %error_code
+  call void @__quantum__rt__tuple_unreference(%Tuple* %7)
+  call void @__quantum__rt__result_unreference(%Result* %10)
+  %152 = load i64, i64* %error_code
   call void @__quantum__rt__callable_unreference(%Callable* %0)
-  %170 = getelementptr { %Callable*, i64 }, { %Callable*, i64 }* %2, i64 0, i32 0
-  %171 = load %Callable*, %Callable** %170
-  call void @__quantum__rt__callable_unreference(%Callable* %171)
-  %172 = bitcast { %Callable*, i64 }* %2 to %Tuple*
-  call void @__quantum__rt__tuple_unreference(%Tuple* %172)
+  %153 = getelementptr { %Callable*, i64 }, { %Callable*, i64 }* %2, i64 0, i32 0
+  %154 = load %Callable*, %Callable** %153
+  call void @__quantum__rt__callable_unreference(%Callable* %154)
+  call void @__quantum__rt__tuple_unreference(%Tuple* %1)
   call void @__quantum__rt__callable_unreference(%Callable* %qop)
   call void @__quantum__rt__callable_unreference(%Callable* %adj_qop)
   call void @__quantum__rt__callable_unreference(%Callable* %ctl_qop)
   call void @__quantum__rt__callable_unreference(%Callable* %adj_ctl_qop)
   call void @__quantum__rt__callable_unreference(%Callable* %ctl_ctl_qop)
-  ret i64 %169
+  ret i64 %152
 }

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestLocalCallables.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestLocalCallables.ll
@@ -1,89 +1,82 @@
 ﻿define { %String*, double }* @Microsoft__Quantum__Testing__QIR__TestLocalCallables__body() {
 entry:
+  %0 = call %Callable* @__quantum__rt__callable_create([4 x void (%Tuple*, %Tuple*, %Tuple*)*]* @Microsoft__Quantum__Testing__QIR__DoNothing, %Tuple* null)
   %arr = call %Array* @__quantum__rt__array_create_1d(i32 8, i64 1)
-  %0 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %arr, i64 0)
-  %1 = bitcast i8* %0 to %Callable**
-  %2 = call %Callable* @__quantum__rt__callable_create([4 x void (%Tuple*, %Tuple*, %Tuple*)*]* @Microsoft__Quantum__Testing__QIR__DoNothing, %Tuple* null)
-  store %Callable* %2, %Callable** %1
-  call void @__quantum__rt__callable_reference(%Callable* %2)
+  %1 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %arr, i64 0)
+  %2 = bitcast i8* %1 to %Callable**
+  store %Callable* %0, %Callable** %2
+  call void @__quantum__rt__callable_reference(%Callable* %0)
+  call void @__quantum__rt__array_add_access(%Array* %arr)
   %3 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %arr, i64 0)
   %4 = bitcast i8* %3 to %Callable**
   %5 = load %Callable*, %Callable** %4
-  %6 = call %Callable* @__quantum__rt__callable_copy(%Callable* %5)
+  %6 = call %Callable* @__quantum__rt__callable_copy(%Callable* %5, i1 true)
   call void @__quantum__rt__callable_make_adjoint(%Callable* %6)
   call void @__quantum__rt__callable_invoke(%Callable* %6, %Tuple* null, %Tuple* null)
   %7 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %arr, i64 0)
   %8 = bitcast i8* %7 to %Callable**
   %9 = load %Callable*, %Callable** %8
-  %10 = call %Callable* @__quantum__rt__callable_copy(%Callable* %9)
+  %10 = call %Callable* @__quantum__rt__callable_copy(%Callable* %9, i1 true)
   call void @__quantum__rt__callable_make_controlled(%Callable* %10)
-  %11 = call %Array* @__quantum__rt__array_create_1d(i32 8, i64 0)
-  %12 = call %Tuple* @__quantum__rt__tuple_create(i64 mul nuw (i64 ptrtoint (i1** getelementptr (i1*, i1** null, i32 1) to i64), i64 2))
-  %13 = bitcast %Tuple* %12 to { %Array*, %Tuple* }*
-  %14 = getelementptr { %Array*, %Tuple* }, { %Array*, %Tuple* }* %13, i64 0, i32 0
-  %15 = getelementptr { %Array*, %Tuple* }, { %Array*, %Tuple* }* %13, i64 0, i32 1
-  store %Array* %11, %Array** %14
-  call void @__quantum__rt__array_reference(%Array* %11)
-  store %Tuple* null, %Tuple** %15
-  %16 = bitcast { %Array*, %Tuple* }* %13 to %Tuple*
-  call void @__quantum__rt__callable_invoke(%Callable* %10, %Tuple* %16, %Tuple* null)
-  %17 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %arr, i64 0)
-  %18 = bitcast i8* %17 to %Callable**
-  %19 = load %Callable*, %Callable** %18
-  call void @__quantum__rt__callable_invoke(%Callable* %19, %Tuple* null, %Tuple* null)
+  %11 = call %Tuple* @__quantum__rt__tuple_create(i64 mul nuw (i64 ptrtoint (i1** getelementptr (i1*, i1** null, i32 1) to i64), i64 2))
+  %12 = bitcast %Tuple* %11 to { %Array*, %Tuple* }*
+  %13 = getelementptr { %Array*, %Tuple* }, { %Array*, %Tuple* }* %12, i64 0, i32 0
+  %14 = getelementptr { %Array*, %Tuple* }, { %Array*, %Tuple* }* %12, i64 0, i32 1
+  %15 = call %Array* @__quantum__rt__array_create_1d(i32 8, i64 0)
+  store %Array* %15, %Array** %13
+  call void @__quantum__rt__array_reference(%Array* %15)
+  store %Tuple* null, %Tuple** %14
+  call void @__quantum__rt__callable_invoke(%Callable* %10, %Tuple* %11, %Tuple* null)
+  %16 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %arr, i64 0)
+  %17 = bitcast i8* %16 to %Callable**
+  %18 = load %Callable*, %Callable** %17
+  call void @__quantum__rt__callable_invoke(%Callable* %18, %Tuple* null, %Tuple* null)
   %fct = call %Callable* @__quantum__rt__callable_create([4 x void (%Tuple*, %Tuple*, %Tuple*)*]* @Microsoft__Quantum__Testing__QIR__ReturnTuple, %Tuple* null)
-  %20 = call %String* @__quantum__rt__string_create(i32 0, [0 x i8] zeroinitializer)
-  %21 = call %Tuple* @__quantum__rt__tuple_create(i64 ptrtoint (i1** getelementptr (i1*, i1** null, i32 1) to i64))
-  %22 = bitcast %Tuple* %21 to { %String* }*
-  %23 = getelementptr { %String* }, { %String* }* %22, i64 0, i32 0
-  store %String* %20, %String** %23
-  call void @__quantum__rt__string_reference(%String* %20)
-  %24 = call %Tuple* @__quantum__rt__tuple_create(i64 mul nuw (i64 ptrtoint (i1** getelementptr (i1*, i1** null, i32 1) to i64), i64 2))
-  %25 = bitcast %Tuple* %24 to { %String*, { i64, double }* }*
-  %26 = bitcast { %String*, { i64, double }* }* %25 to %Tuple*
-  call void @__quantum__rt__callable_invoke(%Callable* %fct, %Tuple* %21, %Tuple* %26)
-  %27 = getelementptr { %String*, { i64, double }* }, { %String*, { i64, double }* }* %25, i64 0, i32 0
-  %28 = getelementptr { %String*, { i64, double }* }, { %String*, { i64, double }* }* %25, i64 0, i32 1
-  %str = load %String*, %String** %27
-  %29 = load { i64, double }*, { i64, double }** %28
-  %30 = getelementptr { i64, double }, { i64, double }* %29, i64 0, i32 0
-  %31 = getelementptr { i64, double }, { i64, double }* %29, i64 0, i32 1
-  %val = load double, double* %31
-  %32 = call %Tuple* @__quantum__rt__tuple_create(i64 ptrtoint ({ %String*, double }* getelementptr ({ %String*, double }, { %String*, double }* null, i32 1) to i64))
-  %33 = bitcast %Tuple* %32 to { %String*, double }*
-  %34 = getelementptr { %String*, double }, { %String*, double }* %33, i64 0, i32 0
-  %35 = getelementptr { %String*, double }, { %String*, double }* %33, i64 0, i32 1
-  store %String* %str, %String** %34
+  %19 = call %String* @__quantum__rt__string_create(i32 0, [0 x i8] zeroinitializer)
+  %20 = call %Tuple* @__quantum__rt__tuple_create(i64 ptrtoint (i1** getelementptr (i1*, i1** null, i32 1) to i64))
+  %21 = bitcast %Tuple* %20 to { %String* }*
+  %22 = getelementptr { %String* }, { %String* }* %21, i64 0, i32 0
+  store %String* %19, %String** %22
+  call void @__quantum__rt__string_reference(%String* %19)
+  %23 = call %Tuple* @__quantum__rt__tuple_create(i64 mul nuw (i64 ptrtoint (i1** getelementptr (i1*, i1** null, i32 1) to i64), i64 2))
+  %24 = bitcast %Tuple* %23 to { %String*, { i64, double }* }*
+  call void @__quantum__rt__callable_invoke(%Callable* %fct, %Tuple* %20, %Tuple* %23)
+  %25 = getelementptr { %String*, { i64, double }* }, { %String*, { i64, double }* }* %24, i64 0, i32 0
+  %str = load %String*, %String** %25
+  %26 = getelementptr { %String*, { i64, double }* }, { %String*, { i64, double }* }* %24, i64 0, i32 1
+  %27 = load { i64, double }*, { i64, double }** %26
+  %28 = getelementptr { i64, double }, { i64, double }* %27, i64 0, i32 1
+  %val = load double, double* %28
+  %29 = call %Tuple* @__quantum__rt__tuple_create(i64 ptrtoint ({ %String*, double }* getelementptr ({ %String*, double }, { %String*, double }* null, i32 1) to i64))
+  %30 = bitcast %Tuple* %29 to { %String*, double }*
+  %31 = getelementptr { %String*, double }, { %String*, double }* %30, i64 0, i32 0
+  %32 = getelementptr { %String*, double }, { %String*, double }* %30, i64 0, i32 1
+  store %String* %str, %String** %31
   call void @__quantum__rt__string_reference(%String* %str)
-  store double %val, double* %35
-  call void @__quantum__rt__callable_unreference(%Callable* %2)
+  store double %val, double* %32
+  call void @__quantum__rt__array_remove_access(%Array* %arr)
+  call void @__quantum__rt__callable_unreference(%Callable* %0)
   call void @__quantum__rt__array_unreference(%Array* %arr)
-  call void @__quantum__rt__callable_unreference(%Callable* %5)
   call void @__quantum__rt__callable_unreference(%Callable* %6)
-  call void @__quantum__rt__callable_unreference(%Callable* %9)
   call void @__quantum__rt__callable_unreference(%Callable* %10)
-  call void @__quantum__rt__array_unreference(%Array* %11)
-  %36 = getelementptr { %Array*, %Tuple* }, { %Array*, %Tuple* }* %13, i64 0, i32 0
-  %37 = load %Array*, %Array** %36
-  call void @__quantum__rt__array_unreference(%Array* %37)
-  %38 = bitcast { %Array*, %Tuple* }* %13 to %Tuple*
-  call void @__quantum__rt__tuple_unreference(%Tuple* %38)
-  call void @__quantum__rt__callable_unreference(%Callable* %19)
+  %33 = getelementptr { %Array*, %Tuple* }, { %Array*, %Tuple* }* %12, i64 0, i32 0
+  %34 = load %Array*, %Array** %33
+  call void @__quantum__rt__array_unreference(%Array* %34)
+  call void @__quantum__rt__tuple_unreference(%Tuple* %11)
+  call void @__quantum__rt__array_unreference(%Array* %15)
   call void @__quantum__rt__callable_unreference(%Callable* %fct)
-  call void @__quantum__rt__string_unreference(%String* %20)
-  %39 = getelementptr { %String* }, { %String* }* %22, i64 0, i32 0
-  %40 = load %String*, %String** %39
-  call void @__quantum__rt__string_unreference(%String* %40)
-  %41 = bitcast { %String* }* %22 to %Tuple*
+  call void @__quantum__rt__string_unreference(%String* %19)
+  %35 = getelementptr { %String* }, { %String* }* %21, i64 0, i32 0
+  %36 = load %String*, %String** %35
+  call void @__quantum__rt__string_unreference(%String* %36)
+  call void @__quantum__rt__tuple_unreference(%Tuple* %20)
+  %37 = getelementptr { %String*, { i64, double }* }, { %String*, { i64, double }* }* %24, i64 0, i32 0
+  %38 = load %String*, %String** %37
+  call void @__quantum__rt__string_unreference(%String* %38)
+  %39 = getelementptr { %String*, { i64, double }* }, { %String*, { i64, double }* }* %24, i64 0, i32 1
+  %40 = load { i64, double }*, { i64, double }** %39
+  %41 = bitcast { i64, double }* %40 to %Tuple*
   call void @__quantum__rt__tuple_unreference(%Tuple* %41)
-  %42 = getelementptr { %String*, { i64, double }* }, { %String*, { i64, double }* }* %25, i64 0, i32 0
-  %43 = load %String*, %String** %42
-  call void @__quantum__rt__string_unreference(%String* %43)
-  %44 = getelementptr { %String*, { i64, double }* }, { %String*, { i64, double }* }* %25, i64 0, i32 1
-  %45 = load { i64, double }*, { i64, double }** %44
-  %46 = bitcast { i64, double }* %45 to %Tuple*
-  call void @__quantum__rt__tuple_unreference(%Tuple* %46)
-  %47 = bitcast { %String*, { i64, double }* }* %25 to %Tuple*
-  call void @__quantum__rt__tuple_unreference(%Tuple* %47)
-  ret { %String*, double }* %33
+  call void @__quantum__rt__tuple_unreference(%Tuple* %23)
+  ret { %String*, double }* %30
 }

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestLocalCallables.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestLocalCallables.ll
@@ -39,8 +39,8 @@ entry:
   store %String* %19, %String** %22
   call void @__quantum__rt__string_reference(%String* %19)
   %23 = call %Tuple* @__quantum__rt__tuple_create(i64 mul nuw (i64 ptrtoint (i1** getelementptr (i1*, i1** null, i32 1) to i64), i64 2))
-  %24 = bitcast %Tuple* %23 to { %String*, { i64, double }* }*
   call void @__quantum__rt__callable_invoke(%Callable* %fct, %Tuple* %20, %Tuple* %23)
+  %24 = bitcast %Tuple* %23 to { %String*, { i64, double }* }*
   %25 = getelementptr { %String*, { i64, double }* }, { %String*, { i64, double }* }* %24, i64 0, i32 0
   %str = load %String*, %String** %25
   %26 = getelementptr { %String*, { i64, double }* }, { %String*, { i64, double }* }* %24, i64 0, i32 1
@@ -56,27 +56,46 @@ entry:
   store double %val, double* %32
   call void @__quantum__rt__array_remove_access(%Array* %arr)
   call void @__quantum__rt__callable_unreference(%Callable* %0)
+  br label %header__1
+
+header__1:                                        ; preds = %exiting__1, %entry
+  %33 = phi i64 [ 0, %entry ], [ %38, %exiting__1 ]
+  %34 = icmp sle i64 %33, 0
+  br i1 %34, label %body__1, label %exit__1
+
+body__1:                                          ; preds = %header__1
+  %35 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %arr, i64 %33)
+  %36 = bitcast i8* %35 to %Callable**
+  %37 = load %Callable*, %Callable** %36
+  call void @__quantum__rt__callable_unreference(%Callable* %37)
+  br label %exiting__1
+
+exiting__1:                                       ; preds = %body__1
+  %38 = add i64 %33, 1
+  br label %header__1
+
+exit__1:                                          ; preds = %header__1
   call void @__quantum__rt__array_unreference(%Array* %arr)
   call void @__quantum__rt__callable_unreference(%Callable* %6)
   call void @__quantum__rt__callable_unreference(%Callable* %10)
-  %33 = getelementptr { %Array*, %Tuple* }, { %Array*, %Tuple* }* %12, i64 0, i32 0
-  %34 = load %Array*, %Array** %33
-  call void @__quantum__rt__array_unreference(%Array* %34)
+  %39 = getelementptr { %Array*, %Tuple* }, { %Array*, %Tuple* }* %12, i64 0, i32 0
+  %40 = load %Array*, %Array** %39
+  call void @__quantum__rt__array_unreference(%Array* %40)
   call void @__quantum__rt__tuple_unreference(%Tuple* %11)
   call void @__quantum__rt__array_unreference(%Array* %15)
   call void @__quantum__rt__callable_unreference(%Callable* %fct)
   call void @__quantum__rt__string_unreference(%String* %19)
-  %35 = getelementptr { %String* }, { %String* }* %21, i64 0, i32 0
-  %36 = load %String*, %String** %35
-  call void @__quantum__rt__string_unreference(%String* %36)
+  %41 = getelementptr { %String* }, { %String* }* %21, i64 0, i32 0
+  %42 = load %String*, %String** %41
+  call void @__quantum__rt__string_unreference(%String* %42)
   call void @__quantum__rt__tuple_unreference(%Tuple* %20)
-  %37 = getelementptr { %String*, { i64, double }* }, { %String*, { i64, double }* }* %24, i64 0, i32 0
-  %38 = load %String*, %String** %37
-  call void @__quantum__rt__string_unreference(%String* %38)
-  %39 = getelementptr { %String*, { i64, double }* }, { %String*, { i64, double }* }* %24, i64 0, i32 1
-  %40 = load { i64, double }*, { i64, double }** %39
-  %41 = bitcast { i64, double }* %40 to %Tuple*
-  call void @__quantum__rt__tuple_unreference(%Tuple* %41)
+  %43 = getelementptr { %String*, { i64, double }* }, { %String*, { i64, double }* }* %24, i64 0, i32 0
+  %44 = load %String*, %String** %43
+  call void @__quantum__rt__string_unreference(%String* %44)
+  %45 = getelementptr { %String*, { i64, double }* }, { %String*, { i64, double }* }* %24, i64 0, i32 1
+  %46 = load { i64, double }*, { i64, double }** %45
+  %47 = bitcast { i64, double }* %46 to %Tuple*
+  call void @__quantum__rt__tuple_unreference(%Tuple* %47)
   call void @__quantum__rt__tuple_unreference(%Tuple* %23)
   ret { %String*, double }* %30
 }

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestOpArgument.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestOpArgument.ll
@@ -8,9 +8,10 @@ entry:
   %4 = getelementptr { %Qubit*, %Qubit* }, { %Qubit*, %Qubit* }* %qs, i64 0, i32 1
   store %Qubit* %0, %Qubit** %3
   store %Qubit* %1, %Qubit** %4
+  call void @__quantum__rt__tuple_add_access(%Tuple* %2)
   %5 = getelementptr { %Qubit*, %Qubit* }, { %Qubit*, %Qubit* }* %qs, i64 0, i32 0
-  %6 = getelementptr { %Qubit*, %Qubit* }, { %Qubit*, %Qubit* }* %qs, i64 0, i32 1
   %q1 = load %Qubit*, %Qubit** %5
+  %6 = getelementptr { %Qubit*, %Qubit* }, { %Qubit*, %Qubit* }* %qs, i64 0, i32 1
   %q2 = load %Qubit*, %Qubit** %6
   %7 = call %Callable* @__quantum__rt__callable_create([4 x void (%Tuple*, %Tuple*, %Tuple*)*]* @Microsoft__Quantum__Testing__QIR___Choose, %Tuple* null)
   %8 = call %Tuple* @__quantum__rt__tuple_create(i64 mul nuw (i64 ptrtoint (i1** getelementptr (i1*, i1** null, i32 1) to i64), i64 2))
@@ -21,128 +22,148 @@ entry:
   call void @__quantum__rt__callable_reference(%Callable* %7)
   store %Qubit* %q1, %Qubit** %11
   %op = call %Callable* @__quantum__rt__callable_create([4 x void (%Tuple*, %Tuple*, %Tuple*)*]* @PartialApplication__1, %Tuple* %8)
-  %12 = getelementptr { %Qubit*, %Qubit* }, { %Qubit*, %Qubit* }* %qs, i64 0, i32 0
-  %13 = getelementptr { %Qubit*, %Qubit* }, { %Qubit*, %Qubit* }* %qs, i64 0, i32 1
-  %.control = load %Qubit*, %Qubit** %12
-  %.target = load %Qubit*, %Qubit** %13
-  call void @__quantum__qis__cnot__body(%Qubit* %.control, %Qubit* %.target)
+  %12 = getelementptr { %Callable*, %Qubit* }, { %Callable*, %Qubit* }* %9, i64 0, i32 0
+  %13 = load %Callable*, %Callable** %12
+  call void @__quantum__rt__callable_reference(%Callable* %13)
+  call void @__quantum__rt__tuple_reference(%Tuple* %8)
   %14 = getelementptr { %Qubit*, %Qubit* }, { %Qubit*, %Qubit* }* %qs, i64 0, i32 0
+  %control__inline__1 = load %Qubit*, %Qubit** %14
   %15 = getelementptr { %Qubit*, %Qubit* }, { %Qubit*, %Qubit* }* %qs, i64 0, i32 1
-  %16 = load %Qubit*, %Qubit** %14
-  %17 = load %Qubit*, %Qubit** %15
-  call void @__quantum__qis__swap(%Qubit* %16, %Qubit* %17)
-  %18 = call %Callable* @__quantum__rt__callable_create([4 x void (%Tuple*, %Tuple*, %Tuple*)*]* @Microsoft__Quantum__Intrinsic__CNOT, %Tuple* null)
-  %19 = call %Tuple* @__quantum__rt__tuple_create(i64 mul nuw (i64 ptrtoint (i1** getelementptr (i1*, i1** null, i32 1) to i64), i64 2))
-  %20 = bitcast %Tuple* %19 to { %Callable*, %Qubit* }*
-  %21 = getelementptr { %Callable*, %Qubit* }, { %Callable*, %Qubit* }* %20, i64 0, i32 0
-  %22 = getelementptr { %Callable*, %Qubit* }, { %Callable*, %Qubit* }* %20, i64 0, i32 1
-  store %Callable* %18, %Callable** %21
-  call void @__quantum__rt__callable_reference(%Callable* %18)
-  store %Qubit* %q1, %Qubit** %22
-  %23 = call %Callable* @__quantum__rt__callable_create([4 x void (%Tuple*, %Tuple*, %Tuple*)*]* @PartialApplication__2, %Tuple* %19)
-  call void @Microsoft__Quantum__Testing__QIR__Apply__body(%Callable* %23)
-  %24 = call %Callable* @__quantum__rt__callable_create([4 x void (%Tuple*, %Tuple*, %Tuple*)*]* @Microsoft__Quantum__Testing__QIR___SWAP, %Tuple* null)
-  %25 = call %Tuple* @__quantum__rt__tuple_create(i64 mul nuw (i64 ptrtoint (i1** getelementptr (i1*, i1** null, i32 1) to i64), i64 2))
-  %26 = bitcast %Tuple* %25 to { %Callable*, %Qubit* }*
-  %27 = getelementptr { %Callable*, %Qubit* }, { %Callable*, %Qubit* }* %26, i64 0, i32 0
-  %28 = getelementptr { %Callable*, %Qubit* }, { %Callable*, %Qubit* }* %26, i64 0, i32 1
-  store %Callable* %24, %Callable** %27
-  call void @__quantum__rt__callable_reference(%Callable* %24)
-  store %Qubit* %q1, %Qubit** %28
-  %29 = call %Callable* @__quantum__rt__callable_create([4 x void (%Tuple*, %Tuple*, %Tuple*)*]* @PartialApplication__3, %Tuple* %25)
-  call void @Microsoft__Quantum__Testing__QIR__Apply__body(%Callable* %29)
-  %30 = call %Callable* @__quantum__rt__callable_create([4 x void (%Tuple*, %Tuple*, %Tuple*)*]* @Microsoft__Quantum__Testing__QIR___Choose, %Tuple* null)
-  %31 = call %Tuple* @__quantum__rt__tuple_create(i64 mul nuw (i64 ptrtoint (i1** getelementptr (i1*, i1** null, i32 1) to i64), i64 3))
-  %32 = bitcast %Tuple* %31 to { %Callable*, %Qubit*, %Qubit* }*
-  %33 = getelementptr { %Callable*, %Qubit*, %Qubit* }, { %Callable*, %Qubit*, %Qubit* }* %32, i64 0, i32 0
-  %34 = getelementptr { %Callable*, %Qubit*, %Qubit* }, { %Callable*, %Qubit*, %Qubit* }* %32, i64 0, i32 1
-  %35 = getelementptr { %Callable*, %Qubit*, %Qubit* }, { %Callable*, %Qubit*, %Qubit* }* %32, i64 0, i32 2
-  store %Callable* %30, %Callable** %33
-  call void @__quantum__rt__callable_reference(%Callable* %30)
-  store %Qubit* %q1, %Qubit** %34
-  store %Qubit* %q2, %Qubit** %35
-  %36 = call %Callable* @__quantum__rt__callable_create([4 x void (%Tuple*, %Tuple*, %Tuple*)*]* @PartialApplication__4, %Tuple* %31)
-  call void @Microsoft__Quantum__Testing__QIR__Apply__body(%Callable* %36)
-  %37 = call %Callable* @__quantum__rt__callable_create([4 x void (%Tuple*, %Tuple*, %Tuple*)*]* @Microsoft__Quantum__Testing__QIR___Choose, %Tuple* null)
-  %38 = call %Tuple* @__quantum__rt__tuple_create(i64 mul nuw (i64 ptrtoint (i1** getelementptr (i1*, i1** null, i32 1) to i64), i64 3))
-  %39 = bitcast %Tuple* %38 to { %Callable*, %Qubit*, %Qubit* }*
-  %40 = getelementptr { %Callable*, %Qubit*, %Qubit* }, { %Callable*, %Qubit*, %Qubit* }* %39, i64 0, i32 0
-  %41 = getelementptr { %Callable*, %Qubit*, %Qubit* }, { %Callable*, %Qubit*, %Qubit* }* %39, i64 0, i32 1
-  %42 = getelementptr { %Callable*, %Qubit*, %Qubit* }, { %Callable*, %Qubit*, %Qubit* }* %39, i64 0, i32 2
-  store %Callable* %37, %Callable** %40
-  call void @__quantum__rt__callable_reference(%Callable* %37)
-  store %Qubit* %q1, %Qubit** %41
-  store %Qubit* %q2, %Qubit** %42
-  %43 = call %Callable* @__quantum__rt__callable_create([4 x void (%Tuple*, %Tuple*, %Tuple*)*]* @PartialApplication__5, %Tuple* %38)
-  call void @Microsoft__Quantum__Testing__QIR__Apply__body(%Callable* %43)
-  %44 = call %Callable* @__quantum__rt__callable_create([4 x void (%Tuple*, %Tuple*, %Tuple*)*]* @Microsoft__Quantum__Testing__QIR___Choose, %Tuple* null)
-  %45 = call %Tuple* @__quantum__rt__tuple_create(i64 mul nuw (i64 ptrtoint (i1** getelementptr (i1*, i1** null, i32 1) to i64), i64 2))
-  %46 = bitcast %Tuple* %45 to { %Callable*, { %Qubit*, %Qubit* }* }*
-  %47 = getelementptr { %Callable*, { %Qubit*, %Qubit* }* }, { %Callable*, { %Qubit*, %Qubit* }* }* %46, i64 0, i32 0
-  %48 = getelementptr { %Callable*, { %Qubit*, %Qubit* }* }, { %Callable*, { %Qubit*, %Qubit* }* }* %46, i64 0, i32 1
-  store %Callable* %44, %Callable** %47
+  %target__inline__1 = load %Qubit*, %Qubit** %15
+  call void @__quantum__qis__cnot__body(%Qubit* %control__inline__1, %Qubit* %target__inline__1)
+  %16 = getelementptr { %Qubit*, %Qubit* }, { %Qubit*, %Qubit* }* %qs, i64 0, i32 0
+  %17 = getelementptr { %Qubit*, %Qubit* }, { %Qubit*, %Qubit* }* %qs, i64 0, i32 1
+  %18 = load %Qubit*, %Qubit** %16
+  %19 = load %Qubit*, %Qubit** %17
+  call void @__quantum__qis__swap(%Qubit* %18, %Qubit* %19)
+  %20 = call %Callable* @__quantum__rt__callable_create([4 x void (%Tuple*, %Tuple*, %Tuple*)*]* @Microsoft__Quantum__Intrinsic__CNOT, %Tuple* null)
+  %21 = call %Tuple* @__quantum__rt__tuple_create(i64 mul nuw (i64 ptrtoint (i1** getelementptr (i1*, i1** null, i32 1) to i64), i64 2))
+  %22 = bitcast %Tuple* %21 to { %Callable*, %Qubit* }*
+  %23 = getelementptr { %Callable*, %Qubit* }, { %Callable*, %Qubit* }* %22, i64 0, i32 0
+  %24 = getelementptr { %Callable*, %Qubit* }, { %Callable*, %Qubit* }* %22, i64 0, i32 1
+  store %Callable* %20, %Callable** %23
+  call void @__quantum__rt__callable_reference(%Callable* %20)
+  store %Qubit* %q1, %Qubit** %24
+  %25 = call %Callable* @__quantum__rt__callable_create([4 x void (%Tuple*, %Tuple*, %Tuple*)*]* @PartialApplication__2, %Tuple* %21)
+  %26 = getelementptr { %Callable*, %Qubit* }, { %Callable*, %Qubit* }* %22, i64 0, i32 0
+  %27 = load %Callable*, %Callable** %26
+  call void @__quantum__rt__callable_reference(%Callable* %27)
+  call void @__quantum__rt__tuple_reference(%Tuple* %21)
+  call void @Microsoft__Quantum__Testing__QIR__Apply__body(%Callable* %25)
+  %28 = call %Callable* @__quantum__rt__callable_create([4 x void (%Tuple*, %Tuple*, %Tuple*)*]* @Microsoft__Quantum__Testing__QIR___SWAP, %Tuple* null)
+  %29 = call %Tuple* @__quantum__rt__tuple_create(i64 mul nuw (i64 ptrtoint (i1** getelementptr (i1*, i1** null, i32 1) to i64), i64 2))
+  %30 = bitcast %Tuple* %29 to { %Callable*, %Qubit* }*
+  %31 = getelementptr { %Callable*, %Qubit* }, { %Callable*, %Qubit* }* %30, i64 0, i32 0
+  %32 = getelementptr { %Callable*, %Qubit* }, { %Callable*, %Qubit* }* %30, i64 0, i32 1
+  store %Callable* %28, %Callable** %31
+  call void @__quantum__rt__callable_reference(%Callable* %28)
+  store %Qubit* %q1, %Qubit** %32
+  %33 = call %Callable* @__quantum__rt__callable_create([4 x void (%Tuple*, %Tuple*, %Tuple*)*]* @PartialApplication__3, %Tuple* %29)
+  %34 = getelementptr { %Callable*, %Qubit* }, { %Callable*, %Qubit* }* %30, i64 0, i32 0
+  %35 = load %Callable*, %Callable** %34
+  call void @__quantum__rt__callable_reference(%Callable* %35)
+  call void @__quantum__rt__tuple_reference(%Tuple* %29)
+  call void @Microsoft__Quantum__Testing__QIR__Apply__body(%Callable* %33)
+  %36 = call %Callable* @__quantum__rt__callable_create([4 x void (%Tuple*, %Tuple*, %Tuple*)*]* @Microsoft__Quantum__Testing__QIR___Choose, %Tuple* null)
+  %37 = call %Tuple* @__quantum__rt__tuple_create(i64 mul nuw (i64 ptrtoint (i1** getelementptr (i1*, i1** null, i32 1) to i64), i64 3))
+  %38 = bitcast %Tuple* %37 to { %Callable*, %Qubit*, %Qubit* }*
+  %39 = getelementptr { %Callable*, %Qubit*, %Qubit* }, { %Callable*, %Qubit*, %Qubit* }* %38, i64 0, i32 0
+  %40 = getelementptr { %Callable*, %Qubit*, %Qubit* }, { %Callable*, %Qubit*, %Qubit* }* %38, i64 0, i32 1
+  %41 = getelementptr { %Callable*, %Qubit*, %Qubit* }, { %Callable*, %Qubit*, %Qubit* }* %38, i64 0, i32 2
+  store %Callable* %36, %Callable** %39
+  call void @__quantum__rt__callable_reference(%Callable* %36)
+  store %Qubit* %q1, %Qubit** %40
+  store %Qubit* %q2, %Qubit** %41
+  %42 = call %Callable* @__quantum__rt__callable_create([4 x void (%Tuple*, %Tuple*, %Tuple*)*]* @PartialApplication__4, %Tuple* %37)
+  %43 = getelementptr { %Callable*, %Qubit*, %Qubit* }, { %Callable*, %Qubit*, %Qubit* }* %38, i64 0, i32 0
+  %44 = load %Callable*, %Callable** %43
   call void @__quantum__rt__callable_reference(%Callable* %44)
-  store { %Qubit*, %Qubit* }* %qs, { %Qubit*, %Qubit* }** %48
-  %49 = bitcast { %Qubit*, %Qubit* }* %qs to %Tuple*
-  call void @__quantum__rt__tuple_reference(%Tuple* %49)
-  %50 = call %Callable* @__quantum__rt__callable_create([4 x void (%Tuple*, %Tuple*, %Tuple*)*]* @PartialApplication__6, %Tuple* %45)
-  call void @Microsoft__Quantum__Testing__QIR__Apply__body(%Callable* %50)
-  %51 = bitcast { %Qubit*, %Qubit* }* %qs to %Tuple*
-  call void @__quantum__rt__callable_invoke(%Callable* %op, %Tuple* %51, %Tuple* null)
+  call void @__quantum__rt__tuple_reference(%Tuple* %37)
+  call void @Microsoft__Quantum__Testing__QIR__Apply__body(%Callable* %42)
+  %45 = call %Callable* @__quantum__rt__callable_create([4 x void (%Tuple*, %Tuple*, %Tuple*)*]* @Microsoft__Quantum__Testing__QIR___Choose, %Tuple* null)
+  %46 = call %Tuple* @__quantum__rt__tuple_create(i64 mul nuw (i64 ptrtoint (i1** getelementptr (i1*, i1** null, i32 1) to i64), i64 3))
+  %47 = bitcast %Tuple* %46 to { %Callable*, %Qubit*, %Qubit* }*
+  %48 = getelementptr { %Callable*, %Qubit*, %Qubit* }, { %Callable*, %Qubit*, %Qubit* }* %47, i64 0, i32 0
+  %49 = getelementptr { %Callable*, %Qubit*, %Qubit* }, { %Callable*, %Qubit*, %Qubit* }* %47, i64 0, i32 1
+  %50 = getelementptr { %Callable*, %Qubit*, %Qubit* }, { %Callable*, %Qubit*, %Qubit* }* %47, i64 0, i32 2
+  store %Callable* %45, %Callable** %48
+  call void @__quantum__rt__callable_reference(%Callable* %45)
+  store %Qubit* %q1, %Qubit** %49
+  store %Qubit* %q2, %Qubit** %50
+  %51 = call %Callable* @__quantum__rt__callable_create([4 x void (%Tuple*, %Tuple*, %Tuple*)*]* @PartialApplication__5, %Tuple* %46)
+  %52 = getelementptr { %Callable*, %Qubit*, %Qubit* }, { %Callable*, %Qubit*, %Qubit* }* %47, i64 0, i32 0
+  %53 = load %Callable*, %Callable** %52
+  call void @__quantum__rt__callable_reference(%Callable* %53)
+  call void @__quantum__rt__tuple_reference(%Tuple* %46)
+  call void @Microsoft__Quantum__Testing__QIR__Apply__body(%Callable* %51)
+  %54 = call %Callable* @__quantum__rt__callable_create([4 x void (%Tuple*, %Tuple*, %Tuple*)*]* @Microsoft__Quantum__Testing__QIR___Choose, %Tuple* null)
+  %55 = call %Tuple* @__quantum__rt__tuple_create(i64 mul nuw (i64 ptrtoint (i1** getelementptr (i1*, i1** null, i32 1) to i64), i64 2))
+  %56 = bitcast %Tuple* %55 to { %Callable*, { %Qubit*, %Qubit* }* }*
+  %57 = getelementptr { %Callable*, { %Qubit*, %Qubit* }* }, { %Callable*, { %Qubit*, %Qubit* }* }* %56, i64 0, i32 0
+  %58 = getelementptr { %Callable*, { %Qubit*, %Qubit* }* }, { %Callable*, { %Qubit*, %Qubit* }* }* %56, i64 0, i32 1
+  store %Callable* %54, %Callable** %57
+  call void @__quantum__rt__callable_reference(%Callable* %54)
+  store { %Qubit*, %Qubit* }* %qs, { %Qubit*, %Qubit* }** %58
+  call void @__quantum__rt__tuple_reference(%Tuple* %2)
+  %59 = call %Callable* @__quantum__rt__callable_create([4 x void (%Tuple*, %Tuple*, %Tuple*)*]* @PartialApplication__6, %Tuple* %55)
+  %60 = getelementptr { %Callable*, { %Qubit*, %Qubit* }* }, { %Callable*, { %Qubit*, %Qubit* }* }* %56, i64 0, i32 0
+  %61 = load %Callable*, %Callable** %60
+  call void @__quantum__rt__callable_reference(%Callable* %61)
+  %62 = getelementptr { %Callable*, { %Qubit*, %Qubit* }* }, { %Callable*, { %Qubit*, %Qubit* }* }* %56, i64 0, i32 1
+  %63 = load { %Qubit*, %Qubit* }*, { %Qubit*, %Qubit* }** %62
+  %64 = bitcast { %Qubit*, %Qubit* }* %63 to %Tuple*
+  call void @__quantum__rt__tuple_reference(%Tuple* %64)
+  call void @__quantum__rt__tuple_reference(%Tuple* %55)
+  call void @Microsoft__Quantum__Testing__QIR__Apply__body(%Callable* %59)
+  call void @__quantum__rt__callable_invoke(%Callable* %op, %Tuple* %2, %Tuple* null)
   call void @__quantum__rt__qubit_release(%Qubit* %0)
   call void @__quantum__rt__qubit_release(%Qubit* %1)
-  %52 = bitcast { %Qubit*, %Qubit* }* %qs to %Tuple*
-  call void @__quantum__rt__tuple_unreference(%Tuple* %52)
+  call void @__quantum__rt__tuple_remove_access(%Tuple* %2)
+  call void @__quantum__rt__tuple_unreference(%Tuple* %2)
   call void @__quantum__rt__callable_unreference(%Callable* %7)
-  %53 = getelementptr { %Callable*, %Qubit* }, { %Callable*, %Qubit* }* %9, i64 0, i32 0
-  %54 = load %Callable*, %Callable** %53
-  call void @__quantum__rt__callable_unreference(%Callable* %54)
-  %55 = bitcast { %Callable*, %Qubit* }* %9 to %Tuple*
-  call void @__quantum__rt__tuple_unreference(%Tuple* %55)
-  call void @__quantum__rt__callable_unreference(%Callable* %op)
-  call void @__quantum__rt__callable_unreference(%Callable* %18)
-  %56 = getelementptr { %Callable*, %Qubit* }, { %Callable*, %Qubit* }* %20, i64 0, i32 0
-  %57 = load %Callable*, %Callable** %56
-  call void @__quantum__rt__callable_unreference(%Callable* %57)
-  %58 = bitcast { %Callable*, %Qubit* }* %20 to %Tuple*
-  call void @__quantum__rt__tuple_unreference(%Tuple* %58)
-  call void @__quantum__rt__callable_unreference(%Callable* %23)
-  call void @__quantum__rt__callable_unreference(%Callable* %24)
-  %59 = getelementptr { %Callable*, %Qubit* }, { %Callable*, %Qubit* }* %26, i64 0, i32 0
-  %60 = load %Callable*, %Callable** %59
-  call void @__quantum__rt__callable_unreference(%Callable* %60)
-  %61 = bitcast { %Callable*, %Qubit* }* %26 to %Tuple*
-  call void @__quantum__rt__tuple_unreference(%Tuple* %61)
-  call void @__quantum__rt__callable_unreference(%Callable* %29)
-  call void @__quantum__rt__callable_unreference(%Callable* %30)
-  %62 = getelementptr { %Callable*, %Qubit*, %Qubit* }, { %Callable*, %Qubit*, %Qubit* }* %32, i64 0, i32 0
-  %63 = load %Callable*, %Callable** %62
-  call void @__quantum__rt__callable_unreference(%Callable* %63)
-  %64 = bitcast { %Callable*, %Qubit*, %Qubit* }* %32 to %Tuple*
-  call void @__quantum__rt__tuple_unreference(%Tuple* %64)
-  call void @__quantum__rt__callable_unreference(%Callable* %36)
-  call void @__quantum__rt__callable_unreference(%Callable* %37)
-  %65 = getelementptr { %Callable*, %Qubit*, %Qubit* }, { %Callable*, %Qubit*, %Qubit* }* %39, i64 0, i32 0
+  %65 = getelementptr { %Callable*, %Qubit* }, { %Callable*, %Qubit* }* %9, i64 0, i32 0
   %66 = load %Callable*, %Callable** %65
   call void @__quantum__rt__callable_unreference(%Callable* %66)
-  %67 = bitcast { %Callable*, %Qubit*, %Qubit* }* %39 to %Tuple*
-  call void @__quantum__rt__tuple_unreference(%Tuple* %67)
-  call void @__quantum__rt__callable_unreference(%Callable* %43)
-  call void @__quantum__rt__callable_unreference(%Callable* %44)
-  %68 = getelementptr { %Callable*, { %Qubit*, %Qubit* }* }, { %Callable*, { %Qubit*, %Qubit* }* }* %46, i64 0, i32 0
-  %69 = load %Callable*, %Callable** %68
-  call void @__quantum__rt__callable_unreference(%Callable* %69)
-  %70 = getelementptr { %Callable*, { %Qubit*, %Qubit* }* }, { %Callable*, { %Qubit*, %Qubit* }* }* %46, i64 0, i32 1
-  %71 = load { %Qubit*, %Qubit* }*, { %Qubit*, %Qubit* }** %70
-  %72 = bitcast { %Qubit*, %Qubit* }* %71 to %Tuple*
-  call void @__quantum__rt__tuple_unreference(%Tuple* %72)
-  %73 = bitcast { %Callable*, { %Qubit*, %Qubit* }* }* %46 to %Tuple*
-  call void @__quantum__rt__tuple_unreference(%Tuple* %73)
-  call void @__quantum__rt__callable_unreference(%Callable* %50)
-  %74 = call %Callable* @__quantum__rt__callable_create([4 x void (%Tuple*, %Tuple*, %Tuple*)*]* @Microsoft__Quantum__Testing__QIR__GetNestedTuple, %Tuple* null)
-  call void @Microsoft__Quantum__Testing__QIR_____GUID___InvokeAndIgnore__body(%Callable* %74)
-  call void @__quantum__qis__diagnose__body()
-  %75 = call %String* @__quantum__qis__message()
+  call void @__quantum__rt__tuple_unreference(%Tuple* %8)
+  call void @__quantum__rt__callable_unreference(%Callable* %op)
+  call void @__quantum__rt__callable_unreference(%Callable* %20)
+  %67 = getelementptr { %Callable*, %Qubit* }, { %Callable*, %Qubit* }* %22, i64 0, i32 0
+  %68 = load %Callable*, %Callable** %67
+  call void @__quantum__rt__callable_unreference(%Callable* %68)
+  call void @__quantum__rt__tuple_unreference(%Tuple* %21)
+  call void @__quantum__rt__callable_unreference(%Callable* %25)
+  call void @__quantum__rt__callable_unreference(%Callable* %28)
+  %69 = getelementptr { %Callable*, %Qubit* }, { %Callable*, %Qubit* }* %30, i64 0, i32 0
+  %70 = load %Callable*, %Callable** %69
+  call void @__quantum__rt__callable_unreference(%Callable* %70)
+  call void @__quantum__rt__tuple_unreference(%Tuple* %29)
+  call void @__quantum__rt__callable_unreference(%Callable* %33)
+  call void @__quantum__rt__callable_unreference(%Callable* %36)
+  %71 = getelementptr { %Callable*, %Qubit*, %Qubit* }, { %Callable*, %Qubit*, %Qubit* }* %38, i64 0, i32 0
+  %72 = load %Callable*, %Callable** %71
+  call void @__quantum__rt__callable_unreference(%Callable* %72)
+  call void @__quantum__rt__tuple_unreference(%Tuple* %37)
+  call void @__quantum__rt__callable_unreference(%Callable* %42)
+  call void @__quantum__rt__callable_unreference(%Callable* %45)
+  %73 = getelementptr { %Callable*, %Qubit*, %Qubit* }, { %Callable*, %Qubit*, %Qubit* }* %47, i64 0, i32 0
+  %74 = load %Callable*, %Callable** %73
   call void @__quantum__rt__callable_unreference(%Callable* %74)
-  ret %String* %75
+  call void @__quantum__rt__tuple_unreference(%Tuple* %46)
+  call void @__quantum__rt__callable_unreference(%Callable* %51)
+  call void @__quantum__rt__callable_unreference(%Callable* %54)
+  %75 = getelementptr { %Callable*, { %Qubit*, %Qubit* }* }, { %Callable*, { %Qubit*, %Qubit* }* }* %56, i64 0, i32 0
+  %76 = load %Callable*, %Callable** %75
+  call void @__quantum__rt__callable_unreference(%Callable* %76)
+  %77 = getelementptr { %Callable*, { %Qubit*, %Qubit* }* }, { %Callable*, { %Qubit*, %Qubit* }* }* %56, i64 0, i32 1
+  %78 = load { %Qubit*, %Qubit* }*, { %Qubit*, %Qubit* }** %77
+  %79 = bitcast { %Qubit*, %Qubit* }* %78 to %Tuple*
+  call void @__quantum__rt__tuple_unreference(%Tuple* %79)
+  call void @__quantum__rt__tuple_unreference(%Tuple* %55)
+  call void @__quantum__rt__callable_unreference(%Callable* %59)
+  %80 = call %Callable* @__quantum__rt__callable_create([4 x void (%Tuple*, %Tuple*, %Tuple*)*]* @Microsoft__Quantum__Testing__QIR__GetNestedTuple, %Tuple* null)
+  call void @Microsoft__Quantum__Testing__QIR_____GUID___InvokeAndIgnore__body(%Callable* %80)
+  call void @__quantum__qis__diagnose__body()
+  %81 = call %String* @__quantum__qis__message()
+  call void @__quantum__rt__callable_unreference(%Callable* %80)
+  ret %String* %81
 }

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestOpCall1.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestOpCall1.ll
@@ -33,13 +33,12 @@ entry:
   %15 = getelementptr { %Array* }, { %Array* }* %7, i64 0, i32 0
   %16 = load %Array*, %Array** %15
   call void @__quantum__rt__array_unreference(%Array* %16)
-  %17 = bitcast { %Array* }* %7 to %Tuple*
-  call void @__quantum__rt__tuple_unreference(%Tuple* %17)
+  call void @__quantum__rt__tuple_unreference(%Tuple* %6)
   call void @__quantum__rt__array_unreference(%Array* %9)
   call void @__quantum__rt__array_unreference(%Array* %12)
-  %18 = call %Callable* @__quantum__rt__callable_create([4 x void (%Tuple*, %Tuple*, %Tuple*)*]* @Microsoft__Quantum__Testing__QIR__ReturnDoNothing, %Tuple* null)
-  call void @Microsoft__Quantum__Testing__QIR__TakesSingleTupleArg__body(i64 2, %Callable* %18)
+  %17 = call %Callable* @__quantum__rt__callable_create([4 x void (%Tuple*, %Tuple*, %Tuple*)*]* @Microsoft__Quantum__Testing__QIR__ReturnDoNothing, %Tuple* null)
+  call void @Microsoft__Quantum__Testing__QIR__TakesSingleTupleArg__body(i64 2, %Callable* %17)
   call void @__quantum__rt__callable_unreference(%Callable* %doNothing)
-  call void @__quantum__rt__callable_unreference(%Callable* %18)
+  call void @__quantum__rt__callable_unreference(%Callable* %17)
   ret void
 }

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestOpCall2.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestOpCall2.ll
@@ -1,32 +1,38 @@
 define void @Microsoft__Quantum__Testing__QIR__CNOT__ctl(%Array* %__controlQubits__, { %Qubit*, %Qubit* }* %arg__1) {
 entry:
-  %0 = getelementptr { %Qubit*, %Qubit* }, { %Qubit*, %Qubit* }* %arg__1, i64 0, i32 0
-  %control = load %Qubit*, %Qubit** %0
-  %1 = getelementptr { %Qubit*, %Qubit* }, { %Qubit*, %Qubit* }* %arg__1, i64 0, i32 1
-  %target = load %Qubit*, %Qubit** %1
-  %2 = call %Array* @__quantum__rt__array_create_1d(i32 8, i64 1)
-  %3 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %2, i64 0)
-  %4 = bitcast i8* %3 to %Qubit**
-  store %Qubit* %control, %Qubit** %4
-  %5 = call %Array* @__quantum__rt__array_concatenate(%Array* %__controlQubits__, %Array* %2)
-  %6 = call %Tuple* @__quantum__rt__tuple_create(i64 mul nuw (i64 ptrtoint (i1** getelementptr (i1*, i1** null, i32 1) to i64), i64 2))
-  %7 = bitcast %Tuple* %6 to { %Array*, %Qubit* }*
-  %8 = getelementptr { %Array*, %Qubit* }, { %Array*, %Qubit* }* %7, i64 0, i32 0
-  %9 = getelementptr { %Array*, %Qubit* }, { %Array*, %Qubit* }* %7, i64 0, i32 1
-  store %Array* %5, %Array** %8
-  call void @__quantum__rt__array_reference(%Array* %5)
-  store %Qubit* %target, %Qubit** %9
-  %10 = getelementptr { %Array*, %Qubit* }, { %Array*, %Qubit* }* %7, i64 0, i32 0
-  %11 = getelementptr { %Array*, %Qubit* }, { %Array*, %Qubit* }* %7, i64 0, i32 1
-  %.__controlQubits__ = load %Array*, %Array** %10
-  %.q = load %Qubit*, %Qubit** %11
-  call void @__quantum__qis__x__ctl(%Array* %.__controlQubits__, %Qubit* %.q)
-  call void @__quantum__rt__array_unreference(%Array* %2)
-  call void @__quantum__rt__array_unreference(%Array* %5)
-  %12 = getelementptr { %Array*, %Qubit* }, { %Array*, %Qubit* }* %7, i64 0, i32 0
-  %13 = load %Array*, %Array** %12
-  call void @__quantum__rt__array_unreference(%Array* %13)
-  %14 = bitcast { %Array*, %Qubit* }* %7 to %Tuple*
-  call void @__quantum__rt__tuple_unreference(%Tuple* %14)
+  call void @__quantum__rt__array_add_access(%Array* %__controlQubits__)
+  %0 = bitcast { %Qubit*, %Qubit* }* %arg__1 to %Tuple*
+  call void @__quantum__rt__tuple_add_access(%Tuple* %0)
+  %1 = getelementptr { %Qubit*, %Qubit* }, { %Qubit*, %Qubit* }* %arg__1, i64 0, i32 0
+  %control = load %Qubit*, %Qubit** %1
+  %2 = getelementptr { %Qubit*, %Qubit* }, { %Qubit*, %Qubit* }* %arg__1, i64 0, i32 1
+  %target = load %Qubit*, %Qubit** %2
+  %3 = call %Array* @__quantum__rt__array_create_1d(i32 8, i64 1)
+  %4 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %3, i64 0)
+  %5 = bitcast i8* %4 to %Qubit**
+  store %Qubit* %control, %Qubit** %5
+  %6 = call %Array* @__quantum__rt__array_concatenate(%Array* %__controlQubits__, %Array* %3)
+  %7 = call %Tuple* @__quantum__rt__tuple_create(i64 mul nuw (i64 ptrtoint (i1** getelementptr (i1*, i1** null, i32 1) to i64), i64 2))
+  %8 = bitcast %Tuple* %7 to { %Array*, %Qubit* }*
+  %9 = getelementptr { %Array*, %Qubit* }, { %Array*, %Qubit* }* %8, i64 0, i32 0
+  %10 = getelementptr { %Array*, %Qubit* }, { %Array*, %Qubit* }* %8, i64 0, i32 1
+  store %Array* %6, %Array** %9
+  call void @__quantum__rt__array_reference(%Array* %6)
+  store %Qubit* %target, %Qubit** %10
+  %11 = getelementptr { %Array*, %Qubit* }, { %Array*, %Qubit* }* %8, i64 0, i32 0
+  %__controlQubits____inline__1 = load %Array*, %Array** %11
+  call void @__quantum__rt__array_add_access(%Array* %__controlQubits____inline__1)
+  %12 = getelementptr { %Array*, %Qubit* }, { %Array*, %Qubit* }* %8, i64 0, i32 1
+  %q__inline__1 = load %Qubit*, %Qubit** %12
+  call void @__quantum__qis__x__ctl(%Array* %__controlQubits____inline__1, %Qubit* %q__inline__1)
+  call void @__quantum__rt__array_remove_access(%Array* %__controlQubits____inline__1)
+  call void @__quantum__rt__array_unreference(%Array* %3)
+  call void @__quantum__rt__array_unreference(%Array* %6)
+  %13 = getelementptr { %Array*, %Qubit* }, { %Array*, %Qubit* }* %8, i64 0, i32 0
+  %14 = load %Array*, %Array** %13
+  call void @__quantum__rt__array_unreference(%Array* %14)
+  call void @__quantum__rt__tuple_unreference(%Tuple* %7)
+  call void @__quantum__rt__array_remove_access(%Array* %__controlQubits__)
+  call void @__quantum__rt__tuple_remove_access(%Tuple* %0)
   ret void
 }

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestPartials1.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestPartials1.ll
@@ -9,224 +9,251 @@ entry:
   call void @__quantum__rt__callable_reference(%Callable* %0)
   store double 2.500000e-01, double* %4
   %rotate = call %Callable* @__quantum__rt__callable_create([4 x void (%Tuple*, %Tuple*, %Tuple*)*]* @PartialApplication__1, %Tuple* %1)
-  %unrotate = call %Callable* @__quantum__rt__callable_copy(%Callable* %rotate)
+  %5 = getelementptr { %Callable*, double }, { %Callable*, double }* %2, i64 0, i32 0
+  %6 = load %Callable*, %Callable** %5
+  call void @__quantum__rt__callable_reference(%Callable* %6)
+  call void @__quantum__rt__tuple_reference(%Tuple* %1)
+  %unrotate = call %Callable* @__quantum__rt__callable_copy(%Callable* %rotate, i1 true)
   call void @__quantum__rt__callable_make_adjoint(%Callable* %unrotate)
-  br label %preheader__1
-
-preheader__1:                                     ; preds = %entry
   br label %header__1
 
-header__1:                                        ; preds = %exiting__1, %preheader__1
-  %i = phi i64 [ 0, %preheader__1 ], [ %107, %exiting__1 ]
-  %5 = icmp sge i64 %i, 100
-  %6 = icmp sle i64 %i, 100
-  %7 = select i1 true, i1 %6, i1 %5
-  br i1 %7, label %body__1, label %exit__1
+header__1:                                        ; preds = %exiting__1, %entry
+  %i = phi i64 [ 0, %entry ], [ %117, %exiting__1 ]
+  %7 = icmp sge i64 %i, 100
+  %8 = icmp sle i64 %i, 100
+  %9 = select i1 true, i1 %8, i1 %7
+  br i1 %9, label %body__1, label %exit__1
 
 body__1:                                          ; preds = %header__1
   %qb = call %Qubit* @__quantum__rt__qubit_allocate()
-  %8 = call %Tuple* @__quantum__rt__tuple_create(i64 ptrtoint (i1** getelementptr (i1*, i1** null, i32 1) to i64))
-  %9 = bitcast %Tuple* %8 to { %Qubit* }*
-  %10 = getelementptr { %Qubit* }, { %Qubit* }* %9, i64 0, i32 0
-  store %Qubit* %qb, %Qubit** %10
-  call void @__quantum__rt__callable_invoke(%Callable* %rotate, %Tuple* %8, %Tuple* null)
-  %11 = call %Tuple* @__quantum__rt__tuple_create(i64 ptrtoint (i1** getelementptr (i1*, i1** null, i32 1) to i64))
-  %12 = bitcast %Tuple* %11 to { %Qubit* }*
-  %13 = getelementptr { %Qubit* }, { %Qubit* }* %12, i64 0, i32 0
-  store %Qubit* %qb, %Qubit** %13
-  call void @__quantum__rt__callable_invoke(%Callable* %unrotate, %Tuple* %11, %Tuple* null)
-  %14 = call %Result* @__quantum__qis__mz(%Qubit* %qb)
-  %15 = load %Result*, %Result** @ResultZero
-  %16 = call i1 @__quantum__rt__result_equal(%Result* %14, %Result* %15)
-  %17 = xor i1 %16, true
-  br i1 %17, label %then0__1, label %continue__1
+  %10 = call %Tuple* @__quantum__rt__tuple_create(i64 ptrtoint (i1** getelementptr (i1*, i1** null, i32 1) to i64))
+  %11 = bitcast %Tuple* %10 to { %Qubit* }*
+  %12 = getelementptr { %Qubit* }, { %Qubit* }* %11, i64 0, i32 0
+  store %Qubit* %qb, %Qubit** %12
+  call void @__quantum__rt__callable_invoke(%Callable* %rotate, %Tuple* %10, %Tuple* null)
+  %13 = call %Tuple* @__quantum__rt__tuple_create(i64 ptrtoint (i1** getelementptr (i1*, i1** null, i32 1) to i64))
+  %14 = bitcast %Tuple* %13 to { %Qubit* }*
+  %15 = getelementptr { %Qubit* }, { %Qubit* }* %14, i64 0, i32 0
+  store %Qubit* %qb, %Qubit** %15
+  call void @__quantum__rt__callable_invoke(%Callable* %unrotate, %Tuple* %13, %Tuple* null)
+  %16 = call %Result* @__quantum__qis__mz(%Qubit* %qb)
+  %17 = load %Result*, %Result** @ResultZero
+  %18 = call i1 @__quantum__rt__result_equal(%Result* %16, %Result* %17)
+  %19 = xor i1 %18, true
+  br i1 %19, label %then0__1, label %continue__1
 
 then0__1:                                         ; preds = %body__1
-  %18 = call %Tuple* @__quantum__rt__tuple_create(i64 ptrtoint ({ i64, double }* getelementptr ({ i64, double }, { i64, double }* null, i32 1) to i64))
-  %tuple1 = bitcast %Tuple* %18 to { i64, double }*
-  %19 = getelementptr { i64, double }, { i64, double }* %tuple1, i64 0, i32 0
-  %20 = getelementptr { i64, double }, { i64, double }* %tuple1, i64 0, i32 1
-  store i64 %a, i64* %19
-  store double %b, double* %20
-  %21 = call %String* @__quantum__rt__string_create(i32 0, [0 x i8] zeroinitializer)
-  %22 = call %Tuple* @__quantum__rt__tuple_create(i64 mul nuw (i64 ptrtoint (i1** getelementptr (i1*, i1** null, i32 1) to i64), i64 2))
-  %tuple2 = bitcast %Tuple* %22 to { %String*, %Qubit* }*
-  %23 = getelementptr { %String*, %Qubit* }, { %String*, %Qubit* }* %tuple2, i64 0, i32 0
-  %24 = getelementptr { %String*, %Qubit* }, { %String*, %Qubit* }* %tuple2, i64 0, i32 1
-  store %String* %21, %String** %23
-  call void @__quantum__rt__string_reference(%String* %21)
-  store %Qubit* %qb, %Qubit** %24
-  %25 = call %Callable* @__quantum__rt__callable_create([4 x void (%Tuple*, %Tuple*, %Tuple*)*]* @Microsoft__Quantum__Testing__QIR__InnerNestedTuple, %Tuple* null)
-  %26 = call %Tuple* @__quantum__rt__tuple_create(i64 mul nuw (i64 ptrtoint (i1** getelementptr (i1*, i1** null, i32 1) to i64), i64 2))
-  %27 = bitcast %Tuple* %26 to { %Callable*, { i64, double }* }*
-  %28 = getelementptr { %Callable*, { i64, double }* }, { %Callable*, { i64, double }* }* %27, i64 0, i32 0
-  %29 = getelementptr { %Callable*, { i64, double }* }, { %Callable*, { i64, double }* }* %27, i64 0, i32 1
-  store %Callable* %25, %Callable** %28
-  call void @__quantum__rt__callable_reference(%Callable* %25)
-  store { i64, double }* %tuple1, { i64, double }** %29
-  %30 = bitcast { i64, double }* %tuple1 to %Tuple*
-  call void @__quantum__rt__tuple_reference(%Tuple* %30)
-  %partial1 = call %Callable* @__quantum__rt__callable_create([4 x void (%Tuple*, %Tuple*, %Tuple*)*]* @PartialApplication__2, %Tuple* %26)
-  %31 = call %Callable* @__quantum__rt__callable_create([4 x void (%Tuple*, %Tuple*, %Tuple*)*]* @Microsoft__Quantum__Testing__QIR__InnerNestedTuple, %Tuple* null)
-  %32 = call %Tuple* @__quantum__rt__tuple_create(i64 mul nuw (i64 ptrtoint (i1** getelementptr (i1*, i1** null, i32 1) to i64), i64 2))
-  %33 = bitcast %Tuple* %32 to { %Callable*, { %String*, %Qubit* }* }*
-  %34 = getelementptr { %Callable*, { %String*, %Qubit* }* }, { %Callable*, { %String*, %Qubit* }* }* %33, i64 0, i32 0
-  %35 = getelementptr { %Callable*, { %String*, %Qubit* }* }, { %Callable*, { %String*, %Qubit* }* }* %33, i64 0, i32 1
-  store %Callable* %31, %Callable** %34
-  call void @__quantum__rt__callable_reference(%Callable* %31)
-  store { %String*, %Qubit* }* %tuple2, { %String*, %Qubit* }** %35
-  %36 = getelementptr { %String*, %Qubit* }, { %String*, %Qubit* }* %tuple2, i64 0, i32 0
-  %37 = load %String*, %String** %36
-  call void @__quantum__rt__string_reference(%String* %37)
-  %38 = bitcast { %String*, %Qubit* }* %tuple2 to %Tuple*
+  %20 = call %Tuple* @__quantum__rt__tuple_create(i64 ptrtoint ({ i64, double }* getelementptr ({ i64, double }, { i64, double }* null, i32 1) to i64))
+  %tuple1 = bitcast %Tuple* %20 to { i64, double }*
+  %21 = getelementptr { i64, double }, { i64, double }* %tuple1, i64 0, i32 0
+  %22 = getelementptr { i64, double }, { i64, double }* %tuple1, i64 0, i32 1
+  store i64 %a, i64* %21
+  store double %b, double* %22
+  call void @__quantum__rt__tuple_add_access(%Tuple* %20)
+  %23 = call %String* @__quantum__rt__string_create(i32 0, [0 x i8] zeroinitializer)
+  %24 = call %Tuple* @__quantum__rt__tuple_create(i64 mul nuw (i64 ptrtoint (i1** getelementptr (i1*, i1** null, i32 1) to i64), i64 2))
+  %tuple2 = bitcast %Tuple* %24 to { %String*, %Qubit* }*
+  %25 = getelementptr { %String*, %Qubit* }, { %String*, %Qubit* }* %tuple2, i64 0, i32 0
+  %26 = getelementptr { %String*, %Qubit* }, { %String*, %Qubit* }* %tuple2, i64 0, i32 1
+  store %String* %23, %String** %25
+  call void @__quantum__rt__string_reference(%String* %23)
+  store %Qubit* %qb, %Qubit** %26
+  call void @__quantum__rt__tuple_add_access(%Tuple* %24)
+  %27 = call %Callable* @__quantum__rt__callable_create([4 x void (%Tuple*, %Tuple*, %Tuple*)*]* @Microsoft__Quantum__Testing__QIR__InnerNestedTuple, %Tuple* null)
+  %28 = call %Tuple* @__quantum__rt__tuple_create(i64 mul nuw (i64 ptrtoint (i1** getelementptr (i1*, i1** null, i32 1) to i64), i64 2))
+  %29 = bitcast %Tuple* %28 to { %Callable*, { i64, double }* }*
+  %30 = getelementptr { %Callable*, { i64, double }* }, { %Callable*, { i64, double }* }* %29, i64 0, i32 0
+  %31 = getelementptr { %Callable*, { i64, double }* }, { %Callable*, { i64, double }* }* %29, i64 0, i32 1
+  store %Callable* %27, %Callable** %30
+  call void @__quantum__rt__callable_reference(%Callable* %27)
+  store { i64, double }* %tuple1, { i64, double }** %31
+  call void @__quantum__rt__tuple_reference(%Tuple* %20)
+  %partial1 = call %Callable* @__quantum__rt__callable_create([4 x void (%Tuple*, %Tuple*, %Tuple*)*]* @PartialApplication__2, %Tuple* %28)
+  %32 = getelementptr { %Callable*, { i64, double }* }, { %Callable*, { i64, double }* }* %29, i64 0, i32 0
+  %33 = load %Callable*, %Callable** %32
+  call void @__quantum__rt__callable_reference(%Callable* %33)
+  %34 = getelementptr { %Callable*, { i64, double }* }, { %Callable*, { i64, double }* }* %29, i64 0, i32 1
+  %35 = load { i64, double }*, { i64, double }** %34
+  %36 = bitcast { i64, double }* %35 to %Tuple*
+  call void @__quantum__rt__tuple_reference(%Tuple* %36)
+  call void @__quantum__rt__tuple_reference(%Tuple* %28)
+  %37 = call %Callable* @__quantum__rt__callable_create([4 x void (%Tuple*, %Tuple*, %Tuple*)*]* @Microsoft__Quantum__Testing__QIR__InnerNestedTuple, %Tuple* null)
+  %38 = call %Tuple* @__quantum__rt__tuple_create(i64 mul nuw (i64 ptrtoint (i1** getelementptr (i1*, i1** null, i32 1) to i64), i64 2))
+  %39 = bitcast %Tuple* %38 to { %Callable*, { %String*, %Qubit* }* }*
+  %40 = getelementptr { %Callable*, { %String*, %Qubit* }* }, { %Callable*, { %String*, %Qubit* }* }* %39, i64 0, i32 0
+  %41 = getelementptr { %Callable*, { %String*, %Qubit* }* }, { %Callable*, { %String*, %Qubit* }* }* %39, i64 0, i32 1
+  store %Callable* %37, %Callable** %40
+  call void @__quantum__rt__callable_reference(%Callable* %37)
+  store { %String*, %Qubit* }* %tuple2, { %String*, %Qubit* }** %41
+  %42 = getelementptr { %String*, %Qubit* }, { %String*, %Qubit* }* %tuple2, i64 0, i32 0
+  %43 = load %String*, %String** %42
+  call void @__quantum__rt__string_reference(%String* %43)
+  call void @__quantum__rt__tuple_reference(%Tuple* %24)
+  %partial2 = call %Callable* @__quantum__rt__callable_create([4 x void (%Tuple*, %Tuple*, %Tuple*)*]* @PartialApplication__3, %Tuple* %38)
+  %44 = getelementptr { %Callable*, { %String*, %Qubit* }* }, { %Callable*, { %String*, %Qubit* }* }* %39, i64 0, i32 0
+  %45 = load %Callable*, %Callable** %44
+  call void @__quantum__rt__callable_reference(%Callable* %45)
+  %46 = getelementptr { %Callable*, { %String*, %Qubit* }* }, { %Callable*, { %String*, %Qubit* }* }* %39, i64 0, i32 1
+  %47 = load { %String*, %Qubit* }*, { %String*, %Qubit* }** %46
+  %48 = getelementptr { %String*, %Qubit* }, { %String*, %Qubit* }* %47, i64 0, i32 0
+  %49 = load %String*, %String** %48
+  call void @__quantum__rt__string_reference(%String* %49)
+  %50 = bitcast { %String*, %Qubit* }* %47 to %Tuple*
+  call void @__quantum__rt__tuple_reference(%Tuple* %50)
   call void @__quantum__rt__tuple_reference(%Tuple* %38)
-  %partial2 = call %Callable* @__quantum__rt__callable_create([4 x void (%Tuple*, %Tuple*, %Tuple*)*]* @PartialApplication__3, %Tuple* %32)
-  %39 = bitcast { %String*, %Qubit* }* %tuple2 to %Tuple*
-  call void @__quantum__rt__callable_invoke(%Callable* %partial1, %Tuple* %39, %Tuple* null)
-  %40 = bitcast { i64, double }* %tuple1 to %Tuple*
-  call void @__quantum__rt__callable_invoke(%Callable* %partial2, %Tuple* %40, %Tuple* null)
-  %41 = call %Callable* @__quantum__rt__callable_create([4 x void (%Tuple*, %Tuple*, %Tuple*)*]* @Microsoft__Quantum__Testing__QIR__TakesNestedTuple, %Tuple* null)
-  %42 = call %Tuple* @__quantum__rt__tuple_create(i64 mul nuw (i64 ptrtoint (i1** getelementptr (i1*, i1** null, i32 1) to i64), i64 2))
-  %43 = bitcast %Tuple* %42 to { %Callable*, { i64, double }* }*
-  %44 = getelementptr { %Callable*, { i64, double }* }, { %Callable*, { i64, double }* }* %43, i64 0, i32 0
-  %45 = getelementptr { %Callable*, { i64, double }* }, { %Callable*, { i64, double }* }* %43, i64 0, i32 1
-  store %Callable* %41, %Callable** %44
-  call void @__quantum__rt__callable_reference(%Callable* %41)
-  store { i64, double }* %tuple1, { i64, double }** %45
-  %46 = bitcast { i64, double }* %tuple1 to %Tuple*
-  call void @__quantum__rt__tuple_reference(%Tuple* %46)
-  %partial3 = call %Callable* @__quantum__rt__callable_create([4 x void (%Tuple*, %Tuple*, %Tuple*)*]* @PartialApplication__4, %Tuple* %42)
-  %47 = call %Callable* @__quantum__rt__callable_create([4 x void (%Tuple*, %Tuple*, %Tuple*)*]* @Microsoft__Quantum__Testing__QIR__TakesNestedTuple, %Tuple* null)
-  %48 = call %String* @__quantum__rt__string_create(i32 0, [0 x i8] zeroinitializer)
-  %49 = call %Tuple* @__quantum__rt__tuple_create(i64 mul nuw (i64 ptrtoint (i1** getelementptr (i1*, i1** null, i32 1) to i64), i64 3))
-  %50 = bitcast %Tuple* %49 to { %Callable*, %String*, %Qubit* }*
-  %51 = getelementptr { %Callable*, %String*, %Qubit* }, { %Callable*, %String*, %Qubit* }* %50, i64 0, i32 0
-  %52 = getelementptr { %Callable*, %String*, %Qubit* }, { %Callable*, %String*, %Qubit* }* %50, i64 0, i32 1
-  %53 = getelementptr { %Callable*, %String*, %Qubit* }, { %Callable*, %String*, %Qubit* }* %50, i64 0, i32 2
-  store %Callable* %47, %Callable** %51
-  call void @__quantum__rt__callable_reference(%Callable* %47)
-  store %String* %48, %String** %52
-  call void @__quantum__rt__string_reference(%String* %48)
-  store %Qubit* %qb, %Qubit** %53
-  %partial4 = call %Callable* @__quantum__rt__callable_create([4 x void (%Tuple*, %Tuple*, %Tuple*)*]* @PartialApplication__5, %Tuple* %49)
-  %54 = bitcast { %String*, %Qubit* }* %tuple2 to %Tuple*
-  call void @__quantum__rt__callable_invoke(%Callable* %partial3, %Tuple* %54, %Tuple* null)
-  %55 = bitcast { i64, double }* %tuple1 to %Tuple*
-  call void @__quantum__rt__callable_invoke(%Callable* %partial4, %Tuple* %55, %Tuple* null)
-  %56 = bitcast { i64, double }* %tuple1 to %Tuple*
-  call void @__quantum__rt__tuple_unreference(%Tuple* %56)
-  call void @__quantum__rt__string_unreference(%String* %21)
-  %57 = getelementptr { %String*, %Qubit* }, { %String*, %Qubit* }* %tuple2, i64 0, i32 0
-  %58 = load %String*, %String** %57
-  call void @__quantum__rt__string_unreference(%String* %58)
-  %59 = bitcast { %String*, %Qubit* }* %tuple2 to %Tuple*
-  call void @__quantum__rt__tuple_unreference(%Tuple* %59)
-  call void @__quantum__rt__callable_unreference(%Callable* %25)
-  %60 = getelementptr { %Callable*, { i64, double }* }, { %Callable*, { i64, double }* }* %27, i64 0, i32 0
-  %61 = load %Callable*, %Callable** %60
-  call void @__quantum__rt__callable_unreference(%Callable* %61)
-  %62 = getelementptr { %Callable*, { i64, double }* }, { %Callable*, { i64, double }* }* %27, i64 0, i32 1
-  %63 = load { i64, double }*, { i64, double }** %62
-  %64 = bitcast { i64, double }* %63 to %Tuple*
-  call void @__quantum__rt__tuple_unreference(%Tuple* %64)
-  %65 = bitcast { %Callable*, { i64, double }* }* %27 to %Tuple*
-  call void @__quantum__rt__tuple_unreference(%Tuple* %65)
-  call void @__quantum__rt__callable_unreference(%Callable* %partial1)
-  call void @__quantum__rt__callable_unreference(%Callable* %31)
-  %66 = getelementptr { %Callable*, { %String*, %Qubit* }* }, { %Callable*, { %String*, %Qubit* }* }* %33, i64 0, i32 0
-  %67 = load %Callable*, %Callable** %66
-  call void @__quantum__rt__callable_unreference(%Callable* %67)
-  %68 = getelementptr { %Callable*, { %String*, %Qubit* }* }, { %Callable*, { %String*, %Qubit* }* }* %33, i64 0, i32 1
-  %69 = load { %String*, %Qubit* }*, { %String*, %Qubit* }** %68
-  %70 = getelementptr { %String*, %Qubit* }, { %String*, %Qubit* }* %69, i64 0, i32 0
+  call void @__quantum__rt__callable_invoke(%Callable* %partial1, %Tuple* %24, %Tuple* null)
+  call void @__quantum__rt__callable_invoke(%Callable* %partial2, %Tuple* %20, %Tuple* null)
+  %51 = call %Callable* @__quantum__rt__callable_create([4 x void (%Tuple*, %Tuple*, %Tuple*)*]* @Microsoft__Quantum__Testing__QIR__TakesNestedTuple, %Tuple* null)
+  %52 = call %Tuple* @__quantum__rt__tuple_create(i64 mul nuw (i64 ptrtoint (i1** getelementptr (i1*, i1** null, i32 1) to i64), i64 2))
+  %53 = bitcast %Tuple* %52 to { %Callable*, { i64, double }* }*
+  %54 = getelementptr { %Callable*, { i64, double }* }, { %Callable*, { i64, double }* }* %53, i64 0, i32 0
+  %55 = getelementptr { %Callable*, { i64, double }* }, { %Callable*, { i64, double }* }* %53, i64 0, i32 1
+  store %Callable* %51, %Callable** %54
+  call void @__quantum__rt__callable_reference(%Callable* %51)
+  store { i64, double }* %tuple1, { i64, double }** %55
+  call void @__quantum__rt__tuple_reference(%Tuple* %20)
+  %partial3 = call %Callable* @__quantum__rt__callable_create([4 x void (%Tuple*, %Tuple*, %Tuple*)*]* @PartialApplication__4, %Tuple* %52)
+  %56 = getelementptr { %Callable*, { i64, double }* }, { %Callable*, { i64, double }* }* %53, i64 0, i32 0
+  %57 = load %Callable*, %Callable** %56
+  call void @__quantum__rt__callable_reference(%Callable* %57)
+  %58 = getelementptr { %Callable*, { i64, double }* }, { %Callable*, { i64, double }* }* %53, i64 0, i32 1
+  %59 = load { i64, double }*, { i64, double }** %58
+  %60 = bitcast { i64, double }* %59 to %Tuple*
+  call void @__quantum__rt__tuple_reference(%Tuple* %60)
+  call void @__quantum__rt__tuple_reference(%Tuple* %52)
+  %61 = call %Callable* @__quantum__rt__callable_create([4 x void (%Tuple*, %Tuple*, %Tuple*)*]* @Microsoft__Quantum__Testing__QIR__TakesNestedTuple, %Tuple* null)
+  %62 = call %String* @__quantum__rt__string_create(i32 0, [0 x i8] zeroinitializer)
+  %63 = call %Tuple* @__quantum__rt__tuple_create(i64 mul nuw (i64 ptrtoint (i1** getelementptr (i1*, i1** null, i32 1) to i64), i64 3))
+  %64 = bitcast %Tuple* %63 to { %Callable*, %String*, %Qubit* }*
+  %65 = getelementptr { %Callable*, %String*, %Qubit* }, { %Callable*, %String*, %Qubit* }* %64, i64 0, i32 0
+  %66 = getelementptr { %Callable*, %String*, %Qubit* }, { %Callable*, %String*, %Qubit* }* %64, i64 0, i32 1
+  %67 = getelementptr { %Callable*, %String*, %Qubit* }, { %Callable*, %String*, %Qubit* }* %64, i64 0, i32 2
+  store %Callable* %61, %Callable** %65
+  call void @__quantum__rt__callable_reference(%Callable* %61)
+  store %String* %62, %String** %66
+  call void @__quantum__rt__string_reference(%String* %62)
+  store %Qubit* %qb, %Qubit** %67
+  %partial4 = call %Callable* @__quantum__rt__callable_create([4 x void (%Tuple*, %Tuple*, %Tuple*)*]* @PartialApplication__5, %Tuple* %63)
+  %68 = getelementptr { %Callable*, %String*, %Qubit* }, { %Callable*, %String*, %Qubit* }* %64, i64 0, i32 0
+  %69 = load %Callable*, %Callable** %68
+  call void @__quantum__rt__callable_reference(%Callable* %69)
+  %70 = getelementptr { %Callable*, %String*, %Qubit* }, { %Callable*, %String*, %Qubit* }* %64, i64 0, i32 1
   %71 = load %String*, %String** %70
-  call void @__quantum__rt__string_unreference(%String* %71)
-  %72 = bitcast { %String*, %Qubit* }* %69 to %Tuple*
-  call void @__quantum__rt__tuple_unreference(%Tuple* %72)
-  %73 = bitcast { %Callable*, { %String*, %Qubit* }* }* %33 to %Tuple*
-  call void @__quantum__rt__tuple_unreference(%Tuple* %73)
-  call void @__quantum__rt__callable_unreference(%Callable* %partial2)
-  call void @__quantum__rt__callable_unreference(%Callable* %41)
-  %74 = getelementptr { %Callable*, { i64, double }* }, { %Callable*, { i64, double }* }* %43, i64 0, i32 0
+  call void @__quantum__rt__string_reference(%String* %71)
+  call void @__quantum__rt__tuple_reference(%Tuple* %63)
+  call void @__quantum__rt__callable_invoke(%Callable* %partial3, %Tuple* %24, %Tuple* null)
+  call void @__quantum__rt__callable_invoke(%Callable* %partial4, %Tuple* %20, %Tuple* null)
+  call void @__quantum__rt__tuple_remove_access(%Tuple* %20)
+  call void @__quantum__rt__tuple_remove_access(%Tuple* %24)
+  call void @__quantum__rt__tuple_unreference(%Tuple* %20)
+  call void @__quantum__rt__string_unreference(%String* %23)
+  %72 = getelementptr { %String*, %Qubit* }, { %String*, %Qubit* }* %tuple2, i64 0, i32 0
+  %73 = load %String*, %String** %72
+  call void @__quantum__rt__string_unreference(%String* %73)
+  call void @__quantum__rt__tuple_unreference(%Tuple* %24)
+  call void @__quantum__rt__callable_unreference(%Callable* %27)
+  %74 = getelementptr { %Callable*, { i64, double }* }, { %Callable*, { i64, double }* }* %29, i64 0, i32 0
   %75 = load %Callable*, %Callable** %74
   call void @__quantum__rt__callable_unreference(%Callable* %75)
-  %76 = getelementptr { %Callable*, { i64, double }* }, { %Callable*, { i64, double }* }* %43, i64 0, i32 1
+  %76 = getelementptr { %Callable*, { i64, double }* }, { %Callable*, { i64, double }* }* %29, i64 0, i32 1
   %77 = load { i64, double }*, { i64, double }** %76
   %78 = bitcast { i64, double }* %77 to %Tuple*
   call void @__quantum__rt__tuple_unreference(%Tuple* %78)
-  %79 = bitcast { %Callable*, { i64, double }* }* %43 to %Tuple*
-  call void @__quantum__rt__tuple_unreference(%Tuple* %79)
+  call void @__quantum__rt__tuple_unreference(%Tuple* %28)
+  call void @__quantum__rt__callable_unreference(%Callable* %partial1)
+  call void @__quantum__rt__callable_unreference(%Callable* %37)
+  %79 = getelementptr { %Callable*, { %String*, %Qubit* }* }, { %Callable*, { %String*, %Qubit* }* }* %39, i64 0, i32 0
+  %80 = load %Callable*, %Callable** %79
+  call void @__quantum__rt__callable_unreference(%Callable* %80)
+  %81 = getelementptr { %Callable*, { %String*, %Qubit* }* }, { %Callable*, { %String*, %Qubit* }* }* %39, i64 0, i32 1
+  %82 = load { %String*, %Qubit* }*, { %String*, %Qubit* }** %81
+  %83 = getelementptr { %String*, %Qubit* }, { %String*, %Qubit* }* %82, i64 0, i32 0
+  %84 = load %String*, %String** %83
+  call void @__quantum__rt__string_unreference(%String* %84)
+  %85 = bitcast { %String*, %Qubit* }* %82 to %Tuple*
+  call void @__quantum__rt__tuple_unreference(%Tuple* %85)
+  call void @__quantum__rt__tuple_unreference(%Tuple* %38)
+  call void @__quantum__rt__callable_unreference(%Callable* %partial2)
+  call void @__quantum__rt__callable_unreference(%Callable* %51)
+  %86 = getelementptr { %Callable*, { i64, double }* }, { %Callable*, { i64, double }* }* %53, i64 0, i32 0
+  %87 = load %Callable*, %Callable** %86
+  call void @__quantum__rt__callable_unreference(%Callable* %87)
+  %88 = getelementptr { %Callable*, { i64, double }* }, { %Callable*, { i64, double }* }* %53, i64 0, i32 1
+  %89 = load { i64, double }*, { i64, double }** %88
+  %90 = bitcast { i64, double }* %89 to %Tuple*
+  call void @__quantum__rt__tuple_unreference(%Tuple* %90)
+  call void @__quantum__rt__tuple_unreference(%Tuple* %52)
   call void @__quantum__rt__callable_unreference(%Callable* %partial3)
-  call void @__quantum__rt__callable_unreference(%Callable* %47)
-  call void @__quantum__rt__string_unreference(%String* %48)
-  %80 = getelementptr { %Callable*, %String*, %Qubit* }, { %Callable*, %String*, %Qubit* }* %50, i64 0, i32 0
-  %81 = load %Callable*, %Callable** %80
-  call void @__quantum__rt__callable_unreference(%Callable* %81)
-  %82 = getelementptr { %Callable*, %String*, %Qubit* }, { %Callable*, %String*, %Qubit* }* %50, i64 0, i32 1
-  %83 = load %String*, %String** %82
-  call void @__quantum__rt__string_unreference(%String* %83)
-  %84 = bitcast { %Callable*, %String*, %Qubit* }* %50 to %Tuple*
-  call void @__quantum__rt__tuple_unreference(%Tuple* %84)
+  call void @__quantum__rt__callable_unreference(%Callable* %61)
+  call void @__quantum__rt__string_unreference(%String* %62)
+  %91 = getelementptr { %Callable*, %String*, %Qubit* }, { %Callable*, %String*, %Qubit* }* %64, i64 0, i32 0
+  %92 = load %Callable*, %Callable** %91
+  call void @__quantum__rt__callable_unreference(%Callable* %92)
+  %93 = getelementptr { %Callable*, %String*, %Qubit* }, { %Callable*, %String*, %Qubit* }* %64, i64 0, i32 1
+  %94 = load %String*, %String** %93
+  call void @__quantum__rt__string_unreference(%String* %94)
+  call void @__quantum__rt__tuple_unreference(%Tuple* %63)
   call void @__quantum__rt__callable_unreference(%Callable* %partial4)
   br label %continue__1
 
 continue__1:                                      ; preds = %then0__1, %body__1
-  %85 = call %Callable* @__quantum__rt__callable_create([4 x void (%Tuple*, %Tuple*, %Tuple*)*]* @Microsoft__Quantum__Testing__QIR__ApplyToLittleEndian, %Tuple* null)
-  %86 = call %Callable* @__quantum__rt__callable_create([4 x void (%Tuple*, %Tuple*, %Tuple*)*]* @Microsoft__Quantum__Testing__QIR__Dummy, %Tuple* null)
-  call void @__quantum__rt__callable_make_adjoint(%Callable* %86)
-  %87 = call %Tuple* @__quantum__rt__tuple_create(i64 mul nuw (i64 ptrtoint (i1** getelementptr (i1*, i1** null, i32 1) to i64), i64 2))
-  %88 = bitcast %Tuple* %87 to { %Callable*, %Callable* }*
-  %89 = getelementptr { %Callable*, %Callable* }, { %Callable*, %Callable* }* %88, i64 0, i32 0
-  %90 = getelementptr { %Callable*, %Callable* }, { %Callable*, %Callable* }* %88, i64 0, i32 1
-  store %Callable* %85, %Callable** %89
-  call void @__quantum__rt__callable_reference(%Callable* %85)
-  store %Callable* %86, %Callable** %90
-  call void @__quantum__rt__callable_reference(%Callable* %86)
-  %91 = call %Callable* @__quantum__rt__callable_create([4 x void (%Tuple*, %Tuple*, %Tuple*)*]* @PartialApplication__6, %Tuple* %87)
-  %92 = call %Array* @__quantum__rt__array_create_1d(i32 8, i64 1)
-  %93 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %92, i64 0)
-  %94 = bitcast i8* %93 to %Qubit**
-  store %Qubit* %qb, %Qubit** %94
-  %95 = call { %Array* }* @Microsoft__Quantum__Testing__QIR__LittleEndian__body(%Array* %92)
-  %96 = bitcast { %Array* }* %95 to %Tuple*
-  call void @__quantum__rt__callable_invoke(%Callable* %91, %Tuple* %96, %Tuple* null)
+  %95 = call %Callable* @__quantum__rt__callable_create([4 x void (%Tuple*, %Tuple*, %Tuple*)*]* @Microsoft__Quantum__Testing__QIR__ApplyToLittleEndian, %Tuple* null)
+  %96 = call %Callable* @__quantum__rt__callable_create([4 x void (%Tuple*, %Tuple*, %Tuple*)*]* @Microsoft__Quantum__Testing__QIR__Dummy, %Tuple* null)
+  call void @__quantum__rt__callable_make_adjoint(%Callable* %96)
+  %97 = call %Tuple* @__quantum__rt__tuple_create(i64 mul nuw (i64 ptrtoint (i1** getelementptr (i1*, i1** null, i32 1) to i64), i64 2))
+  %98 = bitcast %Tuple* %97 to { %Callable*, %Callable* }*
+  %99 = getelementptr { %Callable*, %Callable* }, { %Callable*, %Callable* }* %98, i64 0, i32 0
+  %100 = getelementptr { %Callable*, %Callable* }, { %Callable*, %Callable* }* %98, i64 0, i32 1
+  store %Callable* %95, %Callable** %99
+  call void @__quantum__rt__callable_reference(%Callable* %95)
+  store %Callable* %96, %Callable** %100
+  call void @__quantum__rt__callable_reference(%Callable* %96)
+  %101 = call %Callable* @__quantum__rt__callable_create([4 x void (%Tuple*, %Tuple*, %Tuple*)*]* @PartialApplication__6, %Tuple* %97)
+  %102 = getelementptr { %Callable*, %Callable* }, { %Callable*, %Callable* }* %98, i64 0, i32 0
+  %103 = load %Callable*, %Callable** %102
+  call void @__quantum__rt__callable_reference(%Callable* %103)
+  %104 = getelementptr { %Callable*, %Callable* }, { %Callable*, %Callable* }* %98, i64 0, i32 1
+  %105 = load %Callable*, %Callable** %104
+  call void @__quantum__rt__callable_reference(%Callable* %105)
+  call void @__quantum__rt__tuple_reference(%Tuple* %97)
+  %106 = call %Array* @__quantum__rt__array_create_1d(i32 8, i64 1)
+  %107 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %106, i64 0)
+  %108 = bitcast i8* %107 to %Qubit**
+  store %Qubit* %qb, %Qubit** %108
+  %109 = call { %Array* }* @Microsoft__Quantum__Testing__QIR__LittleEndian__body(%Array* %106)
+  %110 = bitcast { %Array* }* %109 to %Tuple*
+  call void @__quantum__rt__callable_invoke(%Callable* %101, %Tuple* %110, %Tuple* null)
   call void @__quantum__rt__qubit_release(%Qubit* %qb)
-  %97 = bitcast { %Qubit* }* %9 to %Tuple*
+  call void @__quantum__rt__tuple_unreference(%Tuple* %10)
+  call void @__quantum__rt__tuple_unreference(%Tuple* %13)
+  call void @__quantum__rt__result_unreference(%Result* %16)
+  call void @__quantum__rt__callable_unreference(%Callable* %95)
+  call void @__quantum__rt__callable_unreference(%Callable* %96)
+  %111 = getelementptr { %Callable*, %Callable* }, { %Callable*, %Callable* }* %98, i64 0, i32 0
+  %112 = load %Callable*, %Callable** %111
+  call void @__quantum__rt__callable_unreference(%Callable* %112)
+  %113 = getelementptr { %Callable*, %Callable* }, { %Callable*, %Callable* }* %98, i64 0, i32 1
+  %114 = load %Callable*, %Callable** %113
+  call void @__quantum__rt__callable_unreference(%Callable* %114)
   call void @__quantum__rt__tuple_unreference(%Tuple* %97)
-  %98 = bitcast { %Qubit* }* %12 to %Tuple*
-  call void @__quantum__rt__tuple_unreference(%Tuple* %98)
-  call void @__quantum__rt__result_unreference(%Result* %14)
-  call void @__quantum__rt__result_unreference(%Result* %15)
-  call void @__quantum__rt__callable_unreference(%Callable* %85)
-  call void @__quantum__rt__callable_unreference(%Callable* %86)
-  %99 = getelementptr { %Callable*, %Callable* }, { %Callable*, %Callable* }* %88, i64 0, i32 0
-  %100 = load %Callable*, %Callable** %99
-  call void @__quantum__rt__callable_unreference(%Callable* %100)
-  %101 = getelementptr { %Callable*, %Callable* }, { %Callable*, %Callable* }* %88, i64 0, i32 1
-  %102 = load %Callable*, %Callable** %101
-  call void @__quantum__rt__callable_unreference(%Callable* %102)
-  %103 = bitcast { %Callable*, %Callable* }* %88 to %Tuple*
-  call void @__quantum__rt__tuple_unreference(%Tuple* %103)
-  call void @__quantum__rt__callable_unreference(%Callable* %91)
-  call void @__quantum__rt__array_unreference(%Array* %92)
-  %104 = getelementptr { %Array* }, { %Array* }* %95, i64 0, i32 0
-  %105 = load %Array*, %Array** %104
-  call void @__quantum__rt__array_unreference(%Array* %105)
-  %106 = bitcast { %Array* }* %95 to %Tuple*
-  call void @__quantum__rt__tuple_unreference(%Tuple* %106)
+  call void @__quantum__rt__callable_unreference(%Callable* %101)
+  call void @__quantum__rt__array_unreference(%Array* %106)
+  %115 = getelementptr { %Array* }, { %Array* }* %109, i64 0, i32 0
+  %116 = load %Array*, %Array** %115
+  call void @__quantum__rt__array_unreference(%Array* %116)
+  call void @__quantum__rt__tuple_unreference(%Tuple* %110)
   br label %exiting__1
 
 exiting__1:                                       ; preds = %continue__1
-  %107 = add i64 %i, 1
+  %117 = add i64 %i, 1
   br label %header__1
 
 exit__1:                                          ; preds = %header__1
   call void @__quantum__rt__callable_unreference(%Callable* %0)
-  %108 = getelementptr { %Callable*, double }, { %Callable*, double }* %2, i64 0, i32 0
-  %109 = load %Callable*, %Callable** %108
-  call void @__quantum__rt__callable_unreference(%Callable* %109)
-  %110 = bitcast { %Callable*, double }* %2 to %Tuple*
-  call void @__quantum__rt__tuple_unreference(%Tuple* %110)
+  %118 = getelementptr { %Callable*, double }, { %Callable*, double }* %2, i64 0, i32 0
+  %119 = load %Callable*, %Callable** %118
+  call void @__quantum__rt__callable_unreference(%Callable* %119)
+  call void @__quantum__rt__tuple_unreference(%Tuple* %1)
   call void @__quantum__rt__callable_unreference(%Callable* %rotate)
   call void @__quantum__rt__callable_unreference(%Callable* %unrotate)
   ret i1 true

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestPartials3.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestPartials3.ll
@@ -1,38 +1,35 @@
 ﻿define void @Lifted__PartialApplication__2__body__wrapper(%Tuple* %capture-tuple, %Tuple* %arg-tuple, %Tuple* %result-tuple) {
 entry:
   %0 = bitcast %Tuple* %capture-tuple to { %Callable*, { i64, double }* }*
-  %1 = bitcast %Tuple* %arg-tuple to { %String*, %Qubit* }*
-  %2 = getelementptr { %Callable*, { i64, double }* }, { %Callable*, { i64, double }* }* %0, i64 0, i32 1
-  %3 = load { i64, double }*, { i64, double }** %2
-  %4 = call %Tuple* @__quantum__rt__tuple_create(i64 mul nuw (i64 ptrtoint (i1** getelementptr (i1*, i1** null, i32 1) to i64), i64 2))
-  %5 = bitcast %Tuple* %4 to { { i64, double }*, { %String*, %Qubit* }* }*
-  %6 = getelementptr { { i64, double }*, { %String*, %Qubit* }* }, { { i64, double }*, { %String*, %Qubit* }* }* %5, i64 0, i32 0
-  %7 = getelementptr { { i64, double }*, { %String*, %Qubit* }* }, { { i64, double }*, { %String*, %Qubit* }* }* %5, i64 0, i32 1
-  store { i64, double }* %3, { i64, double }** %6
-  %8 = bitcast { i64, double }* %3 to %Tuple*
-  call void @__quantum__rt__tuple_reference(%Tuple* %8)
-  store { %String*, %Qubit* }* %1, { %String*, %Qubit* }** %7
-  %9 = getelementptr { %String*, %Qubit* }, { %String*, %Qubit* }* %1, i64 0, i32 0
+  %1 = getelementptr { %Callable*, { i64, double }* }, { %Callable*, { i64, double }* }* %0, i64 0, i32 1
+  %2 = load { i64, double }*, { i64, double }** %1
+  %3 = call %Tuple* @__quantum__rt__tuple_create(i64 mul nuw (i64 ptrtoint (i1** getelementptr (i1*, i1** null, i32 1) to i64), i64 2))
+  %4 = bitcast %Tuple* %3 to { { i64, double }*, { %String*, %Qubit* }* }*
+  %5 = getelementptr { { i64, double }*, { %String*, %Qubit* }* }, { { i64, double }*, { %String*, %Qubit* }* }* %4, i64 0, i32 0
+  %6 = getelementptr { { i64, double }*, { %String*, %Qubit* }* }, { { i64, double }*, { %String*, %Qubit* }* }* %4, i64 0, i32 1
+  store { i64, double }* %2, { i64, double }** %5
+  %7 = bitcast { i64, double }* %2 to %Tuple*
+  call void @__quantum__rt__tuple_reference(%Tuple* %7)
+  %8 = bitcast %Tuple* %arg-tuple to { %String*, %Qubit* }*
+  store { %String*, %Qubit* }* %8, { %String*, %Qubit* }** %6
+  %9 = getelementptr { %String*, %Qubit* }, { %String*, %Qubit* }* %8, i64 0, i32 0
   %10 = load %String*, %String** %9
   call void @__quantum__rt__string_reference(%String* %10)
-  %11 = bitcast { %String*, %Qubit* }* %1 to %Tuple*
-  call void @__quantum__rt__tuple_reference(%Tuple* %11)
-  %12 = bitcast { { i64, double }*, { %String*, %Qubit* }* }* %5 to %Tuple*
-  %13 = getelementptr { %Callable*, { i64, double }* }, { %Callable*, { i64, double }* }* %0, i64 0, i32 0
-  %14 = load %Callable*, %Callable** %13
-  call void @__quantum__rt__callable_invoke(%Callable* %14, %Tuple* %12, %Tuple* %result-tuple)
-  %15 = getelementptr { { i64, double }*, { %String*, %Qubit* }* }, { { i64, double }*, { %String*, %Qubit* }* }* %5, i64 0, i32 0
-  %16 = load { i64, double }*, { i64, double }** %15
-  %17 = bitcast { i64, double }* %16 to %Tuple*
-  call void @__quantum__rt__tuple_unreference(%Tuple* %17)
-  %18 = getelementptr { { i64, double }*, { %String*, %Qubit* }* }, { { i64, double }*, { %String*, %Qubit* }* }* %5, i64 0, i32 1
-  %19 = load { %String*, %Qubit* }*, { %String*, %Qubit* }** %18
-  %20 = getelementptr { %String*, %Qubit* }, { %String*, %Qubit* }* %19, i64 0, i32 0
-  %21 = load %String*, %String** %20
-  call void @__quantum__rt__string_unreference(%String* %21)
-  %22 = bitcast { %String*, %Qubit* }* %19 to %Tuple*
-  call void @__quantum__rt__tuple_unreference(%Tuple* %22)
-  %23 = bitcast { { i64, double }*, { %String*, %Qubit* }* }* %5 to %Tuple*
-  call void @__quantum__rt__tuple_unreference(%Tuple* %23)
+  call void @__quantum__rt__tuple_reference(%Tuple* %arg-tuple)
+  %11 = getelementptr { %Callable*, { i64, double }* }, { %Callable*, { i64, double }* }* %0, i64 0, i32 0
+  %12 = load %Callable*, %Callable** %11
+  call void @__quantum__rt__callable_invoke(%Callable* %12, %Tuple* %3, %Tuple* %result-tuple)
+  %13 = getelementptr { { i64, double }*, { %String*, %Qubit* }* }, { { i64, double }*, { %String*, %Qubit* }* }* %4, i64 0, i32 0
+  %14 = load { i64, double }*, { i64, double }** %13
+  %15 = bitcast { i64, double }* %14 to %Tuple*
+  call void @__quantum__rt__tuple_unreference(%Tuple* %15)
+  %16 = getelementptr { { i64, double }*, { %String*, %Qubit* }* }, { { i64, double }*, { %String*, %Qubit* }* }* %4, i64 0, i32 1
+  %17 = load { %String*, %Qubit* }*, { %String*, %Qubit* }** %16
+  %18 = getelementptr { %String*, %Qubit* }, { %String*, %Qubit* }* %17, i64 0, i32 0
+  %19 = load %String*, %String** %18
+  call void @__quantum__rt__string_unreference(%String* %19)
+  %20 = bitcast { %String*, %Qubit* }* %17 to %Tuple*
+  call void @__quantum__rt__tuple_unreference(%Tuple* %20)
+  call void @__quantum__rt__tuple_unreference(%Tuple* %3)
   ret void
 }

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestPartials4.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestPartials4.ll
@@ -1,54 +1,51 @@
 ﻿define void @Lifted__PartialApplication__2__adj__wrapper(%Tuple* %capture-tuple, %Tuple* %arg-tuple, %Tuple* %result-tuple) {
 entry:
   %0 = bitcast %Tuple* %capture-tuple to { %Callable*, { i64, double }* }*
-  %1 = bitcast %Tuple* %arg-tuple to { %String*, %Qubit* }*
-  %2 = getelementptr { %Callable*, { i64, double }* }, { %Callable*, { i64, double }* }* %0, i64 0, i32 1
-  %3 = load { i64, double }*, { i64, double }** %2
-  %4 = call %Tuple* @__quantum__rt__tuple_create(i64 mul nuw (i64 ptrtoint (i1** getelementptr (i1*, i1** null, i32 1) to i64), i64 2))
-  %5 = bitcast %Tuple* %4 to { { i64, double }*, { %String*, %Qubit* }* }*
-  %6 = getelementptr { { i64, double }*, { %String*, %Qubit* }* }, { { i64, double }*, { %String*, %Qubit* }* }* %5, i64 0, i32 0
-  %7 = getelementptr { { i64, double }*, { %String*, %Qubit* }* }, { { i64, double }*, { %String*, %Qubit* }* }* %5, i64 0, i32 1
-  store { i64, double }* %3, { i64, double }** %6
-  %8 = bitcast { i64, double }* %3 to %Tuple*
-  call void @__quantum__rt__tuple_reference(%Tuple* %8)
-  store { %String*, %Qubit* }* %1, { %String*, %Qubit* }** %7
-  %9 = getelementptr { %String*, %Qubit* }, { %String*, %Qubit* }* %1, i64 0, i32 0
+  %1 = getelementptr { %Callable*, { i64, double }* }, { %Callable*, { i64, double }* }* %0, i64 0, i32 1
+  %2 = load { i64, double }*, { i64, double }** %1
+  %3 = call %Tuple* @__quantum__rt__tuple_create(i64 mul nuw (i64 ptrtoint (i1** getelementptr (i1*, i1** null, i32 1) to i64), i64 2))
+  %4 = bitcast %Tuple* %3 to { { i64, double }*, { %String*, %Qubit* }* }*
+  %5 = getelementptr { { i64, double }*, { %String*, %Qubit* }* }, { { i64, double }*, { %String*, %Qubit* }* }* %4, i64 0, i32 0
+  %6 = getelementptr { { i64, double }*, { %String*, %Qubit* }* }, { { i64, double }*, { %String*, %Qubit* }* }* %4, i64 0, i32 1
+  store { i64, double }* %2, { i64, double }** %5
+  %7 = bitcast { i64, double }* %2 to %Tuple*
+  call void @__quantum__rt__tuple_reference(%Tuple* %7)
+  %8 = bitcast %Tuple* %arg-tuple to { %String*, %Qubit* }*
+  store { %String*, %Qubit* }* %8, { %String*, %Qubit* }** %6
+  %9 = getelementptr { %String*, %Qubit* }, { %String*, %Qubit* }* %8, i64 0, i32 0
   %10 = load %String*, %String** %9
   call void @__quantum__rt__string_reference(%String* %10)
-  %11 = bitcast { %String*, %Qubit* }* %1 to %Tuple*
-  call void @__quantum__rt__tuple_reference(%Tuple* %11)
-  %12 = bitcast { { i64, double }*, { %String*, %Qubit* }* }* %5 to %Tuple*
-  %13 = getelementptr { %Callable*, { i64, double }* }, { %Callable*, { i64, double }* }* %0, i64 0, i32 0
-  %14 = load %Callable*, %Callable** %13
-  %15 = call %Callable* @__quantum__rt__callable_copy(%Callable* %14)
-  call void @__quantum__rt__callable_make_adjoint(%Callable* %15)
-  call void @__quantum__rt__callable_invoke(%Callable* %15, %Tuple* %12, %Tuple* %result-tuple)
-  %16 = getelementptr { { i64, double }*, { %String*, %Qubit* }* }, { { i64, double }*, { %String*, %Qubit* }* }* %5, i64 0, i32 0
-  %17 = load { i64, double }*, { i64, double }** %16
-  %18 = bitcast { i64, double }* %17 to %Tuple*
-  call void @__quantum__rt__tuple_unreference(%Tuple* %18)
-  %19 = getelementptr { { i64, double }*, { %String*, %Qubit* }* }, { { i64, double }*, { %String*, %Qubit* }* }* %5, i64 0, i32 1
-  %20 = load { %String*, %Qubit* }*, { %String*, %Qubit* }** %19
-  %21 = getelementptr { %String*, %Qubit* }, { %String*, %Qubit* }* %20, i64 0, i32 0
-  %22 = load %String*, %String** %21
-  call void @__quantum__rt__string_unreference(%String* %22)
-  %23 = bitcast { %String*, %Qubit* }* %20 to %Tuple*
-  call void @__quantum__rt__tuple_unreference(%Tuple* %23)
-  %24 = bitcast { { i64, double }*, { %String*, %Qubit* }* }* %5 to %Tuple*
-  call void @__quantum__rt__tuple_unreference(%Tuple* %24)
-  call void @__quantum__rt__callable_unreference(%Callable* %15)
+  call void @__quantum__rt__tuple_reference(%Tuple* %arg-tuple)
+  %11 = getelementptr { %Callable*, { i64, double }* }, { %Callable*, { i64, double }* }* %0, i64 0, i32 0
+  %12 = load %Callable*, %Callable** %11
+  %13 = call %Callable* @__quantum__rt__callable_copy(%Callable* %12, i1 true)
+  call void @__quantum__rt__callable_make_adjoint(%Callable* %13)
+  call void @__quantum__rt__callable_invoke(%Callable* %13, %Tuple* %3, %Tuple* %result-tuple)
+  %14 = getelementptr { { i64, double }*, { %String*, %Qubit* }* }, { { i64, double }*, { %String*, %Qubit* }* }* %4, i64 0, i32 0
+  %15 = load { i64, double }*, { i64, double }** %14
+  %16 = bitcast { i64, double }* %15 to %Tuple*
+  call void @__quantum__rt__tuple_unreference(%Tuple* %16)
+  %17 = getelementptr { { i64, double }*, { %String*, %Qubit* }* }, { { i64, double }*, { %String*, %Qubit* }* }* %4, i64 0, i32 1
+  %18 = load { %String*, %Qubit* }*, { %String*, %Qubit* }** %17
+  %19 = getelementptr { %String*, %Qubit* }, { %String*, %Qubit* }* %18, i64 0, i32 0
+  %20 = load %String*, %String** %19
+  call void @__quantum__rt__string_unreference(%String* %20)
+  %21 = bitcast { %String*, %Qubit* }* %18 to %Tuple*
+  call void @__quantum__rt__tuple_unreference(%Tuple* %21)
+  call void @__quantum__rt__tuple_unreference(%Tuple* %3)
+  call void @__quantum__rt__callable_unreference(%Callable* %13)
   ret void
 }
 
 define void @Lifted__PartialApplication__2__ctl__wrapper(%Tuple* %capture-tuple, %Tuple* %arg-tuple, %Tuple* %result-tuple) {
 entry:
-  %0 = bitcast %Tuple* %capture-tuple to { %Callable*, { i64, double }* }*
-  %1 = bitcast %Tuple* %arg-tuple to { %Array*, { %String*, %Qubit* }* }*
-  %2 = getelementptr { %Array*, { %String*, %Qubit* }* }, { %Array*, { %String*, %Qubit* }* }* %1, i64 0, i32 0
-  %3 = getelementptr { %Array*, { %String*, %Qubit* }* }, { %Array*, { %String*, %Qubit* }* }* %1, i64 0, i32 1
-  %4 = load %Array*, %Array** %2
-  %5 = load { %String*, %Qubit* }*, { %String*, %Qubit* }** %3
-  %6 = getelementptr { %Callable*, { i64, double }* }, { %Callable*, { i64, double }* }* %0, i64 0, i32 1
+  %0 = bitcast %Tuple* %arg-tuple to { %Array*, { %String*, %Qubit* }* }*
+  %1 = getelementptr { %Array*, { %String*, %Qubit* }* }, { %Array*, { %String*, %Qubit* }* }* %0, i64 0, i32 0
+  %2 = getelementptr { %Array*, { %String*, %Qubit* }* }, { %Array*, { %String*, %Qubit* }* }* %0, i64 0, i32 1
+  %3 = load %Array*, %Array** %1
+  %4 = load { %String*, %Qubit* }*, { %String*, %Qubit* }** %2
+  %5 = bitcast %Tuple* %capture-tuple to { %Callable*, { i64, double }* }*
+  %6 = getelementptr { %Callable*, { i64, double }* }, { %Callable*, { i64, double }* }* %5, i64 0, i32 1
   %7 = load { i64, double }*, { i64, double }** %6
   %8 = call %Tuple* @__quantum__rt__tuple_create(i64 mul nuw (i64 ptrtoint (i1** getelementptr (i1*, i1** null, i32 1) to i64), i64 2))
   %9 = bitcast %Tuple* %8 to { { i64, double }*, { %String*, %Qubit* }* }*
@@ -57,18 +54,18 @@ entry:
   store { i64, double }* %7, { i64, double }** %10
   %12 = bitcast { i64, double }* %7 to %Tuple*
   call void @__quantum__rt__tuple_reference(%Tuple* %12)
-  store { %String*, %Qubit* }* %5, { %String*, %Qubit* }** %11
-  %13 = getelementptr { %String*, %Qubit* }, { %String*, %Qubit* }* %5, i64 0, i32 0
+  store { %String*, %Qubit* }* %4, { %String*, %Qubit* }** %11
+  %13 = getelementptr { %String*, %Qubit* }, { %String*, %Qubit* }* %4, i64 0, i32 0
   %14 = load %String*, %String** %13
   call void @__quantum__rt__string_reference(%String* %14)
-  %15 = bitcast { %String*, %Qubit* }* %5 to %Tuple*
+  %15 = bitcast { %String*, %Qubit* }* %4 to %Tuple*
   call void @__quantum__rt__tuple_reference(%Tuple* %15)
   %16 = call %Tuple* @__quantum__rt__tuple_create(i64 mul nuw (i64 ptrtoint (i1** getelementptr (i1*, i1** null, i32 1) to i64), i64 2))
   %17 = bitcast %Tuple* %16 to { %Array*, { { i64, double }*, { %String*, %Qubit* }* }* }*
   %18 = getelementptr { %Array*, { { i64, double }*, { %String*, %Qubit* }* }* }, { %Array*, { { i64, double }*, { %String*, %Qubit* }* }* }* %17, i64 0, i32 0
   %19 = getelementptr { %Array*, { { i64, double }*, { %String*, %Qubit* }* }* }, { %Array*, { { i64, double }*, { %String*, %Qubit* }* }* }* %17, i64 0, i32 1
-  store %Array* %4, %Array** %18
-  call void @__quantum__rt__array_reference(%Array* %4)
+  store %Array* %3, %Array** %18
+  call void @__quantum__rt__array_reference(%Array* %3)
   store { { i64, double }*, { %String*, %Qubit* }* }* %9, { { i64, double }*, { %String*, %Qubit* }* }** %19
   %20 = getelementptr { { i64, double }*, { %String*, %Qubit* }* }, { { i64, double }*, { %String*, %Qubit* }* }* %9, i64 0, i32 0
   %21 = load { i64, double }*, { i64, double }** %20
@@ -81,59 +78,56 @@ entry:
   call void @__quantum__rt__string_reference(%String* %26)
   %27 = bitcast { %String*, %Qubit* }* %24 to %Tuple*
   call void @__quantum__rt__tuple_reference(%Tuple* %27)
-  %28 = bitcast { { i64, double }*, { %String*, %Qubit* }* }* %9 to %Tuple*
-  call void @__quantum__rt__tuple_reference(%Tuple* %28)
-  %29 = getelementptr { %Callable*, { i64, double }* }, { %Callable*, { i64, double }* }* %0, i64 0, i32 0
-  %30 = load %Callable*, %Callable** %29
-  %31 = call %Callable* @__quantum__rt__callable_copy(%Callable* %30)
-  call void @__quantum__rt__callable_make_controlled(%Callable* %31)
-  call void @__quantum__rt__callable_invoke(%Callable* %31, %Tuple* %16, %Tuple* %result-tuple)
-  %32 = getelementptr { { i64, double }*, { %String*, %Qubit* }* }, { { i64, double }*, { %String*, %Qubit* }* }* %9, i64 0, i32 0
-  %33 = load { i64, double }*, { i64, double }** %32
-  %34 = bitcast { i64, double }* %33 to %Tuple*
-  call void @__quantum__rt__tuple_unreference(%Tuple* %34)
-  %35 = getelementptr { { i64, double }*, { %String*, %Qubit* }* }, { { i64, double }*, { %String*, %Qubit* }* }* %9, i64 0, i32 1
-  %36 = load { %String*, %Qubit* }*, { %String*, %Qubit* }** %35
-  %37 = getelementptr { %String*, %Qubit* }, { %String*, %Qubit* }* %36, i64 0, i32 0
-  %38 = load %String*, %String** %37
-  call void @__quantum__rt__string_unreference(%String* %38)
-  %39 = bitcast { %String*, %Qubit* }* %36 to %Tuple*
-  call void @__quantum__rt__tuple_unreference(%Tuple* %39)
-  %40 = bitcast { { i64, double }*, { %String*, %Qubit* }* }* %9 to %Tuple*
-  call void @__quantum__rt__tuple_unreference(%Tuple* %40)
-  %41 = getelementptr { %Array*, { { i64, double }*, { %String*, %Qubit* }* }* }, { %Array*, { { i64, double }*, { %String*, %Qubit* }* }* }* %17, i64 0, i32 0
-  %42 = load %Array*, %Array** %41
-  call void @__quantum__rt__array_unreference(%Array* %42)
-  %43 = getelementptr { %Array*, { { i64, double }*, { %String*, %Qubit* }* }* }, { %Array*, { { i64, double }*, { %String*, %Qubit* }* }* }* %17, i64 0, i32 1
-  %44 = load { { i64, double }*, { %String*, %Qubit* }* }*, { { i64, double }*, { %String*, %Qubit* }* }** %43
-  %45 = getelementptr { { i64, double }*, { %String*, %Qubit* }* }, { { i64, double }*, { %String*, %Qubit* }* }* %44, i64 0, i32 0
-  %46 = load { i64, double }*, { i64, double }** %45
-  %47 = bitcast { i64, double }* %46 to %Tuple*
-  call void @__quantum__rt__tuple_unreference(%Tuple* %47)
-  %48 = getelementptr { { i64, double }*, { %String*, %Qubit* }* }, { { i64, double }*, { %String*, %Qubit* }* }* %44, i64 0, i32 1
-  %49 = load { %String*, %Qubit* }*, { %String*, %Qubit* }** %48
-  %50 = getelementptr { %String*, %Qubit* }, { %String*, %Qubit* }* %49, i64 0, i32 0
-  %51 = load %String*, %String** %50
-  call void @__quantum__rt__string_unreference(%String* %51)
-  %52 = bitcast { %String*, %Qubit* }* %49 to %Tuple*
-  call void @__quantum__rt__tuple_unreference(%Tuple* %52)
-  %53 = bitcast { { i64, double }*, { %String*, %Qubit* }* }* %44 to %Tuple*
-  call void @__quantum__rt__tuple_unreference(%Tuple* %53)
-  %54 = bitcast { %Array*, { { i64, double }*, { %String*, %Qubit* }* }* }* %17 to %Tuple*
-  call void @__quantum__rt__tuple_unreference(%Tuple* %54)
-  call void @__quantum__rt__callable_unreference(%Callable* %31)
+  call void @__quantum__rt__tuple_reference(%Tuple* %8)
+  %28 = getelementptr { %Callable*, { i64, double }* }, { %Callable*, { i64, double }* }* %5, i64 0, i32 0
+  %29 = load %Callable*, %Callable** %28
+  %30 = call %Callable* @__quantum__rt__callable_copy(%Callable* %29, i1 true)
+  call void @__quantum__rt__callable_make_controlled(%Callable* %30)
+  call void @__quantum__rt__callable_invoke(%Callable* %30, %Tuple* %16, %Tuple* %result-tuple)
+  %31 = getelementptr { { i64, double }*, { %String*, %Qubit* }* }, { { i64, double }*, { %String*, %Qubit* }* }* %9, i64 0, i32 0
+  %32 = load { i64, double }*, { i64, double }** %31
+  %33 = bitcast { i64, double }* %32 to %Tuple*
+  call void @__quantum__rt__tuple_unreference(%Tuple* %33)
+  %34 = getelementptr { { i64, double }*, { %String*, %Qubit* }* }, { { i64, double }*, { %String*, %Qubit* }* }* %9, i64 0, i32 1
+  %35 = load { %String*, %Qubit* }*, { %String*, %Qubit* }** %34
+  %36 = getelementptr { %String*, %Qubit* }, { %String*, %Qubit* }* %35, i64 0, i32 0
+  %37 = load %String*, %String** %36
+  call void @__quantum__rt__string_unreference(%String* %37)
+  %38 = bitcast { %String*, %Qubit* }* %35 to %Tuple*
+  call void @__quantum__rt__tuple_unreference(%Tuple* %38)
+  call void @__quantum__rt__tuple_unreference(%Tuple* %8)
+  %39 = getelementptr { %Array*, { { i64, double }*, { %String*, %Qubit* }* }* }, { %Array*, { { i64, double }*, { %String*, %Qubit* }* }* }* %17, i64 0, i32 0
+  %40 = load %Array*, %Array** %39
+  call void @__quantum__rt__array_unreference(%Array* %40)
+  %41 = getelementptr { %Array*, { { i64, double }*, { %String*, %Qubit* }* }* }, { %Array*, { { i64, double }*, { %String*, %Qubit* }* }* }* %17, i64 0, i32 1
+  %42 = load { { i64, double }*, { %String*, %Qubit* }* }*, { { i64, double }*, { %String*, %Qubit* }* }** %41
+  %43 = getelementptr { { i64, double }*, { %String*, %Qubit* }* }, { { i64, double }*, { %String*, %Qubit* }* }* %42, i64 0, i32 0
+  %44 = load { i64, double }*, { i64, double }** %43
+  %45 = bitcast { i64, double }* %44 to %Tuple*
+  call void @__quantum__rt__tuple_unreference(%Tuple* %45)
+  %46 = getelementptr { { i64, double }*, { %String*, %Qubit* }* }, { { i64, double }*, { %String*, %Qubit* }* }* %42, i64 0, i32 1
+  %47 = load { %String*, %Qubit* }*, { %String*, %Qubit* }** %46
+  %48 = getelementptr { %String*, %Qubit* }, { %String*, %Qubit* }* %47, i64 0, i32 0
+  %49 = load %String*, %String** %48
+  call void @__quantum__rt__string_unreference(%String* %49)
+  %50 = bitcast { %String*, %Qubit* }* %47 to %Tuple*
+  call void @__quantum__rt__tuple_unreference(%Tuple* %50)
+  %51 = bitcast { { i64, double }*, { %String*, %Qubit* }* }* %42 to %Tuple*
+  call void @__quantum__rt__tuple_unreference(%Tuple* %51)
+  call void @__quantum__rt__tuple_unreference(%Tuple* %16)
+  call void @__quantum__rt__callable_unreference(%Callable* %30)
   ret void
 }
 
 define void @Lifted__PartialApplication__2__ctladj__wrapper(%Tuple* %capture-tuple, %Tuple* %arg-tuple, %Tuple* %result-tuple) {
 entry:
-  %0 = bitcast %Tuple* %capture-tuple to { %Callable*, { i64, double }* }*
-  %1 = bitcast %Tuple* %arg-tuple to { %Array*, { %String*, %Qubit* }* }*
-  %2 = getelementptr { %Array*, { %String*, %Qubit* }* }, { %Array*, { %String*, %Qubit* }* }* %1, i64 0, i32 0
-  %3 = getelementptr { %Array*, { %String*, %Qubit* }* }, { %Array*, { %String*, %Qubit* }* }* %1, i64 0, i32 1
-  %4 = load %Array*, %Array** %2
-  %5 = load { %String*, %Qubit* }*, { %String*, %Qubit* }** %3
-  %6 = getelementptr { %Callable*, { i64, double }* }, { %Callable*, { i64, double }* }* %0, i64 0, i32 1
+  %0 = bitcast %Tuple* %arg-tuple to { %Array*, { %String*, %Qubit* }* }*
+  %1 = getelementptr { %Array*, { %String*, %Qubit* }* }, { %Array*, { %String*, %Qubit* }* }* %0, i64 0, i32 0
+  %2 = getelementptr { %Array*, { %String*, %Qubit* }* }, { %Array*, { %String*, %Qubit* }* }* %0, i64 0, i32 1
+  %3 = load %Array*, %Array** %1
+  %4 = load { %String*, %Qubit* }*, { %String*, %Qubit* }** %2
+  %5 = bitcast %Tuple* %capture-tuple to { %Callable*, { i64, double }* }*
+  %6 = getelementptr { %Callable*, { i64, double }* }, { %Callable*, { i64, double }* }* %5, i64 0, i32 1
   %7 = load { i64, double }*, { i64, double }** %6
   %8 = call %Tuple* @__quantum__rt__tuple_create(i64 mul nuw (i64 ptrtoint (i1** getelementptr (i1*, i1** null, i32 1) to i64), i64 2))
   %9 = bitcast %Tuple* %8 to { { i64, double }*, { %String*, %Qubit* }* }*
@@ -142,18 +136,18 @@ entry:
   store { i64, double }* %7, { i64, double }** %10
   %12 = bitcast { i64, double }* %7 to %Tuple*
   call void @__quantum__rt__tuple_reference(%Tuple* %12)
-  store { %String*, %Qubit* }* %5, { %String*, %Qubit* }** %11
-  %13 = getelementptr { %String*, %Qubit* }, { %String*, %Qubit* }* %5, i64 0, i32 0
+  store { %String*, %Qubit* }* %4, { %String*, %Qubit* }** %11
+  %13 = getelementptr { %String*, %Qubit* }, { %String*, %Qubit* }* %4, i64 0, i32 0
   %14 = load %String*, %String** %13
   call void @__quantum__rt__string_reference(%String* %14)
-  %15 = bitcast { %String*, %Qubit* }* %5 to %Tuple*
+  %15 = bitcast { %String*, %Qubit* }* %4 to %Tuple*
   call void @__quantum__rt__tuple_reference(%Tuple* %15)
   %16 = call %Tuple* @__quantum__rt__tuple_create(i64 mul nuw (i64 ptrtoint (i1** getelementptr (i1*, i1** null, i32 1) to i64), i64 2))
   %17 = bitcast %Tuple* %16 to { %Array*, { { i64, double }*, { %String*, %Qubit* }* }* }*
   %18 = getelementptr { %Array*, { { i64, double }*, { %String*, %Qubit* }* }* }, { %Array*, { { i64, double }*, { %String*, %Qubit* }* }* }* %17, i64 0, i32 0
   %19 = getelementptr { %Array*, { { i64, double }*, { %String*, %Qubit* }* }* }, { %Array*, { { i64, double }*, { %String*, %Qubit* }* }* }* %17, i64 0, i32 1
-  store %Array* %4, %Array** %18
-  call void @__quantum__rt__array_reference(%Array* %4)
+  store %Array* %3, %Array** %18
+  call void @__quantum__rt__array_reference(%Array* %3)
   store { { i64, double }*, { %String*, %Qubit* }* }* %9, { { i64, double }*, { %String*, %Qubit* }* }** %19
   %20 = getelementptr { { i64, double }*, { %String*, %Qubit* }* }, { { i64, double }*, { %String*, %Qubit* }* }* %9, i64 0, i32 0
   %21 = load { i64, double }*, { i64, double }** %20
@@ -166,47 +160,44 @@ entry:
   call void @__quantum__rt__string_reference(%String* %26)
   %27 = bitcast { %String*, %Qubit* }* %24 to %Tuple*
   call void @__quantum__rt__tuple_reference(%Tuple* %27)
-  %28 = bitcast { { i64, double }*, { %String*, %Qubit* }* }* %9 to %Tuple*
-  call void @__quantum__rt__tuple_reference(%Tuple* %28)
-  %29 = getelementptr { %Callable*, { i64, double }* }, { %Callable*, { i64, double }* }* %0, i64 0, i32 0
-  %30 = load %Callable*, %Callable** %29
-  %31 = call %Callable* @__quantum__rt__callable_copy(%Callable* %30)
-  call void @__quantum__rt__callable_make_adjoint(%Callable* %31)
-  call void @__quantum__rt__callable_make_controlled(%Callable* %31)
-  call void @__quantum__rt__callable_invoke(%Callable* %31, %Tuple* %16, %Tuple* %result-tuple)
-  %32 = getelementptr { { i64, double }*, { %String*, %Qubit* }* }, { { i64, double }*, { %String*, %Qubit* }* }* %9, i64 0, i32 0
-  %33 = load { i64, double }*, { i64, double }** %32
-  %34 = bitcast { i64, double }* %33 to %Tuple*
-  call void @__quantum__rt__tuple_unreference(%Tuple* %34)
-  %35 = getelementptr { { i64, double }*, { %String*, %Qubit* }* }, { { i64, double }*, { %String*, %Qubit* }* }* %9, i64 0, i32 1
-  %36 = load { %String*, %Qubit* }*, { %String*, %Qubit* }** %35
-  %37 = getelementptr { %String*, %Qubit* }, { %String*, %Qubit* }* %36, i64 0, i32 0
-  %38 = load %String*, %String** %37
-  call void @__quantum__rt__string_unreference(%String* %38)
-  %39 = bitcast { %String*, %Qubit* }* %36 to %Tuple*
-  call void @__quantum__rt__tuple_unreference(%Tuple* %39)
-  %40 = bitcast { { i64, double }*, { %String*, %Qubit* }* }* %9 to %Tuple*
-  call void @__quantum__rt__tuple_unreference(%Tuple* %40)
-  %41 = getelementptr { %Array*, { { i64, double }*, { %String*, %Qubit* }* }* }, { %Array*, { { i64, double }*, { %String*, %Qubit* }* }* }* %17, i64 0, i32 0
-  %42 = load %Array*, %Array** %41
-  call void @__quantum__rt__array_unreference(%Array* %42)
-  %43 = getelementptr { %Array*, { { i64, double }*, { %String*, %Qubit* }* }* }, { %Array*, { { i64, double }*, { %String*, %Qubit* }* }* }* %17, i64 0, i32 1
-  %44 = load { { i64, double }*, { %String*, %Qubit* }* }*, { { i64, double }*, { %String*, %Qubit* }* }** %43
-  %45 = getelementptr { { i64, double }*, { %String*, %Qubit* }* }, { { i64, double }*, { %String*, %Qubit* }* }* %44, i64 0, i32 0
-  %46 = load { i64, double }*, { i64, double }** %45
-  %47 = bitcast { i64, double }* %46 to %Tuple*
-  call void @__quantum__rt__tuple_unreference(%Tuple* %47)
-  %48 = getelementptr { { i64, double }*, { %String*, %Qubit* }* }, { { i64, double }*, { %String*, %Qubit* }* }* %44, i64 0, i32 1
-  %49 = load { %String*, %Qubit* }*, { %String*, %Qubit* }** %48
-  %50 = getelementptr { %String*, %Qubit* }, { %String*, %Qubit* }* %49, i64 0, i32 0
-  %51 = load %String*, %String** %50
-  call void @__quantum__rt__string_unreference(%String* %51)
-  %52 = bitcast { %String*, %Qubit* }* %49 to %Tuple*
-  call void @__quantum__rt__tuple_unreference(%Tuple* %52)
-  %53 = bitcast { { i64, double }*, { %String*, %Qubit* }* }* %44 to %Tuple*
-  call void @__quantum__rt__tuple_unreference(%Tuple* %53)
-  %54 = bitcast { %Array*, { { i64, double }*, { %String*, %Qubit* }* }* }* %17 to %Tuple*
-  call void @__quantum__rt__tuple_unreference(%Tuple* %54)
-  call void @__quantum__rt__callable_unreference(%Callable* %31)
+  call void @__quantum__rt__tuple_reference(%Tuple* %8)
+  %28 = getelementptr { %Callable*, { i64, double }* }, { %Callable*, { i64, double }* }* %5, i64 0, i32 0
+  %29 = load %Callable*, %Callable** %28
+  %30 = call %Callable* @__quantum__rt__callable_copy(%Callable* %29, i1 true)
+  call void @__quantum__rt__callable_make_adjoint(%Callable* %30)
+  call void @__quantum__rt__callable_make_controlled(%Callable* %30)
+  call void @__quantum__rt__callable_invoke(%Callable* %30, %Tuple* %16, %Tuple* %result-tuple)
+  %31 = getelementptr { { i64, double }*, { %String*, %Qubit* }* }, { { i64, double }*, { %String*, %Qubit* }* }* %9, i64 0, i32 0
+  %32 = load { i64, double }*, { i64, double }** %31
+  %33 = bitcast { i64, double }* %32 to %Tuple*
+  call void @__quantum__rt__tuple_unreference(%Tuple* %33)
+  %34 = getelementptr { { i64, double }*, { %String*, %Qubit* }* }, { { i64, double }*, { %String*, %Qubit* }* }* %9, i64 0, i32 1
+  %35 = load { %String*, %Qubit* }*, { %String*, %Qubit* }** %34
+  %36 = getelementptr { %String*, %Qubit* }, { %String*, %Qubit* }* %35, i64 0, i32 0
+  %37 = load %String*, %String** %36
+  call void @__quantum__rt__string_unreference(%String* %37)
+  %38 = bitcast { %String*, %Qubit* }* %35 to %Tuple*
+  call void @__quantum__rt__tuple_unreference(%Tuple* %38)
+  call void @__quantum__rt__tuple_unreference(%Tuple* %8)
+  %39 = getelementptr { %Array*, { { i64, double }*, { %String*, %Qubit* }* }* }, { %Array*, { { i64, double }*, { %String*, %Qubit* }* }* }* %17, i64 0, i32 0
+  %40 = load %Array*, %Array** %39
+  call void @__quantum__rt__array_unreference(%Array* %40)
+  %41 = getelementptr { %Array*, { { i64, double }*, { %String*, %Qubit* }* }* }, { %Array*, { { i64, double }*, { %String*, %Qubit* }* }* }* %17, i64 0, i32 1
+  %42 = load { { i64, double }*, { %String*, %Qubit* }* }*, { { i64, double }*, { %String*, %Qubit* }* }** %41
+  %43 = getelementptr { { i64, double }*, { %String*, %Qubit* }* }, { { i64, double }*, { %String*, %Qubit* }* }* %42, i64 0, i32 0
+  %44 = load { i64, double }*, { i64, double }** %43
+  %45 = bitcast { i64, double }* %44 to %Tuple*
+  call void @__quantum__rt__tuple_unreference(%Tuple* %45)
+  %46 = getelementptr { { i64, double }*, { %String*, %Qubit* }* }, { { i64, double }*, { %String*, %Qubit* }* }* %42, i64 0, i32 1
+  %47 = load { %String*, %Qubit* }*, { %String*, %Qubit* }** %46
+  %48 = getelementptr { %String*, %Qubit* }, { %String*, %Qubit* }* %47, i64 0, i32 0
+  %49 = load %String*, %String** %48
+  call void @__quantum__rt__string_unreference(%String* %49)
+  %50 = bitcast { %String*, %Qubit* }* %47 to %Tuple*
+  call void @__quantum__rt__tuple_unreference(%Tuple* %50)
+  %51 = bitcast { { i64, double }*, { %String*, %Qubit* }* }* %42 to %Tuple*
+  call void @__quantum__rt__tuple_unreference(%Tuple* %51)
+  call void @__quantum__rt__tuple_unreference(%Tuple* %16)
+  call void @__quantum__rt__callable_unreference(%Callable* %30)
   ret void
 }

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestRange.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestRange.ll
@@ -7,32 +7,34 @@ entry:
   %a = call %Array* @__quantum__rt__array_create_1d(i32 8, i64 9)
   %3 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %a, i64 0)
   %4 = bitcast i8* %3 to i64*
-  store i64 0, i64* %4
   %5 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %a, i64 1)
   %6 = bitcast i8* %5 to i64*
-  store i64 2, i64* %6
   %7 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %a, i64 2)
   %8 = bitcast i8* %7 to i64*
-  store i64 4, i64* %8
   %9 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %a, i64 3)
   %10 = bitcast i8* %9 to i64*
-  store i64 6, i64* %10
   %11 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %a, i64 4)
   %12 = bitcast i8* %11 to i64*
-  store i64 8, i64* %12
   %13 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %a, i64 5)
   %14 = bitcast i8* %13 to i64*
-  store i64 10, i64* %14
   %15 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %a, i64 6)
   %16 = bitcast i8* %15 to i64*
-  store i64 12, i64* %16
   %17 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %a, i64 7)
   %18 = bitcast i8* %17 to i64*
-  store i64 14, i64* %18
   %19 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %a, i64 8)
   %20 = bitcast i8* %19 to i64*
+  store i64 0, i64* %4
+  store i64 2, i64* %6
+  store i64 4, i64* %8
+  store i64 6, i64* %10
+  store i64 8, i64* %12
+  store i64 10, i64* %14
+  store i64 12, i64* %16
+  store i64 14, i64* %18
   store i64 16, i64* %20
+  call void @__quantum__rt__array_add_access(%Array* %a)
   %b = call %Array* @__quantum__rt__array_slice_1d(%Array* %a, %Range %x, i1 false)
+  call void @__quantum__rt__array_add_access(%Array* %b)
   %21 = load %Range, %Range* @EmptyRange
   %22 = insertvalue %Range %21, i64 0, 0
   %23 = insertvalue %Range %22, i64 1, 1
@@ -61,6 +63,8 @@ exiting__1:                                       ; preds = %body__1
   br label %header__1
 
 exit__1:                                          ; preds = %header__1
+  call void @__quantum__rt__array_remove_access(%Array* %a)
+  call void @__quantum__rt__array_remove_access(%Array* %b)
   call void @__quantum__rt__array_unreference(%Array* %a)
   call void @__quantum__rt__array_unreference(%Array* %b)
   ret %Range %x

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestRepeat.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestRepeat.ll
@@ -27,10 +27,12 @@ fixup__1:                                         ; preds = %until__1
 
 then0__1:                                         ; preds = %fixup__1
   %7 = call %String* @__quantum__rt__string_create(i32 19, [0 x i8] bitcast ([19 x i8] c"Too many iterations" to [0 x i8]))
+  call void @__quantum__rt__result_unreference(%Result* %0)
   call void @__quantum__rt__fail(%String* %7)
   unreachable
 
 continue__1:                                      ; preds = %fixup__1
+  call void @__quantum__rt__result_unreference(%Result* %0)
   br label %repeat__1
 
 rend__1:                                          ; preds = %until__1

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestRepeat.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestRepeat.ll
@@ -27,8 +27,6 @@ fixup__1:                                         ; preds = %until__1
 
 then0__1:                                         ; preds = %fixup__1
   %7 = call %String* @__quantum__rt__string_create(i32 19, [0 x i8] bitcast ([19 x i8] c"Too many iterations" to [0 x i8]))
-  call void @__quantum__rt__result_unreference(%Result* %0)
-  call void @__quantum__rt__result_unreference(%Result* %1)
   call void @__quantum__rt__fail(%String* %7)
   unreachable
 
@@ -36,8 +34,6 @@ continue__1:                                      ; preds = %fixup__1
   br label %repeat__1
 
 rend__1:                                          ; preds = %until__1
-  call void @__quantum__rt__result_unreference(%Result* %0)
-  call void @__quantum__rt__result_unreference(%Result* %1)
   %8 = load i64, i64* %n
   ret i64 %8
 }

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestResults.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestResults.ll
@@ -5,6 +5,7 @@ entry:
 
 then0__1:                                         ; preds = %entry
   %1 = load %Result*, %Result** @ResultOne
+  call void @__quantum__rt__result_reference(%Result* %1)
   ret %Result* %1
 
 test1__1:                                         ; preds = %entry
@@ -13,11 +14,11 @@ test1__1:                                         ; preds = %entry
   br i1 %3, label %then1__1, label %continue__1
 
 then1__1:                                         ; preds = %test1__1
-  call void @__quantum__rt__result_unreference(%Result* %2)
+  call void @__quantum__rt__result_reference(%Result* %b)
   ret %Result* %b
 
 continue__1:                                      ; preds = %test1__1
   %4 = load %Result*, %Result** @ResultZero
-  call void @__quantum__rt__result_unreference(%Result* %2)
+  call void @__quantum__rt__result_reference(%Result* %4)
   ret %Result* %4
 }

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestScoping.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestScoping.ll
@@ -1,5 +1,6 @@
 define i64 @Microsoft__Quantum__Testing__QIR__TestScoping__body(%Array* %a) {
 entry:
+  call void @__quantum__rt__array_add_access(%Array* %a)
   %sum = alloca i64
   store i64 0, i64* %sum
   %0 = call i64 @__quantum__rt__array_get_size_1d(%Array* %a)
@@ -40,29 +41,29 @@ exiting__1:                                       ; preds = %continue__1
   br label %header__1
 
 exit__1:                                          ; preds = %header__1
-  %12 = call i64 @__quantum__rt__array_get_size_1d(%Array* %a)
-  %13 = sub i64 %12, 1
+  %12 = sub i64 %0, 1
   br label %header__2
 
 header__2:                                        ; preds = %exiting__2, %exit__1
-  %14 = phi i64 [ 0, %exit__1 ], [ %20, %exiting__2 ]
-  %15 = icmp sle i64 %14, %13
-  br i1 %15, label %body__2, label %exit__2
+  %13 = phi i64 [ 0, %exit__1 ], [ %19, %exiting__2 ]
+  %14 = icmp sle i64 %13, %12
+  br i1 %14, label %body__2, label %exit__2
 
 body__2:                                          ; preds = %header__2
-  %16 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %a, i64 %14)
-  %17 = bitcast i8* %16 to i64*
-  %i2 = load i64, i64* %17
-  %18 = load i64, i64* %sum
-  %19 = add i64 %18, %i2
-  store i64 %19, i64* %sum
+  %15 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %a, i64 %13)
+  %16 = bitcast i8* %15 to i64*
+  %i2 = load i64, i64* %16
+  %17 = load i64, i64* %sum
+  %18 = add i64 %17, %i2
+  store i64 %18, i64* %sum
   br label %exiting__2
 
 exiting__2:                                       ; preds = %body__2
-  %20 = add i64 %14, 1
+  %19 = add i64 %13, 1
   br label %header__2
 
 exit__2:                                          ; preds = %header__2
-  %21 = load i64, i64* %sum
-  ret i64 %21
+  %20 = load i64, i64* %sum
+  call void @__quantum__rt__array_remove_access(%Array* %a)
+  ret i64 %20
 }

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestStrings.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestStrings.ll
@@ -76,7 +76,6 @@ entry:
   call void @__quantum__rt__string_unreference(%String* %x)
   call void @__quantum__rt__string_unreference(%String* %y)
   call void @__quantum__rt__string_unreference(%String* %y)
-  call void @__quantum__rt__result_unreference(%Result* %21)
   call void @__quantum__rt__bigint_unreference(%BigInt* %26)
   call void @__quantum__rt__string_unreference(%String* %i)
   ret %String* %37

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestUdt.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestUdt.ll
@@ -1,12 +1,15 @@
 define { { i2, i64 }*, double }* @Microsoft__Quantum__Testing__QIR__TestType__body({ i2, i64 }* %arg__1, double %D) {
 entry:
-  %0 = call %Tuple* @__quantum__rt__tuple_create(i64 ptrtoint ({ { i2, i64 }*, double }* getelementptr ({ { i2, i64 }*, double }, { { i2, i64 }*, double }* null, i32 1) to i64))
-  %1 = bitcast %Tuple* %0 to { { i2, i64 }*, double }*
-  %2 = getelementptr { { i2, i64 }*, double }, { { i2, i64 }*, double }* %1, i64 0, i32 0
-  %3 = getelementptr { { i2, i64 }*, double }, { { i2, i64 }*, double }* %1, i64 0, i32 1
-  store { i2, i64 }* %arg__1, { i2, i64 }** %2
-  %4 = bitcast { i2, i64 }* %arg__1 to %Tuple*
-  call void @__quantum__rt__tuple_reference(%Tuple* %4)
-  store double %D, double* %3
-  ret { { i2, i64 }*, double }* %1
+  %0 = bitcast { i2, i64 }* %arg__1 to %Tuple*
+  call void @__quantum__rt__tuple_add_access(%Tuple* %0)
+  %1 = call %Tuple* @__quantum__rt__tuple_create(i64 ptrtoint ({ { i2, i64 }*, double }* getelementptr ({ { i2, i64 }*, double }, { { i2, i64 }*, double }* null, i32 1) to i64))
+  %2 = bitcast %Tuple* %1 to { { i2, i64 }*, double }*
+  %3 = getelementptr { { i2, i64 }*, double }, { { i2, i64 }*, double }* %2, i64 0, i32 0
+  %4 = getelementptr { { i2, i64 }*, double }, { { i2, i64 }*, double }* %2, i64 0, i32 1
+  store { i2, i64 }* %arg__1, { i2, i64 }** %3
+  %5 = bitcast { i2, i64 }* %arg__1 to %Tuple*
+  call void @__quantum__rt__tuple_reference(%Tuple* %5)
+  store double %D, double* %4
+  call void @__quantum__rt__tuple_remove_access(%Tuple* %0)
+  ret { { i2, i64 }*, double }* %2
 }

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestUdtAccessor.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestUdtAccessor.ll
@@ -10,28 +10,40 @@ entry:
   %x = call { { i2, i64 }*, double }* @Microsoft__Quantum__Testing__QIR__TestType__body({ i2, i64 }* %2, double 2.000000e+00)
   %5 = getelementptr { { i2, i64 }*, double }, { { i2, i64 }*, double }* %x, i64 0, i32 0
   %6 = load { i2, i64 }*, { i2, i64 }** %5
-  %7 = getelementptr { i2, i64 }, { i2, i64 }* %6, i64 0, i32 1
-  %y = load i64, i64* %7
-  %8 = bitcast { i2, i64 }* %2 to %Tuple*
-  call void @__quantum__rt__tuple_unreference(%Tuple* %8)
+  %7 = bitcast { i2, i64 }* %6 to %Tuple*
+  call void @__quantum__rt__tuple_add_access(%Tuple* %7)
+  %8 = bitcast { { i2, i64 }*, double }* %x to %Tuple*
+  call void @__quantum__rt__tuple_add_access(%Tuple* %8)
   %9 = getelementptr { { i2, i64 }*, double }, { { i2, i64 }*, double }* %x, i64 0, i32 0
   %10 = load { i2, i64 }*, { i2, i64 }** %9
-  %11 = bitcast { i2, i64 }* %10 to %Tuple*
-  call void @__quantum__rt__tuple_unreference(%Tuple* %11)
-  %12 = bitcast { { i2, i64 }*, double }* %x to %Tuple*
-  call void @__quantum__rt__tuple_unreference(%Tuple* %12)
+  %11 = getelementptr { i2, i64 }, { i2, i64 }* %10, i64 0, i32 1
+  %y = load i64, i64* %11
+  %12 = getelementptr { { i2, i64 }*, double }, { { i2, i64 }*, double }* %x, i64 0, i32 0
+  %13 = load { i2, i64 }*, { i2, i64 }** %12
+  %14 = bitcast { i2, i64 }* %13 to %Tuple*
+  call void @__quantum__rt__tuple_remove_access(%Tuple* %14)
+  call void @__quantum__rt__tuple_remove_access(%Tuple* %8)
+  call void @__quantum__rt__tuple_unreference(%Tuple* %1)
+  %15 = getelementptr { { i2, i64 }*, double }, { { i2, i64 }*, double }* %x, i64 0, i32 0
+  %16 = load { i2, i64 }*, { i2, i64 }** %15
+  %17 = bitcast { i2, i64 }* %16 to %Tuple*
+  call void @__quantum__rt__tuple_unreference(%Tuple* %17)
+  call void @__quantum__rt__tuple_unreference(%Tuple* %8)
   ret i64 %y
 }
 
 define { { i2, i64 }*, double }* @Microsoft__Quantum__Testing__QIR__TestType__body({ i2, i64 }* %arg__1, double %D) {
 entry:
-  %0 = call %Tuple* @__quantum__rt__tuple_create(i64 ptrtoint ({ { i2, i64 }*, double }* getelementptr ({ { i2, i64 }*, double }, { { i2, i64 }*, double }* null, i32 1) to i64))
-  %1 = bitcast %Tuple* %0 to { { i2, i64 }*, double }*
-  %2 = getelementptr { { i2, i64 }*, double }, { { i2, i64 }*, double }* %1, i64 0, i32 0
-  %3 = getelementptr { { i2, i64 }*, double }, { { i2, i64 }*, double }* %1, i64 0, i32 1
-  store { i2, i64 }* %arg__1, { i2, i64 }** %2
-  %4 = bitcast { i2, i64 }* %arg__1 to %Tuple*
-  call void @__quantum__rt__tuple_reference(%Tuple* %4)
-  store double %D, double* %3
-  ret { { i2, i64 }*, double }* %1
+  %0 = bitcast { i2, i64 }* %arg__1 to %Tuple*
+  call void @__quantum__rt__tuple_add_access(%Tuple* %0)
+  %1 = call %Tuple* @__quantum__rt__tuple_create(i64 ptrtoint ({ { i2, i64 }*, double }* getelementptr ({ { i2, i64 }*, double }, { { i2, i64 }*, double }* null, i32 1) to i64))
+  %2 = bitcast %Tuple* %1 to { { i2, i64 }*, double }*
+  %3 = getelementptr { { i2, i64 }*, double }, { { i2, i64 }*, double }* %2, i64 0, i32 0
+  %4 = getelementptr { { i2, i64 }*, double }, { { i2, i64 }*, double }* %2, i64 0, i32 1
+  store { i2, i64 }* %arg__1, { i2, i64 }** %3
+  %5 = bitcast { i2, i64 }* %arg__1 to %Tuple*
+  call void @__quantum__rt__tuple_reference(%Tuple* %5)
+  store double %D, double* %4
+  call void @__quantum__rt__tuple_remove_access(%Tuple* %0)
+  ret { { i2, i64 }*, double }* %2
 }

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestUdtArgument.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestUdtArgument.ll
@@ -2,68 +2,83 @@ define { i64, { i2, i64 }* }* @Microsoft__Quantum__Testing__QIR__TestUdtArgument
 entry:
   %0 = call %Callable* @__quantum__rt__callable_create([4 x void (%Tuple*, %Tuple*, %Tuple*)*]* @Microsoft__Quantum__Testing__QIR__TestType1, %Tuple* null)
   %udt1 = call { i64 }* @Microsoft__Quantum__Testing__QIR_____GUID___Build__body(%Callable* %0)
-  %1 = call %Callable* @__quantum__rt__callable_create([4 x void (%Tuple*, %Tuple*, %Tuple*)*]* @Microsoft__Quantum__Testing__QIR__TestType2, %Tuple* null)
-  %2 = load i2, i2* @PauliX
-  %3 = call %Tuple* @__quantum__rt__tuple_create(i64 ptrtoint ({ %Callable*, i2 }* getelementptr ({ %Callable*, i2 }, { %Callable*, i2 }* null, i32 1) to i64))
-  %4 = bitcast %Tuple* %3 to { %Callable*, i2 }*
-  %5 = getelementptr { %Callable*, i2 }, { %Callable*, i2 }* %4, i64 0, i32 0
-  %6 = getelementptr { %Callable*, i2 }, { %Callable*, i2 }* %4, i64 0, i32 1
-  store %Callable* %1, %Callable** %5
-  call void @__quantum__rt__callable_reference(%Callable* %1)
-  store i2 %2, i2* %6
-  %7 = call %Callable* @__quantum__rt__callable_create([4 x void (%Tuple*, %Tuple*, %Tuple*)*]* @PartialApplication__1, %Tuple* %3)
-  %udt2 = call { i2, i64 }* @Microsoft__Quantum__Testing__QIR_____GUID___Build__body(%Callable* %7)
-  %8 = call %Callable* @__quantum__rt__callable_create([4 x void (%Tuple*, %Tuple*, %Tuple*)*]* @Microsoft__Quantum__Testing__QIR__TestType3, %Tuple* null)
-  %9 = load i2, i2* @PauliX
-  %10 = call %Tuple* @__quantum__rt__tuple_create(i64 ptrtoint ({ %Callable*, i2, double }* getelementptr ({ %Callable*, i2, double }, { %Callable*, i2, double }* null, i32 1) to i64))
-  %11 = bitcast %Tuple* %10 to { %Callable*, i2, double }*
-  %12 = getelementptr { %Callable*, i2, double }, { %Callable*, i2, double }* %11, i64 0, i32 0
-  %13 = getelementptr { %Callable*, i2, double }, { %Callable*, i2, double }* %11, i64 0, i32 1
-  %14 = getelementptr { %Callable*, i2, double }, { %Callable*, i2, double }* %11, i64 0, i32 2
-  store %Callable* %8, %Callable** %12
-  call void @__quantum__rt__callable_reference(%Callable* %8)
-  store i2 %9, i2* %13
-  store double 2.000000e+00, double* %14
-  %15 = call %Callable* @__quantum__rt__callable_create([4 x void (%Tuple*, %Tuple*, %Tuple*)*]* @PartialApplication__2, %Tuple* %10)
-  %udt3 = call { { i2, i64 }*, double }* @Microsoft__Quantum__Testing__QIR_____GUID___Build__body(%Callable* %15)
-  %16 = getelementptr { i64 }, { i64 }* %udt1, i64 0, i32 0
-  %17 = load i64, i64* %16
-  %18 = bitcast { i2, i64 }* %udt2 to %Tuple*
-  call void @__quantum__rt__tuple_reference(%Tuple* %18)
-  %19 = call %Tuple* @__quantum__rt__tuple_create(i64 ptrtoint ({ i64, { i2, i64 }* }* getelementptr ({ i64, { i2, i64 }* }, { i64, { i2, i64 }* }* null, i32 1) to i64))
-  %20 = bitcast %Tuple* %19 to { i64, { i2, i64 }* }*
-  %21 = getelementptr { i64, { i2, i64 }* }, { i64, { i2, i64 }* }* %20, i64 0, i32 0
-  %22 = getelementptr { i64, { i2, i64 }* }, { i64, { i2, i64 }* }* %20, i64 0, i32 1
-  store i64 %17, i64* %21
-  store { i2, i64 }* %udt2, { i2, i64 }** %22
-  %23 = bitcast { i2, i64 }* %udt2 to %Tuple*
-  call void @__quantum__rt__tuple_reference(%Tuple* %23)
-  call void @__quantum__rt__callable_unreference(%Callable* %0)
-  %24 = bitcast { i64 }* %udt1 to %Tuple*
-  call void @__quantum__rt__tuple_unreference(%Tuple* %24)
-  call void @__quantum__rt__callable_unreference(%Callable* %1)
-  %25 = getelementptr { %Callable*, i2 }, { %Callable*, i2 }* %4, i64 0, i32 0
-  %26 = load %Callable*, %Callable** %25
-  call void @__quantum__rt__callable_unreference(%Callable* %26)
-  %27 = bitcast { %Callable*, i2 }* %4 to %Tuple*
-  call void @__quantum__rt__tuple_unreference(%Tuple* %27)
-  call void @__quantum__rt__callable_unreference(%Callable* %7)
-  %28 = bitcast { i2, i64 }* %udt2 to %Tuple*
-  call void @__quantum__rt__tuple_unreference(%Tuple* %28)
-  call void @__quantum__rt__callable_unreference(%Callable* %8)
-  %29 = getelementptr { %Callable*, i2, double }, { %Callable*, i2, double }* %11, i64 0, i32 0
-  %30 = load %Callable*, %Callable** %29
-  call void @__quantum__rt__callable_unreference(%Callable* %30)
-  %31 = bitcast { %Callable*, i2, double }* %11 to %Tuple*
-  call void @__quantum__rt__tuple_unreference(%Tuple* %31)
-  call void @__quantum__rt__callable_unreference(%Callable* %15)
+  %1 = bitcast { i64 }* %udt1 to %Tuple*
+  call void @__quantum__rt__tuple_add_access(%Tuple* %1)
+  %2 = call %Callable* @__quantum__rt__callable_create([4 x void (%Tuple*, %Tuple*, %Tuple*)*]* @Microsoft__Quantum__Testing__QIR__TestType2, %Tuple* null)
+  %3 = load i2, i2* @PauliX
+  %4 = call %Tuple* @__quantum__rt__tuple_create(i64 ptrtoint ({ %Callable*, i2 }* getelementptr ({ %Callable*, i2 }, { %Callable*, i2 }* null, i32 1) to i64))
+  %5 = bitcast %Tuple* %4 to { %Callable*, i2 }*
+  %6 = getelementptr { %Callable*, i2 }, { %Callable*, i2 }* %5, i64 0, i32 0
+  %7 = getelementptr { %Callable*, i2 }, { %Callable*, i2 }* %5, i64 0, i32 1
+  store %Callable* %2, %Callable** %6
+  call void @__quantum__rt__callable_reference(%Callable* %2)
+  store i2 %3, i2* %7
+  %8 = call %Callable* @__quantum__rt__callable_create([4 x void (%Tuple*, %Tuple*, %Tuple*)*]* @PartialApplication__1, %Tuple* %4)
+  %9 = getelementptr { %Callable*, i2 }, { %Callable*, i2 }* %5, i64 0, i32 0
+  %10 = load %Callable*, %Callable** %9
+  call void @__quantum__rt__callable_reference(%Callable* %10)
+  call void @__quantum__rt__tuple_reference(%Tuple* %4)
+  %udt2 = call { i2, i64 }* @Microsoft__Quantum__Testing__QIR_____GUID___Build__body(%Callable* %8)
+  %11 = bitcast { i2, i64 }* %udt2 to %Tuple*
+  call void @__quantum__rt__tuple_add_access(%Tuple* %11)
+  %12 = call %Callable* @__quantum__rt__callable_create([4 x void (%Tuple*, %Tuple*, %Tuple*)*]* @Microsoft__Quantum__Testing__QIR__TestType3, %Tuple* null)
+  %13 = load i2, i2* @PauliX
+  %14 = call %Tuple* @__quantum__rt__tuple_create(i64 ptrtoint ({ %Callable*, i2, double }* getelementptr ({ %Callable*, i2, double }, { %Callable*, i2, double }* null, i32 1) to i64))
+  %15 = bitcast %Tuple* %14 to { %Callable*, i2, double }*
+  %16 = getelementptr { %Callable*, i2, double }, { %Callable*, i2, double }* %15, i64 0, i32 0
+  %17 = getelementptr { %Callable*, i2, double }, { %Callable*, i2, double }* %15, i64 0, i32 1
+  %18 = getelementptr { %Callable*, i2, double }, { %Callable*, i2, double }* %15, i64 0, i32 2
+  store %Callable* %12, %Callable** %16
+  call void @__quantum__rt__callable_reference(%Callable* %12)
+  store i2 %13, i2* %17
+  store double 2.000000e+00, double* %18
+  %19 = call %Callable* @__quantum__rt__callable_create([4 x void (%Tuple*, %Tuple*, %Tuple*)*]* @PartialApplication__2, %Tuple* %14)
+  %20 = getelementptr { %Callable*, i2, double }, { %Callable*, i2, double }* %15, i64 0, i32 0
+  %21 = load %Callable*, %Callable** %20
+  call void @__quantum__rt__callable_reference(%Callable* %21)
+  call void @__quantum__rt__tuple_reference(%Tuple* %14)
+  %udt3 = call { { i2, i64 }*, double }* @Microsoft__Quantum__Testing__QIR_____GUID___Build__body(%Callable* %19)
+  %22 = getelementptr { { i2, i64 }*, double }, { { i2, i64 }*, double }* %udt3, i64 0, i32 0
+  %23 = load { i2, i64 }*, { i2, i64 }** %22
+  %24 = bitcast { i2, i64 }* %23 to %Tuple*
+  call void @__quantum__rt__tuple_add_access(%Tuple* %24)
+  %25 = bitcast { { i2, i64 }*, double }* %udt3 to %Tuple*
+  call void @__quantum__rt__tuple_add_access(%Tuple* %25)
+  %26 = getelementptr { i64 }, { i64 }* %udt1, i64 0, i32 0
+  %27 = load i64, i64* %26
+  %28 = call %Tuple* @__quantum__rt__tuple_create(i64 ptrtoint ({ i64, { i2, i64 }* }* getelementptr ({ i64, { i2, i64 }* }, { i64, { i2, i64 }* }* null, i32 1) to i64))
+  %29 = bitcast %Tuple* %28 to { i64, { i2, i64 }* }*
+  %30 = getelementptr { i64, { i2, i64 }* }, { i64, { i2, i64 }* }* %29, i64 0, i32 0
+  %31 = getelementptr { i64, { i2, i64 }* }, { i64, { i2, i64 }* }* %29, i64 0, i32 1
+  store i64 %27, i64* %30
+  store { i2, i64 }* %udt2, { i2, i64 }** %31
+  call void @__quantum__rt__tuple_reference(%Tuple* %11)
+  call void @__quantum__rt__tuple_remove_access(%Tuple* %1)
+  call void @__quantum__rt__tuple_remove_access(%Tuple* %11)
   %32 = getelementptr { { i2, i64 }*, double }, { { i2, i64 }*, double }* %udt3, i64 0, i32 0
   %33 = load { i2, i64 }*, { i2, i64 }** %32
   %34 = bitcast { i2, i64 }* %33 to %Tuple*
-  call void @__quantum__rt__tuple_unreference(%Tuple* %34)
-  %35 = bitcast { { i2, i64 }*, double }* %udt3 to %Tuple*
-  call void @__quantum__rt__tuple_unreference(%Tuple* %35)
-  %36 = bitcast { i2, i64 }* %udt2 to %Tuple*
-  call void @__quantum__rt__tuple_unreference(%Tuple* %36)
-  ret { i64, { i2, i64 }* }* %20
+  call void @__quantum__rt__tuple_remove_access(%Tuple* %34)
+  call void @__quantum__rt__tuple_remove_access(%Tuple* %25)
+  call void @__quantum__rt__callable_unreference(%Callable* %0)
+  call void @__quantum__rt__tuple_unreference(%Tuple* %1)
+  call void @__quantum__rt__callable_unreference(%Callable* %2)
+  %35 = getelementptr { %Callable*, i2 }, { %Callable*, i2 }* %5, i64 0, i32 0
+  %36 = load %Callable*, %Callable** %35
+  call void @__quantum__rt__callable_unreference(%Callable* %36)
+  call void @__quantum__rt__tuple_unreference(%Tuple* %4)
+  call void @__quantum__rt__callable_unreference(%Callable* %8)
+  call void @__quantum__rt__tuple_unreference(%Tuple* %11)
+  call void @__quantum__rt__callable_unreference(%Callable* %12)
+  %37 = getelementptr { %Callable*, i2, double }, { %Callable*, i2, double }* %15, i64 0, i32 0
+  %38 = load %Callable*, %Callable** %37
+  call void @__quantum__rt__callable_unreference(%Callable* %38)
+  call void @__quantum__rt__tuple_unreference(%Tuple* %14)
+  call void @__quantum__rt__callable_unreference(%Callable* %19)
+  %39 = getelementptr { { i2, i64 }*, double }, { { i2, i64 }*, double }* %udt3, i64 0, i32 0
+  %40 = load { i2, i64 }*, { i2, i64 }** %39
+  %41 = bitcast { i2, i64 }* %40 to %Tuple*
+  call void @__quantum__rt__tuple_unreference(%Tuple* %41)
+  call void @__quantum__rt__tuple_unreference(%Tuple* %25)
+  ret { i64, { i2, i64 }* }* %29
 }

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestUdtConstruction.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestUdtConstruction.ll
@@ -6,24 +6,26 @@ entry:
   %2 = getelementptr { double, double }, { double, double }* %args, i64 0, i32 1
   store double 1.000000e+00, double* %1
   store double 2.000000e+00, double* %2
+  call void @__quantum__rt__tuple_add_access(%Tuple* %0)
   %3 = getelementptr { double, double }, { double, double }* %args, i64 0, i32 0
   %4 = getelementptr { double, double }, { double, double }* %args, i64 0, i32 1
   %5 = load double, double* %3
   %6 = load double, double* %4
   %complex = call { double, double }* @Microsoft__Quantum__Testing__QIR__Complex__body(double %5, double %6)
-  %7 = load i2, i2* @PauliX
-  %8 = call %Tuple* @__quantum__rt__tuple_create(i64 ptrtoint ({ i2, i64 }* getelementptr ({ i2, i64 }, { i2, i64 }* null, i32 1) to i64))
-  %9 = bitcast %Tuple* %8 to { i2, i64 }*
-  %10 = getelementptr { i2, i64 }, { i2, i64 }* %9, i64 0, i32 0
-  %11 = getelementptr { i2, i64 }, { i2, i64 }* %9, i64 0, i32 1
-  store i2 %7, i2* %10
-  store i64 1, i64* %11
-  %12 = call { { i2, i64 }*, double }* @Microsoft__Quantum__Testing__QIR__TestType__body({ i2, i64 }* %9, double 2.000000e+00)
-  %13 = bitcast { double, double }* %args to %Tuple*
-  call void @__quantum__rt__tuple_unreference(%Tuple* %13)
-  %14 = bitcast { double, double }* %complex to %Tuple*
-  call void @__quantum__rt__tuple_unreference(%Tuple* %14)
-  %15 = bitcast { i2, i64 }* %9 to %Tuple*
-  call void @__quantum__rt__tuple_unreference(%Tuple* %15)
-  ret { { i2, i64 }*, double }* %12
+  %7 = bitcast { double, double }* %complex to %Tuple*
+  call void @__quantum__rt__tuple_add_access(%Tuple* %7)
+  %8 = load i2, i2* @PauliX
+  %9 = call %Tuple* @__quantum__rt__tuple_create(i64 ptrtoint ({ i2, i64 }* getelementptr ({ i2, i64 }, { i2, i64 }* null, i32 1) to i64))
+  %10 = bitcast %Tuple* %9 to { i2, i64 }*
+  %11 = getelementptr { i2, i64 }, { i2, i64 }* %10, i64 0, i32 0
+  %12 = getelementptr { i2, i64 }, { i2, i64 }* %10, i64 0, i32 1
+  store i2 %8, i2* %11
+  store i64 1, i64* %12
+  %13 = call { { i2, i64 }*, double }* @Microsoft__Quantum__Testing__QIR__TestType__body({ i2, i64 }* %10, double 2.000000e+00)
+  call void @__quantum__rt__tuple_remove_access(%Tuple* %0)
+  call void @__quantum__rt__tuple_remove_access(%Tuple* %7)
+  call void @__quantum__rt__tuple_unreference(%Tuple* %0)
+  call void @__quantum__rt__tuple_unreference(%Tuple* %7)
+  call void @__quantum__rt__tuple_unreference(%Tuple* %9)
+  ret { { i2, i64 }*, double }* %13
 }

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestUdtUpdate.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestUdtUpdate.ll
@@ -1,49 +1,37 @@
 define { { double, i64 }*, i64 }* @Microsoft__Quantum__Testing__QIR__TestUdtUpdate__body(i64 %a, i64 %b) {
 entry:
   %0 = call %Tuple* @__quantum__rt__tuple_create(i64 ptrtoint ({ double, i64 }* getelementptr ({ double, i64 }, { double, i64 }* null, i32 1) to i64))
-create tuple for argument in initial rhs construction
-
   %1 = bitcast %Tuple* %0 to { double, i64 }*
   %2 = getelementptr { double, i64 }, { double, i64 }* %1, i64 0, i32 0
   %3 = getelementptr { double, i64 }, { double, i64 }* %1, i64 0, i32 1
   store double 1.000000e+00, double* %2
   store i64 %a, i64* %3
   %4 = call { { double, i64 }*, i64 }* @Microsoft__Quantum__Testing__QIR__TestType__body({ double, i64 }* %1, i64 %b)
-evaluate initial rhs
-
   %x = alloca { { double, i64 }*, i64 }*
   store { { double, i64 }*, i64 }* %4, { { double, i64 }*, i64 }** %x
-  %5 = load { { double, i64 }*, i64 }*, { { double, i64 }*, i64 }** %x // FIXME: unnecessary load
+  %5 = load { { double, i64 }*, i64 }*, { { double, i64 }*, i64 }** %x
   %6 = getelementptr { { double, i64 }*, i64 }, { { double, i64 }*, i64 }* %5, i64 0, i32 0
   %7 = load { double, i64 }*, { double, i64 }** %6
   %8 = bitcast { double, i64 }* %7 to %Tuple*
   call void @__quantum__rt__tuple_add_access(%Tuple* %8)
   %9 = bitcast { { double, i64 }*, i64 }* %5 to %Tuple*
   call void @__quantum__rt__tuple_add_access(%Tuple* %9)
-assign to x and increase access count for orig outer and orig inner tuple
-
   %10 = load { { double, i64 }*, i64 }*, { { double, i64 }*, i64 }** %x
   %11 = bitcast { { double, i64 }*, i64 }* %10 to %Tuple*
   %12 = call %Tuple* @__quantum__rt__tuple_copy(%Tuple* %11, i1 false)
   %13 = bitcast %Tuple* %12 to { { double, i64 }*, i64 }*
   %14 = getelementptr { { double, i64 }*, i64 }, { { double, i64 }*, i64 }* %13, i64 0, i32 0
   %15 = getelementptr { { double, i64 }*, i64 }, { { double, i64 }*, i64 }* %13, i64 0, i32 1
-  %16 = load i64, i64* %15 // FIXME: SPARE LOAD (FIXED BY RETURNING POINTERVALUES)
-create new outer tuple and increase the ref count for everything that is not updated
-
+  %16 = load i64, i64* %15
   %17 = load { double, i64 }*, { double, i64 }** %14
   %18 = bitcast { double, i64 }* %17 to %Tuple*
   %19 = call %Tuple* @__quantum__rt__tuple_copy(%Tuple* %18, i1 false)
   %20 = bitcast %Tuple* %19 to { double, i64 }*
   store { double, i64 }* %20, { double, i64 }** %14
-create new inner tuple and store it in the outer copy
-
   %21 = getelementptr { double, i64 }, { double, i64 }* %20, i64 0, i32 0
   %22 = getelementptr { double, i64 }, { double, i64 }* %20, i64 0, i32 1
   %23 = load double, double* %21
   store i64 2, i64* %22
-update the ref count in the inner tuple items for everything that is not updated, and update the item
-
   %24 = load { { double, i64 }*, i64 }*, { { double, i64 }*, i64 }** %x
   %25 = getelementptr { { double, i64 }*, i64 }, { { double, i64 }*, i64 }* %24, i64 0, i32 0
   %26 = load { double, i64 }*, { double, i64 }** %25
@@ -51,16 +39,12 @@ update the ref count in the inner tuple items for everything that is not updated
   call void @__quantum__rt__tuple_remove_access(%Tuple* %27)
   %28 = bitcast { { double, i64 }*, i64 }* %24 to %Tuple*
   call void @__quantum__rt__tuple_remove_access(%Tuple* %28)
-decrease the access count for the original outer and inner tuple
-
   store { { double, i64 }*, i64 }* %13, { { double, i64 }*, i64 }** %x
   %29 = getelementptr { { double, i64 }*, i64 }, { { double, i64 }*, i64 }* %13, i64 0, i32 0
   %30 = load { double, i64 }*, { double, i64 }** %29
   %31 = bitcast { double, i64 }* %30 to %Tuple*
   call void @__quantum__rt__tuple_add_access(%Tuple* %31)
   call void @__quantum__rt__tuple_add_access(%Tuple* %12)
-assign the constructed copy and update to x and increase the access count for outer and inner 
-
   %32 = load { { double, i64 }*, i64 }*, { { double, i64 }*, i64 }** %x
   %33 = getelementptr { { double, i64 }*, i64 }, { { double, i64 }*, i64 }* %32, i64 0, i32 0
   %34 = load { double, i64 }*, { double, i64 }** %33
@@ -68,8 +52,6 @@ assign the constructed copy and update to x and increase the access count for ou
   call void @__quantum__rt__tuple_reference(%Tuple* %35)
   %36 = bitcast { { double, i64 }*, i64 }* %32 to %Tuple*
   call void @__quantum__rt__tuple_reference(%Tuple* %36)
-reference the outer and inner tuple of the copy and update, because it will be returned
-
   %37 = load { { double, i64 }*, i64 }*, { { double, i64 }*, i64 }** %x
   %38 = getelementptr { { double, i64 }*, i64 }, { { double, i64 }*, i64 }* %37, i64 0, i32 0
   %39 = load { double, i64 }*, { double, i64 }** %38
@@ -77,28 +59,18 @@ reference the outer and inner tuple of the copy and update, because it will be r
   call void @__quantum__rt__tuple_remove_access(%Tuple* %40)
   %41 = bitcast { { double, i64 }*, i64 }* %37 to %Tuple*
   call void @__quantum__rt__tuple_remove_access(%Tuple* %41)
-remove access for the outer and inner tuple in copy and update (x is going out of scope)
-  
   call void @__quantum__rt__tuple_unreference(%Tuple* %0)
-unref the first tuple that was the arg for the original construction (will be dealloc)
-
   %42 = getelementptr { { double, i64 }*, i64 }, { { double, i64 }*, i64 }* %4, i64 0, i32 0
   %43 = load { double, i64 }*, { double, i64 }** %42
   %44 = bitcast { double, i64 }* %43 to %Tuple*
   call void @__quantum__rt__tuple_unreference(%Tuple* %44)
   %45 = bitcast { { double, i64 }*, i64 }* %4 to %Tuple*
   call void @__quantum__rt__tuple_unreference(%Tuple* %45)
-unreference the orig outer and inner tuple (will be dealloc)
-
   %46 = getelementptr { { double, i64 }*, i64 }, { { double, i64 }*, i64 }* %13, i64 0, i32 0
   %47 = load { double, i64 }*, { double, i64 }** %46
   %48 = bitcast { double, i64 }* %47 to %Tuple*
   call void @__quantum__rt__tuple_unreference(%Tuple* %48)
   call void @__quantum__rt__tuple_unreference(%Tuple* %12)
-unreference the copy outer and inner tuple (remains alive with ref count 1)
-
   call void @__quantum__rt__tuple_unreference(%Tuple* %19)
-unreference created inner tuple
-
   ret { { double, i64 }*, i64 }* %32
 }

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestUdtUpdate.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestUdtUpdate.ll
@@ -1,67 +1,104 @@
 define { { double, i64 }*, i64 }* @Microsoft__Quantum__Testing__QIR__TestUdtUpdate__body(i64 %a, i64 %b) {
 entry:
   %0 = call %Tuple* @__quantum__rt__tuple_create(i64 ptrtoint ({ double, i64 }* getelementptr ({ double, i64 }, { double, i64 }* null, i32 1) to i64))
+create tuple for argument in initial rhs construction
+
   %1 = bitcast %Tuple* %0 to { double, i64 }*
   %2 = getelementptr { double, i64 }, { double, i64 }* %1, i64 0, i32 0
   %3 = getelementptr { double, i64 }, { double, i64 }* %1, i64 0, i32 1
   store double 1.000000e+00, double* %2
   store i64 %a, i64* %3
   %4 = call { { double, i64 }*, i64 }* @Microsoft__Quantum__Testing__QIR__TestType__body({ double, i64 }* %1, i64 %b)
+evaluate initial rhs
+
   %x = alloca { { double, i64 }*, i64 }*
   store { { double, i64 }*, i64 }* %4, { { double, i64 }*, i64 }** %x
-  %5 = load { { double, i64 }*, i64 }*, { { double, i64 }*, i64 }** %x
-  %6 = call %Tuple* @__quantum__rt__tuple_create(i64 ptrtoint ({ { double, i64 }*, i64 }* getelementptr ({ { double, i64 }*, i64 }, { { double, i64 }*, i64 }* null, i32 1) to i64))
-  %7 = bitcast %Tuple* %6 to { { double, i64 }*, i64 }*
-  %8 = getelementptr { { double, i64 }*, i64 }, { { double, i64 }*, i64 }* %5, i64 0, i32 0
-  %9 = load { double, i64 }*, { double, i64 }** %8
-  %10 = call %Tuple* @__quantum__rt__tuple_create(i64 ptrtoint ({ double, i64 }* getelementptr ({ double, i64 }, { double, i64 }* null, i32 1) to i64))
-  %11 = bitcast %Tuple* %10 to { double, i64 }*
-  %12 = getelementptr { double, i64 }, { double, i64 }* %9, i64 0, i32 0
-  %13 = load double, double* %12
-  %14 = getelementptr { double, i64 }, { double, i64 }* %11, i64 0, i32 0
-  store double %13, double* %14
-  %15 = getelementptr { double, i64 }, { double, i64 }* %9, i64 0, i32 1
-  %16 = load i64, i64* %15
-  %17 = getelementptr { double, i64 }, { double, i64 }* %11, i64 0, i32 1
-  store i64 %16, i64* %17
-  %18 = getelementptr { { double, i64 }*, i64 }, { { double, i64 }*, i64 }* %7, i64 0, i32 0
-  store { double, i64 }* %11, { double, i64 }** %18
-  %19 = getelementptr { { double, i64 }*, i64 }, { { double, i64 }*, i64 }* %5, i64 0, i32 1
-  %20 = load i64, i64* %19
-  %21 = getelementptr { { double, i64 }*, i64 }, { { double, i64 }*, i64 }* %7, i64 0, i32 1
-  store i64 %20, i64* %21
-  %22 = getelementptr { { double, i64 }*, i64 }, { { double, i64 }*, i64 }* %7, i64 0, i32 0
-  %23 = load { double, i64 }*, { double, i64 }** %22
-  %24 = getelementptr { double, i64 }, { double, i64 }* %23, i64 0, i32 1
-  store i64 2, i64* %24
-  %25 = load { { double, i64 }*, i64 }*, { { double, i64 }*, i64 }** %x
-  store { { double, i64 }*, i64 }* %7, { { double, i64 }*, i64 }** %x
-  %26 = getelementptr { { double, i64 }*, i64 }, { { double, i64 }*, i64 }* %7, i64 0, i32 0
-  %27 = load { double, i64 }*, { double, i64 }** %26
-  %28 = bitcast { double, i64 }* %27 to %Tuple*
-  call void @__quantum__rt__tuple_reference(%Tuple* %28)
-  %29 = bitcast { { double, i64 }*, i64 }* %7 to %Tuple*
-  call void @__quantum__rt__tuple_reference(%Tuple* %29)
-  %30 = load { { double, i64 }*, i64 }*, { { double, i64 }*, i64 }** %x
-  %31 = bitcast { double, i64 }* %1 to %Tuple*
-  call void @__quantum__rt__tuple_unreference(%Tuple* %31)
-  %32 = getelementptr { { double, i64 }*, i64 }, { { double, i64 }*, i64 }* %4, i64 0, i32 0
-  %33 = load { double, i64 }*, { double, i64 }** %32
-  %34 = bitcast { double, i64 }* %33 to %Tuple*
-  call void @__quantum__rt__tuple_unreference(%Tuple* %34)
-  %35 = bitcast { { double, i64 }*, i64 }* %4 to %Tuple*
-  call void @__quantum__rt__tuple_unreference(%Tuple* %35)
-  %36 = getelementptr { { double, i64 }*, i64 }, { { double, i64 }*, i64 }* %7, i64 0, i32 0
-  %37 = load { double, i64 }*, { double, i64 }** %36
-  %38 = bitcast { double, i64 }* %37 to %Tuple*
-  call void @__quantum__rt__tuple_unreference(%Tuple* %38)
-  %39 = bitcast { { double, i64 }*, i64 }* %7 to %Tuple*
-  call void @__quantum__rt__tuple_unreference(%Tuple* %39)
-  %40 = getelementptr { { double, i64 }*, i64 }, { { double, i64 }*, i64 }* %25, i64 0, i32 0
-  %41 = load { double, i64 }*, { double, i64 }** %40
-  %42 = bitcast { double, i64 }* %41 to %Tuple*
-  call void @__quantum__rt__tuple_unreference(%Tuple* %42)
-  %43 = bitcast { { double, i64 }*, i64 }* %25 to %Tuple*
-  call void @__quantum__rt__tuple_unreference(%Tuple* %43)
-  ret { { double, i64 }*, i64 }* %30
+  %5 = load { { double, i64 }*, i64 }*, { { double, i64 }*, i64 }** %x // FIXME: unnecessary load
+  %6 = getelementptr { { double, i64 }*, i64 }, { { double, i64 }*, i64 }* %5, i64 0, i32 0
+  %7 = load { double, i64 }*, { double, i64 }** %6
+  %8 = bitcast { double, i64 }* %7 to %Tuple*
+  call void @__quantum__rt__tuple_add_access(%Tuple* %8)
+  %9 = bitcast { { double, i64 }*, i64 }* %5 to %Tuple*
+  call void @__quantum__rt__tuple_add_access(%Tuple* %9)
+assign to x and increase access count for orig outer and orig inner tuple
+
+  %10 = load { { double, i64 }*, i64 }*, { { double, i64 }*, i64 }** %x
+  %11 = bitcast { { double, i64 }*, i64 }* %10 to %Tuple*
+  %12 = call %Tuple* @__quantum__rt__tuple_copy(%Tuple* %11, i1 false)
+  %13 = bitcast %Tuple* %12 to { { double, i64 }*, i64 }*
+  %14 = getelementptr { { double, i64 }*, i64 }, { { double, i64 }*, i64 }* %13, i64 0, i32 0
+  %15 = getelementptr { { double, i64 }*, i64 }, { { double, i64 }*, i64 }* %13, i64 0, i32 1
+  %16 = load i64, i64* %15 // FIXME: SPARE LOAD (FIXED BY RETURNING POINTERVALUES)
+create new outer tuple and increase the ref count for everything that is not updated
+
+  %17 = load { double, i64 }*, { double, i64 }** %14
+  %18 = bitcast { double, i64 }* %17 to %Tuple*
+  %19 = call %Tuple* @__quantum__rt__tuple_copy(%Tuple* %18, i1 false)
+  %20 = bitcast %Tuple* %19 to { double, i64 }*
+  store { double, i64 }* %20, { double, i64 }** %14
+create new inner tuple and store it in the outer copy
+
+  %21 = getelementptr { double, i64 }, { double, i64 }* %20, i64 0, i32 0
+  %22 = getelementptr { double, i64 }, { double, i64 }* %20, i64 0, i32 1
+  %23 = load double, double* %21
+  store i64 2, i64* %22
+update the ref count in the inner tuple items for everything that is not updated, and update the item
+
+  %24 = load { { double, i64 }*, i64 }*, { { double, i64 }*, i64 }** %x
+  %25 = getelementptr { { double, i64 }*, i64 }, { { double, i64 }*, i64 }* %24, i64 0, i32 0
+  %26 = load { double, i64 }*, { double, i64 }** %25
+  %27 = bitcast { double, i64 }* %26 to %Tuple*
+  call void @__quantum__rt__tuple_remove_access(%Tuple* %27)
+  %28 = bitcast { { double, i64 }*, i64 }* %24 to %Tuple*
+  call void @__quantum__rt__tuple_remove_access(%Tuple* %28)
+decrease the access count for the original outer and inner tuple
+
+  store { { double, i64 }*, i64 }* %13, { { double, i64 }*, i64 }** %x
+  %29 = getelementptr { { double, i64 }*, i64 }, { { double, i64 }*, i64 }* %13, i64 0, i32 0
+  %30 = load { double, i64 }*, { double, i64 }** %29
+  %31 = bitcast { double, i64 }* %30 to %Tuple*
+  call void @__quantum__rt__tuple_add_access(%Tuple* %31)
+  call void @__quantum__rt__tuple_add_access(%Tuple* %12)
+assign the constructed copy and update to x and increase the access count for outer and inner 
+
+  %32 = load { { double, i64 }*, i64 }*, { { double, i64 }*, i64 }** %x
+  %33 = getelementptr { { double, i64 }*, i64 }, { { double, i64 }*, i64 }* %32, i64 0, i32 0
+  %34 = load { double, i64 }*, { double, i64 }** %33
+  %35 = bitcast { double, i64 }* %34 to %Tuple*
+  call void @__quantum__rt__tuple_reference(%Tuple* %35)
+  %36 = bitcast { { double, i64 }*, i64 }* %32 to %Tuple*
+  call void @__quantum__rt__tuple_reference(%Tuple* %36)
+reference the outer and inner tuple of the copy and update, because it will be returned
+
+  %37 = load { { double, i64 }*, i64 }*, { { double, i64 }*, i64 }** %x
+  %38 = getelementptr { { double, i64 }*, i64 }, { { double, i64 }*, i64 }* %37, i64 0, i32 0
+  %39 = load { double, i64 }*, { double, i64 }** %38
+  %40 = bitcast { double, i64 }* %39 to %Tuple*
+  call void @__quantum__rt__tuple_remove_access(%Tuple* %40)
+  %41 = bitcast { { double, i64 }*, i64 }* %37 to %Tuple*
+  call void @__quantum__rt__tuple_remove_access(%Tuple* %41)
+remove access for the outer and inner tuple in copy and update (x is going out of scope)
+  
+  call void @__quantum__rt__tuple_unreference(%Tuple* %0)
+unref the first tuple that was the arg for the original construction (will be dealloc)
+
+  %42 = getelementptr { { double, i64 }*, i64 }, { { double, i64 }*, i64 }* %4, i64 0, i32 0
+  %43 = load { double, i64 }*, { double, i64 }** %42
+  %44 = bitcast { double, i64 }* %43 to %Tuple*
+  call void @__quantum__rt__tuple_unreference(%Tuple* %44)
+  %45 = bitcast { { double, i64 }*, i64 }* %4 to %Tuple*
+  call void @__quantum__rt__tuple_unreference(%Tuple* %45)
+unreference the orig outer and inner tuple (will be dealloc)
+
+  %46 = getelementptr { { double, i64 }*, i64 }, { { double, i64 }*, i64 }* %13, i64 0, i32 0
+  %47 = load { double, i64 }*, { double, i64 }** %46
+  %48 = bitcast { double, i64 }* %47 to %Tuple*
+  call void @__quantum__rt__tuple_unreference(%Tuple* %48)
+  call void @__quantum__rt__tuple_unreference(%Tuple* %12)
+unreference the copy outer and inner tuple (remains alive with ref count 1)
+
+  call void @__quantum__rt__tuple_unreference(%Tuple* %19)
+unreference created inner tuple
+
+  ret { { double, i64 }*, i64 }* %32
 }

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestUsing.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestUsing.ll
@@ -2,8 +2,10 @@ define i64 @Microsoft__Quantum__Testing__QIR__TestUsing__body() {
 entry:
   %a = call %Qubit* @__quantum__rt__qubit_allocate()
   %b = call %Array* @__quantum__rt__qubit_allocate_array(i64 3)
+  call void @__quantum__rt__array_add_access(%Array* %b)
   %c = call %Qubit* @__quantum__rt__qubit_allocate()
   %d = call %Array* @__quantum__rt__qubit_allocate_array(i64 2)
+  call void @__quantum__rt__array_add_access(%Array* %d)
   %0 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %b, i64 1)
   %1 = bitcast i8* %0 to %Qubit**
   %x = load %Qubit*, %Qubit** %1
@@ -13,29 +15,36 @@ entry:
   %4 = insertvalue %Range %3, i64 2, 1
   %5 = insertvalue %Range %4, i64 3, 2
   %y = call %Array* @__quantum__rt__array_slice_1d(%Array* %b, %Range %5, i1 false)
+  call void @__quantum__rt__array_add_access(%Array* %y)
   %6 = call i64 @__quantum__rt__array_get_size_1d(%Array* %y)
   %7 = icmp eq i64 %6, 3
   br i1 %7, label %then0__1, label %continue__1
 
 then0__1:                                         ; preds = %entry
   call void @__quantum__rt__qubit_release(%Qubit* %z)
+  call void @__quantum__rt__array_remove_access(%Array* %y)
   call void @__quantum__rt__array_unreference(%Array* %y)
   call void @__quantum__rt__qubit_release(%Qubit* %a)
   call void @__quantum__rt__qubit_release_array(%Array* %b)
-  call void @__quantum__rt__array_unreference(%Array* %b)
   call void @__quantum__rt__qubit_release(%Qubit* %c)
   call void @__quantum__rt__qubit_release_array(%Array* %d)
+  call void @__quantum__rt__array_remove_access(%Array* %b)
+  call void @__quantum__rt__array_remove_access(%Array* %d)
+  call void @__quantum__rt__array_unreference(%Array* %b)
   call void @__quantum__rt__array_unreference(%Array* %d)
   ret i64 5
 
 continue__1:                                      ; preds = %entry
   call void @__quantum__rt__qubit_release(%Qubit* %z)
+  call void @__quantum__rt__array_remove_access(%Array* %y)
   call void @__quantum__rt__array_unreference(%Array* %y)
   call void @__quantum__rt__qubit_release(%Qubit* %a)
   call void @__quantum__rt__qubit_release_array(%Array* %b)
-  call void @__quantum__rt__array_unreference(%Array* %b)
   call void @__quantum__rt__qubit_release(%Qubit* %c)
   call void @__quantum__rt__qubit_release_array(%Array* %d)
+  call void @__quantum__rt__array_remove_access(%Array* %b)
+  call void @__quantum__rt__array_remove_access(%Array* %d)
+  call void @__quantum__rt__array_unreference(%Array* %b)
   call void @__quantum__rt__array_unreference(%Array* %d)
   ret i64 4
 }


### PR DESCRIPTION
Switching from Value to IValue in particular means we are passing the Q# type around with the corresponding value. This allows to properly manage reference and access counts for array items without having to rely on the LLVM type system to provide sufficient information. It should also permit to simplify the generated QIR without much effort by having things like contained items readily available (not yet done).