### PR TITLE
Fixing duplicate intrinsics

### DIFF
--- a/src/QsCompiler/Tests.Compiler/LinkingTests.fs
+++ b/src/QsCompiler/Tests.Compiler/LinkingTests.fs
@@ -353,6 +353,15 @@ type LinkingTests(output: ITestOutputHelper) =
 
 
     [<Fact>]
+    [<Trait("Category", "Monomorphization")>]
+    member this.``Monomorphization Test Duplicate Intrinsic``() =
+        let source = (LinkingTests.ReadAndChunkSourceFile "Monomorphization.qs").[13]
+        let compilation = this.CompileMonomorphization source
+
+        let callables = compilation.Namespaces |> Callables
+        Assert.Equal(callables |> Seq.distinct |> Seq.length, callables |> Seq.length)
+
+    [<Fact>]
     [<Trait("Category", "Intrinsic Resolution")>]
     member this.``Intrinsic Resolution Basic Implementation``() = this.RunIntrinsicResolutionTest 1
 

--- a/src/QsCompiler/Tests.Compiler/TestCases/LinkingTests/Monomorphization.qs
+++ b/src/QsCompiler/Tests.Compiler/TestCases/LinkingTests/Monomorphization.qs
@@ -228,3 +228,18 @@ namespace Microsoft.Quantum.Testing.Monomorphization {
         let idx = IndexRange(qs);
     }
 }
+
+// =================================
+
+namespace Microsoft.Quantum.Testing.Monomorphization {
+    open Microsoft.Quantum.Arrays;
+
+    operation CustomIntrinsic() : Unit {
+        body intrinsic;
+    }
+
+    @ EntryPoint()
+    operation TestDuplicateIntrinsic() : Unit {
+        CustomIntrinsic();
+    }
+}

--- a/src/QsCompiler/Transformations/Monomorphization.cs
+++ b/src/QsCompiler/Transformations/Monomorphization.cs
@@ -101,7 +101,12 @@ namespace Microsoft.Quantum.QsCompiler.Transformations.Monomorphization
         {
             public static QsCompilation Apply(QsCompilation compilation, List<QsCallable> callables, ImmutableHashSet<QsQualifiedName> intrinsicCallableSet, bool keepAllIntrinsics)
             {
-                var filter = new ResolveGenerics(callables.ToLookup(res => res.FullName.Namespace), intrinsicCallableSet, keepAllIntrinsics);
+                var filter = new ResolveGenerics(
+                    callables
+                        .Where(call => !keepAllIntrinsics || !intrinsicCallableSet.Contains(call.FullName))
+                        .ToLookup(res => res.FullName.Namespace),
+                    intrinsicCallableSet,
+                    keepAllIntrinsics);
 
                 return filter.OnCompilation(compilation);
             }


### PR DESCRIPTION
This fixes an issue where `body intrinsic` callables would appear twice in monomorphized results by pruning the list of concretized callables based on intrinsic settings.