### PR TITLE
Fixing incorrect ref counts

### DIFF
--- a/src/QsCompiler/QirGeneration/Context.cs
+++ b/src/QsCompiler/QirGeneration/Context.cs
@@ -378,17 +378,16 @@ namespace Microsoft.Quantum.QsCompiler.QIR
             this.runtimeLibrary.AddFunction(RuntimeLibrary.TupleCreate, this.Types.Tuple, this.Context.Int64Type);
             this.runtimeLibrary.AddFunction(RuntimeLibrary.TupleUpdateAliasCount, this.Context.VoidType, this.Types.Tuple, this.Types.Int);
             this.runtimeLibrary.AddFunction(RuntimeLibrary.TupleUpdateReferenceCount, this.Context.VoidType, this.Types.Tuple, this.Types.Int);
-            this.runtimeLibrary.AddFunction(RuntimeLibrary.TupleCopy, this.Types.Tuple, this.Types.Tuple, this.Context.BoolType);
+            this.runtimeLibrary.AddFunction(RuntimeLibrary.TupleCopy, this.Types.TypedTuple(this.Types.Bool, this.Types.Tuple).CreatePointerType(), this.Types.Tuple, this.Context.BoolType);
 
             // array library functions
             this.runtimeLibrary.AddVarArgsFunction(RuntimeLibrary.ArrayCreate, this.Types.Array, this.Context.Int32Type, this.Context.Int32Type);
             this.runtimeLibrary.AddVarArgsFunction(RuntimeLibrary.ArrayGetElementPtr, this.Context.Int8Type.CreatePointerType(), this.Types.Array);
-            // TODO: figure out how to call a varargs function and get rid of these two functions
             this.runtimeLibrary.AddFunction(RuntimeLibrary.ArrayCreate1d, this.Types.Array, this.Context.Int32Type, this.Context.Int64Type);
             this.runtimeLibrary.AddFunction(RuntimeLibrary.ArrayGetElementPtr1d, this.Context.Int8Type.CreatePointerType(), this.Types.Array, this.Context.Int64Type);
             this.runtimeLibrary.AddFunction(RuntimeLibrary.ArrayUpdateAliasCount, this.Context.VoidType, this.Types.Array, this.Types.Int);
             this.runtimeLibrary.AddFunction(RuntimeLibrary.ArrayUpdateReferenceCount, this.Context.VoidType, this.Types.Array, this.Types.Int);
-            this.runtimeLibrary.AddFunction(RuntimeLibrary.ArrayCopy, this.Types.Array, this.Types.Array, this.Context.BoolType);
+            this.runtimeLibrary.AddFunction(RuntimeLibrary.ArrayCopy, this.Types.TypedTuple(this.Types.Bool, this.Types.Array).CreatePointerType(), this.Types.Array, this.Context.BoolType);
             this.runtimeLibrary.AddFunction(RuntimeLibrary.ArrayConcatenate, this.Types.Array, this.Types.Array, this.Types.Array);
             this.runtimeLibrary.AddFunction(RuntimeLibrary.ArraySlice, this.Types.Array, this.Context.Int32Type, this.Types.Array, this.Types.Range);
             this.runtimeLibrary.AddFunction(RuntimeLibrary.ArraySlice1d, this.Types.Array, this.Types.Array, this.Types.Range, this.Context.BoolType);
@@ -397,7 +396,7 @@ namespace Microsoft.Quantum.QsCompiler.QIR
             // callable library functions
             this.runtimeLibrary.AddFunction(RuntimeLibrary.CallableCreate, this.Types.Callable, this.Types.CallableTable.CreatePointerType(), this.Types.CallableMemoryManagementTable.CreatePointerType(), this.Types.Tuple);
             this.runtimeLibrary.AddFunction(RuntimeLibrary.CallableInvoke, this.Context.VoidType, this.Types.Callable, this.Types.Tuple, this.Types.Tuple);
-            this.runtimeLibrary.AddFunction(RuntimeLibrary.CallableCopy, this.Types.Callable, this.Types.Callable, this.Context.BoolType);
+            this.runtimeLibrary.AddFunction(RuntimeLibrary.CallableCopy, this.Types.TypedTuple(this.Types.Bool, this.Types.Callable).CreatePointerType(), this.Types.Callable, this.Context.BoolType);
             this.runtimeLibrary.AddFunction(RuntimeLibrary.CallableMakeAdjoint, this.Context.VoidType, this.Types.Callable);
             this.runtimeLibrary.AddFunction(RuntimeLibrary.CallableMakeControlled, this.Context.VoidType, this.Types.Callable);
             this.runtimeLibrary.AddFunction(RuntimeLibrary.CallableUpdateAliasCount, this.Context.VoidType, this.Types.Callable, this.Types.Int);

--- a/src/QsCompiler/QirGeneration/Context.cs
+++ b/src/QsCompiler/QirGeneration/Context.cs
@@ -378,16 +378,17 @@ namespace Microsoft.Quantum.QsCompiler.QIR
             this.runtimeLibrary.AddFunction(RuntimeLibrary.TupleCreate, this.Types.Tuple, this.Context.Int64Type);
             this.runtimeLibrary.AddFunction(RuntimeLibrary.TupleUpdateAliasCount, this.Context.VoidType, this.Types.Tuple, this.Types.Int);
             this.runtimeLibrary.AddFunction(RuntimeLibrary.TupleUpdateReferenceCount, this.Context.VoidType, this.Types.Tuple, this.Types.Int);
-            this.runtimeLibrary.AddFunction(RuntimeLibrary.TupleCopy, this.Types.TypedTuple(this.Types.Bool, this.Types.Tuple).CreatePointerType(), this.Types.Tuple, this.Context.BoolType);
+            this.runtimeLibrary.AddFunction(RuntimeLibrary.TupleCopy, this.Types.Tuple, this.Types.Tuple, this.Context.BoolType);
 
             // array library functions
             this.runtimeLibrary.AddVarArgsFunction(RuntimeLibrary.ArrayCreate, this.Types.Array, this.Context.Int32Type, this.Context.Int32Type);
             this.runtimeLibrary.AddVarArgsFunction(RuntimeLibrary.ArrayGetElementPtr, this.Context.Int8Type.CreatePointerType(), this.Types.Array);
+            // TODO: figure out how to call a varargs function and get rid of these two functions
             this.runtimeLibrary.AddFunction(RuntimeLibrary.ArrayCreate1d, this.Types.Array, this.Context.Int32Type, this.Context.Int64Type);
             this.runtimeLibrary.AddFunction(RuntimeLibrary.ArrayGetElementPtr1d, this.Context.Int8Type.CreatePointerType(), this.Types.Array, this.Context.Int64Type);
             this.runtimeLibrary.AddFunction(RuntimeLibrary.ArrayUpdateAliasCount, this.Context.VoidType, this.Types.Array, this.Types.Int);
             this.runtimeLibrary.AddFunction(RuntimeLibrary.ArrayUpdateReferenceCount, this.Context.VoidType, this.Types.Array, this.Types.Int);
-            this.runtimeLibrary.AddFunction(RuntimeLibrary.ArrayCopy, this.Types.TypedTuple(this.Types.Bool, this.Types.Array).CreatePointerType(), this.Types.Array, this.Context.BoolType);
+            this.runtimeLibrary.AddFunction(RuntimeLibrary.ArrayCopy, this.Types.Array, this.Types.Array, this.Context.BoolType);
             this.runtimeLibrary.AddFunction(RuntimeLibrary.ArrayConcatenate, this.Types.Array, this.Types.Array, this.Types.Array);
             this.runtimeLibrary.AddFunction(RuntimeLibrary.ArraySlice, this.Types.Array, this.Context.Int32Type, this.Types.Array, this.Types.Range);
             this.runtimeLibrary.AddFunction(RuntimeLibrary.ArraySlice1d, this.Types.Array, this.Types.Array, this.Types.Range, this.Context.BoolType);
@@ -396,7 +397,7 @@ namespace Microsoft.Quantum.QsCompiler.QIR
             // callable library functions
             this.runtimeLibrary.AddFunction(RuntimeLibrary.CallableCreate, this.Types.Callable, this.Types.CallableTable.CreatePointerType(), this.Types.CallableMemoryManagementTable.CreatePointerType(), this.Types.Tuple);
             this.runtimeLibrary.AddFunction(RuntimeLibrary.CallableInvoke, this.Context.VoidType, this.Types.Callable, this.Types.Tuple, this.Types.Tuple);
-            this.runtimeLibrary.AddFunction(RuntimeLibrary.CallableCopy, this.Types.TypedTuple(this.Types.Bool, this.Types.Callable).CreatePointerType(), this.Types.Callable, this.Context.BoolType);
+            this.runtimeLibrary.AddFunction(RuntimeLibrary.CallableCopy, this.Types.Callable, this.Types.Callable, this.Context.BoolType);
             this.runtimeLibrary.AddFunction(RuntimeLibrary.CallableMakeAdjoint, this.Context.VoidType, this.Types.Callable);
             this.runtimeLibrary.AddFunction(RuntimeLibrary.CallableMakeControlled, this.Context.VoidType, this.Types.Callable);
             this.runtimeLibrary.AddFunction(RuntimeLibrary.CallableUpdateAliasCount, this.Context.VoidType, this.Types.Callable, this.Types.Int);

--- a/src/QsCompiler/QirGeneration/QIR/DataStructures.cs
+++ b/src/QsCompiler/QirGeneration/QIR/DataStructures.cs
@@ -326,16 +326,16 @@ namespace Microsoft.Quantum.QIR.Emission
         private IValue.Cached<Value> CreateTypedPointerCache(Value? pointer = null) =>
             new IValue.Cached<Value>(pointer, this.sharedState, this.GetTypedPointer);
 
-        private Value GetElementPointer(int index) =>
-            this.sharedState.CurrentBuilder.GetElementPtr(this.StructType, this.TypedPointer, this.PointerIndex(index));
+        private Value GetElementPointer(uint index) =>
+            this.sharedState.CurrentBuilder.GetStructElementPointer(this.StructType, this.TypedPointer, index);
 
-        private IValue.Cached<PointerValue> CreateCachedPointer(ResolvedType type, int index) =>
+        private IValue.Cached<PointerValue> CreateCachedPointer(ResolvedType type, uint index) =>
             new IValue.Cached<PointerValue>(
                 this.sharedState,
                 () => new PointerValue(this.GetElementPointer(index), type, this.sharedState));
 
         private IValue.Cached<PointerValue>[] CreateTupleElementPointersCaches() =>
-            this.ElementTypes.Select(this.CreateCachedPointer).ToArray();
+            this.ElementTypes.Select((t, i) => this.CreateCachedPointer(t, (uint)i)).ToArray();
 
         private Value AllocateTuple(bool registerWithScopeManager)
         {
@@ -351,15 +351,6 @@ namespace Microsoft.Quantum.QIR.Emission
         }
 
         // methods for item access
-
-        /// <summary>
-        /// Creates a suitable array of values to access the item at a given index for a pointer to a struct.
-        /// </summary>
-        private Value[] PointerIndex(int index) => new[]
-        {
-            this.sharedState.Context.CreateConstant(0L),
-            this.sharedState.Context.CreateConstant(index)
-        };
 
         /// <summary>
         /// Returns a pointer to the tuple element at the given index.

--- a/src/QsCompiler/QirGeneration/QIR/RuntimeLibrary.cs
+++ b/src/QsCompiler/QirGeneration/QIR/RuntimeLibrary.cs
@@ -61,7 +61,6 @@ namespace Microsoft.Quantum.QIR
         // array functions
         public const string ArrayCreate = "array_create";
         public const string ArrayGetElementPtr = "array_get_element_ptr";
-        // TODO: figure out how to call a varargs function and get rid of these two functions
         public const string ArrayCreate1d = "array_create_1d";
         public const string ArrayGetElementPtr1d = "array_get_element_ptr_1d";
         public const string ArrayUpdateAliasCount = "array_update_alias_count";

--- a/src/QsCompiler/QirGeneration/ScopeManager.cs
+++ b/src/QsCompiler/QirGeneration/ScopeManager.cs
@@ -164,7 +164,7 @@ namespace Microsoft.Quantum.QsCompiler.QIR
                 {
                     this.requiredReleases.Add((LoadValue(value), releaseFunction));
                 }
-                if (this.parent.ReferenceCountUpdateFunctionForType(value.LlvmType) != null)
+                if (this.parent.RequiresReferenceCount(value.LlvmType))
                 {
                     this.requiredUnreferences.Add((LoadValue(value), true));
                 }
@@ -176,7 +176,7 @@ namespace Microsoft.Quantum.QsCompiler.QIR
             /// </summary>
             internal void ReferenceValue(IValue value, bool recurIntoInnerItems)
             {
-                if (this.parent.ReferenceCountUpdateFunctionForType(value.LlvmType) != null)
+                if (this.parent.RequiresReferenceCount(value.LlvmType))
                 {
                     this.pendingReferences.Add((LoadValue(value), recurIntoInnerItems));
                 }
@@ -224,7 +224,7 @@ namespace Microsoft.Quantum.QsCompiler.QIR
             /// </summary>
             internal void UnreferenceValue(IValue value, bool recurIntoInnerItems)
             {
-                if (this.parent.ReferenceCountUpdateFunctionForType(value.LlvmType) != null)
+                if (this.parent.RequiresReferenceCount(value.LlvmType))
                 {
                     this.requiredUnreferences.Add((LoadValue(value), recurIntoInnerItems));
                 }
@@ -555,6 +555,10 @@ namespace Microsoft.Quantum.QsCompiler.QIR
                 scope.ExecutePendingCalls();
             }
         }
+
+        /// <returns>True if reference counts are tracked for values of the given type.</returns>
+        internal bool RequiresReferenceCount(ITypeRef type) =>
+            this.ReferenceCountUpdateFunctionForType(type) != null;
 
         /// <summary>
         /// Adds a call to a runtime library function to increase the reference count for the given value if necessary.

--- a/src/QsCompiler/QirGeneration/Subtransformations/ExpressionKindTransformation.cs
+++ b/src/QsCompiler/QirGeneration/Subtransformations/ExpressionKindTransformation.cs
@@ -4,10 +4,8 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Numerics;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.Quantum.QIR;
 using Microsoft.Quantum.QIR.Emission;
 using Microsoft.Quantum.QsCompiler.DataTypes;

--- a/src/QsCompiler/QirGeneration/Subtransformations/ExpressionKindTransformation.cs
+++ b/src/QsCompiler/QirGeneration/Subtransformations/ExpressionKindTransformation.cs
@@ -203,10 +203,9 @@ namespace Microsoft.Quantum.QsCompiler.QIR
                     var falseBlock = sharedState.AddBlockAfterCurrent("condFalse");
 
                     sharedState.CurrentBuilder.Branch(wasCopied, contBlock, falseBlock);
-                    sharedState.ScopeMgr.OpenScope(); // FIXME: ACTUALLY WE ONLY NEED TO ENSURE THAT THE REF COUNT CHANGES ARE PROCESSED HERE...
+                    sharedState.ScopeMgr.OpenScope();
                     sharedState.SetCurrentBlock(falseBlock);
 
-                    // FIXME: IS SHALLOW CORRECT??
                     sharedState.ScopeMgr.IncreaseReferenceCount(value, shallow);
                     sharedState.ScopeMgr.DecreaseReferenceCount(pointer, shallow);
 

--- a/src/QsCompiler/Tests.Compiler/QirTests.fs
+++ b/src/QsCompiler/Tests.Compiler/QirTests.fs
@@ -60,7 +60,10 @@ let ``QIR using`` () =
 let ``QIR inlined call`` () = qirTest true "TestInline"
 
 [<Fact>]
-let ``QIR access counts`` () = qirTest false "TestAccessCounts"
+let ``QIR alias counts`` () = qirTest false "TestAliasCounts"
+
+[<Fact>]
+let ``QIR reference counts`` () = qirTest false "TestReferenceCounts"
 
 [<Fact>]
 let ``QIR built-in functions`` () = qirTest false "TestBuiltIn"

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestAliasCounts.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestAliasCounts.ll
@@ -1,4 +1,4 @@
-define void @Microsoft__Quantum__Testing__QIR__TestAccessCounts__ctl(%Array* %__controlQubits__, { %Array*, { %Array* }* }* %0) {
+define void @Microsoft__Quantum__Testing__QIR__TestAliasCounts__ctl(%Array* %__controlQubits__, { %Array*, { %Array* }* }* %0) {
 entry:
   call void @__quantum__rt__array_update_alias_count(%Array* %__controlQubits__, i64 1)
   %1 = getelementptr { %Array*, { %Array* }* }, { %Array*, { %Array* }* }* %0, i64 0, i32 0

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestAliasCounts.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestAliasCounts.ll
@@ -1,7 +1,7 @@
 define void @Microsoft__Quantum__Testing__QIR__TestAliasCounts__ctl(%Array* %__controlQubits__, { %Array*, { %Array* }* }* %0) {
 entry:
   call void @__quantum__rt__array_update_alias_count(%Array* %__controlQubits__, i64 1)
-  %1 = getelementptr { %Array*, { %Array* }* }, { %Array*, { %Array* }* }* %0, i64 0, i32 0
+  %1 = getelementptr inbounds { %Array*, { %Array* }* }, { %Array*, { %Array* }* }* %0, i32 0, i32 0
   %coefficients = load %Array*, %Array** %1
   %2 = call i64 @__quantum__rt__array_get_size_1d(%Array* %coefficients)
   %3 = sub i64 %2, 1
@@ -26,18 +26,18 @@ exiting__1:                                       ; preds = %body__1
 
 exit__1:                                          ; preds = %header__1
   call void @__quantum__rt__array_update_alias_count(%Array* %coefficients, i64 1)
-  %11 = getelementptr { %Array*, { %Array* }* }, { %Array*, { %Array* }* }* %0, i64 0, i32 1
+  %11 = getelementptr inbounds { %Array*, { %Array* }* }, { %Array*, { %Array* }* }* %0, i32 0, i32 1
   %qubits = load { %Array* }*, { %Array* }** %11
-  %12 = getelementptr { %Array* }, { %Array* }* %qubits, i64 0, i32 0
+  %12 = getelementptr inbounds { %Array* }, { %Array* }* %qubits, i32 0, i32 0
   %13 = load %Array*, %Array** %12
   call void @__quantum__rt__array_update_alias_count(%Array* %13, i64 1)
   %14 = bitcast { %Array* }* %qubits to %Tuple*
   call void @__quantum__rt__tuple_update_alias_count(%Tuple* %14, i64 1)
   %15 = call %Tuple* @__quantum__rt__tuple_create(i64 ptrtoint ({ double, %Array*, { %Array* }* }* getelementptr ({ double, %Array*, { %Array* }* }, { double, %Array*, { %Array* }* }* null, i32 1) to i64))
   %16 = bitcast %Tuple* %15 to { double, %Array*, { %Array* }* }*
-  %17 = getelementptr { double, %Array*, { %Array* }* }, { double, %Array*, { %Array* }* }* %16, i64 0, i32 0
-  %18 = getelementptr { double, %Array*, { %Array* }* }, { double, %Array*, { %Array* }* }* %16, i64 0, i32 1
-  %19 = getelementptr { double, %Array*, { %Array* }* }, { double, %Array*, { %Array* }* }* %16, i64 0, i32 2
+  %17 = getelementptr inbounds { double, %Array*, { %Array* }* }, { double, %Array*, { %Array* }* }* %16, i32 0, i32 0
+  %18 = getelementptr inbounds { double, %Array*, { %Array* }* }, { double, %Array*, { %Array* }* }* %16, i32 0, i32 1
+  %19 = getelementptr inbounds { double, %Array*, { %Array* }* }, { double, %Array*, { %Array* }* }* %16, i32 0, i32 2
   store double 0.000000e+00, double* %17
   store %Array* %coefficients, %Array** %18
   store { %Array* }* %qubits, { %Array* }** %19

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestAliasCounts.qs
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestAliasCounts.qs
@@ -9,7 +9,7 @@ namespace Microsoft.Quantum.Testing.QIR
     operation ApplyOp(dummy : Double, coefficients : Complex[], qubits : LittleEndian) : Unit is Adj + Ctl {
     }
 
-    operation TestAccessCounts(coefficients : Complex[], qubits : LittleEndian) : Unit is Adj + Ctl {
+    operation TestAliasCounts(coefficients : Complex[], qubits : LittleEndian) : Unit is Adj + Ctl {
         ApplyOp(0.0, coefficients, qubits);
     }
 }

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestArrayLoop.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestArrayLoop.ll
@@ -41,9 +41,9 @@ body__2:                                          ; preds = %header__2
   %z = load { i64, i64 }*, { i64, i64 }** %13
   %14 = bitcast { i64, i64 }* %z to %Tuple*
   call void @__quantum__rt__tuple_update_alias_count(%Tuple* %14, i64 1)
-  %15 = getelementptr { i64, i64 }, { i64, i64 }* %z, i64 0, i32 0
+  %15 = getelementptr inbounds { i64, i64 }, { i64, i64 }* %z, i32 0, i32 0
   %j = load i64, i64* %15
-  %16 = getelementptr { i64, i64 }, { i64, i64 }* %z, i64 0, i32 1
+  %16 = getelementptr inbounds { i64, i64 }, { i64, i64 }* %z, i32 0, i32 1
   %k = load i64, i64* %16
   %17 = load i64, i64* %x
   %18 = add i64 %17, %j
@@ -61,8 +61,8 @@ exiting__2:                                       ; preds = %body__2
 exit__2:                                          ; preds = %header__2
   %22 = call %Tuple* @__quantum__rt__tuple_create(i64 mul nuw (i64 ptrtoint (i64* getelementptr (i64, i64* null, i32 1) to i64), i64 2))
   %23 = bitcast %Tuple* %22 to { i64, i64 }*
-  %24 = getelementptr { i64, i64 }, { i64, i64 }* %23, i64 0, i32 0
-  %25 = getelementptr { i64, i64 }, { i64, i64 }* %23, i64 0, i32 1
+  %24 = getelementptr inbounds { i64, i64 }, { i64, i64 }* %23, i32 0, i32 0
+  %25 = getelementptr inbounds { i64, i64 }, { i64, i64 }* %23, i32 0, i32 1
   %26 = load i64, i64* %x
   %27 = load i64, i64* %y
   store i64 %26, i64* %24

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestArrayUpdate1.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestArrayUpdate1.ll
@@ -46,7 +46,7 @@ exit__2:                                          ; preds = %header__2
   br label %header__3
 
 header__3:                                        ; preds = %exiting__3, %exit__2
-  %i = phi i64 [ 0, %exit__2 ], [ %22, %exiting__3 ]
+  %i = phi i64 [ 0, %exit__2 ], [ %23, %exiting__3 ]
   %13 = icmp sle i64 %i, 9
   br i1 %13, label %body__3, label %exit__3
 
@@ -68,46 +68,55 @@ condContinue__1:                                  ; preds = %condFalse__1, %cond
   %17 = load %Array*, %Array** %arr
   call void @__quantum__rt__array_update_alias_count(%Array* %17, i64 -1)
   %18 = call %Array* @__quantum__rt__array_copy(%Array* %17, i1 false)
-  %19 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %18, i64 %i)
-  %20 = bitcast i8* %19 to %String**
+  %19 = icmp ne %Array* %17, %18
+  %20 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %18, i64 %i)
+  %21 = bitcast i8* %20 to %String**
   call void @__quantum__rt__string_update_reference_count(%String* %str, i64 1)
-  %21 = load %String*, %String** %20
-  store %String* %str, %String** %20
+  %22 = load %String*, %String** %21
+  br i1 %19, label %condContinue__2, label %condFalse__2
+
+condFalse__2:                                     ; preds = %condContinue__1
+  call void @__quantum__rt__string_update_reference_count(%String* %str, i64 1)
+  call void @__quantum__rt__string_update_reference_count(%String* %22, i64 -1)
+  br label %condContinue__2
+
+condContinue__2:                                  ; preds = %condFalse__2, %condContinue__1
+  store %String* %str, %String** %21
   call void @__quantum__rt__array_update_reference_count(%Array* %18, i64 1)
   call void @__quantum__rt__array_update_alias_count(%Array* %18, i64 1)
   store %Array* %18, %Array** %arr
   call void @__quantum__rt__string_update_reference_count(%String* %str, i64 -1)
   call void @__quantum__rt__array_update_reference_count(%Array* %17, i64 -1)
-  call void @__quantum__rt__string_update_reference_count(%String* %21, i64 -1)
+  call void @__quantum__rt__string_update_reference_count(%String* %22, i64 -1)
   call void @__quantum__rt__array_update_reference_count(%Array* %18, i64 -1)
   br label %exiting__3
 
-exiting__3:                                       ; preds = %condContinue__1
-  %22 = add i64 %i, 1
+exiting__3:                                       ; preds = %condContinue__2
+  %23 = add i64 %i, 1
   br label %header__3
 
 exit__3:                                          ; preds = %header__3
-  %23 = load %Array*, %Array** %arr
-  call void @__quantum__rt__array_update_alias_count(%Array* %23, i64 -1)
+  %24 = load %Array*, %Array** %arr
+  call void @__quantum__rt__array_update_alias_count(%Array* %24, i64 -1)
   br label %header__4
 
 header__4:                                        ; preds = %exiting__4, %exit__3
-  %24 = phi i64 [ 0, %exit__3 ], [ %29, %exiting__4 ]
-  %25 = icmp sle i64 %24, 9
-  br i1 %25, label %body__4, label %exit__4
+  %25 = phi i64 [ 0, %exit__3 ], [ %30, %exiting__4 ]
+  %26 = icmp sle i64 %25, 9
+  br i1 %26, label %body__4, label %exit__4
 
 body__4:                                          ; preds = %header__4
-  %26 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %0, i64 %24)
-  %27 = bitcast i8* %26 to %String**
-  %28 = load %String*, %String** %27
-  call void @__quantum__rt__string_update_reference_count(%String* %28, i64 -1)
+  %27 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %0, i64 %25)
+  %28 = bitcast i8* %27 to %String**
+  %29 = load %String*, %String** %28
+  call void @__quantum__rt__string_update_reference_count(%String* %29, i64 -1)
   br label %exiting__4
 
 exiting__4:                                       ; preds = %body__4
-  %29 = add i64 %24, 1
+  %30 = add i64 %25, 1
   br label %header__4
 
 exit__4:                                          ; preds = %header__4
   call void @__quantum__rt__array_update_reference_count(%Array* %0, i64 -1)
-  ret %Array* %23
+  ret %Array* %24
 }

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestArrayUpdate2.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestArrayUpdate2.ll
@@ -29,7 +29,7 @@ exit__1:                                          ; preds = %header__1
   br label %header__2
 
 header__2:                                        ; preds = %exiting__2, %exit__1
-  %i = phi i64 [ 0, %exit__1 ], [ %17, %exiting__2 ]
+  %i = phi i64 [ 0, %exit__1 ], [ %18, %exiting__2 ]
   %8 = icmp sle i64 %i, 9
   br i1 %8, label %body__2, label %exit__2
 
@@ -51,27 +51,36 @@ condContinue__1:                                  ; preds = %condFalse__1, %cond
   %12 = load %Array*, %Array** %arr
   call void @__quantum__rt__array_update_alias_count(%Array* %12, i64 -1)
   %13 = call %Array* @__quantum__rt__array_copy(%Array* %12, i1 false)
-  %14 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %13, i64 %i)
-  %15 = bitcast i8* %14 to %String**
+  %14 = icmp ne %Array* %12, %13
+  %15 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %13, i64 %i)
+  %16 = bitcast i8* %15 to %String**
   call void @__quantum__rt__string_update_reference_count(%String* %str, i64 1)
-  %16 = load %String*, %String** %15
-  store %String* %str, %String** %15
+  %17 = load %String*, %String** %16
+  br i1 %14, label %condContinue__2, label %condFalse__2
+
+condFalse__2:                                     ; preds = %condContinue__1
+  call void @__quantum__rt__string_update_reference_count(%String* %str, i64 1)
+  call void @__quantum__rt__string_update_reference_count(%String* %17, i64 -1)
+  br label %condContinue__2
+
+condContinue__2:                                  ; preds = %condFalse__2, %condContinue__1
+  store %String* %str, %String** %16
   call void @__quantum__rt__array_update_reference_count(%Array* %13, i64 1)
   call void @__quantum__rt__array_update_alias_count(%Array* %13, i64 1)
   store %Array* %13, %Array** %arr
   call void @__quantum__rt__string_update_reference_count(%String* %str, i64 -1)
   call void @__quantum__rt__array_update_reference_count(%Array* %12, i64 -1)
-  call void @__quantum__rt__string_update_reference_count(%String* %16, i64 -1)
+  call void @__quantum__rt__string_update_reference_count(%String* %17, i64 -1)
   call void @__quantum__rt__array_update_reference_count(%Array* %13, i64 -1)
   br label %exiting__2
 
-exiting__2:                                       ; preds = %condContinue__1
-  %17 = add i64 %i, 1
+exiting__2:                                       ; preds = %condContinue__2
+  %18 = add i64 %i, 1
   br label %header__2
 
 exit__2:                                          ; preds = %header__2
-  %18 = load %Array*, %Array** %arr
+  %19 = load %Array*, %Array** %arr
   call void @__quantum__rt__array_update_alias_count(%Array* %array, i64 -1)
-  call void @__quantum__rt__array_update_alias_count(%Array* %18, i64 -1)
-  ret %Array* %18
+  call void @__quantum__rt__array_update_alias_count(%Array* %19, i64 -1)
+  ret %Array* %19
 }

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestArrayUpdate3.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestArrayUpdate3.ll
@@ -28,209 +28,236 @@ exit__1:                                          ; preds = %header__1
   call void @__quantum__rt__array_update_reference_count(%Array* %y, i64 1)
   call void @__quantum__rt__array_update_alias_count(%Array* %y, i64 -1)
   %8 = call %Array* @__quantum__rt__array_copy(%Array* %y, i1 false)
-  %9 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %8, i64 0)
-  %10 = bitcast i8* %9 to %String**
+  %9 = icmp ne %Array* %y, %8
+  %10 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %8, i64 0)
+  %11 = bitcast i8* %10 to %String**
   call void @__quantum__rt__string_update_reference_count(%String* %b, i64 1)
