### PR TITLE
Continue with CI even if style check has errors

### DIFF
--- a/build/ci.yml
+++ b/build/ci.yml
@@ -26,14 +26,27 @@ schedules:
     - main
   always: true
 
+pool:
+  vmImage: windows-latest
+
 jobs:
-- job: "QsCompiler"
-  pool: 
-    vmImage: 'windows-latest'
+- job: Initialize
   steps:
   - template: steps.yml
 
-  - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
-    displayName: 'Component detection'
-    inputs:
-      failOnAlert: true
+- job: Style
+  dependsOn: Initialize
+  steps:
+  - script: dotnet tool run fantomas -- --check --recurse .
+    displayName: Check style
+
+- job: Build
+  dependsOn: Initialize
+  steps:
+  - template: steps.yml
+
+- job: Wrap-up
+  dependsOn: Build
+  condition: succeededOrFailed()
+  steps:
+  - template: wrap-up.yml

--- a/build/ci.yml
+++ b/build/ci.yml
@@ -45,7 +45,7 @@ jobs:
   steps:
   - template: steps.yml
 
-- job: Wrap-up
+- job: WrapUp
   dependsOn: Build
   condition: succeededOrFailed()
   steps:

--- a/build/ci.yml
+++ b/build/ci.yml
@@ -37,7 +37,6 @@ jobs:
   - template: wrap-up.yml
 
 - job: Style
-  dependsOn: Initialize
   steps:
   - script: dotnet tool restore
     displayName: Restore .NET tools

--- a/build/ci.yml
+++ b/build/ci.yml
@@ -4,7 +4,7 @@ variables:
   Build.Major: 0
   Build.Minor: 14
   Assembly.Version: $(Build.BuildNumber)
-  Assembly.Constants: ""
+  Assembly.Constants: ''
   Drops.Dir: $(Build.ArtifactStagingDirectory)/drops
   Nuget.Outdir: $(Drops.Dir)/nugets
   VSIX.Outdir: $(Drops.Dir)/vsix
@@ -20,7 +20,7 @@ pr:
 
 schedules:
 - cron: "0 9 * * Sat"
-  displayName: Build for Component Governance
+  displayName: 'Build for Component Governance'
   branches:
     include:
     - main
@@ -30,7 +30,7 @@ pool:
   vmImage: windows-latest
 
 jobs:
-- job: Compiler
+- job: Build
   steps:
   - template: init.yml
   - template: steps.yml

--- a/build/ci.yml
+++ b/build/ci.yml
@@ -32,7 +32,7 @@ pool:
 jobs:
 - job: Initialize
   steps:
-  - template: steps.yml
+  - template: init.yml
 
 - job: Style
   dependsOn: Initialize

--- a/build/ci.yml
+++ b/build/ci.yml
@@ -4,7 +4,7 @@ variables:
   Build.Major: 0
   Build.Minor: 14
   Assembly.Version: $(Build.BuildNumber)
-  Assembly.Constants: ''
+  Assembly.Constants: ""
   Drops.Dir: $(Build.ArtifactStagingDirectory)/drops
   Nuget.Outdir: $(Drops.Dir)/nugets
   VSIX.Outdir: $(Drops.Dir)/vsix
@@ -20,7 +20,7 @@ pr:
 
 schedules:
 - cron: "0 9 * * Sat"
-  displayName: 'Build for Component Governance'
+  displayName: Build for Component Governance
   branches:
     include:
     - main
@@ -30,23 +30,17 @@ pool:
   vmImage: windows-latest
 
 jobs:
-- job: Initialize
+- job: Compiler
   steps:
   - template: init.yml
+  - template: steps.yml
+  - template: wrap-up.yml
 
 - job: Style
   dependsOn: Initialize
   steps:
+  - script: dotnet tool restore
+    displayName: Restore .NET tools
+
   - script: dotnet tool run fantomas -- --check --recurse .
