### PR TITLE
Simplify resolution of file edit in code action to avoid unnecessary execute command

### DIFF
--- a/src/QsCompiler/LanguageServer/LanguageServer.cs
+++ b/src/QsCompiler/LanguageServer/LanguageServer.cs
@@ -581,10 +581,13 @@ namespace Microsoft.Quantum.QsLanguageServer
         [JsonRpcMethod(Methods.TextDocumentCodeActionName)]
         public object OnCodeAction(JToken arg)
         {
-            Command BuildCommand(string title, WorkspaceEdit edit)
+            CodeAction CreateAction(string title, WorkspaceEdit edit)
             {
-                var commandArgs = new ApplyWorkspaceEditParams { Label = $"code action \"{title}\"", Edit = edit };
-                return new Command { Title = title, CommandIdentifier = CommandIds.ApplyEdit, Arguments = new object[] { commandArgs } };
+                return new CodeAction
+                {
+                    Title = title,
+                    Edit = edit
+                };
             }
 
             if (this.waitForInit != null)
@@ -597,14 +600,14 @@ namespace Microsoft.Quantum.QsLanguageServer
                 return
                     QsCompilerError.RaiseOnFailure(
                         () => this.editorState.CodeActions(param)
-                            ?.SelectMany(vs => vs.Select(v => BuildCommand(vs.Key, v)))
-                            ?? Enumerable.Empty<Command>(),
+                            ?.SelectMany(vs => vs.Select(v => CreateAction(vs.Key, v)))
+                            ?? Enumerable.Empty<CodeAction>(),
                         "CodeAction threw an exception")
                     .ToArray();
             }
             catch
             {
-                return Array.Empty<Command>();
+                return Array.Empty<CodeAction>();
             }
         }
 


### PR DESCRIPTION
In the current implementation, handling the code action involves creating an execute command to edit the file. However, this leads to a deadlock in which the apply edit is waiting for the code action handling to complete and this can't complete until the edit action is applied.

It's unclear when this regression was introduced, but it's possible that recent changes in the synchronization model of the protocol are no longer allowing this approach.

This change is shortcutting this by returning an edit Microsoft.VisualStudio.LanguageServer.Protocol.CodeAction directly instead.