-  %11 = load %String*, %String** %10
-  store %String* %b, %String** %10
+  %12 = load %String*, %String** %11
+  br i1 %9, label %condContinue__1, label %condFalse__1
+
+condFalse__1:                                     ; preds = %exit__1
+  call void @__quantum__rt__string_update_reference_count(%String* %b, i64 1)
+  call void @__quantum__rt__string_update_reference_count(%String* %12, i64 -1)
+  br label %condContinue__1
+
+condContinue__1:                                  ; preds = %condFalse__1, %exit__1
+  store %String* %b, %String** %11
   call void @__quantum__rt__array_update_reference_count(%Array* %8, i64 1)
   call void @__quantum__rt__array_update_alias_count(%Array* %8, i64 1)
   store %Array* %8, %Array** %x
   call void @__quantum__rt__array_update_alias_count(%Array* %8, i64 -1)
-  %12 = call %Array* @__quantum__rt__array_copy(%Array* %8, i1 false)
-  %13 = call %String* @__quantum__rt__string_create(i32 5, i8* getelementptr inbounds ([6 x i8], [6 x i8]* @2, i32 0, i32 0))
-  %14 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %12, i64 1)
-  %15 = bitcast i8* %14 to %String**
-  call void @__quantum__rt__string_update_reference_count(%String* %13, i64 1)
-  %16 = load %String*, %String** %15
-  store %String* %13, %String** %15
-  call void @__quantum__rt__array_update_reference_count(%Array* %12, i64 1)
-  call void @__quantum__rt__array_update_alias_count(%Array* %12, i64 1)
-  store %Array* %12, %Array** %x
-  %17 = call %Array* @__quantum__rt__array_create_1d(i32 8, i64 10)
+  %13 = call %Array* @__quantum__rt__array_copy(%Array* %8, i1 false)
+  %14 = icmp ne %Array* %8, %13
+  %15 = call %String* @__quantum__rt__string_create(i32 5, i8* getelementptr inbounds ([6 x i8], [6 x i8]* @2, i32 0, i32 0))
+  %16 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %13, i64 1)
+  %17 = bitcast i8* %16 to %String**
+  call void @__quantum__rt__string_update_reference_count(%String* %15, i64 1)
+  %18 = load %String*, %String** %17
+  br i1 %14, label %condContinue__2, label %condFalse__2
+
+condFalse__2:                                     ; preds = %condContinue__1
+  call void @__quantum__rt__string_update_reference_count(%String* %15, i64 1)
+  call void @__quantum__rt__string_update_reference_count(%String* %18, i64 -1)
+  br label %condContinue__2
+
+condContinue__2:                                  ; preds = %condFalse__2, %condContinue__1
+  store %String* %15, %String** %17
+  call void @__quantum__rt__array_update_reference_count(%Array* %13, i64 1)
+  call void @__quantum__rt__array_update_alias_count(%Array* %13, i64 1)
+  store %Array* %13, %Array** %x
+  %19 = call %Array* @__quantum__rt__array_create_1d(i32 8, i64 10)
   br label %header__2
 
-header__2:                                        ; preds = %exiting__2, %exit__1
-  %18 = phi i64 [ 0, %exit__1 ], [ %26, %exiting__2 ]
-  %19 = icmp sle i64 %18, 9
-  br i1 %19, label %body__2, label %exit__2
+header__2:                                        ; preds = %exiting__2, %condContinue__2
+  %20 = phi i64 [ 0, %condContinue__2 ], [ %28, %exiting__2 ]
+  %21 = icmp sle i64 %20, 9
+  br i1 %21, label %body__2, label %exit__2
 
 body__2:                                          ; preds = %header__2
-  %20 = call %Tuple* @__quantum__rt__tuple_create(i64 mul nuw (i64 ptrtoint (i64* getelementptr (i64, i64* null, i32 1) to i64), i64 2))
-  %21 = bitcast %Tuple* %20 to { i64, i64 }*
-  %22 = getelementptr { i64, i64 }, { i64, i64 }* %21, i64 0, i32 0
-  %23 = getelementptr { i64, i64 }, { i64, i64 }* %21, i64 0, i32 1
-  store i64 0, i64* %22
-  store i64 0, i64* %23
-  %24 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %17, i64 %18)
-  %25 = bitcast i8* %24 to { i64, i64 }**
-  store { i64, i64 }* %21, { i64, i64 }** %25
+  %22 = call %Tuple* @__quantum__rt__tuple_create(i64 mul nuw (i64 ptrtoint (i64* getelementptr (i64, i64* null, i32 1) to i64), i64 2))
+  %23 = bitcast %Tuple* %22 to { i64, i64 }*
+  %24 = getelementptr { i64, i64 }, { i64, i64 }* %23, i64 0, i32 0
+  %25 = getelementptr { i64, i64 }, { i64, i64 }* %23, i64 0, i32 1
+  store i64 0, i64* %24
+  store i64 0, i64* %25
+  %26 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %19, i64 %20)
+  %27 = bitcast i8* %26 to { i64, i64 }**
+  store { i64, i64 }* %23, { i64, i64 }** %27
   br label %exiting__2
 
 exiting__2:                                       ; preds = %body__2
-  %26 = add i64 %18, 1
+  %28 = add i64 %20, 1
   br label %header__2
 
 exit__2:                                          ; preds = %header__2
   %arr = alloca %Array*
-  store %Array* %17, %Array** %arr
+  store %Array* %19, %Array** %arr
   br label %header__3
 
 header__3:                                        ; preds = %exiting__3, %exit__2
-  %27 = phi i64 [ 0, %exit__2 ], [ %33, %exiting__3 ]
-  %28 = icmp sle i64 %27, 9
-  br i1 %28, label %body__3, label %exit__3
+  %29 = phi i64 [ 0, %exit__2 ], [ %35, %exiting__3 ]
+  %30 = icmp sle i64 %29, 9
+  br i1 %30, label %body__3, label %exit__3
 
 body__3:                                          ; preds = %header__3
-  %29 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %17, i64 %27)
-  %30 = bitcast i8* %29 to { i64, i64 }**
-  %31 = load { i64, i64 }*, { i64, i64 }** %30
-  %32 = bitcast { i64, i64 }* %31 to %Tuple*
-  call void @__quantum__rt__tuple_update_alias_count(%Tuple* %32, i64 1)
+  %31 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %19, i64 %29)
+  %32 = bitcast i8* %31 to { i64, i64 }**
+  %33 = load { i64, i64 }*, { i64, i64 }** %32
+  %34 = bitcast { i64, i64 }* %33 to %Tuple*
+  call void @__quantum__rt__tuple_update_alias_count(%Tuple* %34, i64 1)
   br label %exiting__3
 
 exiting__3:                                       ; preds = %body__3
-  %33 = add i64 %27, 1
+  %35 = add i64 %29, 1
   br label %header__3
 
 exit__3:                                          ; preds = %header__3
-  call void @__quantum__rt__array_update_alias_count(%Array* %17, i64 1)
+  call void @__quantum__rt__array_update_alias_count(%Array* %19, i64 1)
   br label %header__4
 
 header__4:                                        ; preds = %exiting__4, %exit__3
-  %34 = phi i64 [ 0, %exit__3 ], [ %40, %exiting__4 ]
-  %35 = icmp sle i64 %34, 9
-  br i1 %35, label %body__4, label %exit__4
+  %36 = phi i64 [ 0, %exit__3 ], [ %42, %exiting__4 ]
+  %37 = icmp sle i64 %36, 9
+  br i1 %37, label %body__4, label %exit__4
 
 body__4:                                          ; preds = %header__4
-  %36 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %17, i64 %34)
-  %37 = bitcast i8* %36 to { i64, i64 }**
-  %38 = load { i64, i64 }*, { i64, i64 }** %37
-  %39 = bitcast { i64, i64 }* %38 to %Tuple*
-  call void @__quantum__rt__tuple_update_reference_count(%Tuple* %39, i64 1)
+  %38 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %19, i64 %36)
+  %39 = bitcast i8* %38 to { i64, i64 }**
+  %40 = load { i64, i64 }*, { i64, i64 }** %39
+  %41 = bitcast { i64, i64 }* %40 to %Tuple*
+  call void @__quantum__rt__tuple_update_reference_count(%Tuple* %41, i64 1)
   br label %exiting__4
 
 exiting__4:                                       ; preds = %body__4
-  %40 = add i64 %34, 1
+  %42 = add i64 %36, 1
   br label %header__4
 
 exit__4:                                          ; preds = %header__4
-  call void @__quantum__rt__array_update_reference_count(%Array* %17, i64 1)
+  call void @__quantum__rt__array_update_reference_count(%Array* %19, i64 1)
   br label %header__5
 
 header__5:                                        ; preds = %exiting__5, %exit__4
-  %i = phi i64 [ 0, %exit__4 ], [ %53, %exiting__5 ]
-  %41 = icmp sle i64 %i, 9
-  br i1 %41, label %body__5, label %exit__5
+  %i = phi i64 [ 0, %exit__4 ], [ %56, %exiting__5 ]
+  %43 = icmp sle i64 %i, 9
+  br i1 %43, label %body__5, label %exit__5
 
 body__5:                                          ; preds = %header__5
-  %42 = load %Array*, %Array** %arr
-  call void @__quantum__rt__array_update_alias_count(%Array* %42, i64 -1)
-  %43 = call %Array* @__quantum__rt__array_copy(%Array* %42, i1 false)
-  %44 = call %Tuple* @__quantum__rt__tuple_create(i64 mul nuw (i64 ptrtoint (i64* getelementptr (i64, i64* null, i32 1) to i64), i64 2))
-  %45 = bitcast %Tuple* %44 to { i64, i64 }*
-  %46 = getelementptr { i64, i64 }, { i64, i64 }* %45, i64 0, i32 0
-  %47 = getelementptr { i64, i64 }, { i64, i64 }* %45, i64 0, i32 1
-  %48 = add i64 %i, 1
-  store i64 %i, i64* %46
-  store i64 %48, i64* %47
-  %49 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %43, i64 %i)
-  %50 = bitcast i8* %49 to { i64, i64 }**
-  call void @__quantum__rt__tuple_update_reference_count(%Tuple* %44, i64 1)
-  call void @__quantum__rt__tuple_update_alias_count(%Tuple* %44, i64 1)
-  %51 = load { i64, i64 }*, { i64, i64 }** %50
-  %52 = bitcast { i64, i64 }* %51 to %Tuple*
-  call void @__quantum__rt__tuple_update_alias_count(%Tuple* %52, i64 -1)
-  store { i64, i64 }* %45, { i64, i64 }** %50
-  call void @__quantum__rt__array_update_reference_count(%Array* %43, i64 1)
-  call void @__quantum__rt__array_update_alias_count(%Array* %43, i64 1)
-  store %Array* %43, %Array** %arr
-  call void @__quantum__rt__array_update_reference_count(%Array* %42, i64 -1)
-  call void @__quantum__rt__tuple_update_reference_count(%Tuple* %44, i64 -1)
-  call void @__quantum__rt__tuple_update_reference_count(%Tuple* %52, i64 -1)
-  call void @__quantum__rt__array_update_reference_count(%Array* %43, i64 -1)
+  %44 = load %Array*, %Array** %arr
+  call void @__quantum__rt__array_update_alias_count(%Array* %44, i64 -1)
+  %45 = call %Array* @__quantum__rt__array_copy(%Array* %44, i1 false)
+  %46 = icmp ne %Array* %44, %45
+  %47 = call %Tuple* @__quantum__rt__tuple_create(i64 mul nuw (i64 ptrtoint (i64* getelementptr (i64, i64* null, i32 1) to i64), i64 2))
+  %48 = bitcast %Tuple* %47 to { i64, i64 }*
+  %49 = getelementptr { i64, i64 }, { i64, i64 }* %48, i64 0, i32 0
+  %50 = getelementptr { i64, i64 }, { i64, i64 }* %48, i64 0, i32 1
+  %51 = add i64 %i, 1
+  store i64 %i, i64* %49
+  store i64 %51, i64* %50
+  %52 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %45, i64 %i)
+  %53 = bitcast i8* %52 to { i64, i64 }**
+  call void @__quantum__rt__tuple_update_reference_count(%Tuple* %47, i64 1)
+  call void @__quantum__rt__tuple_update_alias_count(%Tuple* %47, i64 1)
+  %54 = load { i64, i64 }*, { i64, i64 }** %53
+  %55 = bitcast { i64, i64 }* %54 to %Tuple*
+  call void @__quantum__rt__tuple_update_alias_count(%Tuple* %55, i64 -1)
+  br i1 %46, label %condContinue__3, label %condFalse__3
+
+condFalse__3:                                     ; preds = %body__5
+  call void @__quantum__rt__tuple_update_reference_count(%Tuple* %47, i64 1)
+  call void @__quantum__rt__tuple_update_reference_count(%Tuple* %55, i64 -1)
+  br label %condContinue__3
+
+condContinue__3:                                  ; preds = %condFalse__3, %body__5
+  store { i64, i64 }* %48, { i64, i64 }** %53
+  call void @__quantum__rt__array_update_reference_count(%Array* %45, i64 1)
+  call void @__quantum__rt__array_update_alias_count(%Array* %45, i64 1)
+  store %Array* %45, %Array** %arr
+  call void @__quantum__rt__array_update_reference_count(%Array* %44, i64 -1)
+  call void @__quantum__rt__tuple_update_reference_count(%Tuple* %47, i64 -1)
+  call void @__quantum__rt__tuple_update_reference_count(%Tuple* %55, i64 -1)
+  call void @__quantum__rt__array_update_reference_count(%Array* %45, i64 -1)
   br label %exiting__5
 
-exiting__5:                                       ; preds = %body__5
-  %53 = add i64 %i, 1
+exiting__5:                                       ; preds = %condContinue__3
+  %56 = add i64 %i, 1
   br label %header__5
 
 exit__5:                                          ; preds = %header__5
-  %54 = load %Array*, %Array** %arr
+  %57 = load %Array*, %Array** %arr
   call void @__quantum__rt__array_update_alias_count(%Array* %y, i64 -1)
-  call void @__quantum__rt__array_update_alias_count(%Array* %12, i64 -1)
-  %55 = call i64 @__quantum__rt__array_get_size_1d(%Array* %54)
-  %56 = sub i64 %55, 1
+  call void @__quantum__rt__array_update_alias_count(%Array* %13, i64 -1)
+  %58 = call i64 @__quantum__rt__array_get_size_1d(%Array* %57)
+  %59 = sub i64 %58, 1
   br label %header__6
 
 header__6:                                        ; preds = %exiting__6, %exit__5
-  %57 = phi i64 [ 0, %exit__5 ], [ %63, %exiting__6 ]
-  %58 = icmp sle i64 %57, %56
-  br i1 %58, label %body__6, label %exit__6
+  %60 = phi i64 [ 0, %exit__5 ], [ %66, %exiting__6 ]
+  %61 = icmp sle i64 %60, %59
+  br i1 %61, label %body__6, label %exit__6
 
 body__6:                                          ; preds = %header__6
-  %59 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %54, i64 %57)
-  %60 = bitcast i8* %59 to { i64, i64 }**
-  %61 = load { i64, i64 }*, { i64, i64 }** %60
-  %62 = bitcast { i64, i64 }* %61 to %Tuple*
-  call void @__quantum__rt__tuple_update_alias_count(%Tuple* %62, i64 -1)
+  %62 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %57, i64 %60)
+  %63 = bitcast i8* %62 to { i64, i64 }**
+  %64 = load { i64, i64 }*, { i64, i64 }** %63
+  %65 = bitcast { i64, i64 }* %64 to %Tuple*
+  call void @__quantum__rt__tuple_update_alias_count(%Tuple* %65, i64 -1)
   br label %exiting__6
 
 exiting__6:                                       ; preds = %body__6
-  %63 = add i64 %57, 1
+  %66 = add i64 %60, 1
   br label %header__6
 
 exit__6:                                          ; preds = %header__6
-  call void @__quantum__rt__array_update_alias_count(%Array* %54, i64 -1)
+  call void @__quantum__rt__array_update_alias_count(%Array* %57, i64 -1)
   call void @__quantum__rt__array_update_reference_count(%Array* %y, i64 -1)
-  call void @__quantum__rt__string_update_reference_count(%String* %11, i64 -1)
+  call void @__quantum__rt__string_update_reference_count(%String* %12, i64 -1)
   call void @__quantum__rt__array_update_reference_count(%Array* %8, i64 -1)
   call void @__quantum__rt__array_update_reference_count(%Array* %8, i64 -1)
-  call void @__quantum__rt__string_update_reference_count(%String* %13, i64 -1)
-  call void @__quantum__rt__string_update_reference_count(%String* %16, i64 -1)
-  call void @__quantum__rt__array_update_reference_count(%Array* %12, i64 -1)
+  call void @__quantum__rt__string_update_reference_count(%String* %15, i64 -1)
+  call void @__quantum__rt__string_update_reference_count(%String* %18, i64 -1)
+  call void @__quantum__rt__array_update_reference_count(%Array* %13, i64 -1)
   br label %header__7
 
 header__7:                                        ; preds = %exiting__7, %exit__6
-  %64 = phi i64 [ 0, %exit__6 ], [ %70, %exiting__7 ]
-  %65 = icmp sle i64 %64, 9
-  br i1 %65, label %body__7, label %exit__7
+  %67 = phi i64 [ 0, %exit__6 ], [ %73, %exiting__7 ]
+  %68 = icmp sle i64 %67, 9
+  br i1 %68, label %body__7, label %exit__7
 
 body__7:                                          ; preds = %header__7
-  %66 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %17, i64 %64)
-  %67 = bitcast i8* %66 to { i64, i64 }**
-  %68 = load { i64, i64 }*, { i64, i64 }** %67
-  %69 = bitcast { i64, i64 }* %68 to %Tuple*
-  call void @__quantum__rt__tuple_update_reference_count(%Tuple* %69, i64 -1)
+  %69 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %19, i64 %67)
+  %70 = bitcast i8* %69 to { i64, i64 }**
+  %71 = load { i64, i64 }*, { i64, i64 }** %70
+  %72 = bitcast { i64, i64 }* %71 to %Tuple*
+  call void @__quantum__rt__tuple_update_reference_count(%Tuple* %72, i64 -1)
   br label %exiting__7
 
 exiting__7:                                       ; preds = %body__7
-  %70 = add i64 %64, 1
+  %73 = add i64 %67, 1
   br label %header__7
 
 exit__7:                                          ; preds = %header__7
-  call void @__quantum__rt__array_update_reference_count(%Array* %17, i64 -1)
-  %71 = sub i64 %55, 1
+  call void @__quantum__rt__array_update_reference_count(%Array* %19, i64 -1)
+  %74 = sub i64 %58, 1
   br label %header__8
 
 header__8:                                        ; preds = %exiting__8, %exit__7
-  %72 = phi i64 [ 0, %exit__7 ], [ %78, %exiting__8 ]
-  %73 = icmp sle i64 %72, %71
-  br i1 %73, label %body__8, label %exit__8
+  %75 = phi i64 [ 0, %exit__7 ], [ %81, %exiting__8 ]
+  %76 = icmp sle i64 %75, %74
+  br i1 %76, label %body__8, label %exit__8
 
 body__8:                                          ; preds = %header__8
-  %74 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %54, i64 %72)
-  %75 = bitcast i8* %74 to { i64, i64 }**
-  %76 = load { i64, i64 }*, { i64, i64 }** %75
-  %77 = bitcast { i64, i64 }* %76 to %Tuple*
-  call void @__quantum__rt__tuple_update_reference_count(%Tuple* %77, i64 -1)
+  %77 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %57, i64 %75)
+  %78 = bitcast i8* %77 to { i64, i64 }**
+  %79 = load { i64, i64 }*, { i64, i64 }** %78
+  %80 = bitcast { i64, i64 }* %79 to %Tuple*
+  call void @__quantum__rt__tuple_update_reference_count(%Tuple* %80, i64 -1)
   br label %exiting__8
 
 exiting__8:                                       ; preds = %body__8
-  %78 = add i64 %72, 1
+  %81 = add i64 %75, 1
   br label %header__8
 
 exit__8:                                          ; preds = %header__8
-  call void @__quantum__rt__array_update_reference_count(%Array* %54, i64 -1)
-  ret %Array* %12
+  call void @__quantum__rt__array_update_reference_count(%Array* %57, i64 -1)
+  ret %Array* %13
 }

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestArrayUpdate3.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestArrayUpdate3.ll
@@ -76,8 +76,8 @@ header__2:                                        ; preds = %exiting__2, %condCo
 body__2:                                          ; preds = %header__2
   %22 = call %Tuple* @__quantum__rt__tuple_create(i64 mul nuw (i64 ptrtoint (i64* getelementptr (i64, i64* null, i32 1) to i64), i64 2))
   %23 = bitcast %Tuple* %22 to { i64, i64 }*
-  %24 = getelementptr { i64, i64 }, { i64, i64 }* %23, i64 0, i32 0
-  %25 = getelementptr { i64, i64 }, { i64, i64 }* %23, i64 0, i32 1
+  %24 = getelementptr inbounds { i64, i64 }, { i64, i64 }* %23, i32 0, i32 0
+  %25 = getelementptr inbounds { i64, i64 }, { i64, i64 }* %23, i32 0, i32 1
   store i64 0, i64* %24
   store i64 0, i64* %25
   %26 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %19, i64 %20)
@@ -148,8 +148,8 @@ body__5:                                          ; preds = %header__5
   %46 = icmp ne %Array* %44, %45
   %47 = call %Tuple* @__quantum__rt__tuple_create(i64 mul nuw (i64 ptrtoint (i64* getelementptr (i64, i64* null, i32 1) to i64), i64 2))
   %48 = bitcast %Tuple* %47 to { i64, i64 }*
-  %49 = getelementptr { i64, i64 }, { i64, i64 }* %48, i64 0, i32 0
-  %50 = getelementptr { i64, i64 }, { i64, i64 }* %48, i64 0, i32 1
+  %49 = getelementptr inbounds { i64, i64 }, { i64, i64 }* %48, i32 0, i32 0
+  %50 = getelementptr inbounds { i64, i64 }, { i64, i64 }* %48, i32 0, i32 1
   %51 = add i64 %i, 1
   store i64 %i, i64* %49
   store i64 %51, i64* %50

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestArrayUpdate4.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestArrayUpdate4.ll
@@ -35,7 +35,7 @@ exit__1:                                          ; preds = %header__1
   br label %header__2
 
 header__2:                                        ; preds = %exiting__2, %exit__1
-  %i = phi i64 [ 0, %exit__1 ], [ %15, %exiting__2 ]
+  %i = phi i64 [ 0, %exit__1 ], [ %16, %exiting__2 ]
   %9 = icmp sle i64 %i, 9
   br i1 %9, label %body__2, label %exit__2
 
@@ -43,29 +43,38 @@ body__2:                                          ; preds = %header__2
   %10 = load %Array*, %Array** %arr
   call void @__quantum__rt__array_update_alias_count(%Array* %10, i64 -1)
   %11 = call %Array* @__quantum__rt__array_copy(%Array* %10, i1 false)
-  %12 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %11, i64 %i)
-  %13 = bitcast i8* %12 to %String**
+  %12 = icmp ne %Array* %10, %11
+  %13 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %11, i64 %i)
+  %14 = bitcast i8* %13 to %String**
   call void @__quantum__rt__string_update_reference_count(%String* %item, i64 1)
-  %14 = load %String*, %String** %13
-  store %String* %item, %String** %13
+  %15 = load %String*, %String** %14
+  br i1 %12, label %condContinue__1, label %condFalse__1
+
+condFalse__1:                                     ; preds = %body__2
+  call void @__quantum__rt__string_update_reference_count(%String* %item, i64 1)
+  call void @__quantum__rt__string_update_reference_count(%String* %15, i64 -1)
+  br label %condContinue__1
+
+condContinue__1:                                  ; preds = %condFalse__1, %body__2
+  store %String* %item, %String** %14
   call void @__quantum__rt__array_update_reference_count(%Array* %11, i64 1)
   call void @__quantum__rt__array_update_alias_count(%Array* %11, i64 1)
   store %Array* %11, %Array** %arr
   call void @__quantum__rt__array_update_reference_count(%Array* %10, i64 -1)
-  call void @__quantum__rt__string_update_reference_count(%String* %14, i64 -1)
+  call void @__quantum__rt__string_update_reference_count(%String* %15, i64 -1)
   call void @__quantum__rt__array_update_reference_count(%Array* %11, i64 -1)
   br label %exiting__2
 
-exiting__2:                                       ; preds = %body__2
-  %15 = add i64 %i, 1
+exiting__2:                                       ; preds = %condContinue__1
+  %16 = add i64 %i, 1
   br label %header__2
 
 exit__2:                                          ; preds = %header__2
-  %16 = load %Array*, %Array** %arr
+  %17 = load %Array*, %Array** %arr
   call void @__quantum__rt__array_update_alias_count(%Array* %array, i64 -1)
-  call void @__quantum__rt__array_update_alias_count(%Array* %16, i64 -1)
+  call void @__quantum__rt__array_update_alias_count(%Array* %17, i64 -1)
   call void @__quantum__rt__string_update_reference_count(%String* %item, i64 -1)
   call void @__quantum__rt__array_update_reference_count(%Array* %0, i64 -1)
   call void @__quantum__rt__array_update_reference_count(%Array* %0, i64 -1)
-  ret %Array* %16
+  ret %Array* %17
 }

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestArrayUpdate5.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestArrayUpdate5.ll
@@ -79,7 +79,7 @@ preheader__1:                                     ; preds = %exit__3
   br label %header__4
 
 header__4:                                        ; preds = %exiting__4, %preheader__1
-  %i = phi i64 [ 0, %preheader__1 ], [ %48, %exiting__4 ]
+  %i = phi i64 [ 0, %preheader__1 ], [ %50, %exiting__4 ]
   %27 = icmp sle i64 %i, %26
   %28 = icmp sge i64 %i, %26
   %29 = select i1 true, i1 %27, i1 %28
@@ -89,103 +89,121 @@ body__4:                                          ; preds = %header__4
   %30 = load %Array*, %Array** %arr
   call void @__quantum__rt__array_update_alias_count(%Array* %30, i64 -1)
   %31 = call %Array* @__quantum__rt__array_copy(%Array* %30, i1 false)
-  %32 = srem i64 %i, 2
-  %33 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %30, i64 %32)
-  %34 = bitcast i8* %33 to { double, double }**
-  %35 = load { double, double }*, { double, double }** %34
-  %36 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %31, i64 %i)
-  %37 = bitcast i8* %36 to { double, double }**
-  %38 = bitcast { double, double }* %35 to %Tuple*
-  call void @__quantum__rt__tuple_update_reference_count(%Tuple* %38, i64 1)
-  call void @__quantum__rt__tuple_update_alias_count(%Tuple* %38, i64 1)
-  %39 = load { double, double }*, { double, double }** %37
-  %40 = bitcast { double, double }* %39 to %Tuple*
-  call void @__quantum__rt__tuple_update_alias_count(%Tuple* %40, i64 -1)
-  store { double, double }* %35, { double, double }** %37
+  %32 = icmp ne %Array* %30, %31
+  %33 = srem i64 %i, 2
+  %34 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %30, i64 %33)
+  %35 = bitcast i8* %34 to { double, double }**
+  %36 = load { double, double }*, { double, double }** %35
+  %37 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %31, i64 %i)
+  %38 = bitcast i8* %37 to { double, double }**
+  %39 = bitcast { double, double }* %36 to %Tuple*
+  call void @__quantum__rt__tuple_update_reference_count(%Tuple* %39, i64 1)
+  call void @__quantum__rt__tuple_update_alias_count(%Tuple* %39, i64 1)
+  %40 = load { double, double }*, { double, double }** %38
+  %41 = bitcast { double, double }* %40 to %Tuple*
+  call void @__quantum__rt__tuple_update_alias_count(%Tuple* %41, i64 -1)
+  br i1 %32, label %condContinue__1, label %condFalse__1
+
+condFalse__1:                                     ; preds = %body__4
+  call void @__quantum__rt__tuple_update_reference_count(%Tuple* %39, i64 1)
+  call void @__quantum__rt__tuple_update_reference_count(%Tuple* %41, i64 -1)
+  br label %condContinue__1
+
+condContinue__1:                                  ; preds = %condFalse__1, %body__4
+  store { double, double }* %36, { double, double }** %38
   call void @__quantum__rt__array_update_reference_count(%Array* %31, i64 1)
   call void @__quantum__rt__array_update_alias_count(%Array* %31, i64 1)
   store %Array* %31, %Array** %arr
   br i1 %cond, label %then0__1, label %continue__1
 
-then0__1:                                         ; preds = %body__4
-  %41 = load %Array*, %Array** %arr
-  call void @__quantum__rt__array_update_alias_count(%Array* %41, i64 -1)
-  %42 = call %Array* @__quantum__rt__array_copy(%Array* %41, i1 false)
-  %43 = srem i64 %i, 2
-  %44 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %42, i64 %43)
-  %45 = bitcast i8* %44 to { double, double }**
+then0__1:                                         ; preds = %condContinue__1
+  %42 = load %Array*, %Array** %arr
+  call void @__quantum__rt__array_update_alias_count(%Array* %42, i64 -1)
+  %43 = call %Array* @__quantum__rt__array_copy(%Array* %42, i1 false)
+  %44 = icmp ne %Array* %42, %43
+  %45 = srem i64 %i, 2
+  %46 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %43, i64 %45)
+  %47 = bitcast i8* %46 to { double, double }**
   call void @__quantum__rt__tuple_update_reference_count(%Tuple* %9, i64 1)
   call void @__quantum__rt__tuple_update_alias_count(%Tuple* %9, i64 1)
-  %46 = load { double, double }*, { double, double }** %45
-  %47 = bitcast { double, double }* %46 to %Tuple*
-  call void @__quantum__rt__tuple_update_alias_count(%Tuple* %47, i64 -1)
-  store { double, double }* %item, { double, double }** %45
-  call void @__quantum__rt__array_update_reference_count(%Array* %42, i64 1)
-  call void @__quantum__rt__array_update_alias_count(%Array* %42, i64 1)
-  store %Array* %42, %Array** %arr
-  call void @__quantum__rt__array_update_reference_count(%Array* %41, i64 -1)
-  call void @__quantum__rt__tuple_update_reference_count(%Tuple* %47, i64 -1)
+  %48 = load { double, double }*, { double, double }** %47
+  %49 = bitcast { double, double }* %48 to %Tuple*
+  call void @__quantum__rt__tuple_update_alias_count(%Tuple* %49, i64 -1)
+  br i1 %44, label %condContinue__2, label %condFalse__2
+
+condFalse__2:                                     ; preds = %then0__1
+  call void @__quantum__rt__tuple_update_reference_count(%Tuple* %9, i64 1)
+  call void @__quantum__rt__tuple_update_reference_count(%Tuple* %49, i64 -1)
+  br label %condContinue__2
+
+condContinue__2:                                  ; preds = %condFalse__2, %then0__1
+  store { double, double }* %item, { double, double }** %47
+  call void @__quantum__rt__array_update_reference_count(%Array* %43, i64 1)
+  call void @__quantum__rt__array_update_alias_count(%Array* %43, i64 1)
+  store %Array* %43, %Array** %arr
   call void @__quantum__rt__array_update_reference_count(%Array* %42, i64 -1)
