### PR TITLE
NuGet compliance changes

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -11,6 +11,7 @@
 -->
 <configuration>
   <packageSources>
+    <clear />
     <add key="qdk-alpha" value="https://pkgs.dev.azure.com/ms-quantum-public/Microsoft Quantum (public)/_packaging/alpha/nuget/v3/index.json" protocolVersion="3" />
   </packageSources>
 </configuration>

--- a/NuGet.config
+++ b/NuGet.config
@@ -13,5 +13,6 @@
   <packageSources>
     <clear />
     <add key="qdk-alpha" value="https://pkgs.dev.azure.com/ms-quantum-public/Microsoft Quantum (public)/_packaging/alpha/nuget/v3/index.json" protocolVersion="3" />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
   </packageSources>
 </configuration>

--- a/build/manifest.ps1
+++ b/build/manifest.ps1
@@ -34,8 +34,7 @@ $artifacts = @{
         "Microsoft.Quantum.Compiler",
         "Microsoft.Quantum.DocumentationGenerator"
         "Microsoft.Quantum.ProjectTemplates",
-        "Microsoft.Quantum.Sdk",
-        "qsc"
+        "Microsoft.Quantum.Sdk"
     ) | ForEach-Object { Join-Path $Env:NUGET_OUTDIR "$_.$Env:NUGET_VERSION.nupkg" };
 
     Assemblies = $VsixAssemblies + @(

--- a/build/pack.ps1
+++ b/build/pack.ps1
@@ -36,7 +36,7 @@ function Publish-One {
 
 function Pack-One() {
     param(
-        [string]$project, 
+        [string]$project,
         [string]$include_references=""
     );
 
@@ -89,7 +89,7 @@ Publish-One '../src/QsCompiler/CommandLineTool/CommandLineTool.csproj'
 Publish-One '../src/QuantumSdk/Tools/BuildConfiguration/BuildConfiguration.csproj'
 
 Pack-One '../src/QsCompiler/Compiler/Compiler.csproj' '-IncludeReferencedProjects'
-Pack-One '../src/QsCompiler/CommandLineTool/CommandLineTool.csproj' '-IncludeReferencedProjects'
+# Pack-One '../src/QsCompiler/CommandLineTool/CommandLineTool.csproj' '-IncludeReferencedProjects'
 Pack-Dotnet '../src/Documentation/DocumentationGenerator/DocumentationGenerator.csproj'
 Pack-One '../src/ProjectTemplates/Microsoft.Quantum.ProjectTemplates.nuspec'
 Pack-One '../src/QuantumSdk/QuantumSdk.nuspec'

--- a/build/pack.ps1
+++ b/build/pack.ps1
@@ -89,7 +89,6 @@ Publish-One '../src/QsCompiler/CommandLineTool/CommandLineTool.csproj'
 Publish-One '../src/QuantumSdk/Tools/BuildConfiguration/BuildConfiguration.csproj'
 
 Pack-One '../src/QsCompiler/Compiler/Compiler.csproj' '-IncludeReferencedProjects'
-# Pack-One '../src/QsCompiler/CommandLineTool/CommandLineTool.csproj' '-IncludeReferencedProjects'
 Pack-Dotnet '../src/Documentation/DocumentationGenerator/DocumentationGenerator.csproj'
 Pack-One '../src/ProjectTemplates/Microsoft.Quantum.ProjectTemplates.nuspec'
 Pack-One '../src/QuantumSdk/QuantumSdk.nuspec'


### PR DESCRIPTION
Remove publishing qsc NuGet package and add <clear /> tag to NuGet.Config for compliance.