### PR TITLE
Fix #885

### DIFF
--- a/src/QsCompiler/CommandLineTool/Logging.cs
+++ b/src/QsCompiler/CommandLineTool/Logging.cs
@@ -41,12 +41,14 @@ namespace Microsoft.Quantum.QsCompiler.Diagnostics
         /// Prints the given message to the Console.
         /// Errors and Warnings are printed to the error stream.
         /// </summary>
-        private static void PrintToConsole(DiagnosticSeverity severity, string message)
+        private static void PrintToConsole(DiagnosticSeverity? severity, string message)
         {
-            var (stream, color) =
-                severity == DiagnosticSeverity.Error ? (Console.Error, ConsoleColor.Red) :
-                severity == DiagnosticSeverity.Warning ? (Console.Error, ConsoleColor.Yellow) :
-                (Console.Out, Console.ForegroundColor);
+            var (stream, color) = severity switch
+            {
+                DiagnosticSeverity.Error => (Console.Error, ConsoleColor.Red),
+                DiagnosticSeverity.Warning => (Console.Error, ConsoleColor.Yellow),
+                _ => (Console.Out, Console.ForegroundColor)
+            };
 
             var consoleColor = Console.ForegroundColor;
             Console.ForegroundColor = color;

--- a/src/QsCompiler/CompilationManager/CompilationManager.csproj
+++ b/src/QsCompiler/CompilationManager/CompilationManager.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.VisualStudio.LanguageServer.Protocol" Version="16.3.57" />
+    <PackageReference Include="Microsoft.VisualStudio.LanguageServer.Protocol" Version="16.9.1180" />
     <PackageReference Include="Newtonsoft.Json.Bson" Version="1.0.2" />
   </ItemGroup>
 

--- a/src/QsCompiler/CompilationManager/DiagnosticTools.cs
+++ b/src/QsCompiler/CompilationManager/DiagnosticTools.cs
@@ -47,16 +47,25 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
                     End = CopyPosition(range.End)
                 };
 
+            // NB: The nullability metadata on Diagnostic.Range is incorrect,
+            //     such that some Diagnostic values may have nullable ranges.
+            //     We cannot assign that to a new Diagnostic without
+            //     contradicting nullability metadata, however, so we need to
+            //     explicitly disable nullable references for the following
+            //     statement. Once the upstream bug in the LSP client package
+            //     is fixed, we can remove the nullable disable here.
+            #nullable disable
             return message is null
                 ? null
                 : new Diagnostic
                 {
-                    Range = CopyRange(message.Range),
+                    Range = message.Range == null ? null : CopyRange(message.Range),
                     Severity = message.Severity,
                     Code = message.Code,
                     Source = message.Source,
                     Message = message.Message
                 };
+            #nullable restore
         }
 
         /// <summary>

--- a/src/QsCompiler/CompilationManager/DiagnosticTools.cs
+++ b/src/QsCompiler/CompilationManager/DiagnosticTools.cs
@@ -77,12 +77,17 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         public static Diagnostic WithLineNumOffset(this Diagnostic diagnostic, int offset)
         {
             var copy = diagnostic.Copy();
-            copy.Range.Start.Line += offset;
-            copy.Range.End.Line += offset;
-            if (copy.Range.Start.Line < 0 || copy.Range.End.Line < 0)
+            // NB: Despite the nullability metadata, Range may be null here.
+            //     We thus need to guard accordingly.
+            if (copy.Range != null)
             {
-                throw new ArgumentOutOfRangeException(
-                    nameof(offset), "Translated diagnostic has negative line numbers.");
+                copy.Range.Start.Line += offset;
+                copy.Range.End.Line += offset;
+                if (copy.Range.Start.Line < 0 || copy.Range.End.Line < 0)
+                {
+                    throw new ArgumentOutOfRangeException(
+                        nameof(offset), "Translated diagnostic has negative line numbers.");
+                }
             }
             return copy;
         }

--- a/src/QsCompiler/CompilationManager/DiagnosticTools.cs
+++ b/src/QsCompiler/CompilationManager/DiagnosticTools.cs
@@ -37,17 +37,15 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         [return: NotNullIfNotNull("message")]
         public static Diagnostic? Copy(this Diagnostic message)
         {
-            Lsp.Position? CopyPosition(Lsp.Position? position) =>
-                position is null ? null : new Lsp.Position(position.Line, position.Character);
+            Lsp.Position CopyPosition(Lsp.Position position) =>
+                new Lsp.Position(position.Line, position.Character);
 
-            Lsp.Range? CopyRange(Lsp.Range? range) =>
-                range is null
-                    ? null
-                    : new Lsp.Range
-                    {
-                        Start = CopyPosition(range.Start),
-                        End = CopyPosition(range.End)
-                    };
+            Lsp.Range CopyRange(Lsp.Range range) =>
+                new Lsp.Range
+                {
+                    Start = CopyPosition(range.Start),
+                    End = CopyPosition(range.End)
+                };
 
             return message is null
                 ? null

--- a/src/QsCompiler/CompilationManager/Diagnostics.cs
+++ b/src/QsCompiler/CompilationManager/Diagnostics.cs
@@ -121,7 +121,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
                 Code = Code(code),
                 Source = source,
                 Message = DiagnosticItem.Message(code, args ?? Enumerable.Empty<string>()),
-                Range = null
+                Range = new Lsp.Range()
             };
 
         // warnings 20**