+  call void @__quantum__rt__tuple_update_reference_count(%Tuple* %49, i64 -1)
+  call void @__quantum__rt__array_update_reference_count(%Array* %43, i64 -1)
   br label %continue__1
 
-continue__1:                                      ; preds = %then0__1, %body__4
+continue__1:                                      ; preds = %condContinue__2, %condContinue__1
   call void @__quantum__rt__array_update_reference_count(%Array* %30, i64 -1)
-  call void @__quantum__rt__tuple_update_reference_count(%Tuple* %40, i64 -1)
+  call void @__quantum__rt__tuple_update_reference_count(%Tuple* %41, i64 -1)
   call void @__quantum__rt__array_update_reference_count(%Array* %31, i64 -1)
   br label %exiting__4
 
 exiting__4:                                       ; preds = %continue__1
-  %48 = add i64 %i, 2
+  %50 = add i64 %i, 2
   br label %header__4
 
 exit__4:                                          ; preds = %header__4
-  %49 = load %Array*, %Array** %arr
-  %50 = sub i64 %0, 1
+  %51 = load %Array*, %Array** %arr
+  %52 = sub i64 %0, 1
   br label %header__5
 
 header__5:                                        ; preds = %exiting__5, %exit__4
-  %51 = phi i64 [ 0, %exit__4 ], [ %57, %exiting__5 ]
-  %52 = icmp sle i64 %51, %50
-  br i1 %52, label %body__5, label %exit__5
+  %53 = phi i64 [ 0, %exit__4 ], [ %59, %exiting__5 ]
+  %54 = icmp sle i64 %53, %52
+  br i1 %54, label %body__5, label %exit__5
 
 body__5:                                          ; preds = %header__5
-  %53 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %array, i64 %51)
-  %54 = bitcast i8* %53 to { double, double }**
-  %55 = load { double, double }*, { double, double }** %54
-  %56 = bitcast { double, double }* %55 to %Tuple*
-  call void @__quantum__rt__tuple_update_alias_count(%Tuple* %56, i64 -1)
+  %55 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %array, i64 %53)
+  %56 = bitcast i8* %55 to { double, double }**
+  %57 = load { double, double }*, { double, double }** %56
+  %58 = bitcast { double, double }* %57 to %Tuple*
+  call void @__quantum__rt__tuple_update_alias_count(%Tuple* %58, i64 -1)
   br label %exiting__5
 
 exiting__5:                                       ; preds = %body__5
-  %57 = add i64 %51, 1
+  %59 = add i64 %53, 1
   br label %header__5
 
 exit__5:                                          ; preds = %header__5
   call void @__quantum__rt__array_update_alias_count(%Array* %array, i64 -1)
   call void @__quantum__rt__tuple_update_alias_count(%Tuple* %9, i64 -1)
-  %58 = call i64 @__quantum__rt__array_get_size_1d(%Array* %49)
-  %59 = sub i64 %58, 1
+  %60 = call i64 @__quantum__rt__array_get_size_1d(%Array* %51)
+  %61 = sub i64 %60, 1
   br label %header__6
 
 header__6:                                        ; preds = %exiting__6, %exit__5
-  %60 = phi i64 [ 0, %exit__5 ], [ %66, %exiting__6 ]
-  %61 = icmp sle i64 %60, %59
-  br i1 %61, label %body__6, label %exit__6
+  %62 = phi i64 [ 0, %exit__5 ], [ %68, %exiting__6 ]
+  %63 = icmp sle i64 %62, %61
+  br i1 %63, label %body__6, label %exit__6
 
 body__6:                                          ; preds = %header__6
-  %62 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %49, i64 %60)
-  %63 = bitcast i8* %62 to { double, double }**
-  %64 = load { double, double }*, { double, double }** %63
-  %65 = bitcast { double, double }* %64 to %Tuple*
-  call void @__quantum__rt__tuple_update_alias_count(%Tuple* %65, i64 -1)
+  %64 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %51, i64 %62)
+  %65 = bitcast i8* %64 to { double, double }**
+  %66 = load { double, double }*, { double, double }** %65
+  %67 = bitcast { double, double }* %66 to %Tuple*
+  call void @__quantum__rt__tuple_update_alias_count(%Tuple* %67, i64 -1)
   br label %exiting__6
 
 exiting__6:                                       ; preds = %body__6
-  %66 = add i64 %60, 1
+  %68 = add i64 %62, 1
   br label %header__6
 
 exit__6:                                          ; preds = %header__6
-  call void @__quantum__rt__array_update_alias_count(%Array* %49, i64 -1)
+  call void @__quantum__rt__array_update_alias_count(%Array* %51, i64 -1)
   call void @__quantum__rt__tuple_update_reference_count(%Tuple* %9, i64 -1)
-  ret %Array* %49
+  ret %Array* %51
 }

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestBuiltIn.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestBuiltIn.ll
@@ -5,9 +5,9 @@ entry:
   %i = fptrunc double %d to i64
   %0 = call %Tuple* @__quantum__rt__tuple_create(i64 ptrtoint ({ double, %BigInt*, i64 }* getelementptr ({ double, %BigInt*, i64 }, { double, %BigInt*, i64 }* null, i32 1) to i64))
   %1 = bitcast %Tuple* %0 to { double, %BigInt*, i64 }*
-  %2 = getelementptr { double, %BigInt*, i64 }, { double, %BigInt*, i64 }* %1, i64 0, i32 0
-  %3 = getelementptr { double, %BigInt*, i64 }, { double, %BigInt*, i64 }* %1, i64 0, i32 1
-  %4 = getelementptr { double, %BigInt*, i64 }, { double, %BigInt*, i64 }* %1, i64 0, i32 2
+  %2 = getelementptr inbounds { double, %BigInt*, i64 }, { double, %BigInt*, i64 }* %1, i32 0, i32 0
+  %3 = getelementptr inbounds { double, %BigInt*, i64 }, { double, %BigInt*, i64 }* %1, i32 0, i32 1
+  %4 = getelementptr inbounds { double, %BigInt*, i64 }, { double, %BigInt*, i64 }* %1, i32 0, i32 2
   store double %d, double* %2
   store %BigInt* %bi, %BigInt** %3
   store i64 %i, i64* %4

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestConditional.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestConditional.ll
@@ -1,6 +1,6 @@
 ﻿define i64 @Microsoft__Quantum__Testing__QIR__ReturnInt__body({ %Array* }* %arg) {
 entry:
-  %0 = getelementptr { %Array* }, { %Array* }* %arg, i64 0, i32 0
+  %0 = getelementptr inbounds { %Array* }, { %Array* }* %arg, i32 0, i32 0
   %arg__1 = load %Array*, %Array** %0
   call void @__quantum__rt__array_update_alias_count(%Array* %arg__1, i64 1)
   %1 = bitcast { %Array* }* %arg to %Tuple*

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestControlled1.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestControlled1.ll
@@ -1,26 +1,26 @@
 ﻿define void @Lifted__PartialApplication__1__ctl__wrapper(%Tuple* %capture-tuple, %Tuple* %arg-tuple, %Tuple* %result-tuple) {
 entry:
   %0 = bitcast %Tuple* %arg-tuple to { %Array*, %Qubit* }*
-  %1 = getelementptr { %Array*, %Qubit* }, { %Array*, %Qubit* }* %0, i64 0, i32 0
-  %2 = getelementptr { %Array*, %Qubit* }, { %Array*, %Qubit* }* %0, i64 0, i32 1
+  %1 = getelementptr inbounds { %Array*, %Qubit* }, { %Array*, %Qubit* }* %0, i32 0, i32 0
+  %2 = getelementptr inbounds { %Array*, %Qubit* }, { %Array*, %Qubit* }* %0, i32 0, i32 1
   %3 = load %Array*, %Array** %1
   %4 = load %Qubit*, %Qubit** %2
   %5 = bitcast %Tuple* %capture-tuple to { %Callable*, i64 }*
-  %6 = getelementptr { %Callable*, i64 }, { %Callable*, i64 }* %5, i64 0, i32 1
+  %6 = getelementptr inbounds { %Callable*, i64 }, { %Callable*, i64 }* %5, i32 0, i32 1
   %7 = load i64, i64* %6
   %8 = call %Tuple* @__quantum__rt__tuple_create(i64 ptrtoint ({ %Qubit*, i64 }* getelementptr ({ %Qubit*, i64 }, { %Qubit*, i64 }* null, i32 1) to i64))
   %9 = bitcast %Tuple* %8 to { %Qubit*, i64 }*
-  %10 = getelementptr { %Qubit*, i64 }, { %Qubit*, i64 }* %9, i64 0, i32 0
-  %11 = getelementptr { %Qubit*, i64 }, { %Qubit*, i64 }* %9, i64 0, i32 1
+  %10 = getelementptr inbounds { %Qubit*, i64 }, { %Qubit*, i64 }* %9, i32 0, i32 0
+  %11 = getelementptr inbounds { %Qubit*, i64 }, { %Qubit*, i64 }* %9, i32 0, i32 1
   store %Qubit* %4, %Qubit** %10
   store i64 %7, i64* %11
   %12 = call %Tuple* @__quantum__rt__tuple_create(i64 mul nuw (i64 ptrtoint (i1** getelementptr (i1*, i1** null, i32 1) to i64), i64 2))
   %13 = bitcast %Tuple* %12 to { %Array*, { %Qubit*, i64 }* }*
-  %14 = getelementptr { %Array*, { %Qubit*, i64 }* }, { %Array*, { %Qubit*, i64 }* }* %13, i64 0, i32 0
-  %15 = getelementptr { %Array*, { %Qubit*, i64 }* }, { %Array*, { %Qubit*, i64 }* }* %13, i64 0, i32 1
+  %14 = getelementptr inbounds { %Array*, { %Qubit*, i64 }* }, { %Array*, { %Qubit*, i64 }* }* %13, i32 0, i32 0
+  %15 = getelementptr inbounds { %Array*, { %Qubit*, i64 }* }, { %Array*, { %Qubit*, i64 }* }* %13, i32 0, i32 1
   store %Array* %3, %Array** %14
   store { %Qubit*, i64 }* %9, { %Qubit*, i64 }** %15
-  %16 = getelementptr { %Callable*, i64 }, { %Callable*, i64 }* %5, i64 0, i32 0
+  %16 = getelementptr inbounds { %Callable*, i64 }, { %Callable*, i64 }* %5, i32 0, i32 0
   %17 = load %Callable*, %Callable** %16
   %18 = call %Callable* @__quantum__rt__callable_copy(%Callable* %17, i1 false)
   call void @__quantum__rt__callable_memory_management(i32 0, %Callable* %18, i64 1)

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestControlled2.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestControlled2.ll
@@ -1,28 +1,28 @@
 ﻿define void @Lifted__PartialApplication__2__ctl__wrapper(%Tuple* %capture-tuple, %Tuple* %arg-tuple, %Tuple* %result-tuple) {
 entry:
   %0 = bitcast %Tuple* %arg-tuple to { %Array*, { %Qubit*, i64 }* }*
-  %1 = getelementptr { %Array*, { %Qubit*, i64 }* }, { %Array*, { %Qubit*, i64 }* }* %0, i64 0, i32 0
-  %2 = getelementptr { %Array*, { %Qubit*, i64 }* }, { %Array*, { %Qubit*, i64 }* }* %0, i64 0, i32 1
+  %1 = getelementptr inbounds { %Array*, { %Qubit*, i64 }* }, { %Array*, { %Qubit*, i64 }* }* %0, i32 0, i32 0
+  %2 = getelementptr inbounds { %Array*, { %Qubit*, i64 }* }, { %Array*, { %Qubit*, i64 }* }* %0, i32 0, i32 1
   %3 = load %Array*, %Array** %1
   %4 = load { %Qubit*, i64 }*, { %Qubit*, i64 }** %2
-  %5 = getelementptr { %Qubit*, i64 }, { %Qubit*, i64 }* %4, i64 0, i32 0
+  %5 = getelementptr inbounds { %Qubit*, i64 }, { %Qubit*, i64 }* %4, i32 0, i32 0
   %6 = load %Qubit*, %Qubit** %5
-  %7 = getelementptr { %Qubit*, i64 }, { %Qubit*, i64 }* %4, i64 0, i32 1
+  %7 = getelementptr inbounds { %Qubit*, i64 }, { %Qubit*, i64 }* %4, i32 0, i32 1
   %8 = load i64, i64* %7
   %9 = call %Tuple* @__quantum__rt__tuple_create(i64 ptrtoint ({ %Qubit*, i64 }* getelementptr ({ %Qubit*, i64 }, { %Qubit*, i64 }* null, i32 1) to i64))
   %10 = bitcast %Tuple* %9 to { %Qubit*, i64 }*
-  %11 = getelementptr { %Qubit*, i64 }, { %Qubit*, i64 }* %10, i64 0, i32 0
-  %12 = getelementptr { %Qubit*, i64 }, { %Qubit*, i64 }* %10, i64 0, i32 1
+  %11 = getelementptr inbounds { %Qubit*, i64 }, { %Qubit*, i64 }* %10, i32 0, i32 0
+  %12 = getelementptr inbounds { %Qubit*, i64 }, { %Qubit*, i64 }* %10, i32 0, i32 1
   store %Qubit* %6, %Qubit** %11
   store i64 %8, i64* %12
   %13 = call %Tuple* @__quantum__rt__tuple_create(i64 mul nuw (i64 ptrtoint (i1** getelementptr (i1*, i1** null, i32 1) to i64), i64 2))
   %14 = bitcast %Tuple* %13 to { %Array*, { %Qubit*, i64 }* }*
-  %15 = getelementptr { %Array*, { %Qubit*, i64 }* }, { %Array*, { %Qubit*, i64 }* }* %14, i64 0, i32 0
-  %16 = getelementptr { %Array*, { %Qubit*, i64 }* }, { %Array*, { %Qubit*, i64 }* }* %14, i64 0, i32 1
+  %15 = getelementptr inbounds { %Array*, { %Qubit*, i64 }* }, { %Array*, { %Qubit*, i64 }* }* %14, i32 0, i32 0
+  %16 = getelementptr inbounds { %Array*, { %Qubit*, i64 }* }, { %Array*, { %Qubit*, i64 }* }* %14, i32 0, i32 1
   store %Array* %3, %Array** %15
   store { %Qubit*, i64 }* %10, { %Qubit*, i64 }** %16
   %17 = bitcast %Tuple* %capture-tuple to { %Callable* }*
-  %18 = getelementptr { %Callable* }, { %Callable* }* %17, i64 0, i32 0
+  %18 = getelementptr inbounds { %Callable* }, { %Callable* }* %17, i32 0, i32 0
   %19 = load %Callable*, %Callable** %18
   %20 = call %Callable* @__quantum__rt__callable_copy(%Callable* %19, i1 false)
   call void @__quantum__rt__callable_memory_management(i32 0, %Callable* %20, i64 1)

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestControlled3.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestControlled3.ll
@@ -1,8 +1,8 @@
 ﻿define void @Microsoft__Quantum__Intrinsic__K__ctl__wrapper(%Tuple* %capture-tuple, %Tuple* %arg-tuple, %Tuple* %result-tuple) {
 entry:
   %0 = bitcast %Tuple* %arg-tuple to { %Array*, { %Qubit*, i64 }* }*
-  %1 = getelementptr { %Array*, { %Qubit*, i64 }* }, { %Array*, { %Qubit*, i64 }* }* %0, i64 0, i32 0
-  %2 = getelementptr { %Array*, { %Qubit*, i64 }* }, { %Array*, { %Qubit*, i64 }* }* %0, i64 0, i32 1
+  %1 = getelementptr inbounds { %Array*, { %Qubit*, i64 }* }, { %Array*, { %Qubit*, i64 }* }* %0, i32 0, i32 0
+  %2 = getelementptr inbounds { %Array*, { %Qubit*, i64 }* }, { %Array*, { %Qubit*, i64 }* }* %0, i32 0, i32 1
   %3 = load %Array*, %Array** %1
   %4 = load { %Qubit*, i64 }*, { %Qubit*, i64 }** %2
   call void @Microsoft__Quantum__Intrinsic__K__ctl(%Array* %3, { %Qubit*, i64 }* %4)

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestDeconstruct.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestDeconstruct.ll
@@ -2,8 +2,8 @@ define i64 @Microsoft__Quantum__Testing__QIR__TestDeconstruct__body(i64 %0, { i6
 entry:
   %2 = call %Tuple* @__quantum__rt__tuple_create(i64 ptrtoint ({ i64, { i64, i64 }* }* getelementptr ({ i64, { i64, i64 }* }, { i64, { i64, i64 }* }* null, i32 1) to i64))
   %a = bitcast %Tuple* %2 to { i64, { i64, i64 }* }*
-  %3 = getelementptr { i64, { i64, i64 }* }, { i64, { i64, i64 }* }* %a, i64 0, i32 0
-  %4 = getelementptr { i64, { i64, i64 }* }, { i64, { i64, i64 }* }* %a, i64 0, i32 1
+  %3 = getelementptr inbounds { i64, { i64, i64 }* }, { i64, { i64, i64 }* }* %a, i32 0, i32 0
+  %4 = getelementptr inbounds { i64, { i64, i64 }* }, { i64, { i64, i64 }* }* %a, i32 0, i32 1
   store i64 %0, i64* %3
   store { i64, i64 }* %1, { i64, i64 }** %4
   %5 = bitcast { i64, i64 }* %1 to %Tuple*
@@ -14,10 +14,10 @@ entry:
   store i64 3, i64* %b
   %c = alloca i64
   store i64 5, i64* %c
-  %6 = getelementptr { i64, i64 }, { i64, i64 }* %1, i64 0, i32 0
+  %6 = getelementptr inbounds { i64, i64 }, { i64, i64 }* %1, i32 0, i32 0
   %7 = load i64, i64* %6
   store i64 %7, i64* %b
-  %8 = getelementptr { i64, i64 }, { i64, i64 }* %1, i64 0, i32 1
+  %8 = getelementptr inbounds { i64, i64 }, { i64, i64 }* %1, i32 0, i32 1
   %9 = load i64, i64* %8
   store i64 %9, i64* %c
   %10 = mul i64 %7, %9

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestExpressions.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestExpressions.ll
@@ -48,15 +48,15 @@ entry:
   %45 = call i1 @Microsoft__Quantum__Testing__QIR__ReturnNot__body()
   %46 = call i64 @Microsoft__Quantum__Testing__QIR__ReturnBNot__body()
   %47 = call double @Microsoft__Quantum__Testing__QIR__ReturnNegative__body(double 3.000000e+00)
-  %48 = getelementptr { { i2, i64 }*, double }, { { i2, i64 }*, double }* %5, i64 0, i32 0
+  %48 = getelementptr inbounds { { i2, i64 }*, double }, { { i2, i64 }*, double }* %5, i32 0, i32 0
   %49 = load { i2, i64 }*, { i2, i64 }** %48
-  %50 = getelementptr { i64, { %Callable*, %String* }* }, { i64, { %Callable*, %String* }* }* %8, i64 0, i32 1
+  %50 = getelementptr inbounds { i64, { %Callable*, %String* }* }, { i64, { %Callable*, %String* }* }* %8, i32 0, i32 1
   %51 = load { %Callable*, %String* }*, { %Callable*, %String* }** %50
-  %52 = getelementptr { %Callable*, %String* }, { %Callable*, %String* }* %51, i64 0, i32 0
+  %52 = getelementptr inbounds { %Callable*, %String* }, { %Callable*, %String* }* %51, i32 0, i32 0
   %53 = load %Callable*, %Callable** %52
-  %54 = getelementptr { %Callable*, %String* }, { %Callable*, %String* }* %51, i64 0, i32 1
+  %54 = getelementptr inbounds { %Callable*, %String* }, { %Callable*, %String* }* %51, i32 0, i32 1
   %55 = load %String*, %String** %54
-  %56 = getelementptr { { i2, i64 }*, double }, { { i2, i64 }*, double }* %16, i64 0, i32 0
+  %56 = getelementptr inbounds { { i2, i64 }*, double }, { { i2, i64 }*, double }* %16, i32 0, i32 0
   %57 = load { i2, i64 }*, { i2, i64 }** %56
   call void @__quantum__rt__callable_memory_management(i32 0, %Callable* %0, i64 -1)
   call void @__quantum__rt__callable_update_reference_count(%Callable* %0, i64 -1)

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestForLoop.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestForLoop.ll
@@ -13,69 +13,79 @@ entry:
   call void @__quantum__rt__tuple_update_reference_count(%Tuple* %2, i64 1)
   call void @__quantum__rt__tuple_update_alias_count(%Tuple* %2, i64 -1)
   %5 = call %Tuple* @__quantum__rt__tuple_copy(%Tuple* %2, i1 false)
-  %6 = bitcast %Tuple* %5 to { double, %String* }*
-  %7 = getelementptr { double, %String* }, { double, %String* }* %6, i64 0, i32 1
+  %6 = icmp ne %Tuple* %2, %5
+  %7 = bitcast %Tuple* %5 to { double, %String* }*
+  %8 = getelementptr { double, %String* }, { double, %String* }* %7, i64 0, i32 1
   call void @__quantum__rt__string_update_reference_count(%String* %name, i64 1)
-  %8 = load %String*, %String** %7
-  store %String* %name, %String** %7
+  %9 = load %String*, %String** %8
+  br i1 %6, label %condContinue__1, label %condFalse__1
+
+condFalse__1:                                     ; preds = %entry
+  call void @__quantum__rt__string_update_reference_count(%String* %name, i64 1)
+  call void @__quantum__rt__string_update_reference_count(%String* %9, i64 -1)
+  br label %condContinue__1
+
+condContinue__1:                                  ; preds = %condFalse__1, %entry
+  store %String* %name, %String** %8
   call void @__quantum__rt__tuple_update_reference_count(%Tuple* %5, i64 1)
   call void @__quantum__rt__tuple_update_alias_count(%Tuple* %5, i64 1)
-  store { double, %String* }* %6, { double, %String* }** %res
+  store { double, %String* }* %7, { double, %String* }** %res
   %energy = alloca double
   store double 0.000000e+00, double* %energy
   br label %header__1
 
-header__1:                                        ; preds = %exiting__1, %entry
-  %i = phi i64 [ 0, %entry ], [ %10, %exiting__1 ]
-  %9 = icmp sle i64 %i, 10
-  br i1 %9, label %body__1, label %exit__1
+header__1:                                        ; preds = %exiting__1, %condContinue__1
+  %i = phi i64 [ 0, %condContinue__1 ], [ %11, %exiting__1 ]
+  %10 = icmp sle i64 %i, 10
+  br i1 %10, label %body__1, label %exit__1
 
 body__1:                                          ; preds = %header__1
   br label %preheader__1
 
 exiting__1:                                       ; preds = %exit__2
-  %10 = add i64 %i, 1
+  %11 = add i64 %i, 1
   br label %header__1
 
 exit__1:                                          ; preds = %header__1
-  %11 = call %Tuple* @__quantum__rt__tuple_copy(%Tuple* %5, i1 false)
-  %12 = bitcast %Tuple* %11 to { double, %String* }*
-  %13 = getelementptr { double, %String* }, { double, %String* }* %12, i64 0, i32 0
-  %14 = load double, double* %energy
-  store double %14, double* %13
-  %15 = getelementptr { double, %String* }, { double, %String* }* %12, i64 0, i32 1
-  %16 = load %String*, %String** %15
-  call void @__quantum__rt__string_update_reference_count(%String* %16, i64 1)
+  %12 = call %Tuple* @__quantum__rt__tuple_copy(%Tuple* %5, i1 false)
+  %13 = icmp ne %Tuple* %5, %12
+  %14 = bitcast %Tuple* %12 to { double, %String* }*
+  %15 = getelementptr { double, %String* }, { double, %String* }* %14, i64 0, i32 0
+  %16 = load double, double* %energy
+  store double %16, double* %15
+  %17 = getelementptr { double, %String* }, { double, %String* }* %14, i64 0, i32 1
+  %18 = load %String*, %String** %17
+  call void @__quantum__rt__string_update_reference_count(%String* %18, i64 1)
   call void @__quantum__rt__tuple_update_alias_count(%Tuple* %5, i64 -1)
   call void @__quantum__rt__string_update_reference_count(%String* %name, i64 -1)
   call void @__quantum__rt__string_update_reference_count(%String* %0, i64 -1)
   call void @__quantum__rt__string_update_reference_count(%String* %4, i64 -1)
   call void @__quantum__rt__tuple_update_reference_count(%Tuple* %2, i64 -1)
   call void @__quantum__rt__tuple_update_reference_count(%Tuple* %2, i64 -1)
-  call void @__quantum__rt__string_update_reference_count(%String* %8, i64 -1)
+  call void @__quantum__rt__string_update_reference_count(%String* %9, i64 -1)
   call void @__quantum__rt__tuple_update_reference_count(%Tuple* %5, i64 -1)
   call void @__quantum__rt__string_update_reference_count(%String* %name, i64 -1)
   call void @__quantum__rt__tuple_update_reference_count(%Tuple* %5, i64 -1)
-  ret { double, %String* }* %12
+  ret { double, %String* }* %14
 
 preheader__1:                                     ; preds = %body__1
   br label %header__2
 
 header__2:                                        ; preds = %exiting__2, %preheader__1
-  %j = phi i64 [ 5, %preheader__1 ], [ %22, %exiting__2 ]
-  %17 = icmp sle i64 %j, 0
-  %18 = icmp sge i64 %j, 0
-  %19 = select i1 false, i1 %17, i1 %18
-  br i1 %19, label %body__2, label %exit__2
+  %j = phi i64 [ 5, %preheader__1 ], [ %24, %exiting__2 ]
+  %19 = icmp sle i64 %j, 0
+  %20 = icmp sge i64 %j, 0
+  %21 = select i1 false, i1 %19, i1 %20
+  br i1 %21, label %body__2, label %exit__2
 
 body__2:                                          ; preds = %header__2
-  %20 = load double, double* %energy
-  %21 = fadd double %20, 5.000000e-01
-  store double %21, double* %energy
+  %22 = load double, double* %energy
+  %23 = fadd double %22, 5.000000e-01
+  store double %23, double* %energy
   br label %exiting__2
 
 exiting__2:                                       ; preds = %body__2
-  %22 = add i64 %j, -1
+  %24 = add i64 %j, -1
   br label %header__2
 
 exit__2:                                          ; preds = %header__2

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestForLoop.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestForLoop.ll
@@ -7,7 +7,7 @@ entry:
   store { double, %String* }* %1, { double, %String* }** %res
   %2 = bitcast { double, %String* }* %1 to %Tuple*
   call void @__quantum__rt__tuple_update_alias_count(%Tuple* %2, i64 1)
-  %3 = getelementptr { double, %String* }, { double, %String* }* %1, i64 0, i32 1
+  %3 = getelementptr inbounds { double, %String* }, { double, %String* }* %1, i32 0, i32 1
   %4 = load %String*, %String** %3
   call void @__quantum__rt__string_update_reference_count(%String* %4, i64 1)
   call void @__quantum__rt__tuple_update_reference_count(%Tuple* %2, i64 1)
@@ -15,7 +15,7 @@ entry:
   %5 = call %Tuple* @__quantum__rt__tuple_copy(%Tuple* %2, i1 false)
   %6 = icmp ne %Tuple* %2, %5
   %7 = bitcast %Tuple* %5 to { double, %String* }*
-  %8 = getelementptr { double, %String* }, { double, %String* }* %7, i64 0, i32 1
+  %8 = getelementptr inbounds { double, %String* }, { double, %String* }* %7, i32 0, i32 1
   call void @__quantum__rt__string_update_reference_count(%String* %name, i64 1)
   %9 = load %String*, %String** %8
   br i1 %6, label %condContinue__1, label %condFalse__1
@@ -50,10 +50,10 @@ exit__1:                                          ; preds = %header__1
   %12 = call %Tuple* @__quantum__rt__tuple_copy(%Tuple* %5, i1 false)
   %13 = icmp ne %Tuple* %5, %12
   %14 = bitcast %Tuple* %12 to { double, %String* }*
-  %15 = getelementptr { double, %String* }, { double, %String* }* %14, i64 0, i32 0
+  %15 = getelementptr inbounds { double, %String* }, { double, %String* }* %14, i32 0, i32 0
   %16 = load double, double* %energy
   store double %16, double* %15
-  %17 = getelementptr { double, %String* }, { double, %String* }* %14, i64 0, i32 1
+  %17 = getelementptr inbounds { double, %String* }, { double, %String* }* %14, i32 0, i32 1
   %18 = load %String*, %String** %17
   call void @__quantum__rt__string_update_reference_count(%String* %18, i64 1)
   call void @__quantum__rt__tuple_update_alias_count(%Tuple* %5, i64 -1)

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestFunctors.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestFunctors.ll
@@ -2,8 +2,8 @@ define i64 @Microsoft__Quantum__Testing__QIR__TestControlled__body() #0 {
 entry:
   %0 = call %Tuple* @__quantum__rt__tuple_create(i64 ptrtoint ({ %Callable*, i64 }* getelementptr ({ %Callable*, i64 }, { %Callable*, i64 }* null, i32 1) to i64))
   %1 = bitcast %Tuple* %0 to { %Callable*, i64 }*
-  %2 = getelementptr { %Callable*, i64 }, { %Callable*, i64 }* %1, i64 0, i32 0
-  %3 = getelementptr { %Callable*, i64 }, { %Callable*, i64 }* %1, i64 0, i32 1
+  %2 = getelementptr inbounds { %Callable*, i64 }, { %Callable*, i64 }* %1, i32 0, i32 0
+  %3 = getelementptr inbounds { %Callable*, i64 }, { %Callable*, i64 }* %1, i32 0, i32 1
   %4 = call %Callable* @__quantum__rt__callable_create([4 x void (%Tuple*, %Tuple*, %Tuple*)*]* @Microsoft__Quantum__Testing__QIR__Qop, [2 x void (%Tuple*, i64)*]* null, %Tuple* null)
   store %Callable* %4, %Callable** %2
   store i64 1, i64* %3
@@ -38,7 +38,7 @@ entry:
   %q3 = call %Qubit* @__quantum__rt__qubit_allocate()
   %5 = call %Tuple* @__quantum__rt__tuple_create(i64 ptrtoint (i1** getelementptr (i1*, i1** null, i32 1) to i64))
   %6 = bitcast %Tuple* %5 to { %Qubit* }*
-  %7 = getelementptr { %Qubit* }, { %Qubit* }* %6, i64 0, i32 0
+  %7 = getelementptr inbounds { %Qubit* }, { %Qubit* }* %6, i32 0, i32 0
   store %Qubit* %q1, %Qubit** %7
   call void @__quantum__rt__callable_invoke(%Callable* %qop, %Tuple* %5, %Tuple* null)
   %8 = call %Result* @__quantum__qis__mz(%Qubit* %q1)
@@ -54,7 +54,7 @@ then0__1:                                         ; preds = %entry
 else__1:                                          ; preds = %entry
   %12 = call %Tuple* @__quantum__rt__tuple_create(i64 ptrtoint (i1** getelementptr (i1*, i1** null, i32 1) to i64))
   %13 = bitcast %Tuple* %12 to { %Qubit* }*
-  %14 = getelementptr { %Qubit* }, { %Qubit* }* %13, i64 0, i32 0
+  %14 = getelementptr inbounds { %Qubit* }, { %Qubit* }* %13, i32 0, i32 0
   store %Qubit* %q2, %Qubit** %14
   call void @__quantum__rt__callable_invoke(%Callable* %adj_qop, %Tuple* %12, %Tuple* null)
   %15 = call %Result* @__quantum__qis__mz(%Qubit* %q2)
@@ -70,8 +70,8 @@ then0__2:                                         ; preds = %else__1
 else__2:                                          ; preds = %else__1
   %19 = call %Tuple* @__quantum__rt__tuple_create(i64 mul nuw (i64 ptrtoint (i1** getelementptr (i1*, i1** null, i32 1) to i64), i64 2))
   %20 = bitcast %Tuple* %19 to { %Array*, %Qubit* }*
-  %21 = getelementptr { %Array*, %Qubit* }, { %Array*, %Qubit* }* %20, i64 0, i32 0
-  %22 = getelementptr { %Array*, %Qubit* }, { %Array*, %Qubit* }* %20, i64 0, i32 1
+  %21 = getelementptr inbounds { %Array*, %Qubit* }, { %Array*, %Qubit* }* %20, i32 0, i32 0
+  %22 = getelementptr inbounds { %Array*, %Qubit* }, { %Array*, %Qubit* }* %20, i32 0, i32 1
   %23 = call %Array* @__quantum__rt__array_create_1d(i32 8, i64 1)
   %24 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %23, i64 0)
   %25 = bitcast i8* %24 to %Qubit**
@@ -92,8 +92,8 @@ then0__3:                                         ; preds = %else__2
 else__3:                                          ; preds = %else__2
   %30 = call %Tuple* @__quantum__rt__tuple_create(i64 mul nuw (i64 ptrtoint (i1** getelementptr (i1*, i1** null, i32 1) to i64), i64 2))
   %31 = bitcast %Tuple* %30 to { %Array*, %Qubit* }*
-  %32 = getelementptr { %Array*, %Qubit* }, { %Array*, %Qubit* }* %31, i64 0, i32 0
-  %33 = getelementptr { %Array*, %Qubit* }, { %Array*, %Qubit* }* %31, i64 0, i32 1
+  %32 = getelementptr inbounds { %Array*, %Qubit* }, { %Array*, %Qubit* }* %31, i32 0, i32 0
+  %33 = getelementptr inbounds { %Array*, %Qubit* }, { %Array*, %Qubit* }* %31, i32 0, i32 1
   %34 = call %Array* @__quantum__rt__array_create_1d(i32 8, i64 1)
   %35 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %34, i64 0)
   %36 = bitcast i8* %35 to %Qubit**
@@ -114,16 +114,16 @@ then0__4:                                         ; preds = %else__3
 else__4:                                          ; preds = %else__3
   %41 = call %Tuple* @__quantum__rt__tuple_create(i64 mul nuw (i64 ptrtoint (i1** getelementptr (i1*, i1** null, i32 1) to i64), i64 2))
   %42 = bitcast %Tuple* %41 to { %Array*, { %Array*, %Qubit* }* }*
-  %43 = getelementptr { %Array*, { %Array*, %Qubit* }* }, { %Array*, { %Array*, %Qubit* }* }* %42, i64 0, i32 0
-  %44 = getelementptr { %Array*, { %Array*, %Qubit* }* }, { %Array*, { %Array*, %Qubit* }* }* %42, i64 0, i32 1
+  %43 = getelementptr inbounds { %Array*, { %Array*, %Qubit* }* }, { %Array*, { %Array*, %Qubit* }* }* %42, i32 0, i32 0
+  %44 = getelementptr inbounds { %Array*, { %Array*, %Qubit* }* }, { %Array*, { %Array*, %Qubit* }* }* %42, i32 0, i32 1
   %45 = call %Array* @__quantum__rt__array_create_1d(i32 8, i64 1)
   %46 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %45, i64 0)
   %47 = bitcast i8* %46 to %Qubit**
   store %Qubit* %q1, %Qubit** %47
   %48 = call %Tuple* @__quantum__rt__tuple_create(i64 mul nuw (i64 ptrtoint (i1** getelementptr (i1*, i1** null, i32 1) to i64), i64 2))
   %49 = bitcast %Tuple* %48 to { %Array*, %Qubit* }*
-  %50 = getelementptr { %Array*, %Qubit* }, { %Array*, %Qubit* }* %49, i64 0, i32 0
-  %51 = getelementptr { %Array*, %Qubit* }, { %Array*, %Qubit* }* %49, i64 0, i32 1
+  %50 = getelementptr inbounds { %Array*, %Qubit* }, { %Array*, %Qubit* }* %49, i32 0, i32 0
+  %51 = getelementptr inbounds { %Array*, %Qubit* }, { %Array*, %Qubit* }* %49, i32 0, i32 1
   %52 = call %Array* @__quantum__rt__array_create_1d(i32 8, i64 1)
   %53 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %52, i64 0)
   %54 = bitcast i8* %53 to %Qubit**
@@ -149,8 +149,8 @@ else__5:                                          ; preds = %else__4
   call void @__quantum__rt__callable_make_controlled(%Callable* %59)
   %60 = call %Tuple* @__quantum__rt__tuple_create(i64 mul nuw (i64 ptrtoint (i1** getelementptr (i1*, i1** null, i32 1) to i64), i64 2))
   %61 = bitcast %Tuple* %60 to { %Array*, %Qubit* }*
-  %62 = getelementptr { %Array*, %Qubit* }, { %Array*, %Qubit* }* %61, i64 0, i32 0
-  %63 = getelementptr { %Array*, %Qubit* }, { %Array*, %Qubit* }* %61, i64 0, i32 1
+  %62 = getelementptr inbounds { %Array*, %Qubit* }, { %Array*, %Qubit* }* %61, i32 0, i32 0
+  %63 = getelementptr inbounds { %Array*, %Qubit* }, { %Array*, %Qubit* }* %61, i32 0, i32 1
   %64 = call %Array* @__quantum__rt__array_create_1d(i32 8, i64 2)
   %65 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %64, i64 0)
   %66 = bitcast i8* %65 to %Qubit**
@@ -178,7 +178,7 @@ else__6:                                          ; preds = %else__5
   call void @__quantum__rt__callable_make_adjoint(%Callable* %73)
   %74 = call %Tuple* @__quantum__rt__tuple_create(i64 ptrtoint (i1** getelementptr (i1*, i1** null, i32 1) to i64))
   %75 = bitcast %Tuple* %74 to { %Qubit* }*
-  %76 = getelementptr { %Qubit* }, { %Qubit* }* %75, i64 0, i32 0
+  %76 = getelementptr inbounds { %Qubit* }, { %Qubit* }* %75, i32 0, i32 0
   store %Qubit* %q3, %Qubit** %76
   call void @__quantum__rt__callable_invoke(%Callable* %73, %Tuple* %74, %Tuple* null)
   %77 = call %Callable* @__quantum__rt__callable_copy(%Callable* %ctl_ctl_qop, i1 false)
@@ -187,24 +187,24 @@ else__6:                                          ; preds = %else__5
   call void @__quantum__rt__callable_make_adjoint(%Callable* %77)
   %78 = call %Tuple* @__quantum__rt__tuple_create(i64 mul nuw (i64 ptrtoint (i1** getelementptr (i1*, i1** null, i32 1) to i64), i64 2))
   %79 = bitcast %Tuple* %78 to { %Array*, { %Array*, { %Array*, %Qubit* }* }* }*
-  %80 = getelementptr { %Array*, { %Array*, { %Array*, %Qubit* }* }* }, { %Array*, { %Array*, { %Array*, %Qubit* }* }* }* %79, i64 0, i32 0
-  %81 = getelementptr { %Array*, { %Array*, { %Array*, %Qubit* }* }* }, { %Array*, { %Array*, { %Array*, %Qubit* }* }* }* %79, i64 0, i32 1
+  %80 = getelementptr inbounds { %Array*, { %Array*, { %Array*, %Qubit* }* }* }, { %Array*, { %Array*, { %Array*, %Qubit* }* }* }* %79, i32 0, i32 0
+  %81 = getelementptr inbounds { %Array*, { %Array*, { %Array*, %Qubit* }* }* }, { %Array*, { %Array*, { %Array*, %Qubit* }* }* }* %79, i32 0, i32 1
   %82 = call %Array* @__quantum__rt__array_create_1d(i32 8, i64 1)
   %83 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %82, i64 0)
   %84 = bitcast i8* %83 to %Qubit**
   store %Qubit* %q1, %Qubit** %84
   %85 = call %Tuple* @__quantum__rt__tuple_create(i64 mul nuw (i64 ptrtoint (i1** getelementptr (i1*, i1** null, i32 1) to i64), i64 2))
   %86 = bitcast %Tuple* %85 to { %Array*, { %Array*, %Qubit* }* }*