-    displayName: Check style
-
-- job: Build
-  dependsOn: Initialize
-  steps:
-  - template: steps.yml
-
-- job: WrapUp
-  dependsOn: Build
-  condition: succeededOrFailed()
-  steps:
-  - template: wrap-up.yml
+    displayName: Fantomas

--- a/build/init.yml
+++ b/build/init.yml
@@ -16,10 +16,7 @@ steps:
     versionSpec: '5.6.0'
 
 - task: UseDotNet@2
-  displayName: 'Use .NET Core SDK 3.1.300'
+  displayName: 'Use .NET Core SDK 3.1.405'
   inputs:
     packageType: sdk
-    version: '3.1.300'
-
-- script: dotnet tool restore
-  displayName: 'Restore .NET tools'
+    version: '3.1.405'

--- a/build/steps.yml
+++ b/build/steps.yml
@@ -4,6 +4,7 @@ steps:
 
 - script: dotnet tool run fantomas -- --check --recurse .
   displayName: "Check style"
+  continueOnError: true
 
 
 - pwsh: ./build.ps1

--- a/build/steps.yml
+++ b/build/steps.yml
@@ -21,3 +21,8 @@ steps:
       /p:DefineConstants=$(Assembly.Constants) 
       /p:AssemblyVersion=$(Assembly.Version)
     configuration: $(Build.Configuration)
+
+- pwsh: ./manifest.ps1
+  displayName: "List built packages & assemblies"
+  condition: succeededOrFailed()
+  workingDirectory: '$(System.DefaultWorkingDirectory)/build'

--- a/build/steps.yml
+++ b/build/steps.yml
@@ -1,30 +1,17 @@
 steps:
-- template: init.yml
-
-
-- script: dotnet tool run fantomas -- --check --recurse .
-  displayName: "Check style"
-  continueOnError: true
-
-
 - pwsh: ./build.ps1
   displayName: "Build all"
   workingDirectory: $(System.DefaultWorkingDirectory)/build
-
 
 - pwsh: ./test.ps1
   displayName: "Test all"
   workingDirectory: $(System.DefaultWorkingDirectory)/build
 
-
 - pwsh: ./pack.ps1
   displayName: "Pack NuGets and VS Code"
   workingDirectory: $(System.DefaultWorkingDirectory)/build
 
-
-##
-# VisualStudio Extension can't be built from the build script as msbuild is not available).
-##
+# Visual Studio extension can't be built from the build script as MSBuild is not available.
 - task: VSBuild@1
   displayName: 'Pack VisualStudio extension'
   condition: and(succeeded(), ne(variables['Enable.VSIX'], 'false'))
@@ -34,11 +21,3 @@ steps:
       /p:DefineConstants=$(Assembly.Constants) 
       /p:AssemblyVersion=$(Assembly.Version)
     configuration: $(Build.Configuration)
-
-
-- pwsh: ./manifest.ps1
-  displayName: "List built packages & assemblies"
-  workingDirectory: '$(System.DefaultWorkingDirectory)/build'
-  condition: succeededOrFailed()
-
-- template: wrap-up.yml

--- a/build/wrap-up.yml
+++ b/build/wrap-up.yml
@@ -2,9 +2,12 @@
 # Wrap-up, publish symbols and drop folder.
 ##
 steps:
+- pwsh: ./manifest.ps1
+  displayName: "List built packages & assemblies"
+  workingDirectory: '$(System.DefaultWorkingDirectory)/build'
+
 - task: PublishTestResults@2
   displayName: 'Publish tests results'
-  condition: succeededOrFailed()
   inputs:
     testResultsFormat: VSTest
     testResultsFiles: '$(System.DefaultWorkingDirectory)/**/*.trx'
@@ -12,7 +15,6 @@ steps:
 
 - task: CopyFiles@2
   displayName: 'Copy extensions to: $(VSIX.Outdir)'
-  condition: succeededOrFailed()
   inputs:
     SourceFolder: '$(System.DefaultWorkingDirectory)'
     Contents: 'src\**\*.vsix'