@@ -134,7 +134,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
                 Code = WarningCode.ExcessSemicolon.Code(),
                 Source = filename,
                 Message = DiagnosticItem.Message(WarningCode.ExcessSemicolon, Enumerable.Empty<string>()),
-                Range = pos == null ? null : new Lsp.Range { Start = pos.ToLsp(), End = pos.ToLsp() }
+                Range = new Lsp.Range { Start = pos.ToLsp(), End = pos.ToLsp() }
             };
         }
     }
@@ -156,32 +156,42 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
                 Code = Code(code),
                 Source = source,
                 Message = DiagnosticItem.Message(code, args ?? Enumerable.Empty<string>()),
-                Range = null
+                Range = new Lsp.Range()
             };
 
         // errors 20**
 
         internal static Diagnostic InvalidFragmentEnding(string filename, ErrorCode code, Position pos)
         {
+            if (pos == null)
+            {
+                throw new ArgumentNullException(nameof(pos));
+            }
+
             return new Diagnostic
             {
                 Severity = DiagnosticSeverity.Error,
                 Code = Code(code),
                 Source = filename,
                 Message = DiagnosticItem.Message(code, Enumerable.Empty<string>()),
-                Range = pos == null ? null : new Lsp.Range { Start = pos.ToLsp(), End = pos.ToLsp() }
+                Range = new Lsp.Range { Start = pos.ToLsp(), End = pos.ToLsp() }
             };
         }
 
         internal static Diagnostic MisplacedOpeningBracketError(string filename, Position pos)
         {
+            if (pos == null)
+            {
+                throw new ArgumentNullException(nameof(pos));
+            }
+
             return new Diagnostic
             {
                 Severity = DiagnosticSeverity.Error,
                 Code = ErrorCode.MisplacedOpeningBracket.Code(),
                 Source = filename,
                 Message = DiagnosticItem.Message(ErrorCode.MisplacedOpeningBracket, Enumerable.Empty<string>()),
-                Range = pos == null ? null : new Lsp.Range { Start = pos.ToLsp(), End = pos.ToLsp() }
+                Range = new Lsp.Range { Start = pos.ToLsp(), End = pos.ToLsp() }
             };
         }
 
@@ -189,49 +199,69 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
 
         internal static Diagnostic ExcessBracketError(string filename, Position pos)
         {
+            if (pos == null)
+            {
+                throw new ArgumentNullException(nameof(pos));
+            }
+
             return new Diagnostic
             {
                 Severity = DiagnosticSeverity.Error,
                 Code = ErrorCode.ExcessBracketError.Code(),
                 Source = filename,
                 Message = DiagnosticItem.Message(ErrorCode.ExcessBracketError, Enumerable.Empty<string>()),
-                Range = pos == null ? null : new Lsp.Range { Start = pos.ToLsp(), End = pos.ToLsp() }
+                Range = new Lsp.Range { Start = pos.ToLsp(), End = pos.ToLsp() }
             };
         }
 
         internal static Diagnostic MissingClosingBracketError(string filename, Position pos)
         {
+            if (pos == null)
+            {
+                throw new ArgumentNullException(nameof(pos));
+            }
+
             return new Diagnostic
             {
                 Severity = DiagnosticSeverity.Error,
                 Code = ErrorCode.MissingBracketError.Code(),
                 Source = filename,
                 Message = DiagnosticItem.Message(ErrorCode.MissingBracketError, Enumerable.Empty<string>()),
-                Range = pos == null ? null : new Lsp.Range { Start = pos.ToLsp(), End = pos.ToLsp() }
+                Range = new Lsp.Range { Start = pos.ToLsp(), End = pos.ToLsp() }
             };
         }
 
         internal static Diagnostic MissingStringDelimiterError(string filename, Position pos)
         {
+            if (pos == null)
+            {
+                throw new ArgumentNullException(nameof(pos));
+            }
+
             return new Diagnostic
             {
                 Severity = DiagnosticSeverity.Error,
                 Code = ErrorCode.MissingStringDelimiterError.Code(),
                 Source = filename,
                 Message = DiagnosticItem.Message(ErrorCode.MissingStringDelimiterError, Enumerable.Empty<string>()),
-                Range = pos == null ? null : new Lsp.Range { Start = pos.ToLsp(), End = pos.ToLsp() }
+                Range = new Lsp.Range { Start = pos.ToLsp(), End = pos.ToLsp() }
             };
         }
 
         internal static Diagnostic InvalidCharacterInInterpolatedArgument(string filename, Position pos, char invalidCharacter)
         {
+            if (pos == null)
+            {
+                throw new ArgumentNullException(nameof(pos));
+            }
+
             return new Diagnostic
             {
                 Severity = DiagnosticSeverity.Error,
                 Code = ErrorCode.InvalidCharacterInInterpolatedArgument.Code(),
                 Source = filename,
                 Message = DiagnosticItem.Message(ErrorCode.InvalidCharacterInInterpolatedArgument, new[] { invalidCharacter.ToString() }),
-                Range = pos == null ? null : new Lsp.Range { Start = pos.ToLsp(), End = pos.ToLsp() }
+                Range = new Lsp.Range { Start = pos.ToLsp(), End = pos.ToLsp() }
             };
         }
     }