-  %87 = getelementptr { %Array*, { %Array*, %Qubit* }* }, { %Array*, { %Array*, %Qubit* }* }* %86, i64 0, i32 0
-  %88 = getelementptr { %Array*, { %Array*, %Qubit* }* }, { %Array*, { %Array*, %Qubit* }* }* %86, i64 0, i32 1
+  %87 = getelementptr inbounds { %Array*, { %Array*, %Qubit* }* }, { %Array*, { %Array*, %Qubit* }* }* %86, i32 0, i32 0
+  %88 = getelementptr inbounds { %Array*, { %Array*, %Qubit* }* }, { %Array*, { %Array*, %Qubit* }* }* %86, i32 0, i32 1
   %89 = call %Array* @__quantum__rt__array_create_1d(i32 8, i64 1)
   %90 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %89, i64 0)
   %91 = bitcast i8* %90 to %Qubit**
   store %Qubit* %q2, %Qubit** %91
   %92 = call %Tuple* @__quantum__rt__tuple_create(i64 mul nuw (i64 ptrtoint (i1** getelementptr (i1*, i1** null, i32 1) to i64), i64 2))
   %93 = bitcast %Tuple* %92 to { %Array*, %Qubit* }*
-  %94 = getelementptr { %Array*, %Qubit* }, { %Array*, %Qubit* }* %93, i64 0, i32 0
-  %95 = getelementptr { %Array*, %Qubit* }, { %Array*, %Qubit* }* %93, i64 0, i32 1
+  %94 = getelementptr inbounds { %Array*, %Qubit* }, { %Array*, %Qubit* }* %93, i32 0, i32 0
+  %95 = getelementptr inbounds { %Array*, %Qubit* }, { %Array*, %Qubit* }* %93, i32 0, i32 1
   %96 = call %Array* @__quantum__rt__array_create_1d(i32 8, i64 1)
   %97 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %96, i64 0)
   %98 = bitcast i8* %97 to %Qubit**

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestInline.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestInline.ll
@@ -6,25 +6,25 @@ entry:
   store double 0.000000e+00, double* %y
   %q = call %Qubit* @__quantum__rt__qubit_allocate()
   %0 = call { double, %Qubit* }* @Microsoft__Quantum__Testing__QIR__AsTuple__body(%Qubit* %q)
-  %1 = getelementptr { double, %Qubit* }, { double, %Qubit* }* %0, i64 0, i32 0
+  %1 = getelementptr inbounds { double, %Qubit* }, { double, %Qubit* }* %0, i32 0, i32 0
   %theta = load double, double* %1
-  %2 = getelementptr { double, %Qubit* }, { double, %Qubit* }* %0, i64 0, i32 1
+  %2 = getelementptr inbounds { double, %Qubit* }, { double, %Qubit* }* %0, i32 0, i32 1
   %qb = load %Qubit*, %Qubit** %2
   call void @__quantum__qis__k__body(double %theta, %Qubit* %qb)
   %3 = bitcast { double, %Qubit* }* %0 to %Tuple*
   call void @__quantum__rt__tuple_update_reference_count(%Tuple* %3, i64 -1)
   %4 = call { double, %Qubit* }* @Microsoft__Quantum__Testing__QIR__AsTuple__body(%Qubit* %q)
-  %5 = getelementptr { double, %Qubit* }, { double, %Qubit* }* %4, i64 0, i32 0
+  %5 = getelementptr inbounds { double, %Qubit* }, { double, %Qubit* }* %4, i32 0, i32 0
   %theta__2 = load double, double* %5
-  %6 = getelementptr { double, %Qubit* }, { double, %Qubit* }* %4, i64 0, i32 1
+  %6 = getelementptr inbounds { double, %Qubit* }, { double, %Qubit* }* %4, i32 0, i32 1
   %qb__2 = load %Qubit*, %Qubit** %6
   call void @__quantum__qis__k__body(double %theta__2, %Qubit* %qb__2)
   %7 = bitcast { double, %Qubit* }* %4 to %Tuple*
   call void @__quantum__rt__tuple_update_reference_count(%Tuple* %7, i64 -1)
   %8 = call { double, %Qubit* }* @Microsoft__Quantum__Testing__QIR__AsTuple__body(%Qubit* %q)
-  %9 = getelementptr { double, %Qubit* }, { double, %Qubit* }* %8, i64 0, i32 0
+  %9 = getelementptr inbounds { double, %Qubit* }, { double, %Qubit* }* %8, i32 0, i32 0
   %theta__4 = load double, double* %9
-  %10 = getelementptr { double, %Qubit* }, { double, %Qubit* }* %8, i64 0, i32 1
+  %10 = getelementptr inbounds { double, %Qubit* }, { double, %Qubit* }* %8, i32 0, i32 1
   %qb__4 = load %Qubit*, %Qubit** %10
   call void @__quantum__qis__k__body(double %theta__4, %Qubit* %qb__4)
   %11 = bitcast { double, %Qubit* }* %8 to %Tuple*
@@ -32,15 +32,15 @@ entry:
   %12 = call %Result* @__quantum__qis__mz(%Qubit* %q)
   %13 = call %Tuple* @__quantum__rt__tuple_create(i64 mul nuw (i64 ptrtoint (double* getelementptr (double, double* null, i32 1) to i64), i64 2))
   %14 = bitcast %Tuple* %13 to { double, double }*
-  %15 = getelementptr { double, double }, { double, double }* %14, i64 0, i32 0
-  %16 = getelementptr { double, double }, { double, double }* %14, i64 0, i32 1
+  %15 = getelementptr inbounds { double, double }, { double, double }* %14, i32 0, i32 0
+  %16 = getelementptr inbounds { double, double }, { double, double }* %14, i32 0, i32 1
   store double 0.000000e+00, double* %15
   store double 0.000000e+00, double* %16
   %17 = call { double, double }* @Microsoft__Quantum__Testing__QIR__UpdatedValues__body(%Result* %12, { double, double }* %14)
-  %18 = getelementptr { double, double }, { double, double }* %17, i64 0, i32 0
+  %18 = getelementptr inbounds { double, double }, { double, double }* %17, i32 0, i32 0
   %19 = load double, double* %18
   store double %19, double* %x
-  %20 = getelementptr { double, double }, { double, double }* %17, i64 0, i32 1
+  %20 = getelementptr inbounds { double, double }, { double, double }* %17, i32 0, i32 1
   %21 = load double, double* %20
   store double %21, double* %y
   call void @__quantum__rt__qubit_release(%Qubit* %q)
@@ -50,8 +50,8 @@ entry:
   call void @__quantum__rt__tuple_update_reference_count(%Tuple* %22, i64 -1)
   %23 = call %Tuple* @__quantum__rt__tuple_create(i64 mul nuw (i64 ptrtoint (double* getelementptr (double, double* null, i32 1) to i64), i64 2))
   %24 = bitcast %Tuple* %23 to { double, double }*
-  %25 = getelementptr { double, double }, { double, double }* %24, i64 0, i32 0
-  %26 = getelementptr { double, double }, { double, double }* %24, i64 0, i32 1
+  %25 = getelementptr inbounds { double, double }, { double, double }* %24, i32 0, i32 0
+  %26 = getelementptr inbounds { double, double }, { double, double }* %24, i32 0, i32 1
   store double %19, double* %25
   store double %21, double* %26
   ret { double, double }* %24

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestLocalCallables1.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestLocalCallables1.ll
@@ -41,8 +41,8 @@ exit__1:                                          ; preds = %header__1
   call void @__quantum__rt__callable_make_controlled(%Callable* %16)
   %17 = call %Tuple* @__quantum__rt__tuple_create(i64 mul nuw (i64 ptrtoint (i1** getelementptr (i1*, i1** null, i32 1) to i64), i64 2))
   %18 = bitcast %Tuple* %17 to { %Array*, %Tuple* }*
-  %19 = getelementptr { %Array*, %Tuple* }, { %Array*, %Tuple* }* %18, i64 0, i32 0
-  %20 = getelementptr { %Array*, %Tuple* }, { %Array*, %Tuple* }* %18, i64 0, i32 1
+  %19 = getelementptr inbounds { %Array*, %Tuple* }, { %Array*, %Tuple* }* %18, i32 0, i32 0
+  %20 = getelementptr inbounds { %Array*, %Tuple* }, { %Array*, %Tuple* }* %18, i32 0, i32 1
   %21 = call %Array* @__quantum__rt__array_create_1d(i32 8, i64 0)
   store %Array* %21, %Array** %19
   store %Tuple* null, %Tuple** %20
@@ -57,21 +57,21 @@ exit__1:                                          ; preds = %header__1
   %25 = call %String* @__quantum__rt__string_create(i32 0, i8* null)
   %26 = call %Tuple* @__quantum__rt__tuple_create(i64 ptrtoint (i1** getelementptr (i1*, i1** null, i32 1) to i64))
   %27 = bitcast %Tuple* %26 to { %String* }*
-  %28 = getelementptr { %String* }, { %String* }* %27, i64 0, i32 0
+  %28 = getelementptr inbounds { %String* }, { %String* }* %27, i32 0, i32 0
   store %String* %25, %String** %28
   %29 = call %Tuple* @__quantum__rt__tuple_create(i64 mul nuw (i64 ptrtoint (i1** getelementptr (i1*, i1** null, i32 1) to i64), i64 2))
   call void @__quantum__rt__callable_invoke(%Callable* %fct, %Tuple* %26, %Tuple* %29)
   %30 = bitcast %Tuple* %29 to { %String*, { i64, double }* }*
-  %31 = getelementptr { %String*, { i64, double }* }, { %String*, { i64, double }* }* %30, i64 0, i32 0
+  %31 = getelementptr inbounds { %String*, { i64, double }* }, { %String*, { i64, double }* }* %30, i32 0, i32 0
   %str = load %String*, %String** %31
-  %32 = getelementptr { %String*, { i64, double }* }, { %String*, { i64, double }* }* %30, i64 0, i32 1
+  %32 = getelementptr inbounds { %String*, { i64, double }* }, { %String*, { i64, double }* }* %30, i32 0, i32 1
   %33 = load { i64, double }*, { i64, double }** %32
-  %34 = getelementptr { i64, double }, { i64, double }* %33, i64 0, i32 1
+  %34 = getelementptr inbounds { i64, double }, { i64, double }* %33, i32 0, i32 1
   %val = load double, double* %34
   %35 = call %Tuple* @__quantum__rt__tuple_create(i64 ptrtoint ({ %String*, double }* getelementptr ({ %String*, double }, { %String*, double }* null, i32 1) to i64))
   %36 = bitcast %Tuple* %35 to { %String*, double }*
