### PR TITLE
Updated Source Name Field For New Templates

### DIFF
--- a/src/ProjectTemplates/Quantum.Honeywell.App1/.template.config/template.json.v.template
+++ b/src/ProjectTemplates/Quantum.Honeywell.App1/.template.config/template.json.v.template
@@ -10,6 +10,6 @@
       "language": "Q#",
       "type": "project"
     },
-    "sourceName": "Quantum.App1",
+    "sourceName": "Quantum.Honeywell.App1",
     "preferNameDirectory": true
 }

--- a/src/ProjectTemplates/Quantum.IonQ.App1/.template.config/template.json.v.template
+++ b/src/ProjectTemplates/Quantum.IonQ.App1/.template.config/template.json.v.template
@@ -10,6 +10,6 @@
       "language": "Q#",
       "type": "project"
     },
-    "sourceName": "Quantum.App1",
+    "sourceName": "Quantum.IonQ.App1",
     "preferNameDirectory": true
 }


### PR DESCRIPTION
Updated the sourceName fields for the new templates to match their template names. This will allow the csproj files that get created with a `dotnet new` command to be named appropriately.