--- a/src/QsCompiler/CompilationManager/Diagnostics.cs
+++ b/src/QsCompiler/CompilationManager/Diagnostics.cs
@@ -156,7 +156,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
                 Code = Code(code),
                 Source = source,
                 Message = DiagnosticItem.Message(code, args ?? Enumerable.Empty<string>()),
-                Range = new Lsp.Range()
+                Range = new Lsp.Range { Start = new Lsp.Position(0, 0), End = new Lsp.Position(0, 0) }
             };
 
         // errors 20**

--- a/src/QsCompiler/CompilationManager/Diagnostics.cs
+++ b/src/QsCompiler/CompilationManager/Diagnostics.cs
@@ -121,7 +121,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
                 Code = Code(code),
                 Source = source,
                 Message = DiagnosticItem.Message(code, args ?? Enumerable.Empty<string>()),
-                Range = new Lsp.Range()
+                Range = new Lsp.Range { Start = new Lsp.Position(0, 0), End = new Lsp.Position(0, 0) }
             };
 
         // warnings 20**

--- a/src/QsCompiler/CompilationManager/EditorSupport/CodeCompletion.cs
+++ b/src/QsCompiler/CompilationManager/EditorSupport/CodeCompletion.cs
@@ -430,7 +430,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// completion item data is missing properties.
         /// </summary>
         private static string? TryGetDocumentation(
-            CompilationUnit compilation, CompletionItemData data, CompletionItemKind kind, bool useMarkdown)
+            CompilationUnit compilation, CompletionItemData data, CompletionItemKind? kind, bool useMarkdown)
         {
             if (data.QualifiedName == null
                 || data.SourceFile == null
@@ -619,7 +619,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
             new CompletionList
             {
                 IsIncomplete = isIncomplete,
-                Items = items?.ToArray()
+                Items = items?.ToArray() ?? new CompletionItem[] { }
             };
 
         /// <summary>

--- a/src/QsCompiler/CompilationManager/EditorSupport/EditorCommands.cs
+++ b/src/QsCompiler/CompilationManager/EditorSupport/EditorCommands.cs
@@ -203,7 +203,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
             Hover? GetHover(string? info) => info == null ? null : new Hover
             {
                 Contents = new MarkupContent { Kind = format, Value = info },
-                Range = new Lsp.Range { Start = position?.ToLsp(), End = position?.ToLsp() }
+                Range = new Lsp.Range { Start = position.ToLsp(), End = position.ToLsp() }
             };
 
             var markdown = format == MarkupKind.Markdown;
@@ -393,7 +393,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
             MarkupContent AsMarkupContent(string str) => new MarkupContent { Kind = format, Value = str };
             ParameterInformation AsParameterInfo(string? paramName) => new ParameterInformation
             {
-                Label = paramName,
+                Label = paramName ?? "<unknown parameter>",
                 Documentation = AsMarkupContent(documentation.ParameterDescription(paramName))
             };
 

--- a/src/QsCompiler/CompilationManager/EditorSupport/SymbolInformation.cs
+++ b/src/QsCompiler/CompilationManager/EditorSupport/SymbolInformation.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         internal static Location AsLocation(string source, Position offset, Range relRange) =>
             new Location
             {
-                Uri = CompilationUnitManager.TryGetUri(source, out var uri) ? uri : null,
+                Uri = CompilationUnitManager.TryGetUri(source, out var uri) ? uri : throw new Exception($"Source location {source} could not be converted to a valid URI."),
                 Range = (offset + relRange).ToLsp()
             };
 

--- a/src/QsCompiler/CompilationManager/ProjectManager.cs
+++ b/src/QsCompiler/CompilationManager/ProjectManager.cs
@@ -929,10 +929,30 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
 
             try
             {
+                // NB: As of version 16.9.1180 of the LSP client, document
+                //     changes are presented as the sum type
+                //     TextDocumentEdit[] | (TextDocumentEdit | CreateFile | RenameFile | DeleteFile)[].
+                //     Thus, to collect them with a SelectMany call, we need
+                //     to ensure that the first case (TextDocumentEdit[]) is
+                //     first wrapped in a cast to the sum type
+                //     TextDocumentEdit | CreateFile | RenameFile | DeleteFile.
+                //     Note that the SumType struct is defined in the LSP client,
+                //     and works by defining explicit cast operators for each case.
+                IEnumerable<SumType<TextDocumentEdit, CreateFile, RenameFile, DeleteFile>> CastToSumType(SumType<TextDocumentEdit[], SumType<TextDocumentEdit, CreateFile, RenameFile, DeleteFile>[]>? editCollection) =>
+                    editCollection switch
+                    {
+                        { } edits => edits.Match(
+                            simpleEdits => simpleEdits.Cast<SumType<TextDocumentEdit, CreateFile, RenameFile, DeleteFile>>(),
+                            complexEdits => complexEdits),
+                        null => ImmutableList<SumType<TextDocumentEdit, CreateFile, RenameFile, DeleteFile>>.Empty
+                    };
+
                 // if a file belongs to several compilation units, then this will fail
                 var changes = edits.SelectMany(edit => edit.Changes)
                     .ToDictionary(pair => pair.Key, pair => pair.Value);
-                var documentChanges = edits.SelectMany(edit => edit.DocumentChanges).ToArray();
+                var documentChanges = edits
+                    .SelectMany(edits => CastToSumType(edits.DocumentChanges).ToArray())
+                    .ToArray();
                 return new WorkspaceEdit { Changes = changes, DocumentChanges = documentChanges };
             }
             catch

--- a/src/QsCompiler/CompilationManager/Utils.cs
+++ b/src/QsCompiler/CompilationManager/Utils.cs
@@ -168,8 +168,10 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// <summary>
         /// Converts the Q# compiler position into a language server protocol position.
         /// </summary>
-        public static Lsp.Position ToLsp(this Position position) =>
-            new Lsp.Position(position.Line, position.Column);
+        public static Lsp.Position ToLsp(this Position? position) =>
+            position == null
+            ? new Lsp.Position()
+            : new Lsp.Position(position.Line, position.Column);
 
         /// <summary>
         /// Converts the language server protocol range into a Q# compiler range.

--- a/src/QsCompiler/Compiler/LoadedStep.cs
+++ b/src/QsCompiler/Compiler/LoadedStep.cs
@@ -123,7 +123,9 @@ namespace Microsoft.Quantum.QsCompiler
                 Severity = severity,
                 Message = $"{stageAnnotation}{diagnostic.Message}",
                 Source = diagnostic.Source,
-                Range = diagnostic.Source is null ? null : diagnostic.Range?.ToLsp()
+                Range = diagnostic.Source is null || diagnostic.Range is null
+                        ? new VisualStudio.LanguageServer.Protocol.Range()
+                        : diagnostic.Range.ToLsp()
             };
         }
 

