### PR TITLE
Improve deserializer initialization time

### DIFF
--- a/src/QsCompiler/BondSchemas/Protocols.cs
+++ b/src/QsCompiler/BondSchemas/Protocols.cs
@@ -147,8 +147,13 @@ namespace Microsoft.Quantum.QsCompiler.BondSchemas
         private static Task<SimpleBinaryDeserializer> QueueSimpleBinaryDeserializerInitialization()
         {
             VerifyLockAcquired(BondSharedDataStructuresLock);
-            //return Task.Run(() => new SimpleBinaryDeserializer(typeof(QsCompilation));
-            return Task.Run(() => new SimpleBinaryDeserializer(type: typeof(QsCompilation), factory: (Factory?)null, inlineNested: false));
+
+            // The inlineNested constructor argument is set to false because it optimizes deserialization time at the expense of initialization time and memory.
+            // N.B. For our Bond schemas, passing this argument to the Deserializer constructor does not seem to impact deserialization time.
+            return Task.Run(() => new SimpleBinaryDeserializer(
+                type: typeof(QsCompilation),
+                factory: (Factory?)null,
+                inlineNested: false));
         }
 
         private static Task<SimpleBinarySerializer> QueueSimpleBinarySerializerInitialization()

--- a/src/QsCompiler/BondSchemas/Protocols.cs
+++ b/src/QsCompiler/BondSchemas/Protocols.cs
@@ -148,7 +148,7 @@ namespace Microsoft.Quantum.QsCompiler.BondSchemas
         {
             VerifyLockAcquired(BondSharedDataStructuresLock);
 
-            // The inlineNested constructor argument is set to false because it optimizes deserialization time at the expense of initialization time and memory.
+            // The inlineNested constructor argument is set to false because when it is set to true deserialization time is optimized at the expense of initialization time and memory.
             // N.B. For our Bond schemas, passing this argument to the Deserializer constructor does not seem to impact deserialization time.
             return Task.Run(() => new SimpleBinaryDeserializer(
                 type: typeof(QsCompilation),

--- a/src/QsCompiler/BondSchemas/Protocols.cs
+++ b/src/QsCompiler/BondSchemas/Protocols.cs
@@ -147,7 +147,8 @@ namespace Microsoft.Quantum.QsCompiler.BondSchemas
         private static Task<SimpleBinaryDeserializer> QueueSimpleBinaryDeserializerInitialization()
         {
             VerifyLockAcquired(BondSharedDataStructuresLock);
-            return Task.Run(() => new SimpleBinaryDeserializer(typeof(QsCompilation)));
+            //return Task.Run(() => new SimpleBinaryDeserializer(typeof(QsCompilation));
+            return Task.Run(() => new SimpleBinaryDeserializer(type: typeof(QsCompilation), factory: (Factory?)null, inlineNested: false));
         }
 
         private static Task<SimpleBinarySerializer> QueueSimpleBinarySerializerInitialization()

--- a/src/QsCompiler/BondSchemas/Protocols.cs
+++ b/src/QsCompiler/BondSchemas/Protocols.cs
@@ -148,8 +148,8 @@ namespace Microsoft.Quantum.QsCompiler.BondSchemas
         {
             VerifyLockAcquired(BondSharedDataStructuresLock);
 
-            // The inlineNested constructor argument is set to false because when it is set to true deserialization time is optimized at the expense of initialization time and memory.
-            // N.B. For our Bond schemas, passing this argument to the Deserializer constructor does not seem to impact deserialization time.
+            // inlineNested is false in order to decrease the time needed to initialize the deserializer.
+            // While this setting may also increase deserialization time, we did not notice any performance drawbacks with our Bond schemas.
             return Task.Run(() => new SimpleBinaryDeserializer(
                 type: typeof(QsCompilation),
                 factory: (Factory?)null,


### PR DESCRIPTION
This change improves the deserializer initialization time by setting the `inlineNested` constructor argument to `false`.

This change is an application of a suggestion described in an [issue](https://github.com/microsoft/bond/issues/1083) in the Bond repository.

The documentation comment of the [`inlineNested`](https://github.com/microsoft/bond/blob/a8a56e9f50c9aedfe1234d25be0a47c98e8fbffb/cs/src/core/Deserializer.cs#L131-L140) argument of the constructor mentions that when this argument is set to true it inline nested types if possible (optimizes for reduction of execution time at the expense of initialization time and memory). This means that setting this to `false` might reduce initialization time.

After doing some experiments with a quantum teleportation Q# project, setting this argument to false greatly reduces the deserializer initialization time significantly (from ~2500 ms to ~1000 ms) while not having a measurable degradation on the deserialization time itself.

Here's the experiments' data:
**inlineNested = true**
```
Sample 01
{
  "OverallCompilation": 8233,
  "OverallCompilation.Build": 2554,
  "OverallCompilation.OutputGeneration": 38,
  "OverallCompilation.OutputGeneration.BinaryGeneration": 6,
  "OverallCompilation.OutputGeneration.SyntaxTreeSerialization": 31,
  "OverallCompilation.ReferenceLoading": 3578,
  "OverallCompilation.ReferenceLoading.HeaderAttributesLoading": 22,
  "OverallCompilation.ReferenceLoading.LoadDataFromReferenceToStream": 26,
  "OverallCompilation.ReferenceLoading.ReferenceHeadersCreation": 40,
  "OverallCompilation.ReferenceLoading.SyntaxTreeDeserialization": 3382,
  "OverallCompilation.RewriteSteps": 1756,
  "OverallCompilation.RewriteSteps.SingleRewriteStep-ConjugationInlining": 45,
  "OverallCompilation.RewriteSteps.SingleRewriteStep-CsharpGeneration": 1678,
  "OverallCompilation.RewriteSteps.SingleRewriteStep-FunctorGeneration": 17,
  "OverallCompilation.SourcesLoading": 22
}
Deserializer Stats:
        Initialize: 2616
        Wait: 2270
        Deserialize: 48
        Translate: 195
Deserializer Stats:
        Initialize: 2616
        Wait: 2270
        Deserialize: 75
        Translate: 260
Deserializer Stats:
        Initialize: 2616
        Wait: 2270
        Deserialize: 510
        Translate: 597

Sample 02
{
  "OverallCompilation": 8393,
  "OverallCompilation.Build": 2795,
  "OverallCompilation.OutputGeneration": 39,
  "OverallCompilation.OutputGeneration.BinaryGeneration": 7,
  "OverallCompilation.OutputGeneration.SyntaxTreeSerialization": 31,
  "OverallCompilation.ReferenceLoading": 3394,
  "OverallCompilation.ReferenceLoading.HeaderAttributesLoading": 8,
  "OverallCompilation.ReferenceLoading.LoadDataFromReferenceToStream": 28,
  "OverallCompilation.ReferenceLoading.ReferenceHeadersCreation": 38,
  "OverallCompilation.ReferenceLoading.SyntaxTreeDeserialization": 3113,
  "OverallCompilation.RewriteSteps": 1777,
  "OverallCompilation.RewriteSteps.SingleRewriteStep-ConjugationInlining": 43,
  "OverallCompilation.RewriteSteps.SingleRewriteStep-CsharpGeneration": 1702,
  "OverallCompilation.RewriteSteps.SingleRewriteStep-FunctorGeneration": 15,
  "OverallCompilation.SourcesLoading": 65
}
Deserializer Stats:
        Initialize: 2521
        Wait: 2110
        Deserialize: 56
        Translate: 164
Deserializer Stats:
        Initialize: 2521
        Wait: 2111
        Deserialize: 77
        Translate: 193
Deserializer Stats:
        Initialize: 2521
        Wait: 2111
        Deserialize: 501
        Translate: 476

Sample 03
{
  "OverallCompilation": 8254,
  "OverallCompilation.Build": 2679,
  "OverallCompilation.OutputGeneration": 36,
  "OverallCompilation.OutputGeneration.BinaryGeneration": 5,
  "OverallCompilation.OutputGeneration.SyntaxTreeSerialization": 30,
  "OverallCompilation.ReferenceLoading": 3514,
  "OverallCompilation.ReferenceLoading.HeaderAttributesLoading": 22,
  "OverallCompilation.ReferenceLoading.LoadDataFromReferenceToStream": 29,
  "OverallCompilation.ReferenceLoading.ReferenceHeadersCreation": 34,
  "OverallCompilation.ReferenceLoading.SyntaxTreeDeserialization": 3321,
  "OverallCompilation.RewriteSteps": 1725,
  "OverallCompilation.RewriteSteps.SingleRewriteStep-ConjugationInlining": 43,
  "OverallCompilation.RewriteSteps.SingleRewriteStep-CsharpGeneration": 1651,
  "OverallCompilation.RewriteSteps.SingleRewriteStep-FunctorGeneration": 15,
  "OverallCompilation.SourcesLoading": 22
}
Deserializer Stats:
        Initialize: 2565
        Wait: 2231
        Deserialize: 80
        Translate: 173
Deserializer Stats:
        Initialize: 2565
        Wait: 2231
        Deserialize: 105
        Translate: 237
Deserializer Stats:
        Initialize: 2565
        Wait: 2231
        Deserialize: 523
        Translate: 563

Sample 04
{
  "OverallCompilation": 7656,
  "OverallCompilation.Build": 2437,
  "OverallCompilation.OutputGeneration": 33,
  "OverallCompilation.OutputGeneration.BinaryGeneration": 5,
  "OverallCompilation.OutputGeneration.SyntaxTreeSerialization": 27,
  "OverallCompilation.ReferenceLoading": 3263,
  "OverallCompilation.ReferenceLoading.HeaderAttributesLoading": 25,
  "OverallCompilation.ReferenceLoading.LoadDataFromReferenceToStream": 30,
  "OverallCompilation.ReferenceLoading.ReferenceHeadersCreation": 29,
  "OverallCompilation.ReferenceLoading.SyntaxTreeDeserialization": 3063,
  "OverallCompilation.RewriteSteps": 1565,
  "OverallCompilation.RewriteSteps.SingleRewriteStep-ConjugationInlining": 47,
  "OverallCompilation.RewriteSteps.SingleRewriteStep-CsharpGeneration": 1487,
  "OverallCompilation.RewriteSteps.SingleRewriteStep-FunctorGeneration": 14,
  "OverallCompilation.SourcesLoading": 30
}
Deserializer Stats:
        Initialize: 2377
        Wait: 1993
        Deserialize: 48
        Translate: 170
Deserializer Stats:
        Initialize: 2377
        Wait: 1993
        Deserialize: 70
        Translate: 222
Deserializer Stats:
        Initialize: 2377
        Wait: 1993
        Deserialize: 513
        Translate: 552

Sample 05
{
  "OverallCompilation": 8000,
  "OverallCompilation.Build": 2614,
  "OverallCompilation.OutputGeneration": 36,
  "OverallCompilation.OutputGeneration.BinaryGeneration": 5,
  "OverallCompilation.OutputGeneration.SyntaxTreeSerialization": 30,
  "OverallCompilation.ReferenceLoading": 3352,
  "OverallCompilation.ReferenceLoading.HeaderAttributesLoading": 10,
  "OverallCompilation.ReferenceLoading.LoadDataFromReferenceToStream": 24,
  "OverallCompilation.ReferenceLoading.ReferenceHeadersCreation": 55,
  "OverallCompilation.ReferenceLoading.SyntaxTreeDeserialization": 3165,
  "OverallCompilation.RewriteSteps": 1711,
  "OverallCompilation.RewriteSteps.SingleRewriteStep-ConjugationInlining": 56,
  "OverallCompilation.RewriteSteps.SingleRewriteStep-CsharpGeneration": 1625,
  "OverallCompilation.RewriteSteps.SingleRewriteStep-FunctorGeneration": 15,
  "OverallCompilation.SourcesLoading": 21
}
Deserializer Stats:
        Initialize: 2421
        Wait: 2084
        Deserialize: 63
        Translate: 170
Deserializer Stats:
        Initialize: 2421
        Wait: 2084
        Deserialize: 120
        Translate: 229
Deserializer Stats:
        Initialize: 2421
        Wait: 2084
        Deserialize: 559
        Translate: 516
```

**inlineNested = false**
```
Sample 01
{
  "OverallCompilation": 6331,
  "OverallCompilation.Build": 2517,
  "OverallCompilation.OutputGeneration": 32,
  "OverallCompilation.OutputGeneration.BinaryGeneration": 5,
  "OverallCompilation.OutputGeneration.SyntaxTreeSerialization": 27,
  "OverallCompilation.ReferenceLoading": 1965,
  "OverallCompilation.ReferenceLoading.HeaderAttributesLoading": 11,
  "OverallCompilation.ReferenceLoading.LoadDataFromReferenceToStream": 24,
  "OverallCompilation.ReferenceLoading.ReferenceHeadersCreation": 51,
  "OverallCompilation.ReferenceLoading.SyntaxTreeDeserialization": 1777,
  "OverallCompilation.RewriteSteps": 1505,
  "OverallCompilation.RewriteSteps.SingleRewriteStep-ConjugationInlining": 38,
  "OverallCompilation.RewriteSteps.SingleRewriteStep-CsharpGeneration": 1439,
  "OverallCompilation.RewriteSteps.SingleRewriteStep-FunctorGeneration": 14,
  "OverallCompilation.SourcesLoading": 26
}
Deserializer Stats:
        Initialize: 1047
        Wait: 715
        Deserialize: 57
        Translate: 157
Deserializer Stats:
        Initialize: 1047
        Wait: 715
        Deserialize: 79
        Translate: 197
Deserializer Stats:
        Initialize: 1047
        Wait: 715
        Deserialize: 446
        Translate: 605

Sample 02
{
  "OverallCompilation": 6373,
  "OverallCompilation.Build": 2559,
  "OverallCompilation.OutputGeneration": 32,
  "OverallCompilation.OutputGeneration.BinaryGeneration": 5,
  "OverallCompilation.OutputGeneration.SyntaxTreeSerialization": 27,
  "OverallCompilation.ReferenceLoading": 1961,
  "OverallCompilation.ReferenceLoading.HeaderAttributesLoading": 25,
  "OverallCompilation.ReferenceLoading.LoadDataFromReferenceToStream": 30,
  "OverallCompilation.ReferenceLoading.ReferenceHeadersCreation": 54,
  "OverallCompilation.ReferenceLoading.SyntaxTreeDeserialization": 1753,
  "OverallCompilation.RewriteSteps": 1511,
  "OverallCompilation.RewriteSteps.SingleRewriteStep-ConjugationInlining": 46,
  "OverallCompilation.RewriteSteps.SingleRewriteStep-CsharpGeneration": 1437,
  "OverallCompilation.RewriteSteps.SingleRewriteStep-FunctorGeneration": 14,
  "OverallCompilation.SourcesLoading": 23
}
Deserializer Stats:
        Initialize: 1128
        Wait: 794
        Deserialize: 56
        Translate: 120
Deserializer Stats:
        Initialize: 1128
        Wait: 794
        Deserialize: 79
        Translate: 161
Deserializer Stats:
        Initialize: 1128
        Wait: 794
        Deserialize: 459
        Translate: 495

Sample 03
{
  "OverallCompilation": 6343,
  "OverallCompilation.Build": 2592,
  "OverallCompilation.OutputGeneration": 32,
  "OverallCompilation.OutputGeneration.BinaryGeneration": 5,
  "OverallCompilation.OutputGeneration.SyntaxTreeSerialization": 27,
  "OverallCompilation.ReferenceLoading": 1945,
  "OverallCompilation.ReferenceLoading.HeaderAttributesLoading": 22,
  "OverallCompilation.ReferenceLoading.LoadDataFromReferenceToStream": 23,
  "OverallCompilation.ReferenceLoading.ReferenceHeadersCreation": 27,
  "OverallCompilation.ReferenceLoading.SyntaxTreeDeserialization": 1775,
  "OverallCompilation.RewriteSteps": 1505,
  "OverallCompilation.RewriteSteps.SingleRewriteStep-ConjugationInlining": 44,
  "OverallCompilation.RewriteSteps.SingleRewriteStep-CsharpGeneration": 1430,
  "OverallCompilation.RewriteSteps.SingleRewriteStep-FunctorGeneration": 16,
  "OverallCompilation.SourcesLoading": 22
}
Deserializer Stats:
        Initialize: 1065
        Wait: 773
        Deserialize: 56
        Translate: 117
Deserializer Stats:
        Initialize: 1065
        Wait: 773
        Deserialize: 76
        Translate: 169
Deserializer Stats:
        Initialize: 1065
        Wait: 773
        Deserialize: 452
        Translate: 546

Sample 04
{
  "OverallCompilation": 6213,
  "OverallCompilation.Build": 2504,
  "OverallCompilation.OutputGeneration": 32,
  "OverallCompilation.OutputGeneration.BinaryGeneration": 5,
  "OverallCompilation.OutputGeneration.SyntaxTreeSerialization": 27,
  "OverallCompilation.ReferenceLoading": 1875,
  "OverallCompilation.ReferenceLoading.HeaderAttributesLoading": 9,
  "OverallCompilation.ReferenceLoading.LoadDataFromReferenceToStream": 23,
  "OverallCompilation.ReferenceLoading.ReferenceHeadersCreation": 27,
  "OverallCompilation.ReferenceLoading.SyntaxTreeDeserialization": 1704,
  "OverallCompilation.RewriteSteps": 1497,
  "OverallCompilation.RewriteSteps.SingleRewriteStep-ConjugationInlining": 42,
  "OverallCompilation.RewriteSteps.SingleRewriteStep-CsharpGeneration": 1424,
  "OverallCompilation.RewriteSteps.SingleRewriteStep-FunctorGeneration": 16,
  "OverallCompilation.SourcesLoading": 21
}
Deserializer Stats:
        Initialize: 1032
        Wait: 734
        Deserialize: 51
        Translate: 119
Deserializer Stats:
        Initialize: 1032
        Wait: 734
        Deserialize: 70
        Translate: 157
Deserializer Stats:
        Initialize: 1032
        Wait: 734
        Deserialize: 434
        Translate: 531

Sample 05
{
  "OverallCompilation": 6772,
  "OverallCompilation.Build": 2765,
  "OverallCompilation.OutputGeneration": 33,
  "OverallCompilation.OutputGeneration.BinaryGeneration": 5,
  "OverallCompilation.OutputGeneration.SyntaxTreeSerialization": 27,
  "OverallCompilation.ReferenceLoading": 2171,
  "OverallCompilation.ReferenceLoading.HeaderAttributesLoading": 9,
  "OverallCompilation.ReferenceLoading.LoadDataFromReferenceToStream": 25,
  "OverallCompilation.ReferenceLoading.ReferenceHeadersCreation": 32,
  "OverallCompilation.ReferenceLoading.SyntaxTreeDeserialization": 1981,
  "OverallCompilation.RewriteSteps": 1491,
  "OverallCompilation.RewriteSteps.SingleRewriteStep-ConjugationInlining": 54,
  "OverallCompilation.RewriteSteps.SingleRewriteStep-CsharpGeneration": 1410,
  "OverallCompilation.RewriteSteps.SingleRewriteStep-FunctorGeneration": 14,
  "OverallCompilation.SourcesLoading": 30
}
Deserializer Stats:
        Initialize: 1255
        Wait: 903
        Deserialize: 38
        Translate: 158
Deserializer Stats:
        Initialize: 1255
        Wait: 903
        Deserialize: 69
        Translate: 201
Deserializer Stats:
        Initialize: 1255
        Wait: 903
        Deserialize: 496
        Translate: 577
```