-  %37 = getelementptr { %String*, double }, { %String*, double }* %36, i64 0, i32 0
-  %38 = getelementptr { %String*, double }, { %String*, double }* %36, i64 0, i32 1
+  %37 = getelementptr inbounds { %String*, double }, { %String*, double }* %36, i32 0, i32 0
+  %38 = getelementptr inbounds { %String*, double }, { %String*, double }* %36, i32 0, i32 1
   store %String* %str, %String** %37
   store double %val, double* %38
   br label %header__2

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestLocalCallables2.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestLocalCallables2.ll
@@ -1,16 +1,16 @@
 ﻿define void @Microsoft__Quantum__Testing__QIR__ReturnTuple__body__wrapper(%Tuple* %capture-tuple, %Tuple* %arg-tuple, %Tuple* %result-tuple) {
 entry:
   %0 = bitcast %Tuple* %arg-tuple to { %String* }*
-  %1 = getelementptr { %String* }, { %String* }* %0, i64 0, i32 0
+  %1 = getelementptr inbounds { %String* }, { %String* }* %0, i32 0, i32 0
   %2 = load %String*, %String** %1
   %3 = call { %String*, { i64, double }* }* @Microsoft__Quantum__Testing__QIR__ReturnTuple__body(%String* %2)
   %4 = bitcast %Tuple* %result-tuple to { %String*, { i64, double }* }*
-  %5 = getelementptr { %String*, { i64, double }* }, { %String*, { i64, double }* }* %4, i64 0, i32 0
-  %6 = getelementptr { %String*, { i64, double }* }, { %String*, { i64, double }* }* %3, i64 0, i32 0
+  %5 = getelementptr inbounds { %String*, { i64, double }* }, { %String*, { i64, double }* }* %4, i32 0, i32 0
+  %6 = getelementptr inbounds { %String*, { i64, double }* }, { %String*, { i64, double }* }* %3, i32 0, i32 0
   %7 = load %String*, %String** %6
   store %String* %7, %String** %5
-  %8 = getelementptr { %String*, { i64, double }* }, { %String*, { i64, double }* }* %4, i64 0, i32 1
-  %9 = getelementptr { %String*, { i64, double }* }, { %String*, { i64, double }* }* %3, i64 0, i32 1
+  %8 = getelementptr inbounds { %String*, { i64, double }* }, { %String*, { i64, double }* }* %4, i32 0, i32 1
+  %9 = getelementptr inbounds { %String*, { i64, double }* }, { %String*, { i64, double }* }* %3, i32 0, i32 1
   %10 = load { i64, double }*, { i64, double }** %9
   store { i64, double }* %10, { i64, double }** %8
   ret void

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestOpArgument.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestOpArgument.ll
@@ -4,15 +4,15 @@ entry:
   %q2 = call %Qubit* @__quantum__rt__qubit_allocate()
   %0 = call %Tuple* @__quantum__rt__tuple_create(i64 mul nuw (i64 ptrtoint (i1** getelementptr (i1*, i1** null, i32 1) to i64), i64 2))
   %qs = bitcast %Tuple* %0 to { %Qubit*, %Qubit* }*
-  %1 = getelementptr { %Qubit*, %Qubit* }, { %Qubit*, %Qubit* }* %qs, i64 0, i32 0
-  %2 = getelementptr { %Qubit*, %Qubit* }, { %Qubit*, %Qubit* }* %qs, i64 0, i32 1
+  %1 = getelementptr inbounds { %Qubit*, %Qubit* }, { %Qubit*, %Qubit* }* %qs, i32 0, i32 0
+  %2 = getelementptr inbounds { %Qubit*, %Qubit* }, { %Qubit*, %Qubit* }* %qs, i32 0, i32 1
   store %Qubit* %q1, %Qubit** %1
   store %Qubit* %q2, %Qubit** %2
   call void @__quantum__rt__tuple_update_alias_count(%Tuple* %0, i64 1)
   %3 = call %Tuple* @__quantum__rt__tuple_create(i64 mul nuw (i64 ptrtoint (i1** getelementptr (i1*, i1** null, i32 1) to i64), i64 2))
   %4 = bitcast %Tuple* %3 to { %Callable*, %Qubit* }*
-  %5 = getelementptr { %Callable*, %Qubit* }, { %Callable*, %Qubit* }* %4, i64 0, i32 0
-  %6 = getelementptr { %Callable*, %Qubit* }, { %Callable*, %Qubit* }* %4, i64 0, i32 1
+  %5 = getelementptr inbounds { %Callable*, %Qubit* }, { %Callable*, %Qubit* }* %4, i32 0, i32 0
+  %6 = getelementptr inbounds { %Callable*, %Qubit* }, { %Callable*, %Qubit* }* %4, i32 0, i32 1
   %7 = call %Callable* @__quantum__rt__callable_create([4 x void (%Tuple*, %Tuple*, %Tuple*)*]* @Microsoft__Quantum__Testing__QIR___Choose, [2 x void (%Tuple*, i64)*]* null, %Tuple* null)
   store %Callable* %7, %Callable** %5
   store %Qubit* %q1, %Qubit** %6
@@ -23,8 +23,8 @@ entry:
   call void @__quantum__qis__swap(%Qubit* %q1, %Qubit* %q2)
   %8 = call %Tuple* @__quantum__rt__tuple_create(i64 mul nuw (i64 ptrtoint (i1** getelementptr (i1*, i1** null, i32 1) to i64), i64 2))
   %9 = bitcast %Tuple* %8 to { %Callable*, %Qubit* }*
-  %10 = getelementptr { %Callable*, %Qubit* }, { %Callable*, %Qubit* }* %9, i64 0, i32 0
-  %11 = getelementptr { %Callable*, %Qubit* }, { %Callable*, %Qubit* }* %9, i64 0, i32 1
+  %10 = getelementptr inbounds { %Callable*, %Qubit* }, { %Callable*, %Qubit* }* %9, i32 0, i32 0
+  %11 = getelementptr inbounds { %Callable*, %Qubit* }, { %Callable*, %Qubit* }* %9, i32 0, i32 1
   %12 = call %Callable* @__quantum__rt__callable_create([4 x void (%Tuple*, %Tuple*, %Tuple*)*]* @Microsoft__Quantum__Intrinsic__CNOT, [2 x void (%Tuple*, i64)*]* null, %Tuple* null)
   store %Callable* %12, %Callable** %10
   store %Qubit* %q1, %Qubit** %11
@@ -32,8 +32,8 @@ entry:
   call void @Microsoft__Quantum__Testing__QIR__Apply__body(%Callable* %13)
   %14 = call %Tuple* @__quantum__rt__tuple_create(i64 mul nuw (i64 ptrtoint (i1** getelementptr (i1*, i1** null, i32 1) to i64), i64 2))
   %15 = bitcast %Tuple* %14 to { %Callable*, %Qubit* }*
-  %16 = getelementptr { %Callable*, %Qubit* }, { %Callable*, %Qubit* }* %15, i64 0, i32 0
-  %17 = getelementptr { %Callable*, %Qubit* }, { %Callable*, %Qubit* }* %15, i64 0, i32 1
+  %16 = getelementptr inbounds { %Callable*, %Qubit* }, { %Callable*, %Qubit* }* %15, i32 0, i32 0
+  %17 = getelementptr inbounds { %Callable*, %Qubit* }, { %Callable*, %Qubit* }* %15, i32 0, i32 1
   %18 = call %Callable* @__quantum__rt__callable_create([4 x void (%Tuple*, %Tuple*, %Tuple*)*]* @Microsoft__Quantum__Testing__QIR___SWAP, [2 x void (%Tuple*, i64)*]* null, %Tuple* null)
   store %Callable* %18, %Callable** %16
   store %Qubit* %q1, %Qubit** %17
@@ -41,9 +41,9 @@ entry:
   call void @Microsoft__Quantum__Testing__QIR__Apply__body(%Callable* %19)
   %20 = call %Tuple* @__quantum__rt__tuple_create(i64 mul nuw (i64 ptrtoint (i1** getelementptr (i1*, i1** null, i32 1) to i64), i64 3))
   %21 = bitcast %Tuple* %20 to { %Callable*, %Qubit*, %Qubit* }*
-  %22 = getelementptr { %Callable*, %Qubit*, %Qubit* }, { %Callable*, %Qubit*, %Qubit* }* %21, i64 0, i32 0
-  %23 = getelementptr { %Callable*, %Qubit*, %Qubit* }, { %Callable*, %Qubit*, %Qubit* }* %21, i64 0, i32 1
-  %24 = getelementptr { %Callable*, %Qubit*, %Qubit* }, { %Callable*, %Qubit*, %Qubit* }* %21, i64 0, i32 2
+  %22 = getelementptr inbounds { %Callable*, %Qubit*, %Qubit* }, { %Callable*, %Qubit*, %Qubit* }* %21, i32 0, i32 0
+  %23 = getelementptr inbounds { %Callable*, %Qubit*, %Qubit* }, { %Callable*, %Qubit*, %Qubit* }* %21, i32 0, i32 1
+  %24 = getelementptr inbounds { %Callable*, %Qubit*, %Qubit* }, { %Callable*, %Qubit*, %Qubit* }* %21, i32 0, i32 2
   %25 = call %Callable* @__quantum__rt__callable_create([4 x void (%Tuple*, %Tuple*, %Tuple*)*]* @Microsoft__Quantum__Testing__QIR___Choose, [2 x void (%Tuple*, i64)*]* null, %Tuple* null)
   store %Callable* %25, %Callable** %22
   store %Qubit* %q1, %Qubit** %23
@@ -52,9 +52,9 @@ entry:
   call void @Microsoft__Quantum__Testing__QIR__Apply__body(%Callable* %26)
   %27 = call %Tuple* @__quantum__rt__tuple_create(i64 mul nuw (i64 ptrtoint (i1** getelementptr (i1*, i1** null, i32 1) to i64), i64 3))
   %28 = bitcast %Tuple* %27 to { %Callable*, %Qubit*, %Qubit* }*
-  %29 = getelementptr { %Callable*, %Qubit*, %Qubit* }, { %Callable*, %Qubit*, %Qubit* }* %28, i64 0, i32 0
-  %30 = getelementptr { %Callable*, %Qubit*, %Qubit* }, { %Callable*, %Qubit*, %Qubit* }* %28, i64 0, i32 1
-  %31 = getelementptr { %Callable*, %Qubit*, %Qubit* }, { %Callable*, %Qubit*, %Qubit* }* %28, i64 0, i32 2
+  %29 = getelementptr inbounds { %Callable*, %Qubit*, %Qubit* }, { %Callable*, %Qubit*, %Qubit* }* %28, i32 0, i32 0
+  %30 = getelementptr inbounds { %Callable*, %Qubit*, %Qubit* }, { %Callable*, %Qubit*, %Qubit* }* %28, i32 0, i32 1
+  %31 = getelementptr inbounds { %Callable*, %Qubit*, %Qubit* }, { %Callable*, %Qubit*, %Qubit* }* %28, i32 0, i32 2
   %32 = call %Callable* @__quantum__rt__callable_create([4 x void (%Tuple*, %Tuple*, %Tuple*)*]* @Microsoft__Quantum__Testing__QIR___Choose, [2 x void (%Tuple*, i64)*]* null, %Tuple* null)
   store %Callable* %32, %Callable** %29
   store %Qubit* %q1, %Qubit** %30
@@ -63,8 +63,8 @@ entry:
   call void @Microsoft__Quantum__Testing__QIR__Apply__body(%Callable* %33)
   %34 = call %Tuple* @__quantum__rt__tuple_create(i64 mul nuw (i64 ptrtoint (i1** getelementptr (i1*, i1** null, i32 1) to i64), i64 2))
   %35 = bitcast %Tuple* %34 to { %Callable*, { %Qubit*, %Qubit* }* }*
-  %36 = getelementptr { %Callable*, { %Qubit*, %Qubit* }* }, { %Callable*, { %Qubit*, %Qubit* }* }* %35, i64 0, i32 0
-  %37 = getelementptr { %Callable*, { %Qubit*, %Qubit* }* }, { %Callable*, { %Qubit*, %Qubit* }* }* %35, i64 0, i32 1
+  %36 = getelementptr inbounds { %Callable*, { %Qubit*, %Qubit* }* }, { %Callable*, { %Qubit*, %Qubit* }* }* %35, i32 0, i32 0
+  %37 = getelementptr inbounds { %Callable*, { %Qubit*, %Qubit* }* }, { %Callable*, { %Qubit*, %Qubit* }* }* %35, i32 0, i32 1
   %38 = call %Callable* @__quantum__rt__callable_create([4 x void (%Tuple*, %Tuple*, %Tuple*)*]* @Microsoft__Quantum__Testing__QIR___Choose, [2 x void (%Tuple*, i64)*]* null, %Tuple* null)
   store %Callable* %38, %Callable** %36
   store { %Qubit*, %Qubit* }* %qs, { %Qubit*, %Qubit* }** %37

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestOpCall1.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestOpCall1.ll
@@ -16,7 +16,7 @@ entry:
   store %Qubit* %aux, %Qubit** %5
   %6 = call %Tuple* @__quantum__rt__tuple_create(i64 ptrtoint (i1** getelementptr (i1*, i1** null, i32 1) to i64))
   %7 = bitcast %Tuple* %6 to { %Array* }*
-  %8 = getelementptr { %Array* }, { %Array* }* %7, i64 0, i32 0
+  %8 = getelementptr inbounds { %Array* }, { %Array* }* %7, i32 0, i32 0
   store %Array* %3, %Array** %8
   call void @__quantum__rt__callable_invoke(%Callable* %doNothing, %Tuple* %6, %Tuple* null)
   %9 = call %Array* @__quantum__rt__array_create_1d(i32 8, i64 1)

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestOpCall2.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestOpCall2.ll
@@ -1,9 +1,9 @@
 define void @Microsoft__Quantum__Testing__QIR__CNOT__ctl(%Array* %__controlQubits__, { %Qubit*, %Qubit* }* %0) {
 entry:
   call void @__quantum__rt__array_update_alias_count(%Array* %__controlQubits__, i64 1)
-  %1 = getelementptr { %Qubit*, %Qubit* }, { %Qubit*, %Qubit* }* %0, i64 0, i32 0
+  %1 = getelementptr inbounds { %Qubit*, %Qubit* }, { %Qubit*, %Qubit* }* %0, i32 0, i32 0
   %control = load %Qubit*, %Qubit** %1
-  %2 = getelementptr { %Qubit*, %Qubit* }, { %Qubit*, %Qubit* }* %0, i64 0, i32 1
+  %2 = getelementptr inbounds { %Qubit*, %Qubit* }, { %Qubit*, %Qubit* }* %0, i32 0, i32 1
   %target = load %Qubit*, %Qubit** %2
   %3 = call %Array* @__quantum__rt__array_create_1d(i32 8, i64 1)
   %4 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %3, i64 0)

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestPartials1.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestPartials1.ll
@@ -2,8 +2,8 @@
 entry:
   %0 = call %Tuple* @__quantum__rt__tuple_create(i64 ptrtoint ({ %Callable*, double }* getelementptr ({ %Callable*, double }, { %Callable*, double }* null, i32 1) to i64))
   %1 = bitcast %Tuple* %0 to { %Callable*, double }*
-  %2 = getelementptr { %Callable*, double }, { %Callable*, double }* %1, i64 0, i32 0
-  %3 = getelementptr { %Callable*, double }, { %Callable*, double }* %1, i64 0, i32 1
+  %2 = getelementptr inbounds { %Callable*, double }, { %Callable*, double }* %1, i32 0, i32 0
+  %3 = getelementptr inbounds { %Callable*, double }, { %Callable*, double }* %1, i32 0, i32 1
   %4 = call %Callable* @__quantum__rt__callable_create([4 x void (%Tuple*, %Tuple*, %Tuple*)*]* @Microsoft__Quantum__Intrinsic__Rz, [2 x void (%Tuple*, i64)*]* null, %Tuple* null)
   store %Callable* %4, %Callable** %2
   store double 2.500000e-01, double* %3
@@ -26,12 +26,12 @@ body__1:                                          ; preds = %header__1
   %qb = call %Qubit* @__quantum__rt__qubit_allocate()
   %6 = call %Tuple* @__quantum__rt__tuple_create(i64 ptrtoint (i1** getelementptr (i1*, i1** null, i32 1) to i64))
   %7 = bitcast %Tuple* %6 to { %Qubit* }*
-  %8 = getelementptr { %Qubit* }, { %Qubit* }* %7, i64 0, i32 0
+  %8 = getelementptr inbounds { %Qubit* }, { %Qubit* }* %7, i32 0, i32 0
   store %Qubit* %qb, %Qubit** %8
   call void @__quantum__rt__callable_invoke(%Callable* %rotate, %Tuple* %6, %Tuple* null)
   %9 = call %Tuple* @__quantum__rt__tuple_create(i64 ptrtoint (i1** getelementptr (i1*, i1** null, i32 1) to i64))
   %10 = bitcast %Tuple* %9 to { %Qubit* }*
-  %11 = getelementptr { %Qubit* }, { %Qubit* }* %10, i64 0, i32 0
+  %11 = getelementptr inbounds { %Qubit* }, { %Qubit* }* %10, i32 0, i32 0
   store %Qubit* %qb, %Qubit** %11
   call void @__quantum__rt__callable_invoke(%Callable* %unrotate, %Tuple* %9, %Tuple* null)
   %12 = call %Result* @__quantum__qis__mz(%Qubit* %qb)
@@ -43,23 +43,23 @@ body__1:                                          ; preds = %header__1
 then0__1:                                         ; preds = %body__1
   %16 = call %Tuple* @__quantum__rt__tuple_create(i64 ptrtoint ({ i64, double }* getelementptr ({ i64, double }, { i64, double }* null, i32 1) to i64))
   %tuple1 = bitcast %Tuple* %16 to { i64, double }*
-  %17 = getelementptr { i64, double }, { i64, double }* %tuple1, i64 0, i32 0
-  %18 = getelementptr { i64, double }, { i64, double }* %tuple1, i64 0, i32 1
+  %17 = getelementptr inbounds { i64, double }, { i64, double }* %tuple1, i32 0, i32 0
+  %18 = getelementptr inbounds { i64, double }, { i64, double }* %tuple1, i32 0, i32 1
   store i64 %a, i64* %17
   store double %b, double* %18
   call void @__quantum__rt__tuple_update_alias_count(%Tuple* %16, i64 1)
   %19 = call %Tuple* @__quantum__rt__tuple_create(i64 mul nuw (i64 ptrtoint (i1** getelementptr (i1*, i1** null, i32 1) to i64), i64 2))
   %tuple2 = bitcast %Tuple* %19 to { %String*, %Qubit* }*
-  %20 = getelementptr { %String*, %Qubit* }, { %String*, %Qubit* }* %tuple2, i64 0, i32 0
-  %21 = getelementptr { %String*, %Qubit* }, { %String*, %Qubit* }* %tuple2, i64 0, i32 1
+  %20 = getelementptr inbounds { %String*, %Qubit* }, { %String*, %Qubit* }* %tuple2, i32 0, i32 0
+  %21 = getelementptr inbounds { %String*, %Qubit* }, { %String*, %Qubit* }* %tuple2, i32 0, i32 1
   %22 = call %String* @__quantum__rt__string_create(i32 0, i8* null)
   store %String* %22, %String** %20
   store %Qubit* %qb, %Qubit** %21
   call void @__quantum__rt__tuple_update_alias_count(%Tuple* %19, i64 1)
   %23 = call %Tuple* @__quantum__rt__tuple_create(i64 mul nuw (i64 ptrtoint (i1** getelementptr (i1*, i1** null, i32 1) to i64), i64 2))
   %24 = bitcast %Tuple* %23 to { %Callable*, { i64, double }* }*
-  %25 = getelementptr { %Callable*, { i64, double }* }, { %Callable*, { i64, double }* }* %24, i64 0, i32 0
-  %26 = getelementptr { %Callable*, { i64, double }* }, { %Callable*, { i64, double }* }* %24, i64 0, i32 1
+  %25 = getelementptr inbounds { %Callable*, { i64, double }* }, { %Callable*, { i64, double }* }* %24, i32 0, i32 0
+  %26 = getelementptr inbounds { %Callable*, { i64, double }* }, { %Callable*, { i64, double }* }* %24, i32 0, i32 1
   %27 = call %Callable* @__quantum__rt__callable_create([4 x void (%Tuple*, %Tuple*, %Tuple*)*]* @Microsoft__Quantum__Testing__QIR__InnerNestedTuple, [2 x void (%Tuple*, i64)*]* null, %Tuple* null)
   store %Callable* %27, %Callable** %25
   store { i64, double }* %tuple1, { i64, double }** %26
@@ -68,8 +68,8 @@ then0__1:                                         ; preds = %body__1
   call void @__quantum__rt__callable_update_alias_count(%Callable* %partial1, i64 1)
   %28 = call %Tuple* @__quantum__rt__tuple_create(i64 mul nuw (i64 ptrtoint (i1** getelementptr (i1*, i1** null, i32 1) to i64), i64 2))
   %29 = bitcast %Tuple* %28 to { %Callable*, { %String*, %Qubit* }* }*
-  %30 = getelementptr { %Callable*, { %String*, %Qubit* }* }, { %Callable*, { %String*, %Qubit* }* }* %29, i64 0, i32 0
-  %31 = getelementptr { %Callable*, { %String*, %Qubit* }* }, { %Callable*, { %String*, %Qubit* }* }* %29, i64 0, i32 1
+  %30 = getelementptr inbounds { %Callable*, { %String*, %Qubit* }* }, { %Callable*, { %String*, %Qubit* }* }* %29, i32 0, i32 0
+  %31 = getelementptr inbounds { %Callable*, { %String*, %Qubit* }* }, { %Callable*, { %String*, %Qubit* }* }* %29, i32 0, i32 1
   %32 = call %Callable* @__quantum__rt__callable_create([4 x void (%Tuple*, %Tuple*, %Tuple*)*]* @Microsoft__Quantum__Testing__QIR__InnerNestedTuple, [2 x void (%Tuple*, i64)*]* null, %Tuple* null)
   store %Callable* %32, %Callable** %30
   store { %String*, %Qubit* }* %tuple2, { %String*, %Qubit* }** %31
@@ -80,8 +80,8 @@ then0__1:                                         ; preds = %body__1
   call void @__quantum__rt__callable_invoke(%Callable* %partial2, %Tuple* %16, %Tuple* null)
   %33 = call %Tuple* @__quantum__rt__tuple_create(i64 mul nuw (i64 ptrtoint (i1** getelementptr (i1*, i1** null, i32 1) to i64), i64 2))
   %34 = bitcast %Tuple* %33 to { %Callable*, { i64, double }* }*
-  %35 = getelementptr { %Callable*, { i64, double }* }, { %Callable*, { i64, double }* }* %34, i64 0, i32 0
-  %36 = getelementptr { %Callable*, { i64, double }* }, { %Callable*, { i64, double }* }* %34, i64 0, i32 1
+  %35 = getelementptr inbounds { %Callable*, { i64, double }* }, { %Callable*, { i64, double }* }* %34, i32 0, i32 0
+  %36 = getelementptr inbounds { %Callable*, { i64, double }* }, { %Callable*, { i64, double }* }* %34, i32 0, i32 1
   %37 = call %Callable* @__quantum__rt__callable_create([4 x void (%Tuple*, %Tuple*, %Tuple*)*]* @Microsoft__Quantum__Testing__QIR__TakesNestedTuple, [2 x void (%Tuple*, i64)*]* null, %Tuple* null)
   store %Callable* %37, %Callable** %35
   store { i64, double }* %tuple1, { i64, double }** %36
@@ -90,9 +90,9 @@ then0__1:                                         ; preds = %body__1
   call void @__quantum__rt__callable_update_alias_count(%Callable* %partial3, i64 1)
   %38 = call %Tuple* @__quantum__rt__tuple_create(i64 mul nuw (i64 ptrtoint (i1** getelementptr (i1*, i1** null, i32 1) to i64), i64 3))
   %39 = bitcast %Tuple* %38 to { %Callable*, %String*, %Qubit* }*
-  %40 = getelementptr { %Callable*, %String*, %Qubit* }, { %Callable*, %String*, %Qubit* }* %39, i64 0, i32 0
-  %41 = getelementptr { %Callable*, %String*, %Qubit* }, { %Callable*, %String*, %Qubit* }* %39, i64 0, i32 1
-  %42 = getelementptr { %Callable*, %String*, %Qubit* }, { %Callable*, %String*, %Qubit* }* %39, i64 0, i32 2
+  %40 = getelementptr inbounds { %Callable*, %String*, %Qubit* }, { %Callable*, %String*, %Qubit* }* %39, i32 0, i32 0
+  %41 = getelementptr inbounds { %Callable*, %String*, %Qubit* }, { %Callable*, %String*, %Qubit* }* %39, i32 0, i32 1
+  %42 = getelementptr inbounds { %Callable*, %String*, %Qubit* }, { %Callable*, %String*, %Qubit* }* %39, i32 0, i32 2
   %43 = call %Callable* @__quantum__rt__callable_create([4 x void (%Tuple*, %Tuple*, %Tuple*)*]* @Microsoft__Quantum__Testing__QIR__TakesNestedTuple, [2 x void (%Tuple*, i64)*]* null, %Tuple* null)
   %44 = call %String* @__quantum__rt__string_create(i32 0, i8* null)
   store %Callable* %43, %Callable** %40
@@ -127,8 +127,8 @@ then0__1:                                         ; preds = %body__1
 continue__1:                                      ; preds = %then0__1, %body__1
   %45 = call %Tuple* @__quantum__rt__tuple_create(i64 mul nuw (i64 ptrtoint (i1** getelementptr (i1*, i1** null, i32 1) to i64), i64 2))
   %46 = bitcast %Tuple* %45 to { %Callable*, %Callable* }*
-  %47 = getelementptr { %Callable*, %Callable* }, { %Callable*, %Callable* }* %46, i64 0, i32 0
-  %48 = getelementptr { %Callable*, %Callable* }, { %Callable*, %Callable* }* %46, i64 0, i32 1
+  %47 = getelementptr inbounds { %Callable*, %Callable* }, { %Callable*, %Callable* }* %46, i32 0, i32 0
+  %48 = getelementptr inbounds { %Callable*, %Callable* }, { %Callable*, %Callable* }* %46, i32 0, i32 1
   %49 = call %Callable* @__quantum__rt__callable_create([4 x void (%Tuple*, %Tuple*, %Tuple*)*]* @Microsoft__Quantum__Testing__QIR__ApplyToLittleEndian, [2 x void (%Tuple*, i64)*]* null, %Tuple* null)
   %50 = call %Callable* @__quantum__rt__callable_create([4 x void (%Tuple*, %Tuple*, %Tuple*)*]* @Microsoft__Quantum__Testing__QIR__Dummy, [2 x void (%Tuple*, i64)*]* null, %Tuple* null)
   call void @__quantum__rt__callable_make_adjoint(%Callable* %50)
@@ -143,7 +143,7 @@ continue__1:                                      ; preds = %then0__1, %body__1
   %56 = bitcast { %Array* }* %55 to %Tuple*
   call void @__quantum__rt__callable_invoke(%Callable* %51, %Tuple* %56, %Tuple* null)
   call void @__quantum__rt__qubit_release(%Qubit* %qb)
-  %57 = getelementptr { %Array* }, { %Array* }* %55, i64 0, i32 0
+  %57 = getelementptr inbounds { %Array* }, { %Array* }* %55, i32 0, i32 0
   %58 = load %Array*, %Array** %57
   call void @__quantum__rt__tuple_update_reference_count(%Tuple* %6, i64 -1)
   call void @__quantum__rt__tuple_update_reference_count(%Tuple* %9, i64 -1)

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestPartials2.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestPartials2.ll
@@ -1,8 +1,8 @@
 ﻿define void @Microsoft__Quantum__Intrinsic__Rz__body__wrapper(%Tuple* %capture-tuple, %Tuple* %arg-tuple, %Tuple* %result-tuple) {
 entry:
   %0 = bitcast %Tuple* %arg-tuple to { double, %Qubit* }*
-  %1 = getelementptr { double, %Qubit* }, { double, %Qubit* }* %0, i64 0, i32 0
-  %2 = getelementptr { double, %Qubit* }, { double, %Qubit* }* %0, i64 0, i32 1
+  %1 = getelementptr inbounds { double, %Qubit* }, { double, %Qubit* }* %0, i32 0, i32 0
+  %2 = getelementptr inbounds { double, %Qubit* }, { double, %Qubit* }* %0, i32 0, i32 1
   %3 = load double, double* %1
   %4 = load %Qubit*, %Qubit** %2
   call void @Microsoft__Quantum__Intrinsic__Rz__body(double %3, %Qubit* %4)
@@ -12,8 +12,8 @@ entry:
 define void @Microsoft__Quantum__Intrinsic__Rz__adj__wrapper(%Tuple* %capture-tuple, %Tuple* %arg-tuple, %Tuple* %result-tuple) {
 entry:
   %0 = bitcast %Tuple* %arg-tuple to { double, %Qubit* }*
-  %1 = getelementptr { double, %Qubit* }, { double, %Qubit* }* %0, i64 0, i32 0
-  %2 = getelementptr { double, %Qubit* }, { double, %Qubit* }* %0, i64 0, i32 1
+  %1 = getelementptr inbounds { double, %Qubit* }, { double, %Qubit* }* %0, i32 0, i32 0
+  %2 = getelementptr inbounds { double, %Qubit* }, { double, %Qubit* }* %0, i32 0, i32 1
   %3 = load double, double* %1
   %4 = load %Qubit*, %Qubit** %2
   call void @Microsoft__Quantum__Intrinsic__Rz__adj(double %3, %Qubit* %4)
@@ -23,8 +23,8 @@ entry:
 define void @Microsoft__Quantum__Intrinsic__Rz__ctl__wrapper(%Tuple* %capture-tuple, %Tuple* %arg-tuple, %Tuple* %result-tuple) {
 entry:
   %0 = bitcast %Tuple* %arg-tuple to { %Array*, { double, %Qubit* }* }*
-  %1 = getelementptr { %Array*, { double, %Qubit* }* }, { %Array*, { double, %Qubit* }* }* %0, i64 0, i32 0
-  %2 = getelementptr { %Array*, { double, %Qubit* }* }, { %Array*, { double, %Qubit* }* }* %0, i64 0, i32 1
+  %1 = getelementptr inbounds { %Array*, { double, %Qubit* }* }, { %Array*, { double, %Qubit* }* }* %0, i32 0, i32 0
+  %2 = getelementptr inbounds { %Array*, { double, %Qubit* }* }, { %Array*, { double, %Qubit* }* }* %0, i32 0, i32 1
   %3 = load %Array*, %Array** %1
   %4 = load { double, %Qubit* }*, { double, %Qubit* }** %2
   call void @Microsoft__Quantum__Intrinsic__Rz__ctl(%Array* %3, { double, %Qubit* }* %4)
@@ -34,8 +34,8 @@ entry:
 define void @Microsoft__Quantum__Intrinsic__Rz__ctladj__wrapper(%Tuple* %capture-tuple, %Tuple* %arg-tuple, %Tuple* %result-tuple) {
 entry:
   %0 = bitcast %Tuple* %arg-tuple to { %Array*, { double, %Qubit* }* }*
-  %1 = getelementptr { %Array*, { double, %Qubit* }* }, { %Array*, { double, %Qubit* }* }* %0, i64 0, i32 0
-  %2 = getelementptr { %Array*, { double, %Qubit* }* }, { %Array*, { double, %Qubit* }* }* %0, i64 0, i32 1
+  %1 = getelementptr inbounds { %Array*, { double, %Qubit* }* }, { %Array*, { double, %Qubit* }* }* %0, i32 0, i32 0
+  %2 = getelementptr inbounds { %Array*, { double, %Qubit* }* }, { %Array*, { double, %Qubit* }* }* %0, i32 0, i32 1
   %3 = load %Array*, %Array** %1
   %4 = load { double, %Qubit* }*, { double, %Qubit* }** %2
   call void @Microsoft__Quantum__Intrinsic__Rz__ctladj(%Array* %3, { double, %Qubit* }* %4)

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestPartials3.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestPartials3.ll
@@ -1,16 +1,16 @@
 ﻿define void @Lifted__PartialApplication__2__body__wrapper(%Tuple* %capture-tuple, %Tuple* %arg-tuple, %Tuple* %result-tuple) {
 entry:
   %0 = bitcast %Tuple* %capture-tuple to { %Callable*, { i64, double }* }*
-  %1 = getelementptr { %Callable*, { i64, double }* }, { %Callable*, { i64, double }* }* %0, i64 0, i32 1
+  %1 = getelementptr inbounds { %Callable*, { i64, double }* }, { %Callable*, { i64, double }* }* %0, i32 0, i32 1
   %2 = load { i64, double }*, { i64, double }** %1
   %3 = call %Tuple* @__quantum__rt__tuple_create(i64 mul nuw (i64 ptrtoint (i1** getelementptr (i1*, i1** null, i32 1) to i64), i64 2))
   %4 = bitcast %Tuple* %3 to { { i64, double }*, { %String*, %Qubit* }* }*
-  %5 = getelementptr { { i64, double }*, { %String*, %Qubit* }* }, { { i64, double }*, { %String*, %Qubit* }* }* %4, i64 0, i32 0
-  %6 = getelementptr { { i64, double }*, { %String*, %Qubit* }* }, { { i64, double }*, { %String*, %Qubit* }* }* %4, i64 0, i32 1
+  %5 = getelementptr inbounds { { i64, double }*, { %String*, %Qubit* }* }, { { i64, double }*, { %String*, %Qubit* }* }* %4, i32 0, i32 0
+  %6 = getelementptr inbounds { { i64, double }*, { %String*, %Qubit* }* }, { { i64, double }*, { %String*, %Qubit* }* }* %4, i32 0, i32 1
   store { i64, double }* %2, { i64, double }** %5
   %7 = bitcast %Tuple* %arg-tuple to { %String*, %Qubit* }*
   store { %String*, %Qubit* }* %7, { %String*, %Qubit* }** %6
-  %8 = getelementptr { %Callable*, { i64, double }* }, { %Callable*, { i64, double }* }* %0, i64 0, i32 0
+  %8 = getelementptr inbounds { %Callable*, { i64, double }* }, { %Callable*, { i64, double }* }* %0, i32 0, i32 0
   %9 = load %Callable*, %Callable** %8
   call void @__quantum__rt__callable_invoke(%Callable* %9, %Tuple* %3, %Tuple* %result-tuple)
   call void @__quantum__rt__tuple_update_reference_count(%Tuple* %3, i64 -1)

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestPartials4.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestPartials4.ll
@@ -1,16 +1,16 @@
 ﻿define void @Lifted__PartialApplication__2__adj__wrapper(%Tuple* %capture-tuple, %Tuple* %arg-tuple, %Tuple* %result-tuple) {
 entry:
   %0 = bitcast %Tuple* %capture-tuple to { %Callable*, { i64, double }* }*
-  %1 = getelementptr { %Callable*, { i64, double }* }, { %Callable*, { i64, double }* }* %0, i64 0, i32 1
+  %1 = getelementptr inbounds { %Callable*, { i64, double }* }, { %Callable*, { i64, double }* }* %0, i32 0, i32 1
   %2 = load { i64, double }*, { i64, double }** %1
   %3 = call %Tuple* @__quantum__rt__tuple_create(i64 mul nuw (i64 ptrtoint (i1** getelementptr (i1*, i1** null, i32 1) to i64), i64 2))
   %4 = bitcast %Tuple* %3 to { { i64, double }*, { %String*, %Qubit* }* }*
-  %5 = getelementptr { { i64, double }*, { %String*, %Qubit* }* }, { { i64, double }*, { %String*, %Qubit* }* }* %4, i64 0, i32 0
-  %6 = getelementptr { { i64, double }*, { %String*, %Qubit* }* }, { { i64, double }*, { %String*, %Qubit* }* }* %4, i64 0, i32 1
+  %5 = getelementptr inbounds { { i64, double }*, { %String*, %Qubit* }* }, { { i64, double }*, { %String*, %Qubit* }* }* %4, i32 0, i32 0
+  %6 = getelementptr inbounds { { i64, double }*, { %String*, %Qubit* }* }, { { i64, double }*, { %String*, %Qubit* }* }* %4, i32 0, i32 1
   store { i64, double }* %2, { i64, double }** %5
   %7 = bitcast %Tuple* %arg-tuple to { %String*, %Qubit* }*
   store { %String*, %Qubit* }* %7, { %String*, %Qubit* }** %6
-  %8 = getelementptr { %Callable*, { i64, double }* }, { %Callable*, { i64, double }* }* %0, i64 0, i32 0
+  %8 = getelementptr inbounds { %Callable*, { i64, double }* }, { %Callable*, { i64, double }* }* %0, i32 0, i32 0
   %9 = load %Callable*, %Callable** %8
   %10 = call %Callable* @__quantum__rt__callable_copy(%Callable* %9, i1 false)
   call void @__quantum__rt__callable_memory_management(i32 0, %Callable* %10, i64 1)
@@ -25,26 +25,26 @@ entry:
 define void @Lifted__PartialApplication__2__ctl__wrapper(%Tuple* %capture-tuple, %Tuple* %arg-tuple, %Tuple* %result-tuple) {
 entry:
   %0 = bitcast %Tuple* %arg-tuple to { %Array*, { %String*, %Qubit* }* }*
-  %1 = getelementptr { %Array*, { %String*, %Qubit* }* }, { %Array*, { %String*, %Qubit* }* }* %0, i64 0, i32 0
-  %2 = getelementptr { %Array*, { %String*, %Qubit* }* }, { %Array*, { %String*, %Qubit* }* }* %0, i64 0, i32 1
+  %1 = getelementptr inbounds { %Array*, { %String*, %Qubit* }* }, { %Array*, { %String*, %Qubit* }* }* %0, i32 0, i32 0
+  %2 = getelementptr inbounds { %Array*, { %String*, %Qubit* }* }, { %Array*, { %String*, %Qubit* }* }* %0, i32 0, i32 1
   %3 = load %Array*, %Array** %1
   %4 = load { %String*, %Qubit* }*, { %String*, %Qubit* }** %2
   %5 = bitcast %Tuple* %capture-tuple to { %Callable*, { i64, double }* }*
-  %6 = getelementptr { %Callable*, { i64, double }* }, { %Callable*, { i64, double }* }* %5, i64 0, i32 1
+  %6 = getelementptr inbounds { %Callable*, { i64, double }* }, { %Callable*, { i64, double }* }* %5, i32 0, i32 1
   %7 = load { i64, double }*, { i64, double }** %6
   %8 = call %Tuple* @__quantum__rt__tuple_create(i64 mul nuw (i64 ptrtoint (i1** getelementptr (i1*, i1** null, i32 1) to i64), i64 2))
   %9 = bitcast %Tuple* %8 to { { i64, double }*, { %String*, %Qubit* }* }*
-  %10 = getelementptr { { i64, double }*, { %String*, %Qubit* }* }, { { i64, double }*, { %String*, %Qubit* }* }* %9, i64 0, i32 0
-  %11 = getelementptr { { i64, double }*, { %String*, %Qubit* }* }, { { i64, double }*, { %String*, %Qubit* }* }* %9, i64 0, i32 1
+  %10 = getelementptr inbounds { { i64, double }*, { %String*, %Qubit* }* }, { { i64, double }*, { %String*, %Qubit* }* }* %9, i32 0, i32 0
+  %11 = getelementptr inbounds { { i64, double }*, { %String*, %Qubit* }* }, { { i64, double }*, { %String*, %Qubit* }* }* %9, i32 0, i32 1
   store { i64, double }* %7, { i64, double }** %10
   store { %String*, %Qubit* }* %4, { %String*, %Qubit* }** %11
   %12 = call %Tuple* @__quantum__rt__tuple_create(i64 mul nuw (i64 ptrtoint (i1** getelementptr (i1*, i1** null, i32 1) to i64), i64 2))
   %13 = bitcast %Tuple* %12 to { %Array*, { { i64, double }*, { %String*, %Qubit* }* }* }*
-  %14 = getelementptr { %Array*, { { i64, double }*, { %String*, %Qubit* }* }* }, { %Array*, { { i64, double }*, { %String*, %Qubit* }* }* }* %13, i64 0, i32 0
-  %15 = getelementptr { %Array*, { { i64, double }*, { %String*, %Qubit* }* }* }, { %Array*, { { i64, double }*, { %String*, %Qubit* }* }* }* %13, i64 0, i32 1
+  %14 = getelementptr inbounds { %Array*, { { i64, double }*, { %String*, %Qubit* }* }* }, { %Array*, { { i64, double }*, { %String*, %Qubit* }* }* }* %13, i32 0, i32 0
+  %15 = getelementptr inbounds { %Array*, { { i64, double }*, { %String*, %Qubit* }* }* }, { %Array*, { { i64, double }*, { %String*, %Qubit* }* }* }* %13, i32 0, i32 1
   store %Array* %3, %Array** %14
   store { { i64, double }*, { %String*, %Qubit* }* }* %9, { { i64, double }*, { %String*, %Qubit* }* }** %15
-  %16 = getelementptr { %Callable*, { i64, double }* }, { %Callable*, { i64, double }* }* %5, i64 0, i32 0
+  %16 = getelementptr inbounds { %Callable*, { i64, double }* }, { %Callable*, { i64, double }* }* %5, i32 0, i32 0
   %17 = load %Callable*, %Callable** %16
   %18 = call %Callable* @__quantum__rt__callable_copy(%Callable* %17, i1 false)
   call void @__quantum__rt__callable_memory_management(i32 0, %Callable* %18, i64 1)
@@ -60,26 +60,26 @@ entry:
 define void @Lifted__PartialApplication__2__ctladj__wrapper(%Tuple* %capture-tuple, %Tuple* %arg-tuple, %Tuple* %result-tuple) {
 entry:
   %0 = bitcast %Tuple* %arg-tuple to { %Array*, { %String*, %Qubit* }* }*
-  %1 = getelementptr { %Array*, { %String*, %Qubit* }* }, { %Array*, { %String*, %Qubit* }* }* %0, i64 0, i32 0
-  %2 = getelementptr { %Array*, { %String*, %Qubit* }* }, { %Array*, { %String*, %Qubit* }* }* %0, i64 0, i32 1
+  %1 = getelementptr inbounds { %Array*, { %String*, %Qubit* }* }, { %Array*, { %String*, %Qubit* }* }* %0, i32 0, i32 0
+  %2 = getelementptr inbounds { %Array*, { %String*, %Qubit* }* }, { %Array*, { %String*, %Qubit* }* }* %0, i32 0, i32 1
   %3 = load %Array*, %Array** %1
   %4 = load { %String*, %Qubit* }*, { %String*, %Qubit* }** %2
   %5 = bitcast %Tuple* %capture-tuple to { %Callable*, { i64, double }* }*
-  %6 = getelementptr { %Callable*, { i64, double }* }, { %Callable*, { i64, double }* }* %5, i64 0, i32 1
+  %6 = getelementptr inbounds { %Callable*, { i64, double }* }, { %Callable*, { i64, double }* }* %5, i32 0, i32 1
   %7 = load { i64, double }*, { i64, double }** %6
   %8 = call %Tuple* @__quantum__rt__tuple_create(i64 mul nuw (i64 ptrtoint (i1** getelementptr (i1*, i1** null, i32 1) to i64), i64 2))
   %9 = bitcast %Tuple* %8 to { { i64, double }*, { %String*, %Qubit* }* }*
-  %10 = getelementptr { { i64, double }*, { %String*, %Qubit* }* }, { { i64, double }*, { %String*, %Qubit* }* }* %9, i64 0, i32 0
-  %11 = getelementptr { { i64, double }*, { %String*, %Qubit* }* }, { { i64, double }*, { %String*, %Qubit* }* }* %9, i64 0, i32 1
+  %10 = getelementptr inbounds { { i64, double }*, { %String*, %Qubit* }* }, { { i64, double }*, { %String*, %Qubit* }* }* %9, i32 0, i32 0
+  %11 = getelementptr inbounds { { i64, double }*, { %String*, %Qubit* }* }, { { i64, double }*, { %String*, %Qubit* }* }* %9, i32 0, i32 1
   store { i64, double }* %7, { i64, double }** %10
   store { %String*, %Qubit* }* %4, { %String*, %Qubit* }** %11
   %12 = call %Tuple* @__quantum__rt__tuple_create(i64 mul nuw (i64 ptrtoint (i1** getelementptr (i1*, i1** null, i32 1) to i64), i64 2))
   %13 = bitcast %Tuple* %12 to { %Array*, { { i64, double }*, { %String*, %Qubit* }* }* }*
-  %14 = getelementptr { %Array*, { { i64, double }*, { %String*, %Qubit* }* }* }, { %Array*, { { i64, double }*, { %String*, %Qubit* }* }* }* %13, i64 0, i32 0
-  %15 = getelementptr { %Array*, { { i64, double }*, { %String*, %Qubit* }* }* }, { %Array*, { { i64, double }*, { %String*, %Qubit* }* }* }* %13, i64 0, i32 1
+  %14 = getelementptr inbounds { %Array*, { { i64, double }*, { %String*, %Qubit* }* }* }, { %Array*, { { i64, double }*, { %String*, %Qubit* }* }* }* %13, i32 0, i32 0
+  %15 = getelementptr inbounds { %Array*, { { i64, double }*, { %String*, %Qubit* }* }* }, { %Array*, { { i64, double }*, { %String*, %Qubit* }* }* }* %13, i32 0, i32 1
   store %Array* %3, %Array** %14
   store { { i64, double }*, { %String*, %Qubit* }* }* %9, { { i64, double }*, { %String*, %Qubit* }* }** %15
-  %16 = getelementptr { %Callable*, { i64, double }* }, { %Callable*, { i64, double }* }* %5, i64 0, i32 0
+  %16 = getelementptr inbounds { %Callable*, { i64, double }* }, { %Callable*, { i64, double }* }* %5, i32 0, i32 0
   %17 = load %Callable*, %Callable** %16
   %18 = call %Callable* @__quantum__rt__callable_copy(%Callable* %17, i1 false)
   call void @__quantum__rt__callable_memory_management(i32 0, %Callable* %18, i64 1)
@@ -90,5 +90,35 @@ entry:
   call void @__quantum__rt__tuple_update_reference_count(%Tuple* %12, i64 -1)
   call void @__quantum__rt__callable_memory_management(i32 0, %Callable* %18, i64 -1)
   call void @__quantum__rt__callable_update_reference_count(%Callable* %18, i64 -1)
+  ret void
+}
+
+define void @MemoryManagement__2__RefCount(%Tuple* %capture-tuple, i64 %count-change) {
+entry:
+  %0 = bitcast %Tuple* %capture-tuple to { %Callable*, { i64, double }* }*
+  %1 = getelementptr inbounds { %Callable*, { i64, double }* }, { %Callable*, { i64, double }* }* %0, i32 0, i32 0
+  %2 = load %Callable*, %Callable** %1
+  call void @__quantum__rt__callable_memory_management(i32 0, %Callable* %2, i64 %count-change)
+  call void @__quantum__rt__callable_update_reference_count(%Callable* %2, i64 %count-change)
+  %3 = getelementptr inbounds { %Callable*, { i64, double }* }, { %Callable*, { i64, double }* }* %0, i32 0, i32 1
+  %4 = load { i64, double }*, { i64, double }** %3
+  %5 = bitcast { i64, double }* %4 to %Tuple*
+  call void @__quantum__rt__tuple_update_reference_count(%Tuple* %5, i64 %count-change)
+  call void @__quantum__rt__tuple_update_reference_count(%Tuple* %capture-tuple, i64 %count-change)
+  ret void
+}
+
+define void @MemoryManagement__2__AliasCount(%Tuple* %capture-tuple, i64 %count-change) {
+entry:
+  %0 = bitcast %Tuple* %capture-tuple to { %Callable*, { i64, double }* }*
+  %1 = getelementptr inbounds { %Callable*, { i64, double }* }, { %Callable*, { i64, double }* }* %0, i32 0, i32 0
+  %2 = load %Callable*, %Callable** %1
+  call void @__quantum__rt__callable_memory_management(i32 1, %Callable* %2, i64 %count-change)
+  call void @__quantum__rt__callable_update_alias_count(%Callable* %2, i64 %count-change)
+  %3 = getelementptr inbounds { %Callable*, { i64, double }* }, { %Callable*, { i64, double }* }* %0, i32 0, i32 1
+  %4 = load { i64, double }*, { i64, double }** %3
+  %5 = bitcast { i64, double }* %4 to %Tuple*
+  call void @__quantum__rt__tuple_update_alias_count(%Tuple* %5, i64 %count-change)
+  call void @__quantum__rt__tuple_update_alias_count(%Tuple* %capture-tuple, i64 %count-change)
   ret void
 }

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestReferenceCounts.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestReferenceCounts.ll
@@ -1,0 +1,183 @@
+define void @Microsoft__Quantum__Testing__QIR__TestRefCountsForItemUpdate__body(i1 %cond) {
+entry:
+  %0 = call %Array* @__quantum__rt__array_create_1d(i32 8, i64 5)
+  br label %header__1
+
+header__1:                                        ; preds = %exiting__1, %entry
+  %1 = phi i64 [ 0, %entry ], [ %6, %exiting__1 ]
+  %2 = icmp sle i64 %1, 4
+  br i1 %2, label %body__1, label %exit__1
+
+body__1:                                          ; preds = %header__1
+  %3 = call %Array* @__quantum__rt__array_create_1d(i32 8, i64 0)
+  %4 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %0, i64 %1)
+  %5 = bitcast i8* %4 to %Array**
+  store %Array* %3, %Array** %5
+  br label %exiting__1
+
+exiting__1:                                       ; preds = %body__1
+  %6 = add i64 %1, 1
+  br label %header__1
+
+exit__1:                                          ; preds = %header__1
+  %ops = alloca %Array*
+  store %Array* %0, %Array** %ops
+  br label %header__2
+
+header__2:                                        ; preds = %exiting__2, %exit__1
+  %7 = phi i64 [ 0, %exit__1 ], [ %12, %exiting__2 ]
+  %8 = icmp sle i64 %7, 4
+  br i1 %8, label %body__2, label %exit__2
+
+body__2:                                          ; preds = %header__2
+  %9 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %0, i64 %7)
+  %10 = bitcast i8* %9 to %Array**
+  %11 = load %Array*, %Array** %10
+  call void @__quantum__rt__array_update_alias_count(%Array* %11, i64 1)
+  br label %exiting__2
+
+exiting__2:                                       ; preds = %body__2
+  %12 = add i64 %7, 1
+  br label %header__2
+
+exit__2:                                          ; preds = %header__2
+  call void @__quantum__rt__array_update_alias_count(%Array* %0, i64 1)
+  br label %header__3
+
+header__3:                                        ; preds = %exiting__3, %exit__2
+  %13 = phi i64 [ 0, %exit__2 ], [ %18, %exiting__3 ]
+  %14 = icmp sle i64 %13, 4
+  br i1 %14, label %body__3, label %exit__3
+
+body__3:                                          ; preds = %header__3
+  %15 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %0, i64 %13)
+  %16 = bitcast i8* %15 to %Array**
+  %17 = load %Array*, %Array** %16
+  call void @__quantum__rt__array_update_reference_count(%Array* %17, i64 1)
+  br label %exiting__3
+
+exiting__3:                                       ; preds = %body__3
+  %18 = add i64 %13, 1
+  br label %header__3
+
+exit__3:                                          ; preds = %header__3
+  call void @__quantum__rt__array_update_reference_count(%Array* %0, i64 1)
+  br i1 %cond, label %then0__1, label %continue__1
+
+then0__1:                                         ; preds = %exit__3
+  call void @__quantum__rt__array_update_alias_count(%Array* %0, i64 -1)
+  %19 = call { i1, %Array* }* @__quantum__rt__array_copy(%Array* %0, i1 false)
+  %20 = getelementptr { i1, %Array* }, { i1, %Array* }* %19, i64 0, i32 0
+  %21 = getelementptr { i1, %Array* }, { i1, %Array* }* %19, i64 0, i32 1
+  %22 = load i1, i1* %20
+  %23 = load %Array*, %Array** %21
+  %24 = call %Array* @__quantum__rt__array_create_1d(i32 8, i64 3)
+  br label %header__4
+
+continue__1:                                      ; preds = %condContinue__1, %exit__3
+  %25 = load %Array*, %Array** %ops
+  %26 = call i64 @__quantum__rt__array_get_size_1d(%Array* %25)
+  %27 = sub i64 %26, 1
+  br label %header__5
+
+header__4:                                        ; preds = %exiting__4, %then0__1
+  %28 = phi i64 [ 0, %then0__1 ], [ %32, %exiting__4 ]
+  %29 = icmp sle i64 %28, 2
+  br i1 %29, label %body__4, label %exit__4
+
+body__4:                                          ; preds = %header__4
+  %30 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %24, i64 %28)
+  %31 = bitcast i8* %30 to i64*
+  store i64 0, i64* %31
+  br label %exiting__4
+
+exiting__4:                                       ; preds = %body__4
+  %32 = add i64 %28, 1
+  br label %header__4
+
+exit__4:                                          ; preds = %header__4
+  %33 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %23, i64 0)
+  %34 = bitcast i8* %33 to %Array**
+  call void @__quantum__rt__array_update_reference_count(%Array* %24, i64 1)
+  call void @__quantum__rt__array_update_alias_count(%Array* %24, i64 1)
+  %35 = load %Array*, %Array** %34
+  call void @__quantum__rt__array_update_alias_count(%Array* %35, i64 -1)
+  br i1 %22, label %condContinue__1, label %condFalse__1
+
+condFalse__1:                                     ; preds = %exit__4
+  call void @__quantum__rt__array_update_reference_count(%Array* %24, i64 1)
+  call void @__quantum__rt__array_update_reference_count(%Array* %35, i64 -1)
+  br label %condContinue__1
+
+condContinue__1:                                  ; preds = %condFalse__1, %exit__4
+  store %Array* %24, %Array** %34
+  call void @__quantum__rt__array_update_reference_count(%Array* %23, i64 1)
+  call void @__quantum__rt__array_update_alias_count(%Array* %23, i64 1)
+  store %Array* %23, %Array** %ops
+  call void @__quantum__rt__array_update_reference_count(%Array* %0, i64 -1)
+  call void @__quantum__rt__array_update_reference_count(%Array* %24, i64 -1)
+  call void @__quantum__rt__array_update_reference_count(%Array* %35, i64 -1)
+  call void @__quantum__rt__array_update_reference_count(%Array* %23, i64 -1)
+  br label %continue__1
+
+header__5:                                        ; preds = %exiting__5, %continue__1
+  %36 = phi i64 [ 0, %continue__1 ], [ %41, %exiting__5 ]
+  %37 = icmp sle i64 %36, %27
+  br i1 %37, label %body__5, label %exit__5
+
+body__5:                                          ; preds = %header__5
+  %38 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %25, i64 %36)
+  %39 = bitcast i8* %38 to %Array**
+  %40 = load %Array*, %Array** %39
+  call void @__quantum__rt__array_update_alias_count(%Array* %40, i64 -1)
+  br label %exiting__5
+
+exiting__5:                                       ; preds = %body__5
+  %41 = add i64 %36, 1
+  br label %header__5
+
+exit__5:                                          ; preds = %header__5
+  call void @__quantum__rt__array_update_alias_count(%Array* %25, i64 -1)
+  br label %header__6
+
+header__6:                                        ; preds = %exiting__6, %exit__5
+  %42 = phi i64 [ 0, %exit__5 ], [ %47, %exiting__6 ]
+  %43 = icmp sle i64 %42, 4
+  br i1 %43, label %body__6, label %exit__6
+
+body__6:                                          ; preds = %header__6
+  %44 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %0, i64 %42)
+  %45 = bitcast i8* %44 to %Array**
+  %46 = load %Array*, %Array** %45
+  call void @__quantum__rt__array_update_reference_count(%Array* %46, i64 -1)
+  br label %exiting__6
+
+exiting__6:                                       ; preds = %body__6
+  %47 = add i64 %42, 1
+  br label %header__6
+
+exit__6:                                          ; preds = %header__6
+  call void @__quantum__rt__array_update_reference_count(%Array* %0, i64 -1)
+  %48 = sub i64 %26, 1
+  br label %header__7
+
+header__7:                                        ; preds = %exiting__7, %exit__6
+  %49 = phi i64 [ 0, %exit__6 ], [ %54, %exiting__7 ]
+  %50 = icmp sle i64 %49, %48
+  br i1 %50, label %body__7, label %exit__7
+
+body__7:                                          ; preds = %header__7
+  %51 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %25, i64 %49)
+  %52 = bitcast i8* %51 to %Array**
+  %53 = load %Array*, %Array** %52
+  call void @__quantum__rt__array_update_reference_count(%Array* %53, i64 -1)
+  br label %exiting__7
+
+exiting__7:                                       ; preds = %body__7
+  %54 = add i64 %49, 1
+  br label %header__7
+
+exit__7:                                          ; preds = %header__7
+  call void @__quantum__rt__array_update_reference_count(%Array* %25, i64 -1)
+  ret void
+}

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestReferenceCounts.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestReferenceCounts.ll
@@ -66,118 +66,115 @@ exit__3:                                          ; preds = %header__3
 
 then0__1:                                         ; preds = %exit__3
   call void @__quantum__rt__array_update_alias_count(%Array* %0, i64 -1)
