### PR TITLE
Handling ValueTuples that contain a single item in QIR emission

### DIFF
--- a/src/QsCompiler/QirGeneration/QIR/DataStructures.cs
+++ b/src/QsCompiler/QirGeneration/QIR/DataStructures.cs
@@ -68,7 +68,7 @@ namespace Microsoft.Quantum.QIR.Emission
                     this.cache = (this.sharedState.CurrentBranch, loaded);
                 }
 
-                return this.cache.Item2;
+                return this.cache.Item2!; // safe since IsCached checks for null and load returns a non-null value
             }
 
             /// <summary>

--- a/src/QsCompiler/QirGeneration/Subtransformations/ExpressionKindTransformation.cs
+++ b/src/QsCompiler/QirGeneration/Subtransformations/ExpressionKindTransformation.cs
@@ -400,7 +400,7 @@ namespace Microsoft.Quantum.QsCompiler.QIR
                 {
                     args = vs.Item.Select(this.SharedState.EvaluateSubexpression);
                 }
-                else if (arg.ResolvedType.Resolution.IsTupleType && arg.ResolvedType.Resolution is ResolvedTypeKind.TupleType ts)
+                else if (arg.ResolvedType.Resolution is ResolvedTypeKind.TupleType ts)
                 {
                     var evaluatedArg = (TupleValue)this.SharedState.EvaluateSubexpression(arg);
                     args = evaluatedArg.GetTupleElements();
@@ -2180,7 +2180,10 @@ namespace Microsoft.Quantum.QsCompiler.QIR
 
         public override ResolvedExpressionKind OnValueTuple(ImmutableArray<TypedExpression> vs)
         {
-            var value = this.SharedState.Values.CreateTuple(vs);
+            IValue value =
+                vs.Length == 0 ? this.SharedState.Values.Unit :
+                vs.Length == 1 ? this.SharedState.EvaluateSubexpression(vs.Single()) :
+                this.SharedState.Values.CreateTuple(vs);
             this.SharedState.ValueStack.Push(value);
             return ResolvedExpressionKind.InvalidExpr;
         }

--- a/src/QsCompiler/SyntaxProcessor/ExpressionVerification.fs
+++ b/src/QsCompiler/SyntaxProcessor/ExpressionVerification.fs
@@ -10,7 +10,6 @@ open System.Linq
 open Microsoft.Quantum.QsCompiler
 open Microsoft.Quantum.QsCompiler.DataTypes
 open Microsoft.Quantum.QsCompiler.Diagnostics
-open Microsoft.Quantum.QsCompiler.ReservedKeywords.AssemblyConstants
 open Microsoft.Quantum.QsCompiler.SyntaxExtensions
 open Microsoft.Quantum.QsCompiler.SyntaxGenerator
 open Microsoft.Quantum.QsCompiler.SyntaxProcessing.VerificationTools

--- a/src/QsCompiler/Tests.Compiler/QirTests.fs
+++ b/src/QsCompiler/Tests.Compiler/QirTests.fs
@@ -23,7 +23,7 @@ let private checkAltOutput name actualText =
     let expectedText = ("TestCases", "QirTests", name) |> Path.Combine |> File.ReadAllText
     Assert.Contains(expectedText, GUID.Replace(actualText, "__GUID__"))
 
-let private compilerArgs target (name : string) = 
+let private compilerArgs target (name: string) =
     seq {
         "build"
         "-o"
@@ -34,9 +34,11 @@ let private compilerArgs target (name : string) =
         "--input"
         ("TestCases", "QirTests", name + ".qs") |> Path.Combine
         ("TestCases", "QirTests", "QirCore.qs") |> Path.Combine
+
         (if target
          then ("TestCases", "QirTests", "QirTarget.qs") |> Path.Combine
          else "")
+
         "--qir"
         Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)
         "--verbosity"
@@ -46,6 +48,7 @@ let private compilerArgs target (name : string) =
 let private customTest name compilerArgs snippets =
     clearOutput (name + ".ll")
     compilerArgs |> testOne ReturnCode.Success
+
     let fullText = (name + ".ll") |> File.ReadAllText
     snippets |> List.map (fun s -> checkAltOutput (s + ".ll") fullText)
 
@@ -195,10 +198,8 @@ let ``QIR expressions`` () = qirTest false "TestExpressions"
 [<Fact>]
 let ``QIR targeting`` () =
     let compilerArgs =
-        [
-            "--runtime"
-            "BasicMeasurementFeedback"
-        ]
+        [ "--runtime"; "BasicMeasurementFeedback" ]
         |> Seq.append (compilerArgs true "TestTargeting")
         |> Seq.toArray
-    customTest "TestTargeting" compilerArgs ["TestTargeting"]
+
+    customTest "TestTargeting" compilerArgs [ "TestTargeting" ]

--- a/src/QsCompiler/Tests.Compiler/TestCases/ClassicalControl.qs
+++ b/src/QsCompiler/Tests.Compiler/TestCases/ClassicalControl.qs
@@ -1,29 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-
-namespace Microsoft.Quantum.Simulation.QuantumProcessor.Extensions {
-    operation ApplyIfZero<'T>(measurementResult : Result, (onResultZeroOp : ('T => Unit), zeroArg : 'T)) : Unit { }
-    operation ApplyIfZeroA<'T>(measurementResult : Result, (onResultZeroOp : ('T => Unit is Adj), zeroArg : 'T)) : Unit is Adj { }
-    operation ApplyIfZeroC<'T>(measurementResult : Result, (onResultZeroOp : ('T => Unit is Ctl), zeroArg : 'T)) : Unit is Ctl { }
-    operation ApplyIfZeroCA<'T>(measurementResult : Result, (onResultZeroOp : ('T => Unit is Ctl + Adj), zeroArg : 'T)) : Unit is Ctl + Adj { }
-
-    operation ApplyIfOne<'T>(measurementResult : Result, (onResultOneOp : ('T => Unit), oneArg : 'T)) : Unit { }
-    operation ApplyIfOneA<'T>(measurementResult : Result, (onResultOneOp : ('T => Unit is Adj), oneArg : 'T)) : Unit is Adj { }
-    operation ApplyIfOneC<'T>(measurementResult : Result, (onResultOneOp : ('T => Unit is Ctl), oneArg : 'T)) : Unit is Ctl { }
-    operation ApplyIfOneCA<'T>(measurementResult : Result, (onResultOneOp : ('T => Unit is Ctl + Adj), oneArg : 'T)) : Unit is Ctl + Adj { }
-
-    operation ApplyIfElseR<'T,'U>(measurementResult : Result, (onResultZeroOp : ('T => Unit), zeroArg : 'T) , (onResultOneOp : ('U => Unit), oneArg : 'U)) : Unit { }
-    operation ApplyIfElseRA<'T,'U>(measurementResult : Result, (onResultZeroOp : ('T => Unit is Adj), zeroArg : 'T) , (onResultOneOp : ('U => Unit is Adj), oneArg : 'U)) : Unit is Adj { }
-    operation ApplyIfElseRC<'T,'U>(measurementResult : Result, (onResultZeroOp : ('T => Unit is Ctl), zeroArg : 'T) , (onResultOneOp : ('U => Unit is Ctl), oneArg : 'U)) : Unit is Ctl { }
-    operation ApplyIfElseRCA<'T,'U>(measurementResult : Result, (onResultZeroOp : ('T => Unit is Adj + Ctl), zeroArg : 'T) , (onResultOneOp : ('U => Unit is Adj + Ctl), oneArg : 'U)) : Unit is Ctl + Adj { }
-
-    operation ApplyConditionally<'T,'U>(measurementResults : Result[], resultsValues : Result[], (onEqualOp : ('T => Unit), equalArg : 'T) , (onNonEqualOp : ('U => Unit), nonEqualArg : 'U)) : Unit { }
-    operation ApplyConditionallyA<'T,'U>(measurementResults : Result[], resultsValues : Result[], (onEqualOp : ('T => Unit is Adj), equalArg : 'T) , (onNonEqualOp : ('U => Unit is Adj), nonEqualArg : 'U)) : Unit is Adj { }
-    operation ApplyConditionallyC<'T,'U>(measurementResults : Result[], resultsValues : Result[], (onEqualOp : ('T => Unit is Ctl), equalArg : 'T) , (onNonEqualOp : ('U => Unit is Ctl), nonEqualArg : 'U)) : Unit is Ctl { }
-    operation ApplyConditionallyCA<'T,'U>(measurementResults : Result[], resultsValues : Result[], (onEqualOp : ('T => Unit is Ctl + Adj), equalArg : 'T) , (onNonEqualOp : ('U => Unit is Ctl + Adj), nonEqualArg : 'U)) : Unit is Ctl + Adj { }
-}
-
 namespace SubOps {
     operation SubOp1() : Unit { }
     operation SubOp2() : Unit { }

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestTargeting.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestTargeting.ll
@@ -1,0 +1,19 @@
+define void @Microsoft__Quantum__Testing__QIR__NoArgs__body() {
+entry:
+  %q = call %Qubit* @__quantum__rt__qubit_allocate()
+  %0 = call %Result* @__quantum__qis__mz(%Qubit* %q)
+  %1 = call %Tuple* @__quantum__rt__tuple_create(i64 mul nuw (i64 ptrtoint (i1** getelementptr (i1*, i1** null, i32 1) to i64), i64 2))
+  %2 = bitcast %Tuple* %1 to { %Callable*, %Qubit* }*
+  %3 = getelementptr inbounds { %Callable*, %Qubit* }, { %Callable*, %Qubit* }* %2, i32 0, i32 0
+  %4 = getelementptr inbounds { %Callable*, %Qubit* }, { %Callable*, %Qubit* }* %2, i32 0, i32 1
+  %5 = call %Callable* @__quantum__rt__callable_create([4 x void (%Tuple*, %Tuple*, %Tuple*)*]* @Microsoft__Quantum__Testing__QIR_____GUID___NoArgs, [2 x void (%Tuple*, i64)*]* null, %Tuple* null)
+  store %Callable* %5, %Callable** %3, align 8
+  store %Qubit* %q, %Qubit** %4, align 8
+  call void @Microsoft__Quantum__Simulation__QuantumProcessor__Extensions_____GUID___ApplyIfOne__body(%Result* %0, { %Callable*, %Qubit* }* %2)
+  call void @__quantum__rt__qubit_release(%Qubit* %q)
+  call void @__quantum__rt__result_update_reference_count(%Result* %0, i64 -1)
+  call void @__quantum__rt__callable_memory_management(i32 0, %Callable* %5, i64 -1)
+  call void @__quantum__rt__callable_update_reference_count(%Callable* %5, i64 -1)
+  call void @__quantum__rt__tuple_update_reference_count(%Tuple* %1, i64 -1)
+  ret void
+}

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestTargeting.qs
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestTargeting.qs
@@ -1,0 +1,47 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace Microsoft.Quantum.Testing.QIR {
+    open Microsoft.Quantum.Intrinsic;
+
+    operation NoArgs() : Unit {
+        use q = Qubit();
+        if M(q) != Zero {
+            fail("Unexpected qubit state");
+        }
+    }
+
+    @EntryPoint()
+    operation TestFunctorsNoArgs() : Unit {
+        NoArgs();
+    }
+}
+
+namespace Microsoft.Quantum.Canon {
+
+    operation NoOp<'T>(arg : 'T) : Unit is Adj + Ctl { }
+}
+
+namespace Microsoft.Quantum.Simulation.QuantumProcessor.Extensions {
+
+    operation ApplyIfZero<'T>(measurementResult : Result, (onResultZeroOp : ('T => Unit), zeroArg : 'T)) : Unit { }
+    operation ApplyIfZeroA<'T>(measurementResult : Result, (onResultZeroOp : ('T => Unit is Adj), zeroArg : 'T)) : Unit is Adj { }
+    operation ApplyIfZeroC<'T>(measurementResult : Result, (onResultZeroOp : ('T => Unit is Ctl), zeroArg : 'T)) : Unit is Ctl { }
+    operation ApplyIfZeroCA<'T>(measurementResult : Result, (onResultZeroOp : ('T => Unit is Ctl + Adj), zeroArg : 'T)) : Unit is Ctl + Adj { }
+
+    operation ApplyIfOne<'T>(measurementResult : Result, (onResultOneOp : ('T => Unit), oneArg : 'T)) : Unit { }
+    operation ApplyIfOneA<'T>(measurementResult : Result, (onResultOneOp : ('T => Unit is Adj), oneArg : 'T)) : Unit is Adj { }
+    operation ApplyIfOneC<'T>(measurementResult : Result, (onResultOneOp : ('T => Unit is Ctl), oneArg : 'T)) : Unit is Ctl { }
+    operation ApplyIfOneCA<'T>(measurementResult : Result, (onResultOneOp : ('T => Unit is Ctl + Adj), oneArg : 'T)) : Unit is Ctl + Adj { }
+
+    operation ApplyIfElseR<'T,'U>(measurementResult : Result, (onResultZeroOp : ('T => Unit), zeroArg : 'T) , (onResultOneOp : ('U => Unit), oneArg : 'U)) : Unit { }
+    operation ApplyIfElseRA<'T,'U>(measurementResult : Result, (onResultZeroOp : ('T => Unit is Adj), zeroArg : 'T) , (onResultOneOp : ('U => Unit is Adj), oneArg : 'U)) : Unit is Adj { }
+    operation ApplyIfElseRC<'T,'U>(measurementResult : Result, (onResultZeroOp : ('T => Unit is Ctl), zeroArg : 'T) , (onResultOneOp : ('U => Unit is Ctl), oneArg : 'U)) : Unit is Ctl { }
+    operation ApplyIfElseRCA<'T,'U>(measurementResult : Result, (onResultZeroOp : ('T => Unit is Adj + Ctl), zeroArg : 'T) , (onResultOneOp : ('U => Unit is Adj + Ctl), oneArg : 'U)) : Unit is Ctl + Adj { }
+
+    operation ApplyConditionally<'T,'U>(measurementResults : Result[], resultsValues : Result[], (onEqualOp : ('T => Unit), equalArg : 'T) , (onNonEqualOp : ('U => Unit), nonEqualArg : 'U)) : Unit { }
+    operation ApplyConditionallyA<'T,'U>(measurementResults : Result[], resultsValues : Result[], (onEqualOp : ('T => Unit is Adj), equalArg : 'T) , (onNonEqualOp : ('U => Unit is Adj), nonEqualArg : 'U)) : Unit is Adj { }
+    operation ApplyConditionallyC<'T,'U>(measurementResults : Result[], resultsValues : Result[], (onEqualOp : ('T => Unit is Ctl), equalArg : 'T) , (onNonEqualOp : ('U => Unit is Ctl), nonEqualArg : 'U)) : Unit is Ctl { }
+    operation ApplyConditionallyCA<'T,'U>(measurementResults : Result[], resultsValues : Result[], (onEqualOp : ('T => Unit is Ctl + Adj), equalArg : 'T) , (onNonEqualOp : ('U => Unit is Ctl + Adj), nonEqualArg : 'U)) : Unit is Ctl + Adj { }
+}
+

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestTargeting.qs
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestTargeting.qs
@@ -17,6 +17,8 @@ namespace Microsoft.Quantum.Testing.QIR {
     }
 }
 
+// The following definitions are needed to satisfy the precondition for the target specific compilation pass to run
+
 namespace Microsoft.Quantum.Canon {
 
     operation NoOp<'T>(arg : 'T) : Unit is Adj + Ctl { }

--- a/src/QsCompiler/Tests.Compiler/Tests.Compiler.fsproj
+++ b/src/QsCompiler/Tests.Compiler/Tests.Compiler.fsproj
@@ -246,6 +246,12 @@
     <Content Include="TestCases\QirTests\TestScoping.qs">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
+    <Content Include="TestCases\QirTests\TestTargeting.ll">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="TestCases\QirTests\TestTargeting.qs">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
     <Content Include="TestCases\QirTests\TestStrings.ll">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>


### PR DESCRIPTION
This fixes https://github.com/microsoft/qsharp-compiler/issues/876.
I went with the path of making the QIR emission handle ValueTuples that contain a single item, rather than preventing the construction of expressions of that kind in the first place. Please note that the type of such tuples would not be a TupleType, but indeed is the item type (as it should, see [singleton tuple equivalence](https://github.com/microsoft/qsharp-language/blob/main/Specifications/Language/4_TypeSystem/SingletonTupleEquivalence.md#singleton-tuple-equivalence)). For the type, this behavior is enforced, while for the expression kind it isn't. 