@@ -21,7 +23,11 @@ steps:
 
 - task: PublishBuildArtifacts@1
   displayName: 'Publish Artifact: qsharp-compiler'
-  condition: succeededOrFailed()
   inputs:
     PathtoPublish: '$(Build.ArtifactStagingDirectory)'
     artifactName: qsharp-compiler
+
+- task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
+  displayName: 'Component detection'
+  inputs:
+    failOnAlert: true

--- a/build/wrap-up.yml
+++ b/build/wrap-up.yml
@@ -4,10 +4,12 @@
 steps:
 - pwsh: ./manifest.ps1
   displayName: "List built packages & assemblies"
+  condition: succeededOrFailed()
   workingDirectory: '$(System.DefaultWorkingDirectory)/build'
 
 - task: PublishTestResults@2
   displayName: 'Publish tests results'
+  condition: succeededOrFailed()
   inputs:
     testResultsFormat: VSTest
     testResultsFiles: '$(System.DefaultWorkingDirectory)/**/*.trx'
@@ -15,6 +17,7 @@ steps:
 
 - task: CopyFiles@2
   displayName: 'Copy extensions to: $(VSIX.Outdir)'
+  condition: succeededOrFailed()
   inputs:
     SourceFolder: '$(System.DefaultWorkingDirectory)'
     Contents: 'src\**\*.vsix'
@@ -23,11 +26,13 @@ steps:
 
 - task: PublishBuildArtifacts@1
   displayName: 'Publish Artifact: qsharp-compiler'
+  condition: succeededOrFailed()
   inputs:
     PathtoPublish: '$(Build.ArtifactStagingDirectory)'
     artifactName: qsharp-compiler
 
 - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
+  condition: succeededOrFailed()
   displayName: 'Component detection'
   inputs:
     failOnAlert: true

--- a/build/wrap-up.yml
+++ b/build/wrap-up.yml
@@ -2,11 +2,6 @@
 # Wrap-up, publish symbols and drop folder.
 ##
 steps:
-- pwsh: ./manifest.ps1
-  displayName: "List built packages & assemblies"
-  condition: succeededOrFailed()
-  workingDirectory: '$(System.DefaultWorkingDirectory)/build'
-
 - task: PublishTestResults@2
   displayName: 'Publish tests results'
   condition: succeededOrFailed()
@@ -32,7 +27,7 @@ steps:
     artifactName: qsharp-compiler
 
 - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
-  condition: succeededOrFailed()
   displayName: 'Component detection'
+  condition: succeededOrFailed()
   inputs:
     failOnAlert: true

--- a/src/QsCompiler/SyntaxProcessor/SyntaxExtensions.fs
+++ b/src/QsCompiler/SyntaxProcessor/SyntaxExtensions.fs
@@ -34,7 +34,7 @@ let rec private collectWith collector (exs: 'a seq, ts: QsType seq): QsSymbol li
 
 and private TypeNameSymbols (t: QsType) =
     match t.Type with
-    | QsTypeKind.UnitType _ -> [ t ]
+    | QsTypeKind.UnitType _ -> [t]
     | QsTypeKind.Int _ -> [ t ]
     | QsTypeKind.BigInt _ -> [ t ]
     | QsTypeKind.Double _ -> [ t ]

--- a/src/QsCompiler/SyntaxProcessor/SyntaxExtensions.fs
+++ b/src/QsCompiler/SyntaxProcessor/SyntaxExtensions.fs
@@ -34,7 +34,7 @@ let rec private collectWith collector (exs: 'a seq, ts: QsType seq): QsSymbol li
 
 and private TypeNameSymbols (t: QsType) =
     match t.Type with
-    | QsTypeKind.UnitType _ -> [t]
+    | QsTypeKind.UnitType _ -> [ t ]
     | QsTypeKind.Int _ -> [ t ]
     | QsTypeKind.BigInt _ -> [ t ]
     | QsTypeKind.Double _ -> [ t ]


### PR DESCRIPTION
This allows the style check to run independently of the build and tests, so that the rest of the CI can continue even if Fantomas reports style errors.