-  %19 = call { i1, %Array* }* @__quantum__rt__array_copy(%Array* %0, i1 false)
-  %20 = getelementptr { i1, %Array* }, { i1, %Array* }* %19, i64 0, i32 0
-  %21 = getelementptr { i1, %Array* }, { i1, %Array* }* %19, i64 0, i32 1
-  %22 = load i1, i1* %20
-  %23 = load %Array*, %Array** %21
-  %24 = call %Array* @__quantum__rt__array_create_1d(i32 8, i64 3)
+  %19 = call %Array* @__quantum__rt__array_copy(%Array* %0, i1 false)
+  %20 = icmp ne %Array* %0, %19
+  %21 = call %Array* @__quantum__rt__array_create_1d(i32 8, i64 3)
   br label %header__4
 
 continue__1:                                      ; preds = %condContinue__1, %exit__3
-  %25 = load %Array*, %Array** %ops
-  %26 = call i64 @__quantum__rt__array_get_size_1d(%Array* %25)
-  %27 = sub i64 %26, 1
+  %22 = load %Array*, %Array** %ops
+  %23 = call i64 @__quantum__rt__array_get_size_1d(%Array* %22)
+  %24 = sub i64 %23, 1
   br label %header__5
 
 header__4:                                        ; preds = %exiting__4, %then0__1
-  %28 = phi i64 [ 0, %then0__1 ], [ %32, %exiting__4 ]
-  %29 = icmp sle i64 %28, 2
-  br i1 %29, label %body__4, label %exit__4
+  %25 = phi i64 [ 0, %then0__1 ], [ %29, %exiting__4 ]
+  %26 = icmp sle i64 %25, 2
+  br i1 %26, label %body__4, label %exit__4
 
 body__4:                                          ; preds = %header__4
-  %30 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %24, i64 %28)
-  %31 = bitcast i8* %30 to i64*
-  store i64 0, i64* %31
+  %27 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %21, i64 %25)
+  %28 = bitcast i8* %27 to i64*
+  store i64 0, i64* %28
   br label %exiting__4
 
 exiting__4:                                       ; preds = %body__4
-  %32 = add i64 %28, 1
+  %29 = add i64 %25, 1
   br label %header__4
 
 exit__4:                                          ; preds = %header__4
-  %33 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %23, i64 0)
-  %34 = bitcast i8* %33 to %Array**
-  call void @__quantum__rt__array_update_reference_count(%Array* %24, i64 1)
-  call void @__quantum__rt__array_update_alias_count(%Array* %24, i64 1)
-  %35 = load %Array*, %Array** %34
-  call void @__quantum__rt__array_update_alias_count(%Array* %35, i64 -1)
-  br i1 %22, label %condContinue__1, label %condFalse__1
+  %30 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %19, i64 0)
+  %31 = bitcast i8* %30 to %Array**
+  call void @__quantum__rt__array_update_reference_count(%Array* %21, i64 1)
+  call void @__quantum__rt__array_update_alias_count(%Array* %21, i64 1)
+  %32 = load %Array*, %Array** %31
+  call void @__quantum__rt__array_update_alias_count(%Array* %32, i64 -1)
+  br i1 %20, label %condContinue__1, label %condFalse__1
 
 condFalse__1:                                     ; preds = %exit__4
-  call void @__quantum__rt__array_update_reference_count(%Array* %24, i64 1)
-  call void @__quantum__rt__array_update_reference_count(%Array* %35, i64 -1)
+  call void @__quantum__rt__array_update_reference_count(%Array* %21, i64 1)
+  call void @__quantum__rt__array_update_reference_count(%Array* %32, i64 -1)
   br label %condContinue__1
 
 condContinue__1:                                  ; preds = %condFalse__1, %exit__4
-  store %Array* %24, %Array** %34
-  call void @__quantum__rt__array_update_reference_count(%Array* %23, i64 1)
-  call void @__quantum__rt__array_update_alias_count(%Array* %23, i64 1)
-  store %Array* %23, %Array** %ops
+  store %Array* %21, %Array** %31
+  call void @__quantum__rt__array_update_reference_count(%Array* %19, i64 1)
+  call void @__quantum__rt__array_update_alias_count(%Array* %19, i64 1)
+  store %Array* %19, %Array** %ops
   call void @__quantum__rt__array_update_reference_count(%Array* %0, i64 -1)
-  call void @__quantum__rt__array_update_reference_count(%Array* %24, i64 -1)
-  call void @__quantum__rt__array_update_reference_count(%Array* %35, i64 -1)
-  call void @__quantum__rt__array_update_reference_count(%Array* %23, i64 -1)
+  call void @__quantum__rt__array_update_reference_count(%Array* %21, i64 -1)
+  call void @__quantum__rt__array_update_reference_count(%Array* %32, i64 -1)
+  call void @__quantum__rt__array_update_reference_count(%Array* %19, i64 -1)
   br label %continue__1
 
 header__5:                                        ; preds = %exiting__5, %continue__1
-  %36 = phi i64 [ 0, %continue__1 ], [ %41, %exiting__5 ]
-  %37 = icmp sle i64 %36, %27
-  br i1 %37, label %body__5, label %exit__5
+  %33 = phi i64 [ 0, %continue__1 ], [ %38, %exiting__5 ]
+  %34 = icmp sle i64 %33, %24
+  br i1 %34, label %body__5, label %exit__5
 
 body__5:                                          ; preds = %header__5
-  %38 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %25, i64 %36)
-  %39 = bitcast i8* %38 to %Array**
-  %40 = load %Array*, %Array** %39
-  call void @__quantum__rt__array_update_alias_count(%Array* %40, i64 -1)
+  %35 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %22, i64 %33)
+  %36 = bitcast i8* %35 to %Array**
+  %37 = load %Array*, %Array** %36
+  call void @__quantum__rt__array_update_alias_count(%Array* %37, i64 -1)
   br label %exiting__5
 
 exiting__5:                                       ; preds = %body__5
-  %41 = add i64 %36, 1
+  %38 = add i64 %33, 1
   br label %header__5
 
 exit__5:                                          ; preds = %header__5
-  call void @__quantum__rt__array_update_alias_count(%Array* %25, i64 -1)
+  call void @__quantum__rt__array_update_alias_count(%Array* %22, i64 -1)
   br label %header__6
 
 header__6:                                        ; preds = %exiting__6, %exit__5
-  %42 = phi i64 [ 0, %exit__5 ], [ %47, %exiting__6 ]
-  %43 = icmp sle i64 %42, 4
-  br i1 %43, label %body__6, label %exit__6
+  %39 = phi i64 [ 0, %exit__5 ], [ %44, %exiting__6 ]
+  %40 = icmp sle i64 %39, 4
+  br i1 %40, label %body__6, label %exit__6
 
 body__6:                                          ; preds = %header__6
-  %44 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %0, i64 %42)
-  %45 = bitcast i8* %44 to %Array**
-  %46 = load %Array*, %Array** %45
-  call void @__quantum__rt__array_update_reference_count(%Array* %46, i64 -1)
+  %41 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %0, i64 %39)
+  %42 = bitcast i8* %41 to %Array**
+  %43 = load %Array*, %Array** %42
+  call void @__quantum__rt__array_update_reference_count(%Array* %43, i64 -1)
   br label %exiting__6
 
 exiting__6:                                       ; preds = %body__6
-  %47 = add i64 %42, 1
+  %44 = add i64 %39, 1
   br label %header__6
 
 exit__6:                                          ; preds = %header__6
   call void @__quantum__rt__array_update_reference_count(%Array* %0, i64 -1)
-  %48 = sub i64 %26, 1
+  %45 = sub i64 %23, 1
   br label %header__7
 
 header__7:                                        ; preds = %exiting__7, %exit__6
-  %49 = phi i64 [ 0, %exit__6 ], [ %54, %exiting__7 ]
-  %50 = icmp sle i64 %49, %48
-  br i1 %50, label %body__7, label %exit__7
+  %46 = phi i64 [ 0, %exit__6 ], [ %51, %exiting__7 ]
+  %47 = icmp sle i64 %46, %45
+  br i1 %47, label %body__7, label %exit__7
 
 body__7:                                          ; preds = %header__7
-  %51 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %25, i64 %49)
-  %52 = bitcast i8* %51 to %Array**
-  %53 = load %Array*, %Array** %52
-  call void @__quantum__rt__array_update_reference_count(%Array* %53, i64 -1)
+  %48 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %22, i64 %46)
+  %49 = bitcast i8* %48 to %Array**
+  %50 = load %Array*, %Array** %49
+  call void @__quantum__rt__array_update_reference_count(%Array* %50, i64 -1)
   br label %exiting__7
 
 exiting__7:                                       ; preds = %body__7
-  %54 = add i64 %49, 1
+  %51 = add i64 %46, 1
   br label %header__7
 
 exit__7:                                          ; preds = %header__7
-  call void @__quantum__rt__array_update_reference_count(%Array* %25, i64 -1)
+  call void @__quantum__rt__array_update_reference_count(%Array* %22, i64 -1)
   ret void
 }

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestReferenceCounts.qs
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestReferenceCounts.qs
@@ -1,0 +1,12 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace Microsoft.Quantum.Testing.QIR {
+
+    function TestRefCountsForItemUpdate(cond : Bool) : Unit {
+        mutable ops = new Int[][5];
+        if (cond) {
+            set ops w/= 0 <- new Int[3];
+        }
+    }
+}

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestRepeat.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestRepeat.ll
@@ -4,7 +4,7 @@ entry:
   store i64 0, i64* %n
   br label %repeat__1
 
-repeat__1:                                        ; preds = %continue__1, %entry
+repeat__1:                                        ; preds = %condContinue__2, %entry
   call void @__quantum__qis__t__body(%Qubit* %q)
   call void @__quantum__qis__x__body(%Qubit* %q)
   call void @__quantum__qis__t__adj(%Qubit* %q)
@@ -22,88 +22,106 @@ repeat__1:                                        ; preds = %continue__1, %entry
   call void @__quantum__rt__tuple_update_reference_count(%Tuple* %2, i64 1)
   call void @__quantum__rt__tuple_update_alias_count(%Tuple* %2, i64 -1)
   %5 = call %Tuple* @__quantum__rt__tuple_copy(%Tuple* %2, i1 false)
-  %6 = bitcast %Tuple* %5 to { double, %String* }*
-  %7 = getelementptr { double, %String* }, { double, %String* }* %6, i64 0, i32 1
+  %6 = icmp ne %Tuple* %2, %5
+  %7 = bitcast %Tuple* %5 to { double, %String* }*
+  %8 = getelementptr { double, %String* }, { double, %String* }* %7, i64 0, i32 1
   call void @__quantum__rt__string_update_reference_count(%String* %name, i64 1)
-  %8 = load %String*, %String** %7
-  store %String* %name, %String** %7
+  %9 = load %String*, %String** %8
+  br i1 %6, label %condContinue__1, label %condFalse__1
+
+condFalse__1:                                     ; preds = %repeat__1
+  call void @__quantum__rt__string_update_reference_count(%String* %name, i64 1)
+  call void @__quantum__rt__string_update_reference_count(%String* %9, i64 -1)
+  br label %condContinue__1
+
+condContinue__1:                                  ; preds = %condFalse__1, %repeat__1
+  store %String* %name, %String** %8
   call void @__quantum__rt__tuple_update_reference_count(%Tuple* %5, i64 1)
   call void @__quantum__rt__tuple_update_alias_count(%Tuple* %5, i64 1)
-  store { double, %String* }* %6, { double, %String* }** %res
-  %9 = load i64, i64* %n
-  %10 = add i64 %9, 1
-  store i64 %10, i64* %n
+  store { double, %String* }* %7, { double, %String* }** %res
+  %10 = load i64, i64* %n
+  %11 = add i64 %10, 1
+  store i64 %11, i64* %n
   br label %until__1
 
-until__1:                                         ; preds = %repeat__1
-  %11 = call %Result* @__quantum__qis__mz(%Qubit* %q)
-  %12 = load %Result*, %Result** @ResultZero
-  %13 = call i1 @__quantum__rt__result_equal(%Result* %11, %Result* %12)
+until__1:                                         ; preds = %condContinue__1
+  %12 = call %Result* @__quantum__qis__mz(%Qubit* %q)
+  %13 = load %Result*, %Result** @ResultZero
+  %14 = call i1 @__quantum__rt__result_equal(%Result* %12, %Result* %13)
   call void @__quantum__rt__string_update_reference_count(%String* %name, i64 1)
   call void @__quantum__rt__tuple_update_reference_count(%Tuple* %5, i64 1)
-  br i1 %13, label %rend__1, label %fixup__1
+  br i1 %14, label %rend__1, label %fixup__1
 
 fixup__1:                                         ; preds = %until__1
-  %14 = icmp sgt i64 %10, 100
-  br i1 %14, label %then0__1, label %continue__1
+  %15 = icmp sgt i64 %11, 100
+  br i1 %15, label %then0__1, label %continue__1
 
 then0__1:                                         ; preds = %fixup__1