--- a/src/QsCompiler/Compiler/Logging.cs
+++ b/src/QsCompiler/Compiler/Logging.cs
@@ -180,7 +180,9 @@ namespace Microsoft.Quantum.QsCompiler.Diagnostics
                 ++this.NrWarningsLogged;
             }
 
-            var msg = m.Range == null ? m : m.WithLineNumOffset(this.lineNrOffset);
+            // We only want to print line number offsets if at least one of the
+            // start and end ranges are not both empty.
+            var msg = m.Range == EmptyRange ? m : m.WithLineNumOffset(this.lineNrOffset);
             this.Output(msg);
         }
 

--- a/src/QsCompiler/Compiler/Logging.cs
+++ b/src/QsCompiler/Compiler/Logging.cs
@@ -111,7 +111,7 @@ namespace Microsoft.Quantum.QsCompiler.Diagnostics
                 Code = null, // do not show a code for infos
                 Source = source,
                 Message = $"{DiagnosticItem.Message(code, args ?? Enumerable.Empty<string>())}{Environment.NewLine}{string.Join(Environment.NewLine, messageParam)}",
-                Range = range
+                Range = range ?? new LSP.Range()
             });
 
         /// <summary>
@@ -157,6 +157,7 @@ namespace Microsoft.Quantum.QsCompiler.Diagnostics
         public void Log(Diagnostic m)
         {
             if (m.Severity == DiagnosticSeverity.Warning &&
+                m.Code != null &&
                 CompilationBuilder.Diagnostics.TryGetCode(m.Code, out int code)
                 && this.noWarn.Contains(code))
             {

--- a/src/QsCompiler/Compiler/Logging.cs
+++ b/src/QsCompiler/Compiler/Logging.cs
@@ -69,6 +69,13 @@ namespace Microsoft.Quantum.QsCompiler.Diagnostics
                 Message = $"{Environment.NewLine}{ex}{Environment.NewLine}"
             });
 
+        // NB: Calling the LSP.Range constructor results in an object with
+        //     non-nullable fields set to null values, confusing other places
+        //     where we use nullable reference type metadata. To address this,
+        //     we explicitly construct an empty range that runs from 0:0 to 0:0
+        //     that we can use when there is no reasonable range to provide.
+        private static readonly LSP.Range EmptyRange = new LSP.Range { Start = new Position(0, 0), End = new Position(0, 0) };
+
         // routines for convenience
 
         /// <summary>
@@ -82,7 +89,7 @@ namespace Microsoft.Quantum.QsCompiler.Diagnostics
                 Code = Errors.Code(code),
                 Source = source,
                 Message = DiagnosticItem.Message(code, args ?? Enumerable.Empty<string>()),
-                Range = range ?? new LSP.Range()
+                Range = range ?? EmptyRange
             });
 
         /// <summary>
@@ -96,7 +103,7 @@ namespace Microsoft.Quantum.QsCompiler.Diagnostics
                 Code = Warnings.Code(code),
                 Source = source,
                 Message = DiagnosticItem.Message(code, args ?? Enumerable.Empty<string>()),
-                Range = range ?? new LSP.Range()
+                Range = range ?? EmptyRange
             });
 
         /// <summary>
@@ -111,7 +118,7 @@ namespace Microsoft.Quantum.QsCompiler.Diagnostics
                 Code = null, // do not show a code for infos
                 Source = source,
                 Message = $"{DiagnosticItem.Message(code, args ?? Enumerable.Empty<string>())}{Environment.NewLine}{string.Join(Environment.NewLine, messageParam)}",
-                Range = range ?? new LSP.Range()
+                Range = range ?? EmptyRange
             });
 
         /// <summary>

--- a/src/QsCompiler/Compiler/Logging.cs
+++ b/src/QsCompiler/Compiler/Logging.cs
@@ -82,7 +82,7 @@ namespace Microsoft.Quantum.QsCompiler.Diagnostics
                 Code = Errors.Code(code),
                 Source = source,
                 Message = DiagnosticItem.Message(code, args ?? Enumerable.Empty<string>()),
-                Range = range
+                Range = range ?? new LSP.Range()
             });
 
         /// <summary>
@@ -96,7 +96,7 @@ namespace Microsoft.Quantum.QsCompiler.Diagnostics
                 Code = Warnings.Code(code),
                 Source = source,
                 Message = DiagnosticItem.Message(code, args ?? Enumerable.Empty<string>()),
-                Range = range
+                Range = range ?? new LSP.Range()
             });
 
         /// <summary>

--- a/src/QsCompiler/LanguageServer/Communication.cs
+++ b/src/QsCompiler/LanguageServer/Communication.cs
@@ -64,19 +64,21 @@ namespace Microsoft.Quantum.QsLanguageServer
             [DataMember(Name = "context")]
             public CodeActionContext? Context { get; set; }
 
-            public VisualStudio.LanguageServer.Protocol.CodeActionParams ToCodeActionParams() =>
-                new VisualStudio.LanguageServer.Protocol.CodeActionParams
-                {
-                    TextDocument = this.TextDocument,
-                    Range = this.Range ?? new Range(),
-                    Context = this.Context?.ToCodeActionContext() ??
-                        // Make a blank context if we're missing a code action
-                        // context.
-                        new VisualStudio.LanguageServer.Protocol.CodeActionContext
-                        {
-                            Diagnostics = new Diagnostic[] { }
-                        }
-                };
+            public VisualStudio.LanguageServer.Protocol.CodeActionParams? ToCodeActionParams() =>
+                this.TextDocument == null
+                ? null
+                : new VisualStudio.LanguageServer.Protocol.CodeActionParams
+                  {
+                      TextDocument = this.TextDocument,
+                      Range = this.Range ?? new Range(),
+                      Context = this.Context?.ToCodeActionContext() ??
+                          // Make a blank context if we're missing a code action
+                          // context.
+                          new VisualStudio.LanguageServer.Protocol.CodeActionContext
+                          {
+                              Diagnostics = new Diagnostic[] { }
+                          }
+                  };
         }
 
         /// <summary>

--- a/src/QsCompiler/LanguageServer/Communication.cs
+++ b/src/QsCompiler/LanguageServer/Communication.cs
@@ -68,8 +68,14 @@ namespace Microsoft.Quantum.QsLanguageServer
                 new VisualStudio.LanguageServer.Protocol.CodeActionParams
                 {
                     TextDocument = this.TextDocument,
-                    Range = this.Range,
-                    Context = this.Context?.ToCodeActionContext()
+                    Range = this.Range ?? new Range(),
+                    Context = this.Context?.ToCodeActionContext() ??
+                        // Make a blank context if we're missing a code action
+                        // context.
+                        new VisualStudio.LanguageServer.Protocol.CodeActionContext
+                        {
+                            Diagnostics = new Diagnostic[] { }
+                        }
                 };
         }
 
@@ -87,7 +93,7 @@ namespace Microsoft.Quantum.QsLanguageServer
             public VisualStudio.LanguageServer.Protocol.CodeActionContext ToCodeActionContext() =>
                 new VisualStudio.LanguageServer.Protocol.CodeActionContext
                 {
-                    Diagnostics = this.Diagnostics,
+                    Diagnostics = this.Diagnostics ?? new Diagnostic[] { },
                     Only = null
                 };
         }

--- a/src/QsCompiler/LanguageServer/LanguageServer.cs
+++ b/src/QsCompiler/LanguageServer/LanguageServer.cs
@@ -597,6 +597,12 @@ namespace Microsoft.Quantum.QsLanguageServer
                 return ProtocolError.AwaitingInitialization;
             }
             var param = Utils.TryJTokenAs<Workarounds.CodeActionParams>(arg).ToCodeActionParams();
+            if (param == null)
+            {
+                this.LogToWindow("No code action parameters found; skipping code actions.", MessageType.Warning);
+                return Array.Empty<CodeAction>();
+            }
+
             try
             {
                 return

--- a/src/QsCompiler/LanguageServer/LanguageServer.cs
+++ b/src/QsCompiler/LanguageServer/LanguageServer.cs
@@ -273,6 +273,7 @@ namespace Microsoft.Quantum.QsLanguageServer
                 CompletionProvider = supportsCompletion ? new CompletionOptions() : null,
                 SignatureHelpProvider = new SignatureHelpOptions(),
                 ExecuteCommandProvider = new ExecuteCommandOptions(),
+                DocumentRangeFormattingProvider = false
             };
             capabilities.TextDocumentSync.Change = TextDocumentSyncKind.Incremental;
             capabilities.TextDocumentSync.OpenClose = true;