-  %15 = call %String* @__quantum__rt__string_create(i32 19, i8* getelementptr inbounds ([20 x i8], [20 x i8]* @1, i32 0, i32 0))
-  %16 = load %String*, %String** %3
-  %17 = load %String*, %String** %7
-  %18 = load { double, %String* }*, { double, %String* }** %res
-  %19 = bitcast { double, %String* }* %18 to %Tuple*
-  call void @__quantum__rt__tuple_update_alias_count(%Tuple* %19, i64 -1)
+  %16 = call %String* @__quantum__rt__string_create(i32 19, i8* getelementptr inbounds ([20 x i8], [20 x i8]* @1, i32 0, i32 0))
+  %17 = load %String*, %String** %3
+  %18 = load %String*, %String** %8
+  %19 = load { double, %String* }*, { double, %String* }** %res
+  %20 = bitcast { double, %String* }* %19 to %Tuple*
+  call void @__quantum__rt__tuple_update_alias_count(%Tuple* %20, i64 -1)
   call void @__quantum__rt__string_update_reference_count(%String* %name, i64 -1)
   call void @__quantum__rt__string_update_reference_count(%String* %0, i64 -1)
-  call void @__quantum__rt__string_update_reference_count(%String* %16, i64 -1)
-  call void @__quantum__rt__tuple_update_reference_count(%Tuple* %2, i64 -1)
-  call void @__quantum__rt__tuple_update_reference_count(%Tuple* %2, i64 -1)
   call void @__quantum__rt__string_update_reference_count(%String* %17, i64 -1)
+  call void @__quantum__rt__tuple_update_reference_count(%Tuple* %2, i64 -1)
+  call void @__quantum__rt__tuple_update_reference_count(%Tuple* %2, i64 -1)
+  call void @__quantum__rt__string_update_reference_count(%String* %18, i64 -1)
   call void @__quantum__rt__tuple_update_reference_count(%Tuple* %5, i64 -1)
-  call void @__quantum__rt__string_update_reference_count(%String* %8, i64 -1)
+  call void @__quantum__rt__string_update_reference_count(%String* %9, i64 -1)
   call void @__quantum__rt__tuple_update_reference_count(%Tuple* %5, i64 -1)
-  call void @__quantum__rt__result_update_reference_count(%Result* %11, i64 -1)
-  %20 = getelementptr { double, %String* }, { double, %String* }* %18, i64 0, i32 1
-  %21 = load %String*, %String** %20
-  call void @__quantum__rt__string_update_reference_count(%String* %21, i64 -1)
-  call void @__quantum__rt__tuple_update_reference_count(%Tuple* %19, i64 -1)
-  call void @__quantum__rt__fail(%String* %15)
+  call void @__quantum__rt__result_update_reference_count(%Result* %12, i64 -1)
+  %21 = getelementptr { double, %String* }, { double, %String* }* %19, i64 0, i32 1
+  %22 = load %String*, %String** %21
+  call void @__quantum__rt__string_update_reference_count(%String* %22, i64 -1)
+  call void @__quantum__rt__tuple_update_reference_count(%Tuple* %20, i64 -1)
+  call void @__quantum__rt__fail(%String* %16)
   unreachable
 
 continue__1:                                      ; preds = %fixup__1
-  %22 = load { double, %String* }*, { double, %String* }** %res
-  %23 = bitcast { double, %String* }* %22 to %Tuple*
-  call void @__quantum__rt__tuple_update_alias_count(%Tuple* %23, i64 -1)
-  %24 = call %Tuple* @__quantum__rt__tuple_copy(%Tuple* %23, i1 false)
-  %25 = bitcast %Tuple* %24 to { double, %String* }*
-  %26 = getelementptr { double, %String* }, { double, %String* }* %25, i64 0, i32 1
-  %27 = call %String* @__quantum__rt__string_create(i32 0, i8* null)
-  call void @__quantum__rt__string_update_reference_count(%String* %27, i64 1)
-  %28 = load %String*, %String** %26
-  store %String* %27, %String** %26
-  call void @__quantum__rt__tuple_update_reference_count(%Tuple* %24, i64 1)
-  call void @__quantum__rt__tuple_update_alias_count(%Tuple* %24, i64 1)
-  store { double, %String* }* %25, { double, %String* }** %res
-  %29 = load %String*, %String** %3
-  %30 = load %String*, %String** %7
+  %23 = load { double, %String* }*, { double, %String* }** %res
+  %24 = bitcast { double, %String* }* %23 to %Tuple*
   call void @__quantum__rt__tuple_update_alias_count(%Tuple* %24, i64 -1)
+  %25 = call %Tuple* @__quantum__rt__tuple_copy(%Tuple* %24, i1 false)
+  %26 = icmp ne %Tuple* %24, %25
+  %27 = bitcast %Tuple* %25 to { double, %String* }*
+  %28 = getelementptr { double, %String* }, { double, %String* }* %27, i64 0, i32 1
+  %29 = call %String* @__quantum__rt__string_create(i32 0, i8* null)
+  call void @__quantum__rt__string_update_reference_count(%String* %29, i64 1)
+  %30 = load %String*, %String** %28
+  br i1 %26, label %condContinue__2, label %condFalse__2
+
+condFalse__2:                                     ; preds = %continue__1
+  call void @__quantum__rt__string_update_reference_count(%String* %29, i64 1)
+  call void @__quantum__rt__string_update_reference_count(%String* %30, i64 -1)
+  br label %condContinue__2
+
+condContinue__2:                                  ; preds = %condFalse__2, %continue__1
+  store %String* %29, %String** %28
+  call void @__quantum__rt__tuple_update_reference_count(%Tuple* %25, i64 1)
+  call void @__quantum__rt__tuple_update_alias_count(%Tuple* %25, i64 1)
+  store { double, %String* }* %27, { double, %String* }** %res
+  %31 = load %String*, %String** %3
+  %32 = load %String*, %String** %8
+  call void @__quantum__rt__tuple_update_alias_count(%Tuple* %25, i64 -1)
   call void @__quantum__rt__string_update_reference_count(%String* %name, i64 -1)
   call void @__quantum__rt__string_update_reference_count(%String* %0, i64 -1)
+  call void @__quantum__rt__string_update_reference_count(%String* %31, i64 -1)
+  call void @__quantum__rt__tuple_update_reference_count(%Tuple* %2, i64 -1)
+  call void @__quantum__rt__tuple_update_reference_count(%Tuple* %2, i64 -1)
+  call void @__quantum__rt__string_update_reference_count(%String* %32, i64 -1)
+  call void @__quantum__rt__tuple_update_reference_count(%Tuple* %5, i64 -1)
+  call void @__quantum__rt__string_update_reference_count(%String* %9, i64 -1)
+  call void @__quantum__rt__tuple_update_reference_count(%Tuple* %5, i64 -1)
+  call void @__quantum__rt__result_update_reference_count(%Result* %12, i64 -1)
+  call void @__quantum__rt__tuple_update_reference_count(%Tuple* %24, i64 -1)
   call void @__quantum__rt__string_update_reference_count(%String* %29, i64 -1)
-  call void @__quantum__rt__tuple_update_reference_count(%Tuple* %2, i64 -1)
-  call void @__quantum__rt__tuple_update_reference_count(%Tuple* %2, i64 -1)
   call void @__quantum__rt__string_update_reference_count(%String* %30, i64 -1)
-  call void @__quantum__rt__tuple_update_reference_count(%Tuple* %5, i64 -1)
-  call void @__quantum__rt__string_update_reference_count(%String* %8, i64 -1)
-  call void @__quantum__rt__tuple_update_reference_count(%Tuple* %5, i64 -1)
-  call void @__quantum__rt__result_update_reference_count(%Result* %11, i64 -1)
-  call void @__quantum__rt__tuple_update_reference_count(%Tuple* %23, i64 -1)
-  call void @__quantum__rt__string_update_reference_count(%String* %27, i64 -1)
-  call void @__quantum__rt__string_update_reference_count(%String* %28, i64 -1)
-  call void @__quantum__rt__tuple_update_reference_count(%Tuple* %24, i64 -1)
-  call void @__quantum__rt__string_update_reference_count(%String* %27, i64 -1)
-  call void @__quantum__rt__tuple_update_reference_count(%Tuple* %24, i64 -1)
+  call void @__quantum__rt__tuple_update_reference_count(%Tuple* %25, i64 -1)
+  call void @__quantum__rt__string_update_reference_count(%String* %29, i64 -1)
+  call void @__quantum__rt__tuple_update_reference_count(%Tuple* %25, i64 -1)
   br label %repeat__1
 
 rend__1:                                          ; preds = %until__1
@@ -115,11 +133,11 @@ rend__1:                                          ; preds = %until__1
   call void @__quantum__rt__tuple_update_reference_count(%Tuple* %2, i64 -1)
   call void @__quantum__rt__string_update_reference_count(%String* %name, i64 -1)
   call void @__quantum__rt__tuple_update_reference_count(%Tuple* %5, i64 -1)
-  call void @__quantum__rt__string_update_reference_count(%String* %8, i64 -1)
+  call void @__quantum__rt__string_update_reference_count(%String* %9, i64 -1)
   call void @__quantum__rt__tuple_update_reference_count(%Tuple* %5, i64 -1)
-  call void @__quantum__rt__result_update_reference_count(%Result* %11, i64 -1)
+  call void @__quantum__rt__result_update_reference_count(%Result* %12, i64 -1)
   call void @__quantum__rt__string_update_reference_count(%String* %name, i64 -1)
   call void @__quantum__rt__tuple_update_reference_count(%Tuple* %5, i64 -1)
-  %31 = load i64, i64* %n
-  ret i64 %31
+  %33 = load i64, i64* %n
+  ret i64 %33
 }

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestRepeat.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestRepeat.ll
@@ -16,7 +16,7 @@ repeat__1:                                        ; preds = %condContinue__2, %e
   store { double, %String* }* %1, { double, %String* }** %res
   %2 = bitcast { double, %String* }* %1 to %Tuple*
   call void @__quantum__rt__tuple_update_alias_count(%Tuple* %2, i64 1)
-  %3 = getelementptr { double, %String* }, { double, %String* }* %1, i64 0, i32 1
+  %3 = getelementptr inbounds { double, %String* }, { double, %String* }* %1, i32 0, i32 1
   %4 = load %String*, %String** %3
   call void @__quantum__rt__string_update_reference_count(%String* %4, i64 1)
   call void @__quantum__rt__tuple_update_reference_count(%Tuple* %2, i64 1)
@@ -24,7 +24,7 @@ repeat__1:                                        ; preds = %condContinue__2, %e
   %5 = call %Tuple* @__quantum__rt__tuple_copy(%Tuple* %2, i1 false)
   %6 = icmp ne %Tuple* %2, %5
   %7 = bitcast %Tuple* %5 to { double, %String* }*
-  %8 = getelementptr { double, %String* }, { double, %String* }* %7, i64 0, i32 1
+  %8 = getelementptr inbounds { double, %String* }, { double, %String* }* %7, i32 0, i32 1
   call void @__quantum__rt__string_update_reference_count(%String* %name, i64 1)
   %9 = load %String*, %String** %8
   br i1 %6, label %condContinue__1, label %condFalse__1
@@ -73,7 +73,7 @@ then0__1:                                         ; preds = %fixup__1
   call void @__quantum__rt__string_update_reference_count(%String* %9, i64 -1)
   call void @__quantum__rt__tuple_update_reference_count(%Tuple* %5, i64 -1)
   call void @__quantum__rt__result_update_reference_count(%Result* %12, i64 -1)
-  %21 = getelementptr { double, %String* }, { double, %String* }* %19, i64 0, i32 1
+  %21 = getelementptr inbounds { double, %String* }, { double, %String* }* %19, i32 0, i32 1
   %22 = load %String*, %String** %21
   call void @__quantum__rt__string_update_reference_count(%String* %22, i64 -1)
   call void @__quantum__rt__tuple_update_reference_count(%Tuple* %20, i64 -1)
@@ -87,7 +87,7 @@ continue__1:                                      ; preds = %fixup__1
   %25 = call %Tuple* @__quantum__rt__tuple_copy(%Tuple* %24, i1 false)
   %26 = icmp ne %Tuple* %24, %25
   %27 = bitcast %Tuple* %25 to { double, %String* }*
-  %28 = getelementptr { double, %String* }, { double, %String* }* %27, i64 0, i32 1
+  %28 = getelementptr inbounds { double, %String* }, { double, %String* }* %27, i32 0, i32 1
   %29 = call %String* @__quantum__rt__string_create(i32 0, i8* null)
   call void @__quantum__rt__string_update_reference_count(%String* %29, i64 1)
   %30 = load %String*, %String** %28

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestScoping.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestScoping.ll
@@ -65,8 +65,8 @@ exiting__2:                                       ; preds = %body__2
 exit__2:                                          ; preds = %header__2
   %20 = call %Tuple* @__quantum__rt__tuple_create(i64 ptrtoint ({ %Callable*, i64 }* getelementptr ({ %Callable*, i64 }, { %Callable*, i64 }* null, i32 1) to i64))
   %21 = bitcast %Tuple* %20 to { %Callable*, i64 }*
-  %22 = getelementptr { %Callable*, i64 }, { %Callable*, i64 }* %21, i64 0, i32 0
-  %23 = getelementptr { %Callable*, i64 }, { %Callable*, i64 }* %21, i64 0, i32 1
+  %22 = getelementptr inbounds { %Callable*, i64 }, { %Callable*, i64 }* %21, i32 0, i32 0
+  %23 = getelementptr inbounds { %Callable*, i64 }, { %Callable*, i64 }* %21, i32 0, i32 1
   %24 = call %Callable* @__quantum__rt__callable_create([4 x void (%Tuple*, %Tuple*, %Tuple*)*]* @Microsoft__Quantum__Testing__QIR__Foo, [2 x void (%Tuple*, i64)*]* null, %Tuple* null)
   store %Callable* %24, %Callable** %22
   store i64 1, i64* %23

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestUdt.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestUdt.ll
@@ -2,8 +2,8 @@ define { { i2, i64 }*, double }* @Microsoft__Quantum__Testing__QIR__TestType__bo
 entry:
   %1 = call %Tuple* @__quantum__rt__tuple_create(i64 ptrtoint ({ { i2, i64 }*, double }* getelementptr ({ { i2, i64 }*, double }, { { i2, i64 }*, double }* null, i32 1) to i64))
   %2 = bitcast %Tuple* %1 to { { i2, i64 }*, double }*
-  %3 = getelementptr { { i2, i64 }*, double }, { { i2, i64 }*, double }* %2, i64 0, i32 0
-  %4 = getelementptr { { i2, i64 }*, double }, { { i2, i64 }*, double }* %2, i64 0, i32 1
+  %3 = getelementptr inbounds { { i2, i64 }*, double }, { { i2, i64 }*, double }* %2, i32 0, i32 0
+  %4 = getelementptr inbounds { { i2, i64 }*, double }, { { i2, i64 }*, double }* %2, i32 0, i32 1
   store { i2, i64 }* %0, { i2, i64 }** %3
   store double %D, double* %4
   %5 = bitcast { i2, i64 }* %0 to %Tuple*

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestUdtAccessor.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestUdtAccessor.ll
@@ -2,19 +2,19 @@ define i64 @Microsoft__Quantum__Testing__QIR__TestAccessors__body() {
 entry:
   %0 = call %Tuple* @__quantum__rt__tuple_create(i64 ptrtoint ({ i2, i64 }* getelementptr ({ i2, i64 }, { i2, i64 }* null, i32 1) to i64))
   %1 = bitcast %Tuple* %0 to { i2, i64 }*
-  %2 = getelementptr { i2, i64 }, { i2, i64 }* %1, i64 0, i32 0
-  %3 = getelementptr { i2, i64 }, { i2, i64 }* %1, i64 0, i32 1
+  %2 = getelementptr inbounds { i2, i64 }, { i2, i64 }* %1, i32 0, i32 0
+  %3 = getelementptr inbounds { i2, i64 }, { i2, i64 }* %1, i32 0, i32 1
   %4 = load i2, i2* @PauliX
   store i2 %4, i2* %2
   store i64 1, i64* %3
   %x = call { { i2, i64 }*, double }* @Microsoft__Quantum__Testing__QIR__TestType__body({ i2, i64 }* %1, double 2.000000e+00)
-  %5 = getelementptr { { i2, i64 }*, double }, { { i2, i64 }*, double }* %x, i64 0, i32 0
+  %5 = getelementptr inbounds { { i2, i64 }*, double }, { { i2, i64 }*, double }* %x, i32 0, i32 0
   %6 = load { i2, i64 }*, { i2, i64 }** %5
   %7 = bitcast { i2, i64 }* %6 to %Tuple*
   call void @__quantum__rt__tuple_update_alias_count(%Tuple* %7, i64 1)
   %8 = bitcast { { i2, i64 }*, double }* %x to %Tuple*
   call void @__quantum__rt__tuple_update_alias_count(%Tuple* %8, i64 1)
-  %9 = getelementptr { i2, i64 }, { i2, i64 }* %6, i64 0, i32 1
+  %9 = getelementptr inbounds { i2, i64 }, { i2, i64 }* %6, i32 0, i32 1
   %y = load i64, i64* %9
   call void @__quantum__rt__tuple_update_alias_count(%Tuple* %7, i64 -1)
   call void @__quantum__rt__tuple_update_alias_count(%Tuple* %8, i64 -1)
@@ -28,8 +28,8 @@ define { { i2, i64 }*, double }* @Microsoft__Quantum__Testing__QIR__TestType__bo
 entry:
   %1 = call %Tuple* @__quantum__rt__tuple_create(i64 ptrtoint ({ { i2, i64 }*, double }* getelementptr ({ { i2, i64 }*, double }, { { i2, i64 }*, double }* null, i32 1) to i64))
   %2 = bitcast %Tuple* %1 to { { i2, i64 }*, double }*
-  %3 = getelementptr { { i2, i64 }*, double }, { { i2, i64 }*, double }* %2, i64 0, i32 0
-  %4 = getelementptr { { i2, i64 }*, double }, { { i2, i64 }*, double }* %2, i64 0, i32 1
+  %3 = getelementptr inbounds { { i2, i64 }*, double }, { { i2, i64 }*, double }* %2, i32 0, i32 0
+  %4 = getelementptr inbounds { { i2, i64 }*, double }, { { i2, i64 }*, double }* %2, i32 0, i32 1
   store { i2, i64 }* %0, { i2, i64 }** %3
   store double %D, double* %4
   %5 = bitcast { i2, i64 }* %0 to %Tuple*

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestUdtArgument.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestUdtArgument.ll
@@ -6,8 +6,8 @@ entry:
   call void @__quantum__rt__tuple_update_alias_count(%Tuple* %1, i64 1)
   %2 = call %Tuple* @__quantum__rt__tuple_create(i64 ptrtoint ({ %Callable*, i2 }* getelementptr ({ %Callable*, i2 }, { %Callable*, i2 }* null, i32 1) to i64))
   %3 = bitcast %Tuple* %2 to { %Callable*, i2 }*
-  %4 = getelementptr { %Callable*, i2 }, { %Callable*, i2 }* %3, i64 0, i32 0
-  %5 = getelementptr { %Callable*, i2 }, { %Callable*, i2 }* %3, i64 0, i32 1
+  %4 = getelementptr inbounds { %Callable*, i2 }, { %Callable*, i2 }* %3, i32 0, i32 0
+  %5 = getelementptr inbounds { %Callable*, i2 }, { %Callable*, i2 }* %3, i32 0, i32 1
   %6 = call %Callable* @__quantum__rt__callable_create([4 x void (%Tuple*, %Tuple*, %Tuple*)*]* @Microsoft__Quantum__Testing__QIR__TestType2, [2 x void (%Tuple*, i64)*]* null, %Tuple* null)
   %7 = load i2, i2* @PauliX
   store %Callable* %6, %Callable** %4
@@ -18,9 +18,9 @@ entry:
   call void @__quantum__rt__tuple_update_alias_count(%Tuple* %9, i64 1)
   %10 = call %Tuple* @__quantum__rt__tuple_create(i64 ptrtoint ({ %Callable*, i2, double }* getelementptr ({ %Callable*, i2, double }, { %Callable*, i2, double }* null, i32 1) to i64))
   %11 = bitcast %Tuple* %10 to { %Callable*, i2, double }*
-  %12 = getelementptr { %Callable*, i2, double }, { %Callable*, i2, double }* %11, i64 0, i32 0
-  %13 = getelementptr { %Callable*, i2, double }, { %Callable*, i2, double }* %11, i64 0, i32 1
-  %14 = getelementptr { %Callable*, i2, double }, { %Callable*, i2, double }* %11, i64 0, i32 2
+  %12 = getelementptr inbounds { %Callable*, i2, double }, { %Callable*, i2, double }* %11, i32 0, i32 0
+  %13 = getelementptr inbounds { %Callable*, i2, double }, { %Callable*, i2, double }* %11, i32 0, i32 1
+  %14 = getelementptr inbounds { %Callable*, i2, double }, { %Callable*, i2, double }* %11, i32 0, i32 2
   %15 = call %Callable* @__quantum__rt__callable_create([4 x void (%Tuple*, %Tuple*, %Tuple*)*]* @Microsoft__Quantum__Testing__QIR__TestType3, [2 x void (%Tuple*, i64)*]* null, %Tuple* null)
   %16 = load i2, i2* @PauliX
   store %Callable* %15, %Callable** %12
@@ -28,7 +28,7 @@ entry:
   store double 2.000000e+00, double* %14
   %17 = call %Callable* @__quantum__rt__callable_create([4 x void (%Tuple*, %Tuple*, %Tuple*)*]* @PartialApplication__2, [2 x void (%Tuple*, i64)*]* @MemoryManagement__2, %Tuple* %10)
   %udt3 = call { { i2, i64 }*, double }* @Microsoft__Quantum__Testing__QIR_____GUID___Build__body(%Callable* %17)
-  %18 = getelementptr { { i2, i64 }*, double }, { { i2, i64 }*, double }* %udt3, i64 0, i32 0
+  %18 = getelementptr inbounds { { i2, i64 }*, double }, { { i2, i64 }*, double }* %udt3, i32 0, i32 0
   %19 = load { i2, i64 }*, { i2, i64 }** %18
   %20 = bitcast { i2, i64 }* %19 to %Tuple*
   call void @__quantum__rt__tuple_update_alias_count(%Tuple* %20, i64 1)
@@ -36,9 +36,9 @@ entry:
   call void @__quantum__rt__tuple_update_alias_count(%Tuple* %21, i64 1)
   %22 = call %Tuple* @__quantum__rt__tuple_create(i64 ptrtoint ({ i64, { i2, i64 }* }* getelementptr ({ i64, { i2, i64 }* }, { i64, { i2, i64 }* }* null, i32 1) to i64))
   %23 = bitcast %Tuple* %22 to { i64, { i2, i64 }* }*
-  %24 = getelementptr { i64, { i2, i64 }* }, { i64, { i2, i64 }* }* %23, i64 0, i32 0
-  %25 = getelementptr { i64, { i2, i64 }* }, { i64, { i2, i64 }* }* %23, i64 0, i32 1
-  %26 = getelementptr { i64 }, { i64 }* %udt1, i64 0, i32 0
+  %24 = getelementptr inbounds { i64, { i2, i64 }* }, { i64, { i2, i64 }* }* %23, i32 0, i32 0
+  %25 = getelementptr inbounds { i64, { i2, i64 }* }, { i64, { i2, i64 }* }* %23, i32 0, i32 1
+  %26 = getelementptr inbounds { i64 }, { i64 }* %udt1, i32 0, i32 0
   %27 = load i64, i64* %26
   store i64 %27, i64* %24
   store { i2, i64 }* %udt2, { i2, i64 }** %25

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestUdtConstruction.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestUdtConstruction.ll
@@ -2,8 +2,8 @@ define { { i2, i64 }*, double }* @Microsoft__Quantum__Testing__QIR__TestUdtConst
 entry:
   %0 = call %Tuple* @__quantum__rt__tuple_create(i64 mul nuw (i64 ptrtoint (double* getelementptr (double, double* null, i32 1) to i64), i64 2))
   %args = bitcast %Tuple* %0 to { double, double }*
-  %1 = getelementptr { double, double }, { double, double }* %args, i64 0, i32 0
-  %2 = getelementptr { double, double }, { double, double }* %args, i64 0, i32 1
+  %1 = getelementptr inbounds { double, double }, { double, double }* %args, i32 0, i32 0
+  %2 = getelementptr inbounds { double, double }, { double, double }* %args, i32 0, i32 1
   store double 1.000000e+00, double* %1
   store double 2.000000e+00, double* %2
   call void @__quantum__rt__tuple_update_alias_count(%Tuple* %0, i64 1)
@@ -12,8 +12,8 @@ entry:
   call void @__quantum__rt__tuple_update_alias_count(%Tuple* %3, i64 1)
   %4 = call %Tuple* @__quantum__rt__tuple_create(i64 ptrtoint ({ i2, i64 }* getelementptr ({ i2, i64 }, { i2, i64 }* null, i32 1) to i64))
   %5 = bitcast %Tuple* %4 to { i2, i64 }*
-  %6 = getelementptr { i2, i64 }, { i2, i64 }* %5, i64 0, i32 0
-  %7 = getelementptr { i2, i64 }, { i2, i64 }* %5, i64 0, i32 1
+  %6 = getelementptr inbounds { i2, i64 }, { i2, i64 }* %5, i32 0, i32 0
+  %7 = getelementptr inbounds { i2, i64 }, { i2, i64 }* %5, i32 0, i32 1
   %8 = load i2, i2* @PauliX
   store i2 %8, i2* %6
   store i64 1, i64* %7

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestUdtUpdate1.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestUdtUpdate1.ll
@@ -22,35 +22,53 @@ entry:
   call void @__quantum__rt__tuple_update_reference_count(%Tuple* %8, i64 1)
   call void @__quantum__rt__tuple_update_alias_count(%Tuple* %8, i64 -1)
   %11 = call %Tuple* @__quantum__rt__tuple_copy(%Tuple* %8, i1 false)
-  %12 = bitcast %Tuple* %11 to { { double, %String* }*, i64 }*
-  %13 = getelementptr { { double, %String* }*, i64 }, { { double, %String* }*, i64 }* %12, i64 0, i32 0
-  %14 = load { double, %String* }*, { double, %String* }** %13
-  %15 = bitcast { double, %String* }* %14 to %Tuple*
-  %16 = call %Tuple* @__quantum__rt__tuple_copy(%Tuple* %15, i1 false)
-  call void @__quantum__rt__tuple_update_reference_count(%Tuple* %16, i64 1)
-  call void @__quantum__rt__tuple_update_alias_count(%Tuple* %16, i64 1)
-  call void @__quantum__rt__tuple_update_alias_count(%Tuple* %15, i64 -1)
-  %17 = bitcast %Tuple* %16 to { double, %String* }*
-  store { double, %String* }* %17, { double, %String* }** %13
-  %18 = getelementptr { double, %String* }, { double, %String* }* %17, i64 0, i32 1
-  %19 = call %String* @__quantum__rt__string_create(i32 5, i8* getelementptr inbounds ([6 x i8], [6 x i8]* @0, i32 0, i32 0))
-  call void @__quantum__rt__string_update_reference_count(%String* %19, i64 1)
-  %20 = load %String*, %String** %18
-  store %String* %19, %String** %18
+  %12 = icmp ne %Tuple* %8, %11
+  %13 = bitcast %Tuple* %11 to { { double, %String* }*, i64 }*
+  %14 = getelementptr { { double, %String* }*, i64 }, { { double, %String* }*, i64 }* %13, i64 0, i32 0
+  %15 = load { double, %String* }*, { double, %String* }** %14
+  %16 = bitcast { double, %String* }* %15 to %Tuple*
+  %17 = call %Tuple* @__quantum__rt__tuple_copy(%Tuple* %16, i1 false)
+  %18 = icmp ne %Tuple* %16, %17
+  call void @__quantum__rt__tuple_update_reference_count(%Tuple* %17, i64 1)
+  call void @__quantum__rt__tuple_update_alias_count(%Tuple* %17, i64 1)
+  call void @__quantum__rt__tuple_update_alias_count(%Tuple* %16, i64 -1)
+  br i1 %18, label %condContinue__1, label %condFalse__1
+
+condFalse__1:                                     ; preds = %entry
+  %19 = bitcast %Tuple* %17 to { double, %String* }*
+  call void @__quantum__rt__tuple_update_reference_count(%Tuple* %17, i64 1)
+  call void @__quantum__rt__tuple_update_reference_count(%Tuple* %16, i64 -1)
+  br label %condContinue__1
+
+condContinue__1:                                  ; preds = %condFalse__1, %entry
+  store { double, %String* }* %19, { double, %String* }** %14
+  %20 = getelementptr { double, %String* }, { double, %String* }* %19, i64 0, i32 1
+  %21 = call %String* @__quantum__rt__string_create(i32 5, i8* getelementptr inbounds ([6 x i8], [6 x i8]* @0, i32 0, i32 0))
+  call void @__quantum__rt__string_update_reference_count(%String* %21, i64 1)
+  %22 = load %String*, %String** %20
+  br i1 %12, label %condContinue__2, label %condFalse__2
+
+condFalse__2:                                     ; preds = %condContinue__1
+  call void @__quantum__rt__string_update_reference_count(%String* %21, i64 1)
+  call void @__quantum__rt__string_update_reference_count(%String* %22, i64 -1)
+  br label %condContinue__2
+
+condContinue__2:                                  ; preds = %condFalse__2, %condContinue__1
+  store %String* %21, %String** %20
   call void @__quantum__rt__tuple_update_reference_count(%Tuple* %11, i64 1)
   call void @__quantum__rt__tuple_update_alias_count(%Tuple* %11, i64 1)
-  store { { double, %String* }*, i64 }* %12, { { double, %String* }*, i64 }** %x
-  call void @__quantum__rt__tuple_update_alias_count(%Tuple* %16, i64 -1)
+  store { { double, %String* }*, i64 }* %13, { { double, %String* }*, i64 }** %x
+  call void @__quantum__rt__tuple_update_alias_count(%Tuple* %17, i64 -1)
   call void @__quantum__rt__tuple_update_alias_count(%Tuple* %11, i64 -1)
   call void @__quantum__rt__tuple_update_reference_count(%Tuple* %0, i64 -1)
   call void @__quantum__rt__string_update_reference_count(%String* %10, i64 -1)
   call void @__quantum__rt__tuple_update_reference_count(%Tuple* %7, i64 -1)
   call void @__quantum__rt__tuple_update_reference_count(%Tuple* %8, i64 -1)
   call void @__quantum__rt__tuple_update_reference_count(%Tuple* %8, i64 -1)
-  call void @__quantum__rt__tuple_update_reference_count(%Tuple* %15, i64 -1)
-  call void @__quantum__rt__string_update_reference_count(%String* %19, i64 -1)
-  call void @__quantum__rt__string_update_reference_count(%String* %20, i64 -1)
   call void @__quantum__rt__tuple_update_reference_count(%Tuple* %16, i64 -1)
+  call void @__quantum__rt__string_update_reference_count(%String* %21, i64 -1)
+  call void @__quantum__rt__string_update_reference_count(%String* %22, i64 -1)
+  call void @__quantum__rt__tuple_update_reference_count(%Tuple* %17, i64 -1)
   call void @__quantum__rt__tuple_update_reference_count(%Tuple* %11, i64 -1)
-  ret { { double, %String* }*, i64 }* %12
+  ret { { double, %String* }*, i64 }* %13
 }

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestUdtUpdate1.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestUdtUpdate1.ll
@@ -2,20 +2,20 @@ define { { double, %String* }*, i64 }* @Microsoft__Quantum__Testing__QIR__TestUd
 entry:
   %0 = call %Tuple* @__quantum__rt__tuple_create(i64 ptrtoint ({ double, %String* }* getelementptr ({ double, %String* }, { double, %String* }* null, i32 1) to i64))
   %1 = bitcast %Tuple* %0 to { double, %String* }*