--- a/src/QsCompiler/LanguageServer/LanguageServer.cs
+++ b/src/QsCompiler/LanguageServer/LanguageServer.cs
@@ -398,10 +398,8 @@ namespace Microsoft.Quantum.QsLanguageServer
             var param = Utils.TryJTokenAs<TextDocumentPositionParams>(arg);
             var defaultLocation = new Location
             {
-                Uri = param?.TextDocument?.Uri,
-                Range = param?.Position != null
-                    ? new VisualStudio.LanguageServer.Protocol.Range { Start = param.Position, End = param.Position }
-                    : null
+                Uri = param.TextDocument.Uri,
+                Range = new VisualStudio.LanguageServer.Protocol.Range { Start = param.Position, End = param.Position }
             };
             try
             {

--- a/src/QsCompiler/LanguageServer/LanguageServer.cs
+++ b/src/QsCompiler/LanguageServer/LanguageServer.cs
@@ -353,7 +353,11 @@ namespace Microsoft.Quantum.QsLanguageServer
                 return Task.CompletedTask;
             }
             var param = Utils.TryJTokenAs<DidSaveTextDocumentParams>(arg);
-            return this.editorState.SaveFileAsync(param.TextDocument, param.Text);
+            // NB: if param.Text is null, then there's nothing to actually
+            //     do here.
+            return param.Text == null
+                   ? Task.CompletedTask
+                   : this.editorState.SaveFileAsync(param.TextDocument, param.Text);
         }
 
         [JsonRpcMethod(Methods.TextDocumentDidChangeName)]

--- a/src/QsCompiler/LanguageServer/LanguageServer.csproj
+++ b/src/QsCompiler/LanguageServer/LanguageServer.csproj
@@ -23,7 +23,7 @@
     <PackageReference Include="Microsoft.Build" Version="16.3.0" ExcludeAssets="runtime" />
     <PackageReference Include="Microsoft.Build.Framework" Version="16.3.0" ExcludeAssets="runtime" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="16.3.0" ExcludeAssets="runtime" />
-    <PackageReference Include="Microsoft.VisualStudio.LanguageServer.Protocol" Version="16.3.57" />
+    <PackageReference Include="Microsoft.VisualStudio.LanguageServer.Protocol" Version="16.9.1180" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
     <PackageReference Include="StreamJsonRpc" Version="2.2.34" />
     <PackageReference Include="System.Reactive" Version="4.2.0" />

--- a/src/QsCompiler/Tests.Compiler/CallGraphTests.fs
+++ b/src/QsCompiler/Tests.Compiler/CallGraphTests.fs
@@ -93,7 +93,7 @@ type CallGraphTests(output: ITestOutputHelper) =
 
         let got =
             compilationDataStructures.Diagnostics()
-            |> Seq.filter (fun d -> d.Severity = DiagnosticSeverity.Error)
+            |> Seq.filter (fun d -> d.Severity = Nullable DiagnosticSeverity.Error)
             |> Seq.choose (fun d ->
                 match Diagnostics.TryGetCode d.Code with
                 | true, code -> Some code

--- a/src/QsCompiler/Tests.Compiler/CompilationLoaderTests.fs
+++ b/src/QsCompiler/Tests.Compiler/CompilationLoaderTests.fs
@@ -53,7 +53,7 @@ type CompilationLoaderTests(output: ITestOutputHelper) =
 
         let errors =
             compilation.Diagnostics()
-            |> Seq.filter (fun diagnostic -> diagnostic.Severity = DiagnosticSeverity.Error)
+            |> Seq.filter (fun diagnostic -> diagnostic.Severity = Nullable DiagnosticSeverity.Error)
 
         Assert.Empty errors
         compilation.BuiltCompilation

--- a/src/QsCompiler/Tests.Compiler/LinkingTests.fs
+++ b/src/QsCompiler/Tests.Compiler/LinkingTests.fs
@@ -118,7 +118,7 @@ type LinkingTests(output: ITestOutputHelper) =
 
     member private this.BuildReference(source: string, content) =
         let comp = this.BuildContent(new CompilationUnitManager(), content)
-        Assert.Empty(comp.Diagnostics() |> Seq.filter (fun d -> d.Severity = DiagnosticSeverity.Error))
+        Assert.Empty(comp.Diagnostics() |> Seq.filter (fun d -> d.Severity = Nullable DiagnosticSeverity.Error))
         struct (source, comp.BuiltCompilation.Namespaces)
 
     member private this.CompileMonomorphization input =

--- a/src/QsCompiler/Tests.Compiler/TestUtils/SetupVerificationTests.fs
+++ b/src/QsCompiler/Tests.Compiler/TestUtils/SetupVerificationTests.fs
@@ -90,15 +90,15 @@ type CompilerTests(compilation: CompilationUnitManager.Compilation) =
 
     member this.Verify(name, expected: IEnumerable<ErrorCode>) =
         let expected = expected.Select(fun code -> int code)
-        VerifyDiagnosticsOfSeverity DiagnosticSeverity.Error name expected
+        VerifyDiagnosticsOfSeverity (Nullable DiagnosticSeverity.Error) name expected
 
     member this.Verify(name, expected: IEnumerable<WarningCode>) =
         let expected = expected.Select(fun code -> int code)
-        VerifyDiagnosticsOfSeverity DiagnosticSeverity.Warning name expected
+        VerifyDiagnosticsOfSeverity (Nullable DiagnosticSeverity.Warning) name expected
 
     member this.Verify(name, expected: IEnumerable<InformationCode>) =
         let expected = expected.Select(fun code -> int code)
-        VerifyDiagnosticsOfSeverity DiagnosticSeverity.Information name expected
+        VerifyDiagnosticsOfSeverity (Nullable DiagnosticSeverity.Information) name expected
 
     member this.VerifyDiagnostics(name, expected: IEnumerable<DiagnosticItem>) =
         let errs =

--- a/src/QsCompiler/Tests.LanguageServer/TestSetup.cs
+++ b/src/QsCompiler/Tests.LanguageServer/TestSetup.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Quantum.QsLanguageServer.Testing
         public Task<Diagnostic[]> GetFileDiagnosticsAsync(string? filename = null) =>
             this.rpc.InvokeWithParameterObjectAsync<Diagnostic[]>(
                 Methods.WorkspaceExecuteCommand.Name,
-                TestUtils.ServerCommand(CommandIds.FileDiagnostics, filename == null ? new TextDocumentIdentifier { Uri = null } : TestUtils.GetTextDocumentIdentifier(filename)));
+                TestUtils.ServerCommand(CommandIds.FileDiagnostics, filename == null ? new TextDocumentIdentifier { Uri = new Uri("file://unknown") } : TestUtils.GetTextDocumentIdentifier(filename)));
 
         public Task SetupAsync()
         {

--- a/src/QsCompiler/Tests.LanguageServer/Tests.LanguageServer.csproj
+++ b/src/QsCompiler/Tests.LanguageServer/Tests.LanguageServer.csproj
@@ -16,7 +16,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />
-    <PackageReference Include="Microsoft.VisualStudio.LanguageServer.Client" Version="16.3.57" />
+    <PackageReference Include="Microsoft.VisualStudio.LanguageServer.Client" Version="16.9.1180" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.0.0" />
     <PackageReference Include="MSTest.TestFramework" Version="2.0.0" />
     <PackageReference Include="System.IO.Pipes" Version="4.3.0" />

--- a/src/QsCompiler/Tests.LanguageServer/Tests.cs
+++ b/src/QsCompiler/Tests.LanguageServer/Tests.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Quantum.QsLanguageServer.Testing
     {
         internal static void AssertCapability<TOptions>(this SumType<bool, TOptions>? capability, bool shouldHave = true, Func<TOptions, bool>? condition = null)
         {
-            Assert.IsTrue(capability.HasValue, "Expected capability to have value, but was null.");
+            Assert.IsTrue(shouldHave && capability.HasValue, "Expected capability to have value, but was null.");
             capability!.Value.Match(
                 flag =>
                 {

--- a/src/QsCompiler/Tests.LanguageServer/Tests.cs
+++ b/src/QsCompiler/Tests.LanguageServer/Tests.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Quantum.QsLanguageServer.Testing
     {
         internal static void AssertCapability<TOptions>(this SumType<bool, TOptions>? capability, bool shouldHave = true, Func<TOptions, bool>? condition = null)
         {
-            Assert.IsTrue(capability.HasValue);
+            Assert.IsTrue(capability.HasValue, "Expected capability to have value, but was null.");
             capability!.Value.Match(
                 flag =>
                 {

--- a/src/QsCompiler/Tests.LanguageServer/Tests.cs
+++ b/src/QsCompiler/Tests.LanguageServer/Tests.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Quantum.QsLanguageServer.Testing
             capability!.Value.Match(
                 flag =>
                 {
-                    Assert.Equals(flag, shouldHave);
+                    Assert.AreEqual(flag, shouldHave);
                     return true;
                 },
                 options =>

--- a/src/QsCompiler/Tests.LanguageServer/Tests.cs
+++ b/src/QsCompiler/Tests.LanguageServer/Tests.cs
@@ -16,25 +16,32 @@ namespace Microsoft.Quantum.QsLanguageServer.Testing
     {
         internal static void AssertCapability<TOptions>(this SumType<bool, TOptions>? capability, bool shouldHave = true, Func<TOptions, bool>? condition = null)
         {
-            Assert.IsTrue(shouldHave && capability.HasValue, "Expected capability to have value, but was null.");
-            capability!.Value.Match(
-                flag =>
-                {
-                    Assert.AreEqual(flag, shouldHave);
-                    return true;
-                },
-                options =>
-                {
-                    if (condition != null)
+            if (shouldHave)
+            {
+                Assert.IsTrue(capability.HasValue, "Expected capability to have value, but was null.");
+            }
+
+            if (capability.HasValue)
+            {
+                capability!.Value.Match(
+                    flag =>
                     {
-                        Assert.IsTrue(condition(options));
-                    }
-                    else
+                        Assert.AreEqual(flag, shouldHave);
+                        return true;
+                    },
+                    options =>
                     {
-                        Assert.IsNotNull(options);
-                    }
-                    return true;
-                });
+                        if (condition != null)
+                        {
+                            Assert.IsTrue(condition(options));
+                        }
+                        else
+                        {
+                            Assert.IsNotNull(options);
+                        }
+                        return true;
+                    });
+            }
         }
     }
 

--- a/src/QsCompiler/Tests.LanguageServer/Tests.cs
+++ b/src/QsCompiler/Tests.LanguageServer/Tests.cs
@@ -12,6 +12,32 @@ using Builder = Microsoft.Quantum.QsCompiler.CompilationBuilder.Utils;
 
 namespace Microsoft.Quantum.QsLanguageServer.Testing
 {
+    internal static class Extensions
+    {
+        internal static void AssertCapability<TOptions>(this SumType<bool, TOptions>? capability, bool shouldHave = true, Func<TOptions, bool>? condition = null)
+        {
+            Assert.IsTrue(capability.HasValue);
+            capability!.Value.Match(
+                flag =>
+                {
+                    Assert.Equals(flag, shouldHave);
+                    return true;
+                },
+                options =>
+                {
+                    if (condition != null)
+                    {
+                        Assert.IsTrue(condition(options));
+                    }
+                    else
+                    {
+                        Assert.IsNotNull(options);
+                    }
+                    return true;
+                });
+        }
+    }
+
     [TestClass]
     public partial class BasicFunctionality
     {
@@ -68,16 +94,19 @@ namespace Microsoft.Quantum.QsLanguageServer.Testing
         {
             // NOTE: these assertions need to be adapted when the server capabilities are changed
             var initParams = TestUtils.GetInitializeParams();
-            initParams.Capabilities.Workspace.ApplyEdit = true;
+            Assert.IsNotNull(initParams.Capabilities.Workspace);
+            // We use the null-forgiving operator, since we check that Workspace
+            // is not null above.
+            initParams.Capabilities.Workspace!.ApplyEdit = true;
             var initReply = await this.rpc.InvokeWithParameterObjectAsync<InitializeResult>(Methods.Initialize.Name, initParams);
 
             Assert.IsNotNull(initReply);
             Assert.IsNotNull(initReply.Capabilities);
             Assert.IsNotNull(initReply.Capabilities.TextDocumentSync);
-            Assert.IsNotNull(initReply.Capabilities.TextDocumentSync.Save);
+            Assert.IsNotNull(initReply.Capabilities.TextDocumentSync!.Save);
             Assert.IsNull(initReply.Capabilities.CodeLensProvider);
             Assert.IsNotNull(initReply.Capabilities.CompletionProvider);
-            Assert.IsTrue(initReply.Capabilities.CompletionProvider.ResolveProvider);
+            Assert.IsTrue(initReply.Capabilities.CompletionProvider!.ResolveProvider);
             Assert.IsNotNull(initReply.Capabilities.CompletionProvider.TriggerCharacters);
             Assert.IsTrue(initReply.Capabilities.CompletionProvider.TriggerCharacters.SequenceEqual(new[] { ".", "(" }));
             Assert.IsNotNull(initReply.Capabilities.SignatureHelpProvider?.TriggerCharacters);
@@ -85,18 +114,20 @@ namespace Microsoft.Quantum.QsLanguageServer.Testing
             Assert.IsNotNull(initReply.Capabilities.ExecuteCommandProvider?.Commands);
             Assert.IsTrue(initReply.Capabilities.ExecuteCommandProvider!.Commands.Contains(CommandIds.ApplyEdit));
             Assert.IsTrue(initReply.Capabilities.TextDocumentSync.OpenClose);
-            Assert.IsTrue(initReply.Capabilities.TextDocumentSync.Save.IncludeText);
+            initReply.Capabilities.TextDocumentSync.Save.AssertCapability(
+                true,
+                options => options.IncludeText);
             Assert.AreEqual(TextDocumentSyncKind.Incremental, initReply.Capabilities.TextDocumentSync.Change);
-            Assert.IsTrue(initReply.Capabilities.DefinitionProvider);
-            Assert.IsTrue(initReply.Capabilities.ReferencesProvider);
-            Assert.IsTrue(initReply.Capabilities.DocumentHighlightProvider);
-            Assert.IsTrue(initReply.Capabilities.DocumentSymbolProvider);
-            Assert.IsFalse(initReply.Capabilities.WorkspaceSymbolProvider);
-            Assert.IsTrue(initReply.Capabilities.RenameProvider.Value is bool supported && supported);
-            Assert.IsTrue(initReply.Capabilities.HoverProvider);
-            Assert.IsFalse(initReply.Capabilities.DocumentFormattingProvider);
-            Assert.IsFalse(initReply.Capabilities.DocumentRangeFormattingProvider);
-            Assert.IsTrue(initReply.Capabilities.CodeActionProvider);
+            initReply.Capabilities.DefinitionProvider.AssertCapability();
+            initReply.Capabilities.ReferencesProvider.AssertCapability();
+            initReply.Capabilities.DocumentHighlightProvider.AssertCapability();
+            initReply.Capabilities.DocumentSymbolProvider.AssertCapability();
+            initReply.Capabilities.WorkspaceSymbolProvider.AssertCapability(shouldHave: false);
+            initReply.Capabilities.RenameProvider.AssertCapability();
+            initReply.Capabilities.HoverProvider.AssertCapability();
+            initReply.Capabilities.DocumentFormattingProvider.AssertCapability(shouldHave: false);
+            initReply.Capabilities.DocumentRangeFormattingProvider.AssertCapability(shouldHave: false);
+            initReply.Capabilities.CodeActionProvider.AssertCapability();
         }
 
         [TestMethod]


### PR DESCRIPTION
This PR fixes #885 by updating the Visual Studio LSP client to the latest version. As that version enables nullable reference types, this PR also makes the needed changes to adapt to nullability metadata in that client.