-  %2 = getelementptr { double, %String* }, { double, %String* }* %1, i64 0, i32 0
-  %3 = getelementptr { double, %String* }, { double, %String* }* %1, i64 0, i32 1
+  %2 = getelementptr inbounds { double, %String* }, { double, %String* }* %1, i32 0, i32 0
+  %3 = getelementptr inbounds { double, %String* }, { double, %String* }* %1, i32 0, i32 1
   store double 1.000000e+00, double* %2
   store %String* %a, %String** %3
   %4 = call { { double, %String* }*, i64 }* @Microsoft__Quantum__Testing__QIR__TestType__body({ double, %String* }* %1, i64 %b)
   %x = alloca { { double, %String* }*, i64 }*
   store { { double, %String* }*, i64 }* %4, { { double, %String* }*, i64 }** %x
-  %5 = getelementptr { { double, %String* }*, i64 }, { { double, %String* }*, i64 }* %4, i64 0, i32 0
+  %5 = getelementptr inbounds { { double, %String* }*, i64 }, { { double, %String* }*, i64 }* %4, i32 0, i32 0
   %6 = load { double, %String* }*, { double, %String* }** %5
   %7 = bitcast { double, %String* }* %6 to %Tuple*
   call void @__quantum__rt__tuple_update_alias_count(%Tuple* %7, i64 1)
   %8 = bitcast { { double, %String* }*, i64 }* %4 to %Tuple*
   call void @__quantum__rt__tuple_update_alias_count(%Tuple* %8, i64 1)
-  %9 = getelementptr { double, %String* }, { double, %String* }* %6, i64 0, i32 1
+  %9 = getelementptr inbounds { double, %String* }, { double, %String* }* %6, i32 0, i32 1
   %10 = load %String*, %String** %9
   call void @__quantum__rt__string_update_reference_count(%String* %10, i64 1)
   call void @__quantum__rt__tuple_update_reference_count(%Tuple* %7, i64 1)
@@ -24,7 +24,7 @@ entry:
   %11 = call %Tuple* @__quantum__rt__tuple_copy(%Tuple* %8, i1 false)
   %12 = icmp ne %Tuple* %8, %11
   %13 = bitcast %Tuple* %11 to { { double, %String* }*, i64 }*
-  %14 = getelementptr { { double, %String* }*, i64 }, { { double, %String* }*, i64 }* %13, i64 0, i32 0
+  %14 = getelementptr inbounds { { double, %String* }*, i64 }, { { double, %String* }*, i64 }* %13, i32 0, i32 0
   %15 = load { double, %String* }*, { double, %String* }** %14
   %16 = bitcast { double, %String* }* %15 to %Tuple*
   %17 = call %Tuple* @__quantum__rt__tuple_copy(%Tuple* %16, i1 false)
@@ -42,7 +42,7 @@ condFalse__1:                                     ; preds = %entry
 
 condContinue__1:                                  ; preds = %condFalse__1, %entry
   store { double, %String* }* %19, { double, %String* }** %14
-  %20 = getelementptr { double, %String* }, { double, %String* }* %19, i64 0, i32 1
+  %20 = getelementptr inbounds { double, %String* }, { double, %String* }* %19, i32 0, i32 1
   %21 = call %String* @__quantum__rt__string_create(i32 5, i8* getelementptr inbounds ([6 x i8], [6 x i8]* @0, i32 0, i32 0))
   call void @__quantum__rt__string_update_reference_count(%String* %21, i64 1)
   %22 = load %String*, %String** %20

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestUdtUpdate2.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestUdtUpdate2.ll
@@ -28,86 +28,113 @@ entry:
 then0__1:                                         ; preds = %entry
   call void @__quantum__rt__tuple_update_alias_count(%Tuple* %6, i64 -1)
   %11 = call %Tuple* @__quantum__rt__tuple_copy(%Tuple* %6, i1 false)
-  %12 = bitcast %Tuple* %11 to { %String*, { double, double }*, { double, double }* }*
-  %13 = getelementptr { %String*, { double, double }*, { double, double }* }, { %String*, { double, double }*, { double, double }* }* %12, i64 0, i32 1
-  %14 = call { double, double }* @Microsoft__Quantum__Testing__QIR__Complex__body(double 0.000000e+00, double 0.000000e+00)
-  %15 = bitcast { double, double }* %14 to %Tuple*
-  call void @__quantum__rt__tuple_update_reference_count(%Tuple* %15, i64 1)
-  call void @__quantum__rt__tuple_update_alias_count(%Tuple* %15, i64 1)
-  %16 = load { double, double }*, { double, double }** %13
-  %17 = bitcast { double, double }* %16 to %Tuple*
-  call void @__quantum__rt__tuple_update_alias_count(%Tuple* %17, i64 -1)
-  store { double, double }* %14, { double, double }** %13
+  %12 = icmp ne %Tuple* %6, %11
+  %13 = bitcast %Tuple* %11 to { %String*, { double, double }*, { double, double }* }*
+  %14 = getelementptr { %String*, { double, double }*, { double, double }* }, { %String*, { double, double }*, { double, double }* }* %13, i64 0, i32 1
+  %15 = call { double, double }* @Microsoft__Quantum__Testing__QIR__Complex__body(double 0.000000e+00, double 0.000000e+00)
+  %16 = bitcast { double, double }* %15 to %Tuple*
+  call void @__quantum__rt__tuple_update_reference_count(%Tuple* %16, i64 1)
+  call void @__quantum__rt__tuple_update_alias_count(%Tuple* %16, i64 1)
+  %17 = load { double, double }*, { double, double }** %14
+  %18 = bitcast { double, double }* %17 to %Tuple*
+  call void @__quantum__rt__tuple_update_alias_count(%Tuple* %18, i64 -1)
+  br i1 %12, label %condContinue__1, label %condFalse__1
+
+condFalse__1:                                     ; preds = %then0__1
+  call void @__quantum__rt__tuple_update_reference_count(%Tuple* %16, i64 1)
+  call void @__quantum__rt__tuple_update_reference_count(%Tuple* %18, i64 -1)
+  br label %condContinue__1
+
+condContinue__1:                                  ; preds = %condFalse__1, %then0__1
+  store { double, double }* %15, { double, double }** %14
   call void @__quantum__rt__tuple_update_reference_count(%Tuple* %11, i64 1)
   call void @__quantum__rt__tuple_update_alias_count(%Tuple* %11, i64 1)
-  store { %String*, { double, double }*, { double, double }* }* %12, { %String*, { double, double }*, { double, double }* }** %namedValue
+  store { %String*, { double, double }*, { double, double }* }* %13, { %String*, { double, double }*, { double, double }* }** %namedValue
   br i1 %cond, label %then0__2, label %continue__2
 
-then0__2:                                         ; preds = %then0__1
+then0__2:                                         ; preds = %condContinue__1
   call void @__quantum__rt__tuple_update_alias_count(%Tuple* %11, i64 -1)
-  %18 = call %Tuple* @__quantum__rt__tuple_copy(%Tuple* %11, i1 false)
-  %19 = bitcast %Tuple* %18 to { %String*, { double, double }*, { double, double }* }*
-  %20 = getelementptr { %String*, { double, double }*, { double, double }* }, { %String*, { double, double }*, { double, double }* }* %19, i64 0, i32 1
-  %21 = call { double, double }* @Microsoft__Quantum__Testing__QIR__Complex__body(double 1.000000e+00, double 0.000000e+00)
-  %22 = bitcast { double, double }* %21 to %Tuple*
-  call void @__quantum__rt__tuple_update_reference_count(%Tuple* %22, i64 1)
-  call void @__quantum__rt__tuple_update_alias_count(%Tuple* %22, i64 1)
-  %23 = load { double, double }*, { double, double }** %20
+  %19 = call %Tuple* @__quantum__rt__tuple_copy(%Tuple* %11, i1 false)
+  %20 = icmp ne %Tuple* %11, %19
+  %21 = bitcast %Tuple* %19 to { %String*, { double, double }*, { double, double }* }*
+  %22 = getelementptr { %String*, { double, double }*, { double, double }* }, { %String*, { double, double }*, { double, double }* }* %21, i64 0, i32 1
+  %23 = call { double, double }* @Microsoft__Quantum__Testing__QIR__Complex__body(double 1.000000e+00, double 0.000000e+00)
   %24 = bitcast { double, double }* %23 to %Tuple*
-  call void @__quantum__rt__tuple_update_alias_count(%Tuple* %24, i64 -1)
-  store { double, double }* %21, { double, double }** %20
-  call void @__quantum__rt__tuple_update_reference_count(%Tuple* %18, i64 1)
-  call void @__quantum__rt__tuple_update_alias_count(%Tuple* %18, i64 1)
-  store { %String*, { double, double }*, { double, double }* }* %19, { %String*, { double, double }*, { double, double }* }** %namedValue
+  call void @__quantum__rt__tuple_update_reference_count(%Tuple* %24, i64 1)
+  call void @__quantum__rt__tuple_update_alias_count(%Tuple* %24, i64 1)
+  %25 = load { double, double }*, { double, double }** %22
+  %26 = bitcast { double, double }* %25 to %Tuple*
+  call void @__quantum__rt__tuple_update_alias_count(%Tuple* %26, i64 -1)
+  br i1 %20, label %condContinue__2, label %condFalse__2
+
+condFalse__2:                                     ; preds = %then0__2
+  call void @__quantum__rt__tuple_update_reference_count(%Tuple* %24, i64 1)
+  call void @__quantum__rt__tuple_update_reference_count(%Tuple* %26, i64 -1)
+  br label %condContinue__2
+
+condContinue__2:                                  ; preds = %condFalse__2, %then0__2
+  store { double, double }* %23, { double, double }** %22
+  call void @__quantum__rt__tuple_update_reference_count(%Tuple* %19, i64 1)
+  call void @__quantum__rt__tuple_update_alias_count(%Tuple* %19, i64 1)
+  store { %String*, { double, double }*, { double, double }* }* %21, { %String*, { double, double }*, { double, double }* }** %namedValue
   call void @__quantum__rt__tuple_update_reference_count(%Tuple* %11, i64 -1)
-  call void @__quantum__rt__tuple_update_reference_count(%Tuple* %22, i64 -1)
   call void @__quantum__rt__tuple_update_reference_count(%Tuple* %24, i64 -1)
-  call void @__quantum__rt__tuple_update_reference_count(%Tuple* %18, i64 -1)
+  call void @__quantum__rt__tuple_update_reference_count(%Tuple* %26, i64 -1)
+  call void @__quantum__rt__tuple_update_reference_count(%Tuple* %19, i64 -1)
   br label %continue__2
 
-continue__2:                                      ; preds = %then0__2, %then0__1
-  %25 = load { %String*, { double, double }*, { double, double }* }*, { %String*, { double, double }*, { double, double }* }** %namedValue
-  %26 = bitcast { %String*, { double, double }*, { double, double }* }* %25 to %Tuple*
-  call void @__quantum__rt__tuple_update_alias_count(%Tuple* %26, i64 -1)
-  %27 = call %Tuple* @__quantum__rt__tuple_copy(%Tuple* %26, i1 false)
-  %28 = bitcast %Tuple* %27 to { %String*, { double, double }*, { double, double }* }*
-  %29 = getelementptr { %String*, { double, double }*, { double, double }* }, { %String*, { double, double }*, { double, double }* }* %28, i64 0, i32 2
-  %30 = getelementptr { %String*, { double, double }*, { double, double }* }, { %String*, { double, double }*, { double, double }* }* %25, i64 0, i32 1
-  %31 = load { double, double }*, { double, double }** %30
-  %32 = bitcast { double, double }* %31 to %Tuple*
-  call void @__quantum__rt__tuple_update_reference_count(%Tuple* %32, i64 1)
-  call void @__quantum__rt__tuple_update_alias_count(%Tuple* %32, i64 1)
-  %33 = load { double, double }*, { double, double }** %29
-  %34 = bitcast { double, double }* %33 to %Tuple*
-  call void @__quantum__rt__tuple_update_alias_count(%Tuple* %34, i64 -1)
-  store { double, double }* %31, { double, double }** %29
-  call void @__quantum__rt__tuple_update_reference_count(%Tuple* %27, i64 1)
-  call void @__quantum__rt__tuple_update_alias_count(%Tuple* %27, i64 1)
-  store { %String*, { double, double }*, { double, double }* }* %28, { %String*, { double, double }*, { double, double }* }** %namedValue
+continue__2:                                      ; preds = %condContinue__2, %condContinue__1
+  %27 = load { %String*, { double, double }*, { double, double }* }*, { %String*, { double, double }*, { double, double }* }** %namedValue
+  %28 = bitcast { %String*, { double, double }*, { double, double }* }* %27 to %Tuple*
+  call void @__quantum__rt__tuple_update_alias_count(%Tuple* %28, i64 -1)
+  %29 = call %Tuple* @__quantum__rt__tuple_copy(%Tuple* %28, i1 false)
+  %30 = icmp ne %Tuple* %28, %29
+  %31 = bitcast %Tuple* %29 to { %String*, { double, double }*, { double, double }* }*
+  %32 = getelementptr { %String*, { double, double }*, { double, double }* }, { %String*, { double, double }*, { double, double }* }* %31, i64 0, i32 2
+  %33 = getelementptr { %String*, { double, double }*, { double, double }* }, { %String*, { double, double }*, { double, double }* }* %27, i64 0, i32 1
+  %34 = load { double, double }*, { double, double }** %33
+  %35 = bitcast { double, double }* %34 to %Tuple*
+  call void @__quantum__rt__tuple_update_reference_count(%Tuple* %35, i64 1)
+  call void @__quantum__rt__tuple_update_alias_count(%Tuple* %35, i64 1)
+  %36 = load { double, double }*, { double, double }** %32
+  %37 = bitcast { double, double }* %36 to %Tuple*
+  call void @__quantum__rt__tuple_update_alias_count(%Tuple* %37, i64 -1)
+  br i1 %30, label %condContinue__3, label %condFalse__3
+
+condFalse__3:                                     ; preds = %continue__2
+  call void @__quantum__rt__tuple_update_reference_count(%Tuple* %35, i64 1)
+  call void @__quantum__rt__tuple_update_reference_count(%Tuple* %37, i64 -1)
+  br label %condContinue__3
+
+condContinue__3:                                  ; preds = %condFalse__3, %continue__2
+  store { double, double }* %34, { double, double }** %32
+  call void @__quantum__rt__tuple_update_reference_count(%Tuple* %29, i64 1)
+  call void @__quantum__rt__tuple_update_alias_count(%Tuple* %29, i64 1)
+  store { %String*, { double, double }*, { double, double }* }* %31, { %String*, { double, double }*, { double, double }* }** %namedValue
   call void @__quantum__rt__tuple_update_reference_count(%Tuple* %6, i64 -1)
-  call void @__quantum__rt__tuple_update_reference_count(%Tuple* %15, i64 -1)
-  call void @__quantum__rt__tuple_update_reference_count(%Tuple* %17, i64 -1)
+  call void @__quantum__rt__tuple_update_reference_count(%Tuple* %16, i64 -1)
+  call void @__quantum__rt__tuple_update_reference_count(%Tuple* %18, i64 -1)
   call void @__quantum__rt__tuple_update_reference_count(%Tuple* %11, i64 -1)
-  call void @__quantum__rt__tuple_update_reference_count(%Tuple* %26, i64 -1)
-  call void @__quantum__rt__tuple_update_reference_count(%Tuple* %34, i64 -1)
-  call void @__quantum__rt__tuple_update_reference_count(%Tuple* %27, i64 -1)
+  call void @__quantum__rt__tuple_update_reference_count(%Tuple* %28, i64 -1)
+  call void @__quantum__rt__tuple_update_reference_count(%Tuple* %37, i64 -1)
+  call void @__quantum__rt__tuple_update_reference_count(%Tuple* %29, i64 -1)
   br label %continue__1
 
-continue__1:                                      ; preds = %continue__2, %entry
-  %35 = load { %String*, { double, double }*, { double, double }* }*, { %String*, { double, double }*, { double, double }* }** %namedValue
+continue__1:                                      ; preds = %condContinue__3, %entry
+  %38 = load { %String*, { double, double }*, { double, double }* }*, { %String*, { double, double }*, { double, double }* }** %namedValue
   call void @__quantum__rt__tuple_update_alias_count(%Tuple* %2, i64 -1)
   call void @__quantum__rt__tuple_update_alias_count(%Tuple* %5, i64 -1)
   call void @__quantum__rt__tuple_update_alias_count(%Tuple* %6, i64 -1)
-  %36 = getelementptr { %String*, { double, double }*, { double, double }* }, { %String*, { double, double }*, { double, double }* }* %35, i64 0, i32 1
-  %37 = load { double, double }*, { double, double }** %36
-  %38 = bitcast { double, double }* %37 to %Tuple*
-  call void @__quantum__rt__tuple_update_alias_count(%Tuple* %38, i64 -1)
-  %39 = getelementptr { %String*, { double, double }*, { double, double }* }, { %String*, { double, double }*, { double, double }* }* %35, i64 0, i32 2
+  %39 = getelementptr { %String*, { double, double }*, { double, double }* }, { %String*, { double, double }*, { double, double }* }* %38, i64 0, i32 1
   %40 = load { double, double }*, { double, double }** %39
   %41 = bitcast { double, double }* %40 to %Tuple*
   call void @__quantum__rt__tuple_update_alias_count(%Tuple* %41, i64 -1)
-  %42 = bitcast { %String*, { double, double }*, { double, double }* }* %35 to %Tuple*
-  call void @__quantum__rt__tuple_update_alias_count(%Tuple* %42, i64 -1)
+  %42 = getelementptr { %String*, { double, double }*, { double, double }* }, { %String*, { double, double }*, { double, double }* }* %38, i64 0, i32 2
+  %43 = load { double, double }*, { double, double }** %42
+  %44 = bitcast { double, double }* %43 to %Tuple*
+  call void @__quantum__rt__tuple_update_alias_count(%Tuple* %44, i64 -1)
+  %45 = bitcast { %String*, { double, double }*, { double, double }* }* %38 to %Tuple*
+  call void @__quantum__rt__tuple_update_alias_count(%Tuple* %45, i64 -1)
   call void @__quantum__rt__string_update_reference_count(%String* %9, i64 -1)
-  ret { %String*, { double, double }*, { double, double }* }* %35
+  ret { %String*, { double, double }*, { double, double }* }* %38
 }

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestUdtUpdate2.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestUdtUpdate2.ll
@@ -1,10 +1,10 @@
 define { %String*, { double, double }*, { double, double }* }* @Microsoft__Quantum__Testing__QIR__TestUdtUpdate2__body(i1 %cond, { %String*, { double, double }*, { double, double }* }* %arg) {
 entry:
-  %0 = getelementptr { %String*, { double, double }*, { double, double }* }, { %String*, { double, double }*, { double, double }* }* %arg, i64 0, i32 1
+  %0 = getelementptr inbounds { %String*, { double, double }*, { double, double }* }, { %String*, { double, double }*, { double, double }* }* %arg, i32 0, i32 1
   %1 = load { double, double }*, { double, double }** %0
   %2 = bitcast { double, double }* %1 to %Tuple*
   call void @__quantum__rt__tuple_update_alias_count(%Tuple* %2, i64 1)
-  %3 = getelementptr { %String*, { double, double }*, { double, double }* }, { %String*, { double, double }*, { double, double }* }* %arg, i64 0, i32 2
+  %3 = getelementptr inbounds { %String*, { double, double }*, { double, double }* }, { %String*, { double, double }*, { double, double }* }* %arg, i32 0, i32 2
   %4 = load { double, double }*, { double, double }** %3
   %5 = bitcast { double, double }* %4 to %Tuple*
   call void @__quantum__rt__tuple_update_alias_count(%Tuple* %5, i64 1)
@@ -15,7 +15,7 @@ entry:
   call void @__quantum__rt__tuple_update_alias_count(%Tuple* %2, i64 1)
   call void @__quantum__rt__tuple_update_alias_count(%Tuple* %5, i64 1)
   call void @__quantum__rt__tuple_update_alias_count(%Tuple* %6, i64 1)
-  %7 = getelementptr { %String*, { double, double }*, { double, double }* }, { %String*, { double, double }*, { double, double }* }* %arg, i64 0, i32 0
+  %7 = getelementptr inbounds { %String*, { double, double }*, { double, double }* }, { %String*, { double, double }*, { double, double }* }* %arg, i32 0, i32 0
   %8 = load %String*, %String** %7
   call void @__quantum__rt__string_update_reference_count(%String* %8, i64 1)
   call void @__quantum__rt__tuple_update_reference_count(%Tuple* %2, i64 1)
@@ -30,7 +30,7 @@ then0__1:                                         ; preds = %entry
   %11 = call %Tuple* @__quantum__rt__tuple_copy(%Tuple* %6, i1 false)
   %12 = icmp ne %Tuple* %6, %11
   %13 = bitcast %Tuple* %11 to { %String*, { double, double }*, { double, double }* }*
-  %14 = getelementptr { %String*, { double, double }*, { double, double }* }, { %String*, { double, double }*, { double, double }* }* %13, i64 0, i32 1
+  %14 = getelementptr inbounds { %String*, { double, double }*, { double, double }* }, { %String*, { double, double }*, { double, double }* }* %13, i32 0, i32 1
   %15 = call { double, double }* @Microsoft__Quantum__Testing__QIR__Complex__body(double 0.000000e+00, double 0.000000e+00)
   %16 = bitcast { double, double }* %15 to %Tuple*
   call void @__quantum__rt__tuple_update_reference_count(%Tuple* %16, i64 1)
@@ -57,7 +57,7 @@ then0__2:                                         ; preds = %condContinue__1
   %19 = call %Tuple* @__quantum__rt__tuple_copy(%Tuple* %11, i1 false)
   %20 = icmp ne %Tuple* %11, %19
   %21 = bitcast %Tuple* %19 to { %String*, { double, double }*, { double, double }* }*
-  %22 = getelementptr { %String*, { double, double }*, { double, double }* }, { %String*, { double, double }*, { double, double }* }* %21, i64 0, i32 1
+  %22 = getelementptr inbounds { %String*, { double, double }*, { double, double }* }, { %String*, { double, double }*, { double, double }* }* %21, i32 0, i32 1
   %23 = call { double, double }* @Microsoft__Quantum__Testing__QIR__Complex__body(double 1.000000e+00, double 0.000000e+00)
   %24 = bitcast { double, double }* %23 to %Tuple*
   call void @__quantum__rt__tuple_update_reference_count(%Tuple* %24, i64 1)
@@ -90,8 +90,8 @@ continue__2:                                      ; preds = %condContinue__2, %c
   %29 = call %Tuple* @__quantum__rt__tuple_copy(%Tuple* %28, i1 false)
   %30 = icmp ne %Tuple* %28, %29
   %31 = bitcast %Tuple* %29 to { %String*, { double, double }*, { double, double }* }*
-  %32 = getelementptr { %String*, { double, double }*, { double, double }* }, { %String*, { double, double }*, { double, double }* }* %31, i64 0, i32 2
-  %33 = getelementptr { %String*, { double, double }*, { double, double }* }, { %String*, { double, double }*, { double, double }* }* %27, i64 0, i32 1
+  %32 = getelementptr inbounds { %String*, { double, double }*, { double, double }* }, { %String*, { double, double }*, { double, double }* }* %31, i32 0, i32 2
+  %33 = getelementptr inbounds { %String*, { double, double }*, { double, double }* }, { %String*, { double, double }*, { double, double }* }* %27, i32 0, i32 1
   %34 = load { double, double }*, { double, double }** %33
   %35 = bitcast { double, double }* %34 to %Tuple*
   call void @__quantum__rt__tuple_update_reference_count(%Tuple* %35, i64 1)
@@ -125,11 +125,11 @@ continue__1:                                      ; preds = %condContinue__3, %e
   call void @__quantum__rt__tuple_update_alias_count(%Tuple* %2, i64 -1)
   call void @__quantum__rt__tuple_update_alias_count(%Tuple* %5, i64 -1)
   call void @__quantum__rt__tuple_update_alias_count(%Tuple* %6, i64 -1)
-  %39 = getelementptr { %String*, { double, double }*, { double, double }* }, { %String*, { double, double }*, { double, double }* }* %38, i64 0, i32 1
+  %39 = getelementptr inbounds { %String*, { double, double }*, { double, double }* }, { %String*, { double, double }*, { double, double }* }* %38, i32 0, i32 1
   %40 = load { double, double }*, { double, double }** %39
   %41 = bitcast { double, double }* %40 to %Tuple*
   call void @__quantum__rt__tuple_update_alias_count(%Tuple* %41, i64 -1)
-  %42 = getelementptr { %String*, { double, double }*, { double, double }* }, { %String*, { double, double }*, { double, double }* }* %38, i64 0, i32 2
+  %42 = getelementptr inbounds { %String*, { double, double }*, { double, double }* }, { %String*, { double, double }*, { double, double }* }* %38, i32 0, i32 2
   %43 = load { double, double }*, { double, double }** %42
   %44 = bitcast { double, double }* %43 to %Tuple*
   call void @__quantum__rt__tuple_update_alias_count(%Tuple* %44, i64 -1)

--- a/src/QsCompiler/Tests.Compiler/Tests.Compiler.fsproj
+++ b/src/QsCompiler/Tests.Compiler/Tests.Compiler.fsproj
@@ -27,10 +27,10 @@
     <Content Include="..\..\..\examples\QIR\QirTarget.qs" Link="TestCases\QirTests\QirTarget.qs">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
-    <Content Include="TestCases\QirTests\TestAccessCounts.ll">
+    <Content Include="TestCases\QirTests\TestAliasCounts.ll">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
-    <Content Include="TestCases\QirTests\TestAccessCounts.qs">
+    <Content Include="TestCases\QirTests\TestAliasCounts.qs">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
     <Content Include="TestCases\QirTests\TestArrayLoop.ll">
@@ -217,6 +217,12 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
     <Content Include="TestCases\QirTests\TestRange.qs">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="TestCases\QirTests\TestReferenceCounts.ll">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="TestCases\QirTests\TestReferenceCounts.qs">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
     <Content Include="TestCases\QirTests\TestRepeat.ll">


### PR DESCRIPTION
This PR fixes an issue where the generated QIR resulted in accessing released memory when arrays of pointers are updated in place and the updated item value is constructed in an inner scope.

Longer explanation looking at the test case:

```qsharp
function TestRefCounts(cond : Bool) : Unit {
    mutable ops = new Int[][5];
    if (cond) {
        set ops w/= 0 <- new Int[3];
    }
}
```
The first line gets translated into first creating and then populating the Int[][], After creation and populating it, the array and all its items have ref count 1. Then that array is assigned to the mutable variable. This assignment leads to the array and all its items having ref count 2, and an alias count 1. 
Elaborating more on why the ref count needs to be 2 and can't remain 1, think of the case where the array assigned to the mutable variable has been passed in as an argument. Suppose that argument initially has ref count 1 and is "owned" by the calling function. Then if we kept the ref count at 1, and updated an item in ops, the old item's ref count would drop to 0, releasing it. Hence (assuming we can't know which items will be updated), we increase both the alias and the ref count when assigning to mutable variables for the array and all its item. 
 
Continuing into the if-branch, we create a new array that has ref count 1. Upon assigning it to item 0 in the array, its alias count and ref count are increased. At the same time, the alias count and ref count of the old item are decreased. The ops array and all its items now have an alias count 1 and a ref count 2. The alias count of the old item is now 0, and its ref count is 1. 
 
Now we exit the scope. When we exit the scope, the array value created inside the if-branch goes out of scope. Its ref count is hence decreased by 1. This now causes a problem when we exit TestRefCounts; upon exiting, we decrease the alias count and the ref count of ops and all its items by 1. The alias count of ops and all its items is then 0 (ok), and the ref count of all items except item 0 is 1, while the ref count of item 0 is 0. 
And here is where things go wrong; we also release the initially created array (variable %0), which is correct, since the value goes out of scope. However, the original item at index 0 is no longer accessible by getting the 0-element pointer of %0 - instead of getting the old item that still has a ref count 1 that needs to be set to 0, we get the new item that has a ref count 0 already. 
 
Now why is it relevant whether the ops array has been copied inside the if-branch or not? Suppose after the first line there is another variable defined that is bound to ops, such that the if-branch actually does create the copy. In that case when we exit TestRefCounts, accessing the item at index 0 of %0 indeed still accesses the old item, and everything works fine. 

Whatever scheme we pursue to resolve the issue, it ultimately boils down to that we need to ensure that when %0 goes out of scope, we have a way to access all its items at the time of declaration. Thinking of queuing the unreferencing for each item separately when we increase the ref count for the array and all its items upon the initial assignment to ops, the problem is that iterating over the array means that the items are loaded inside a loop body, and I no longer have access to them when we exit the function. Hence, the simplest and I think cleanest solution I can come up with is that I inject an additional ref count increase for the new item and ref count decrease for the old item when an array item is modified in place. 

I should say that the reason why I think the additional count change has to be exactly 1 is that I don't see a way for the array to be unreferenced more than once at the end of the scope while also not being copied; I believe the only way it would be unreferenced multiple times is if there is another alias for it, in which case the copy would get executed and everything should work.
