### PR TITLE
Add Hindley-Milner type inference module

### DIFF
--- a/src/QsCompiler/BondSchemas/BondSchemaTranslator.cs
+++ b/src/QsCompiler/BondSchemas/BondSchemaTranslator.cs
@@ -536,9 +536,9 @@ namespace Microsoft.Quantum.QsCompiler.BondSchemas
             {
                 Origin = qsTypeParameter.Origin.ToBondSchema(),
                 TypeName = qsTypeParameter.TypeName,
-                Range = qsTypeParameter.Range.IsNull ?
-                    null :
-                    qsTypeParameter.Range.Item.ToBondSchema()
+#pragma warning disable 618 // QsTypeParameter.Range is obsolete.
+                Range = qsTypeParameter.Range.IsNull ? null : qsTypeParameter.Range.Item.ToBondSchema()
+#pragma warning restore 618
             };
 
         private static QsValueUpdate ToBondSchema(this SyntaxTree.QsValueUpdate valueUpdate) =>
@@ -675,9 +675,9 @@ namespace Microsoft.Quantum.QsCompiler.BondSchemas
             {
                 Namespace = userDefinedType.Namespace,
                 Name = userDefinedType.Name,
-                Range = userDefinedType.Range.IsNull ?
-                    null :
-                    userDefinedType.Range.Item.ToBondSchema()
+#pragma warning disable 618 // UserDefinedType.Range is obsolete.
+                Range = userDefinedType.Range.IsNull ? null : userDefinedType.Range.Item.ToBondSchema()
+#pragma warning restore 618
             };
 
         private static CharacteristicsKindComposition<TBond> ToBondSchemaGeneric<TBond, TCompiler>(

--- a/src/QsCompiler/BondSchemas/BondSchemaTranslator.cs
+++ b/src/QsCompiler/BondSchemas/BondSchemaTranslator.cs
@@ -536,9 +536,7 @@ namespace Microsoft.Quantum.QsCompiler.BondSchemas
             {
                 Origin = qsTypeParameter.Origin.ToBondSchema(),
                 TypeName = qsTypeParameter.TypeName,
-#pragma warning disable 618 // QsTypeParameter.Range is obsolete.
-                Range = qsTypeParameter.Range.IsNull ? null : qsTypeParameter.Range.Item.ToBondSchema()
-#pragma warning restore 618
+                Range = null
             };
 
         private static QsValueUpdate ToBondSchema(this SyntaxTree.QsValueUpdate valueUpdate) =>
@@ -675,9 +673,7 @@ namespace Microsoft.Quantum.QsCompiler.BondSchemas
             {
                 Namespace = userDefinedType.Namespace,
                 Name = userDefinedType.Name,
-#pragma warning disable 618 // UserDefinedType.Range is obsolete.
-                Range = userDefinedType.Range.IsNull ? null : userDefinedType.Range.Item.ToBondSchema()
-#pragma warning restore 618
+                Range = null
             };
 
         private static CharacteristicsKindComposition<TBond> ToBondSchemaGeneric<TBond, TCompiler>(

--- a/src/QsCompiler/BondSchemas/CompilerObjectTranslator.cs
+++ b/src/QsCompiler/BondSchemas/CompilerObjectTranslator.cs
@@ -537,9 +537,7 @@ namespace Microsoft.Quantum.QsCompiler.BondSchemas
             new SyntaxTree.QsTypeParameter(
                 origin: bondQsTypeParameter.Origin.ToCompilerObject(),
                 typeName: bondQsTypeParameter.TypeName,
-                range: bondQsTypeParameter.Range != null ?
-                    bondQsTypeParameter.Range.ToCompilerObject().ToQsNullableGeneric() :
-                    QsNullable<DataTypes.Range>.Null);
+                range: QsNullable<DataTypes.Range>.Null);
 
         private static SyntaxTree.QsWhileStatement ToCompilerObject(this QsWhileStatement bondQsWhileStatement) =>
             new SyntaxTree.QsWhileStatement(
@@ -653,9 +651,7 @@ namespace Microsoft.Quantum.QsCompiler.BondSchemas
             new SyntaxTree.UserDefinedType(
                 @namespace: bondUserDefinedType.Namespace,
                 name: bondUserDefinedType.Name,
-                range: bondUserDefinedType.Range != null ?
-                    bondUserDefinedType.Range.ToCompilerObject().ToQsNullableGeneric() :
-                    QsNullable<DataTypes.Range>.Null);
+                range: QsNullable<DataTypes.Range>.Null);
 
         private static Tuple<SyntaxTree.SymbolTuple, SyntaxTree.ResolvedType> ToCompilerObject(this QsLoopItem bondQsLoopItem) =>
             new Tuple<SyntaxTree.SymbolTuple, SyntaxTree.ResolvedType>(

--- a/src/QsCompiler/CompilationManager/Diagnostics.cs
+++ b/src/QsCompiler/CompilationManager/Diagnostics.cs
@@ -83,34 +83,32 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
                 Range = ((positionOffset ?? Position.Zero) + msg.Range).ToLsp()
             };
 
-        internal const string QsCodePrefix = "QS";
+        private const string CodePrefix = "QS";
+
+        internal static string CodeString(int code) => CodePrefix + code.ToString("D4");
 
         public static bool TryGetCode(string str, out int code)
         {
             code = -1;
             str = str?.Trim() ?? "";
             return !string.IsNullOrWhiteSpace(str) &&
-                str.StartsWith(QsCodePrefix, StringComparison.InvariantCultureIgnoreCase) &&
+                str.StartsWith(CodePrefix, StringComparison.InvariantCultureIgnoreCase) &&
                 int.TryParse(str.Substring(2), out code);
         }
     }
 
     public static class Informations
     {
-        public static string Code(this InformationCode code) =>
-            Information((int)code);
+        public static string Code(this InformationCode code) => Information((int)code);
 
-        internal static string Information(int code) =>
-            $"{Diagnostics.QsCodePrefix}{code}";
+        internal static string Information(int code) => Diagnostics.CodeString(code);
     }
 
     public static class Warnings
     {
-        public static string Code(this WarningCode code) =>
-            Warning((int)code);
+        public static string Code(this WarningCode code) => Warning((int)code);
 
-        internal static string Warning(int code) =>
-            $"{Diagnostics.QsCodePrefix}{code}";
+        internal static string Warning(int code) => Diagnostics.CodeString(code);
 
         // warnings 70**
 
@@ -141,11 +139,9 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
 
     public static class Errors
     {
-        public static string Code(this ErrorCode code) =>
-            Error((int)code);
+        public static string Code(this ErrorCode code) => Error((int)code);
 
-        internal static string Error(int code) =>
-            $"{Diagnostics.QsCodePrefix}{code}";
+        internal static string Error(int code) => Diagnostics.CodeString(code);
 
         // errors 70**
 

--- a/src/QsCompiler/CompilationManager/TypeChecking.cs
+++ b/src/QsCompiler/CompilationManager/TypeChecking.cs
@@ -870,9 +870,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
                 var buildClause = BuildStatement(
                     nodes.Current,
                     (relPos, ctx) => Statements.NewConditionalBlock(nodes.Current.Fragment.Comments, relPos, ctx, ifCond.Item),
-#pragma warning disable 612 // WithinIfCondition is obsolete.
-                    context.WithinIfCondition,
-#pragma warning restore 612
+                    context,
                     diagnostics);
                 var ifBlock = buildClause(BuildScope(nodes.Current.Children.GetEnumerator(), context, diagnostics));
 
@@ -884,9 +882,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
                     buildClause = BuildStatement(
                         nodes.Current,
                         (relPos, ctx) => Statements.NewConditionalBlock(nodes.Current.Fragment.Comments, relPos, ctx, elifCond.Item),
-#pragma warning disable 612 // WithinIfCondition is obsolete.
-                        context.WithinIfCondition,
-#pragma warning restore 612
+                        context,
                         diagnostics);
                     elifBlocks.Add(buildClause(BuildScope(nodes.Current.Children.GetEnumerator(), context, diagnostics)));
                     proceed = nodes.MoveNext();

--- a/src/QsCompiler/Core/ConstructorExtensions.fs
+++ b/src/QsCompiler/Core/ConstructorExtensions.fs
@@ -3,18 +3,30 @@
 
 module Microsoft.Quantum.QsCompiler.SyntaxExtensions
 
+#nowarn "44" // TypeParameter.Range and UserDefinedType.Range are deprecated.
+
+open System
 open System.Collections.Generic
-open System.Collections.ObjectModel
 open System.Collections.Immutable
+open System.Collections.ObjectModel
 open System.Linq
+
+open Microsoft.Quantum.QsCompiler.DataTypes
 open Microsoft.Quantum.QsCompiler.SyntaxTokens
 open Microsoft.Quantum.QsCompiler.SyntaxTree
-
 
 type QsQualifiedName with
     static member New(nsName, cName) = { Namespace = nsName; Name = cName }
 
 type UserDefinedType with
+    static member New(ns, name) =
+        {
+            Namespace = ns
+            Name = name
+            Range = Null
+        }
+
+    [<Obsolete "Use UserDefinedType.New(string, string) instead.">]
     static member New(nsName, tName, range) =
         {
             Namespace = nsName
@@ -23,6 +35,14 @@ type UserDefinedType with
         }
 
 type QsTypeParameter with
+    static member New(origin, name) =
+        {
+            Origin = origin
+            TypeName = name
+            Range = Null
+        }
+
+    [<Obsolete "Use QsTypeParameter.New(string, string) instead.">]
     static member New(origin, tName, range) =
         {
             Origin = origin

--- a/src/QsCompiler/Core/SymbolResolution.fs
+++ b/src/QsCompiler/Core/SymbolResolution.fs
@@ -7,10 +7,10 @@ open System
 open System.Collections.Generic
 open System.Collections.Immutable
 open System.Linq
+
 open Microsoft.Quantum.QsCompiler.DataTypes
 open Microsoft.Quantum.QsCompiler.Diagnostics
 open Microsoft.Quantum.QsCompiler.ReservedKeywords
-open Microsoft.Quantum.QsCompiler.SyntaxExtensions
 open Microsoft.Quantum.QsCompiler.SyntaxTokens
 open Microsoft.Quantum.QsCompiler.SyntaxTree
 
@@ -599,9 +599,8 @@ module SymbolResolution =
     /// <exception cref="ArgumentException">The given source file is not listed as source of that namespace.</exception>
     let rec internal ResolveType (processUDT, processTypeParameter) (qsType: QsType) =
         let resolve = ResolveType(processUDT, processTypeParameter)
-        let asResolvedType t = ResolvedType.New(true, t)
-        let buildWith builder ts = builder ts |> asResolvedType
-        let invalid = InvalidType |> asResolvedType
+        let buildWith builder ts = builder ts |> ResolvedType.New
+        let invalid = ResolvedType.New InvalidType
         let range = qsType.Range.ValueOr Range.Zero
 
         match qsType.Type with
@@ -609,7 +608,7 @@ module SymbolResolution =
         | TupleType items -> items |> AccumulateInner resolve (buildWith TupleType)
         | QsTypeKind.TypeParameter sym ->
             match sym.Symbol with
-            | Symbol name -> processTypeParameter (name, sym.Range) |> fun (k, errs) -> k |> asResolvedType, errs
+            | Symbol name -> processTypeParameter (name, sym.Range) |> fun (k, errs) -> ResolvedType.New k, errs
             | InvalidSymbol -> invalid, [||]
             | _ ->
                 invalid,
@@ -631,24 +630,24 @@ module SymbolResolution =
             [ arg; res ] |> AccumulateInner resolve (buildWith (fun ts -> QsTypeKind.Function(ts.[0], ts.[1])))
         | UserDefinedType name ->
             match name.Symbol with
-            | Symbol sym -> processUDT ((None, sym), name.Range) |> fun (k, errs) -> k |> asResolvedType, errs
+            | Symbol sym -> processUDT ((None, sym), name.Range) |> fun (k, errs) -> ResolvedType.New k, errs
             | QualifiedSymbol (ns, sym) ->
-                processUDT ((Some ns, sym), name.Range) |> fun (k, errs) -> k |> asResolvedType, errs
+                processUDT ((Some ns, sym), name.Range) |> fun (k, errs) -> ResolvedType.New k, errs
             | InvalidSymbol -> invalid, [||]
             | MissingSymbol
             | OmittedSymbols
             | SymbolTuple _ -> invalid, [| range |> QsCompilerDiagnostic.Error(ErrorCode.ExpectingIdentifier, []) |]
-        | UnitType -> QsTypeKind.UnitType |> asResolvedType, [||]
-        | Int -> QsTypeKind.Int |> asResolvedType, [||]
-        | BigInt -> QsTypeKind.BigInt |> asResolvedType, [||]
-        | Double -> QsTypeKind.Double |> asResolvedType, [||]
-        | Bool -> QsTypeKind.Bool |> asResolvedType, [||]
-        | String -> QsTypeKind.String |> asResolvedType, [||]
-        | Qubit -> QsTypeKind.Qubit |> asResolvedType, [||]
-        | Result -> QsTypeKind.Result |> asResolvedType, [||]
-        | Pauli -> QsTypeKind.Pauli |> asResolvedType, [||]
-        | Range -> QsTypeKind.Range |> asResolvedType, [||]
-        | InvalidType -> QsTypeKind.InvalidType |> asResolvedType, [||]
+        | UnitType -> ResolvedType.New QsTypeKind.UnitType, [||]
+        | Int -> ResolvedType.New QsTypeKind.Int, [||]
+        | BigInt -> ResolvedType.New QsTypeKind.BigInt, [||]
+        | Double -> ResolvedType.New QsTypeKind.Double, [||]
+        | Bool -> ResolvedType.New QsTypeKind.Bool, [||]
+        | String -> ResolvedType.New QsTypeKind.String, [||]
+        | Qubit -> ResolvedType.New QsTypeKind.Qubit, [||]
+        | Result -> ResolvedType.New QsTypeKind.Result, [||]
+        | Pauli -> ResolvedType.New QsTypeKind.Pauli, [||]
+        | Range -> ResolvedType.New QsTypeKind.Range, [||]
+        | InvalidType -> ResolvedType.New QsTypeKind.InvalidType, [||]
         | MissingType -> NotSupportedException "missing type cannot be resolved" |> raise
 
     /// <summary>

--- a/src/QsCompiler/Core/SymbolResolution.fs
+++ b/src/QsCompiler/Core/SymbolResolution.fs
@@ -599,8 +599,9 @@ module SymbolResolution =
     /// <exception cref="ArgumentException">The given source file is not listed as source of that namespace.</exception>
     let rec internal ResolveType (processUDT, processTypeParameter) (qsType: QsType) =
         let resolve = ResolveType(processUDT, processTypeParameter)
-        let buildWith builder ts = builder ts |> ResolvedType.New
-        let invalid = ResolvedType.New InvalidType
+        let asResolvedType = TypeRange.annotated qsType.Range |> ResolvedType.create
+        let buildWith builder ts = builder ts |> asResolvedType
+        let invalid = asResolvedType InvalidType
         let range = qsType.Range.ValueOr Range.Zero
 
         match qsType.Type with
@@ -608,7 +609,7 @@ module SymbolResolution =
         | TupleType items -> items |> AccumulateInner resolve (buildWith TupleType)
         | QsTypeKind.TypeParameter sym ->
             match sym.Symbol with
-            | Symbol name -> processTypeParameter (name, sym.Range) |> fun (k, errs) -> ResolvedType.New k, errs
+            | Symbol name -> processTypeParameter (name, sym.Range) |> fun (k, errs) -> asResolvedType k, errs
             | InvalidSymbol -> invalid, [||]
             | _ ->
                 invalid,
@@ -630,24 +631,24 @@ module SymbolResolution =
             [ arg; res ] |> AccumulateInner resolve (buildWith (fun ts -> QsTypeKind.Function(ts.[0], ts.[1])))
         | UserDefinedType name ->
             match name.Symbol with
-            | Symbol sym -> processUDT ((None, sym), name.Range) |> fun (k, errs) -> ResolvedType.New k, errs
+            | Symbol sym -> processUDT ((None, sym), name.Range) |> fun (k, errs) -> asResolvedType k, errs
             | QualifiedSymbol (ns, sym) ->
-                processUDT ((Some ns, sym), name.Range) |> fun (k, errs) -> ResolvedType.New k, errs
+                processUDT ((Some ns, sym), name.Range) |> fun (k, errs) -> asResolvedType k, errs
             | InvalidSymbol -> invalid, [||]
             | MissingSymbol
             | OmittedSymbols
             | SymbolTuple _ -> invalid, [| range |> QsCompilerDiagnostic.Error(ErrorCode.ExpectingIdentifier, []) |]
-        | UnitType -> ResolvedType.New QsTypeKind.UnitType, [||]
-        | Int -> ResolvedType.New QsTypeKind.Int, [||]
-        | BigInt -> ResolvedType.New QsTypeKind.BigInt, [||]
-        | Double -> ResolvedType.New QsTypeKind.Double, [||]
-        | Bool -> ResolvedType.New QsTypeKind.Bool, [||]
-        | String -> ResolvedType.New QsTypeKind.String, [||]
-        | Qubit -> ResolvedType.New QsTypeKind.Qubit, [||]
-        | Result -> ResolvedType.New QsTypeKind.Result, [||]
-        | Pauli -> ResolvedType.New QsTypeKind.Pauli, [||]
-        | Range -> ResolvedType.New QsTypeKind.Range, [||]
-        | InvalidType -> ResolvedType.New QsTypeKind.InvalidType, [||]
+        | UnitType -> asResolvedType UnitType, [||]
+        | Int -> asResolvedType Int, [||]
+        | BigInt -> asResolvedType BigInt, [||]
+        | Double -> asResolvedType Double, [||]
+        | Bool -> asResolvedType Bool, [||]
+        | String -> asResolvedType String, [||]
+        | Qubit -> asResolvedType Qubit, [||]
+        | Result -> asResolvedType Result, [||]
+        | Pauli -> asResolvedType Pauli, [||]
+        | Range -> asResolvedType Range, [||]
+        | InvalidType -> asResolvedType InvalidType, [||]
         | MissingType -> NotSupportedException "missing type cannot be resolved" |> raise
 
     /// <summary>

--- a/src/QsCompiler/Core/SymbolTable/NamespaceManager.fs
+++ b/src/QsCompiler/Core/SymbolTable/NamespaceManager.fs
@@ -3,6 +3,8 @@
 
 namespace Microsoft.Quantum.QsCompiler.SymbolManagement
 
+#nowarn "44" // QsTypeParameter.Range and UserDefinedType.Range are deprecated.
+
 open System
 open System.Collections.Generic
 open System.Collections.Immutable

--- a/src/QsCompiler/Core/SyntaxGenerator.fs
+++ b/src/QsCompiler/Core/SyntaxGenerator.fs
@@ -252,7 +252,7 @@ module SyntaxGenerator =
             | BuiltInKind.Function typeParams -> typeParams.[0]
             | _ -> ArgumentException "Length is expected to be a function" |> raise
 
-        let typeParameter = QsTypeParameter.New(callableName, typeParameterName, Null)
+        let typeParameter = QsTypeParameter.New(callableName, typeParameterName)
 
         let genArrayType =
             QsTypeKind.ArrayType(QsTypeKind.TypeParameter typeParameter |> ResolvedType.New) |> ResolvedType.New

--- a/src/QsCompiler/Core/SyntaxTreeExtensions.fs
+++ b/src/QsCompiler/Core/SyntaxTreeExtensions.fs
@@ -5,6 +5,8 @@
 [<System.Runtime.CompilerServices.Extension>]
 module Microsoft.Quantum.QsCompiler.SyntaxTreeExtensions
 
+#nowarn "44" // TypeParameter.Range and UserDefinedType.Range are deprecated.
+
 open System
 open System.Collections.Generic
 open System.Collections.Immutable

--- a/src/QsCompiler/Core/Transformations/ExpressionTransformation.fs
+++ b/src/QsCompiler/Core/Transformations/ExpressionTransformation.fs
@@ -454,12 +454,9 @@ and ExpressionTransformationBase internal (options: TransformationOptions, _inte
      -> ImmutableDictionary<(QsQualifiedName * string), ResolvedType>
 
     default this.OnTypeParamResolutions typeParams =
-        let asTypeParameter (key) =
-            QsTypeParameter.New(fst key, snd key, Null)
-
         let filteredTypeParams =
             typeParams
-            |> Seq.map (fun kv -> this.Types.OnTypeParameter(kv.Key |> asTypeParameter), kv.Value)
+            |> Seq.map (fun kv -> QsTypeParameter.New(fst kv.Key, snd kv.Key) |> this.Types.OnTypeParameter, kv.Value)
             |> Seq.choose (function
                 | TypeParameter tp, value -> Some((tp.Origin, tp.TypeName), this.Types.OnType value)
                 | _ -> None)

--- a/src/QsCompiler/Core/Transformations/TypeTransformation.fs
+++ b/src/QsCompiler/Core/Transformations/TypeTransformation.fs
@@ -144,5 +144,5 @@ type TypeTransformationBase(options: TransformationOptions) =
                 | ExpressionType.Pauli -> this.OnPauli()
                 | ExpressionType.Range -> this.OnRange()
 
-            let ResolvedType t = ResolvedType.New(true, t)
-            ResolvedType |> Node.BuildOr t transformed
+            let range = this.OnRangeInformation t.Range
+            Node.BuildOr t transformed (ResolvedType.create range)

--- a/src/QsCompiler/Core/Transformations/TypeTransformation.fs
+++ b/src/QsCompiler/Core/Transformations/TypeTransformation.fs
@@ -25,6 +25,7 @@ type TypeTransformationBase(options: TransformationOptions) =
 
     // supplementary type information
 
+    // TODO: RELEASE 2021-10: Remove obsolete method.
     [<Obsolete "Use OnRangeInformation(TypeRange) instead.">]
     abstract OnRangeInformation: QsNullable<Range> -> QsNullable<Range>
     default this.OnRangeInformation range = range

--- a/src/QsCompiler/Core/Transformations/TypeTransformation.fs
+++ b/src/QsCompiler/Core/Transformations/TypeTransformation.fs
@@ -123,6 +123,13 @@ type TypeTransformationBase(options: TransformationOptions) =
         if not options.Enable then
             t
         else
+            let range =
+                match t.Range with
+                | Annotated range -> Value range |> this.OnRangeInformation |> QsNullable<_>.Map Annotated
+                | Inferred range -> Value range |> this.OnRangeInformation |> QsNullable<_>.Map Inferred
+                | TypeRange.Generated -> Null
+                |> QsNullable.defaultValue TypeRange.Generated
+
             let transformed =
                 match t.Resolution with
                 | ExpressionType.UnitType -> this.OnUnitType()
@@ -143,12 +150,5 @@ type TypeTransformationBase(options: TransformationOptions) =
                 | ExpressionType.Result -> this.OnResult()
                 | ExpressionType.Pauli -> this.OnPauli()
                 | ExpressionType.Range -> this.OnRange()
-
-            let range =
-                match t.Range with
-                | Annotated range -> Value range |> this.OnRangeInformation |> QsNullable<_>.Map Annotated
-                | Inferred range -> Value range |> this.OnRangeInformation |> QsNullable<_>.Map Inferred
-                | TypeRange.Generated -> Null
-                |> QsNullable.defaultValue TypeRange.Generated
 
             ResolvedType.create range |> Node.BuildOr t transformed

--- a/src/QsCompiler/Core/Transformations/TypeTransformation.fs
+++ b/src/QsCompiler/Core/Transformations/TypeTransformation.fs
@@ -144,5 +144,11 @@ type TypeTransformationBase(options: TransformationOptions) =
                 | ExpressionType.Pauli -> this.OnPauli()
                 | ExpressionType.Range -> this.OnRange()
 
-            let range = this.OnRangeInformation t.Range
-            Node.BuildOr t transformed (ResolvedType.create range)
+            let range =
+                match t.Range with
+                | Annotated range -> Value range |> this.OnRangeInformation |> QsNullable<_>.Map Annotated
+                | Inferred range -> Value range |> this.OnRangeInformation |> QsNullable<_>.Map Inferred
+                | TypeRange.Generated -> Null
+                |> QsNullable.defaultValue TypeRange.Generated
+
+            ResolvedType.create range |> Node.BuildOr t transformed

--- a/src/QsCompiler/Core/Transformations/TypeTransformation.fs
+++ b/src/QsCompiler/Core/Transformations/TypeTransformation.fs
@@ -3,6 +3,8 @@
 
 namespace Microsoft.Quantum.QsCompiler.Transformations.Core
 
+#nowarn "44" // TypeParameter.Range and UserDefinedType.Range are deprecated.
+
 open System.Collections.Immutable
 open Microsoft.Quantum.QsCompiler.DataTypes
 open Microsoft.Quantum.QsCompiler.SyntaxExtensions
@@ -42,7 +44,7 @@ type TypeTransformationBase(options: TransformationOptions) =
     default this.OnUserDefinedType udt =
         let ns, name = udt.Namespace, udt.Name
         let range = this.OnRangeInformation udt.Range
-        ExpressionType.UserDefinedType << UserDefinedType.New |> Node.BuildOr InvalidType (ns, name, range)
+        Node.BuildOr InvalidType (ns, name, range) (UserDefinedType.New >> UserDefinedType)
 
     abstract OnTypeParameter: QsTypeParameter -> ExpressionType
 
@@ -50,9 +52,7 @@ type TypeTransformationBase(options: TransformationOptions) =
         let origin = tp.Origin
         let name = tp.TypeName
         let range = this.OnRangeInformation tp.Range
-
-        ExpressionType.TypeParameter << QsTypeParameter.New
-        |> Node.BuildOr InvalidType (origin, name, range)
+        Node.BuildOr InvalidType (origin, name, range) (QsTypeParameter.New >> TypeParameter)
 
     abstract OnOperation: (ResolvedType * ResolvedType) * CallableInformation -> ExpressionType
 

--- a/src/QsCompiler/DataStructures/DataTypes.fs
+++ b/src/QsCompiler/DataStructures/DataTypes.fs
@@ -94,7 +94,8 @@ module QsNullable =
     /// Returns the original nullable if it is <see cref="Value"/>, otherwise returns the given
     /// <paramref name="ifNull"/>.
     /// </summary>
-    let internal orElse ifNull =
+    [<CompiledName "OrElse">]
+    let orElse ifNull =
         function
         | Null -> ifNull
         | Value value -> Value value

--- a/src/QsCompiler/DataStructures/Diagnostics.fs
+++ b/src/QsCompiler/DataStructures/Diagnostics.fs
@@ -7,6 +7,9 @@ open System
 open System.Collections.Generic
 
 type ErrorCode =
+    | TypeMismatch = 1
+    | MissingBaseType = 2
+
     | ExcessBracketError = 1001
     | MissingBracketError = 1002
     | MissingStringDelimiterError = 1003
@@ -427,6 +430,11 @@ type DiagnosticItem =
         let ApplyArguments =
             DiagnosticItem.ApplyArguments args
             << function
+            | ErrorCode.TypeMismatch ->
+                "The expected type {0} does not match the actual type {1}.\nExpected type: {2}\n  Actual type: {3}"
+            | ErrorCode.MissingBaseType ->
+                "The type {3} cannot be used with the type {4}, because {1} does not {0} {2}."
+
             | ErrorCode.ExcessBracketError -> "No matching opening bracket for this closing bracket."
             | ErrorCode.MissingBracketError -> "An opening bracket has not been closed."
             | ErrorCode.MissingStringDelimiterError -> "File ends with an unclosed string."
@@ -619,8 +627,7 @@ type DiagnosticItem =
                 "The type {0} does not provide item access. Items can only be accessed for values of array type."
             | ErrorCode.InvalidTypeInArithmeticExpr ->
                 "The type {0} does not support arithmetic operators. Expecting an expression of type Int, BigInt or Double."
-            | ErrorCode.InvalidTypeForConcatenation ->
-                "The type {0} does not support concatenation. Expecting an expression of array type."
+            | ErrorCode.InvalidTypeForConcatenation -> "The type {0} does not support the + operator."
             | ErrorCode.InvalidTypeInEqualityComparison -> "The type {0} does not support equality comparison."
             | ErrorCode.ArgumentMismatchInBinaryOp ->
                 "The given arguments of type {0} and {1} do not have a common base type."
@@ -732,7 +739,7 @@ type DiagnosticItem =
                 "The type of the given argument does not match the expected type. Got an argument of type {0}, expecting one of type {1} instead."
             | ErrorCode.UnexpectedTupleArgument -> "Unexpected argument tuple. Expecting an argument of type {0}."
             | ErrorCode.AmbiguousTypeParameterResolution ->
-                "The type parameter resolution for the call is ambiguous. Please provide explicit type arguments, e.g. Op<Int, Double>(arg)."
+                "The type parameter resolution for the expression is ambiguous. Please provide explicit type arguments, e.g. Op<Int, Double>(arg)."
             | ErrorCode.ConstrainsTypeParameter -> "The given expression constrains the type parameter(s) {0}."
             | ErrorCode.DirectRecursionWithinTemplate ->
                 "Direct recursive calls within templates require explicit type arguments. Please provide type arguments, e.g. Op<Int, Double>(arg)."

--- a/src/QsCompiler/DataStructures/SyntaxTree.fs
+++ b/src/QsCompiler/DataStructures/SyntaxTree.fs
@@ -119,35 +119,66 @@ type QsLocation =
 
 
 /// used to represent the use of a type parameter within a fully resolved Q# type
+[<CustomEquality>]
+[<CustomComparison>]
 type QsTypeParameter =
     // TODO: origin needs adapting if we ever allow to declare type parameters on specializations
     {
-        /// the qualified name of the callable the type parameter belongs to
+        /// The qualified name of the callable the type parameter belongs to.
         Origin: QsQualifiedName
-        /// the name of the type parameter
+
+        /// The name of the type parameter.
         TypeName: string
-        /// the range at which the type parameter occurs relative to the statement (or partial statement) root
-        /// -> is Null for auto-generated type information, i.e. in particular for inferred type information
+
+        /// The source code range where the type parameter occurs. Null for auto-generated or inferred types. Range is
+        /// ignored when comparing type parameters.
         Range: QsNullable<Range>
     }
 
+    interface IComparable with
+        member param1.CompareTo param2 =
+            match param2 with
+            | :? QsTypeParameter as param2 -> compare (param1.Origin, param1.TypeName) (param2.Origin, param2.TypeName)
+            | _ -> ArgumentException "Types are different." |> raise
+
+    override param1.Equals param2 =
+        match param2 with
+        | :? QsTypeParameter as param2 -> param1.Origin = param2.Origin && param1.TypeName = param2.TypeName
+        | _ -> false
+
+    override param.GetHashCode() = hash (param.Origin, param.TypeName)
 
 /// used to represent the use of a user defined type within a fully resolved Q# type
+[<CustomEquality>]
+[<CustomComparison>]
 type UserDefinedType =
     {
-        /// the name of the namespace in which the type is declared
+        /// The name of the namespace in which the type is declared.
         Namespace: string
-        /// the name of the declared type
+
+        /// The name of the declared type.
         Name: string
-        /// the range at which the type occurs relative to the statement (or partial statement) root
-        /// -> is Null for auto-generated type information, i.e. in particular for inferred type information
+
+        /// The source code range where the user defined type name occurs. Null for auto-generated or inferred types.
+        /// Range is ignored when comparing user defined types.
         Range: QsNullable<Range>
     }
+
+    interface IComparable with
+        member udt1.CompareTo udt2 =
+            match udt2 with
+            | :? UserDefinedType as udt2 -> compare (udt1.Namespace, udt1.Name) (udt2.Namespace, udt2.Name)
+            | _ -> ArgumentException "Types are different." |> raise
+
+    override udt1.Equals udt2 =
+        match udt2 with
+        | :? UserDefinedType as udt2 -> udt1.Namespace = udt2.Namespace && udt1.Name = udt2.Name
+        | _ -> false
+
+    override udt.GetHashCode() = hash (udt.Namespace, udt.Name)
 
     member this.GetFullName() =
         { Namespace = this.Namespace; Name = this.Name }
-
-
 
 /// Fully resolved operation characteristics used to describe the properties of a Q# callable.
 /// A resolved characteristic expression by construction never contains an empty or invalid set as inner expressions,
@@ -347,61 +378,112 @@ type CallableInformation =
 /// A Q# resolved type by construction never contains any arity-0 or arity-1 tuple types.
 /// User defined types are represented as UserDefinedTypes.
 /// Type parameters are represented as QsTypeParameters containing their origin and name.
+[<CustomEquality>]
+[<CustomComparison>]
 type ResolvedType =
     private
         {
-            // the private constructor enforces that the guarantees given for any instance of ResolvedType
-            // -> the static member New replaces the record constructor
-            _TypeKind: QsTypeKind<ResolvedType, UserDefinedType, QsTypeParameter, CallableInformation>
+            kind: QsTypeKind<ResolvedType, UserDefinedType, QsTypeParameter, CallableInformation>
+            range: Range QsNullable
         }
+
         interface ITuple
+
+        interface IComparable with
+            member this.CompareTo that =
+                match that with
+                | :? ResolvedType as that -> compare this.kind that.kind
+                | _ -> ArgumentException "Types are different." |> raise
+
+        override this.Equals that =
+            match that with
+            | :? ResolvedType as that -> this.kind = that.kind
+            | _ -> false
+
+        override this.GetHashCode() = hash this.kind
 
         /// Contains the fully resolved Q# type,
         /// where type parameters are represented as QsTypeParameters containing their origin (the namespace and the callable they belong to) and their name,
         /// and user defined types are resolved to their fully qualified name.
         /// By construction never contains any arity-0 or arity-1 tuple types.
-        member this.Resolution = this._TypeKind
+        member this.Resolution = this.kind
 
-        /// <summary>
-        /// Builds a ResolvedType based on a compatible Q# type kind, and replaces the (inaccessible) record constructor.
-        /// Replaces an arity-1 tuple by its item type.
-        /// </summary>
-        /// <exception cref="ArgumentException">The given type kind is an empty tuple.</exception>
-        static member New kind = ResolvedType.New(false, kind)
+        /// The source code range where this type originated. For inferred types, this is the range of the expression
+        /// that has this type. Range is ignored when comparing resolved types.
+        member this.Range = this.range
 
-        static member internal New(keepRangeInfo,
-                                   kind: QsTypeKind<ResolvedType, UserDefinedType, QsTypeParameter, CallableInformation>) =
-            match kind with
-            | QsTypeKind.TupleType ts when ts.Length = 0 ->
-                ArgumentException "tuple type requires at least one item" |> raise
-            | QsTypeKind.TupleType ts when ts.Length = 1 -> ts.[0]
-            | QsTypeKind.UserDefinedType udt when not keepRangeInfo ->
-                { _TypeKind = UserDefinedType { udt with Range = Null } }
-            | QsTypeKind.TypeParameter tp when not keepRangeInfo ->
-                { _TypeKind = TypeParameter { tp with Range = Null } }
-            | _ -> { _TypeKind = kind }
+module ResolvedType =
+    /// <summary>
+    /// Replaces singleton tuple types with its contained type.
+    /// </summary>
+    /// <exception cref="ArgumentException">The type kind is an empty tuple.</exception>
+    let private normalizeTuple =
+        function
+        | TupleType items when items.IsEmpty -> ArgumentException "Tuple is empty." |> raise
+        | TupleType items when items.Length = 1 -> (items.[0]: ResolvedType).Resolution
+        | kind -> kind
 
-        /// Given a map that for a type parameter returns the corresponding resolved type it is supposed to be replaced with,
-        /// replaces the type parameters in the given type with their resolutions.
-        static member ResolveTypeParameters (resolutions: ImmutableDictionary<_, _>) (t: ResolvedType) =
-            let inner = ResolvedType.ResolveTypeParameters resolutions
+    /// <summary>
+    /// Creates a resolved type with no source code range.
+    /// </summary>
+    /// <exception cref="ArgumentException"><paramref name="kind"/> is an empty tuple.</exception>
+    [<CompiledName "Create">]
+    let create range kind =
+        { kind = normalizeTuple kind; range = range }
 
-            if resolutions.IsEmpty then
-                t
-            else
-                match t.Resolution with
-                | QsTypeKind.TypeParameter tp ->
-                    match resolutions.TryGetValue((tp.Origin, tp.TypeName)) with
-                    | true, res -> res
-                    | false, _ -> t
-                | QsTypeKind.TupleType ts ->
-                    ts |> Seq.map inner |> fun x -> x.ToImmutableArray() |> TupleType |> ResolvedType.New
-                | QsTypeKind.ArrayType b -> inner b |> ArrayType |> ResolvedType.New
-                | QsTypeKind.Function (it, ot) -> (inner it, inner ot) |> QsTypeKind.Function |> ResolvedType.New
-                | QsTypeKind.Operation ((it, ot), fList) ->
-                    ((inner it, inner ot), fList) |> QsTypeKind.Operation |> ResolvedType.New
-                | _ -> t
+    /// <summary>
+    /// Replaces the type kind of <paramref name="resolvedType"/> with <paramref name="kind"/>.
+    /// </summary>
+    [<CompiledName "WithKind">]
+    let withKind kind resolvedType =
+        { resolvedType with kind = normalizeTuple kind }
 
+    /// <summary>
+    /// Replaces the range of <paramref name="resolvedType"/> with <paramref name="range"/>.
+    /// </summary>
+    [<CompiledName "WithRange">]
+    let withRange range resolvedType = { resolvedType with range = range }
+
+    /// <summary>
+    /// Recursively replaces every range in <paramref name="resolvedType"/> with <paramref name="range"/>.
+    /// </summary>
+    [<CompiledName "WithRangeRecurse">]
+    let rec withAllRanges range (resolvedType: ResolvedType) =
+        match resolvedType.Resolution with
+        | ArrayType item -> withAllRanges range item |> ArrayType
+        | TupleType items -> items |> Seq.map (withAllRanges range) |> ImmutableArray.CreateRange |> TupleType
+        | QsTypeKind.Operation ((input, output), info) ->
+            QsTypeKind.Operation((withAllRanges range input, withAllRanges range output), info)
+        | QsTypeKind.Function (input, output) ->
+            QsTypeKind.Function(withAllRanges range input, withAllRanges range output)
+        | kind -> kind
+        |> create range
+
+type ResolvedType with
+    /// <summary>
+    /// Creates a resolved type with no source code range.
+    /// </summary>
+    /// <exception cref="ArgumentException"><paramref name="kind"/> is an empty tuple.</exception>
+    static member New kind = ResolvedType.create Null kind
+
+    /// Given a map that for a type parameter returns the corresponding resolved type it is supposed to be replaced with,
+    /// replaces the type parameters in the given type with their resolutions.
+    static member ResolveTypeParameters (resolutions: ImmutableDictionary<_, _>) (t: ResolvedType) =
+        let inner = ResolvedType.ResolveTypeParameters resolutions
+
+        match t.Resolution with
+        | _ when resolutions.IsEmpty -> t
+        | QsTypeKind.TypeParameter tp ->
+            match resolutions.TryGetValue((tp.Origin, tp.TypeName)) with
+            | true, res -> res
+            | false, _ -> t
+        | QsTypeKind.TupleType ts ->
+            t |> ResolvedType.withKind (ts |> Seq.map inner |> ImmutableArray.CreateRange |> TupleType)
+        | QsTypeKind.ArrayType b -> t |> ResolvedType.withKind (inner b |> ArrayType)
+        | QsTypeKind.Function (it, ot) -> t |> ResolvedType.withKind (QsTypeKind.Function(inner it, inner ot))
+        | QsTypeKind.Operation ((it, ot), fList) ->
+            t |> ResolvedType.withKind (QsTypeKind.Operation((inner it, inner ot), fList))
+        | _ -> t
 
 /// used to represent information on typed expressions generated and/or tracked during compilation
 type InferredExpressionInformation =

--- a/src/QsCompiler/DataStructures/SyntaxTree.fs
+++ b/src/QsCompiler/DataStructures/SyntaxTree.fs
@@ -132,6 +132,8 @@ type QsTypeParameter =
 
         /// The source code range where the type parameter occurs. Null for auto-generated or inferred types. Range is
         /// ignored when comparing type parameters.
+        // TODO: RELEASE 2021-10: Remove obsolete property.
+        [<Obsolete "Use ResolvedType.Range instead.">]
         Range: QsNullable<Range>
     }
 
@@ -161,6 +163,8 @@ type UserDefinedType =
 
         /// The source code range where the user defined type name occurs. Null for auto-generated or inferred types.
         /// Range is ignored when comparing user defined types.
+        // TODO: RELEASE 2021-10: Remove obsolete property.
+        [<Obsolete "Use ResolvedType.Range instead.">]
         Range: QsNullable<Range>
     }
 
@@ -385,6 +389,12 @@ type TypeRange =
     | Generated
 
 module TypeRange =
+    /// <summary>
+    /// Creates an <see cref="Annotated"/> type range if a range is given, or the <see cref="Generated"/> type range
+    /// otherwise.
+    /// </summary>
+    let annotated = QsNullable<_>.Map Annotated >> QsNullable.defaultValue Generated
+
     /// <summary>
     /// Creates an <see cref="Inferred"/> type range if a range is given, or the <see cref="Generated"/> type range
     /// otherwise.

--- a/src/QsCompiler/DataStructures/SyntaxTree.fs
+++ b/src/QsCompiler/DataStructures/SyntaxTree.fs
@@ -150,6 +150,11 @@ type QsTypeParameter =
 
     override param.GetHashCode() = hash (param.Origin, param.TypeName)
 
+    /// <summary>
+    /// Returns this type parameter with the given <paramref name="origin"/>.
+    /// </summary>
+    member param.WithOrigin origin = { param with Origin = origin }
+
 /// used to represent the use of a user defined type within a fully resolved Q# type
 [<CustomEquality>]
 [<CustomComparison>]

--- a/src/QsCompiler/DataStructures/SyntaxTree.fs
+++ b/src/QsCompiler/DataStructures/SyntaxTree.fs
@@ -393,15 +393,17 @@ module TypeRange =
     /// Creates an <see cref="Annotated"/> type range if a range is given, or the <see cref="Generated"/> type range
     /// otherwise.
     /// </summary>
-    let annotated = QsNullable<_>.Map Annotated >> QsNullable.defaultValue Generated
+    let internal annotated = QsNullable<_>.Map Annotated >> QsNullable.defaultValue Generated
 
     /// <summary>
     /// Creates an <see cref="Inferred"/> type range if a range is given, or the <see cref="Generated"/> type range
     /// otherwise.
     /// </summary>
+    [<CompiledName "Inferred">]
     let inferred = QsNullable<_>.Map Inferred >> QsNullable.defaultValue Generated
 
     /// Returns the range if it exists.
+    [<CompiledName "TryRange">]
     let tryRange =
         function
         | Annotated range
@@ -411,6 +413,7 @@ module TypeRange =
     /// <summary>
     /// Returns the original type range if it is not generated, otherwise returns <paramref name="ifGenerated"/>.
     /// </summary>
+    [<CompiledName "OrElse">]
     let orElse ifGenerated =
         function
         | Annotated _

--- a/src/QsCompiler/DataStructures/SyntaxTree.fs
+++ b/src/QsCompiler/DataStructures/SyntaxTree.fs
@@ -447,7 +447,7 @@ module ResolvedType =
     /// <summary>
     /// Recursively replaces every range in <paramref name="resolvedType"/> with <paramref name="range"/>.
     /// </summary>
-    [<CompiledName "WithRangeRecurse">]
+    [<CompiledName "WithAllRanges">]
     let rec withAllRanges range (resolvedType: ResolvedType) =
         match resolvedType.Resolution with
         | ArrayType item -> withAllRanges range item |> ArrayType

--- a/src/QsCompiler/SyntaxProcessor/ExpressionVerification.fs
+++ b/src/QsCompiler/SyntaxProcessor/ExpressionVerification.fs
@@ -719,7 +719,7 @@ let private VerifyCallExpr buildCallableType
                     // We hence treat self-recursions separately and require that for direct self-recursions all type parameters need to be resolved;
                     // i.e. we prevent type parametrized partial applications of the parent callable, and all type arguments are attached to the identifier.
                     let typeParam =
-                        QsTypeParameter.New(fst entry.Key, snd entry.Key, Null) |> TypeParameter |> ResolvedType.New
+                        QsTypeParameter.New(fst entry.Key, snd entry.Key) |> TypeParameter |> ResolvedType.New
 
                     match res.Resolution with
                     | TypeParameter tp when tp.Origin = fst entry.Key && tp.TypeName = snd entry.Key -> typeParam
@@ -758,7 +758,7 @@ let private VerifyCallExpr buildCallableType
                         invalid
                     else // explicitly specified by type argument
                         let typeParam =
-                            QsTypeParameter.New(fst entry.Key, snd entry.Key, Null) |> TypeParameter |> ResolvedType.New
+                            QsTypeParameter.New(fst entry.Key, snd entry.Key) |> TypeParameter |> ResolvedType.New
 
                         let conflicting = entry |> Seq.filter (fun (t, _) -> typeParam = StripPositionInfo.Apply t)
 
@@ -839,8 +839,7 @@ let internal VerifyAssignment expectedType (parent, definedTypeParams) mismatchE
 
     let nonTrivialResolutions =
         tpResolutions.ToLookup(fst, snd).Where containsNonTrivialResolution
-        |> Seq.map (fun g ->
-            QsTypeParameter.New(fst g.Key, snd g.Key, Null) |> TypeParameter |> ResolvedType.New |> toString)
+        |> Seq.map (fun g -> QsTypeParameter.New(fst g.Key, snd g.Key) |> TypeParameter |> ResolvedType.New |> toString)
         |> Seq.toList
 
     if nonTrivialResolutions.Any() then

--- a/src/QsCompiler/SyntaxProcessor/ScopeContext.fs
+++ b/src/QsCompiler/SyntaxProcessor/ScopeContext.fs
@@ -1,0 +1,66 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Microsoft.Quantum.QsCompiler.SyntaxProcessing
+
+open Microsoft.Quantum.QsCompiler
+open Microsoft.Quantum.QsCompiler.SymbolManagement
+open Microsoft.Quantum.QsCompiler.SyntaxProcessing.TypeInference
+open Microsoft.Quantum.QsCompiler.SyntaxTree
+open System
+
+/// The context used for symbol resolution and type checking within the scope of a callable.
+type ScopeContext =
+    {
+        /// The namespace manager for global symbols.
+        Globals: NamespaceManager
+
+        /// The symbol tracker for the parent callable.
+        Symbols: SymbolTracker
+
+        /// The type inference context.
+        Inference: InferenceContext
+
+        /// True if the parent callable for the current scope is an operation.
+        IsInOperation: bool
+
+        /// The return type of the parent callable for the current scope.
+        ReturnType: ResolvedType
+
+        /// The runtime capability of the compilation unit.
+        Capability: RuntimeCapability
+
+        /// The name of the processor architecture for the compilation unit.
+        ProcessorArchitecture: string
+    }
+
+    /// <summary>
+    /// Creates a scope context for the specialization.
+    ///
+    /// The symbol tracker in the context does not make a copy of the given namespace manager. Instead, it throws an
+    /// <see cref="InvalidOperationException"/> if the namespace manager has been modified (i.e. the version number of
+    /// the namespace manager has changed).
+    /// </summary>
+    /// <exception cref="ArgumentException">
+    /// Thrown if the given namespace manager does not contain all resolutions or if the specialization's parent does
+    /// not exist in the given namespace manager.
+    /// </exception>
+    static member Create (nsManager: NamespaceManager)
+                         capability
+                         processorArchitecture
+                         (spec: SpecializationDeclarationHeader)
+                         =
+        match nsManager.TryGetCallable spec.Parent (spec.Parent.Namespace, Source.assemblyOrCodeFile spec.Source) with
+        | Found declaration ->
+            let symbolTracker = SymbolTracker(nsManager, Source.assemblyOrCodeFile spec.Source, spec.Parent)
+
+            {
+                Globals = nsManager
+                Symbols = symbolTracker
+                Inference = InferenceContext symbolTracker
+                IsInOperation = declaration.Kind = Operation
+                ReturnType = StripPositionInfo.Apply declaration.Signature.ReturnType
+                Capability = capability
+                ProcessorArchitecture = processorArchitecture
+            }
+        | _ -> ArgumentException "The specialization's parent callable does not exist." |> raise

--- a/src/QsCompiler/SyntaxProcessor/SymbolTracker.fs
+++ b/src/QsCompiler/SyntaxProcessor/SymbolTracker.fs
@@ -1,13 +1,12 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 namespace Microsoft.Quantum.QsCompiler.SyntaxProcessing
 
-#nowarn "44" // ScopeContext.IsInIfCondition is deprecated.
-
 open System
 open System.Collections.Generic
 open System.Collections.Immutable
+
 open Microsoft.Quantum.QsCompiler
 open Microsoft.Quantum.QsCompiler.DataTypes
 open Microsoft.Quantum.QsCompiler.Diagnostics
@@ -50,7 +49,6 @@ type private TrackedScope =
                     else requiredSupport (Controlled :: current) tail
 
             requiredSupport [] functors
-
 
 /// <summary>
 /// The <see cref="SymbolTracker"/> class does *not* make a copy of the given <see cref="NamespaceManager"/>,
@@ -299,7 +297,7 @@ type SymbolTracker(globals: NamespaceManager, sourceFile, parent: QsQualifiedNam
             let argType, returnType =
                 decl.ArgumentType |> StripPositionInfo.Apply, decl.ReturnType |> StripPositionInfo.Apply
 
-            let idType = kind ((argType, returnType), decl.Information) |> ResolvedType.New
+            let idType = kind ((argType, returnType), decl.Information) |> ResolvedType.create qsSym.Range
             LocalVariableDeclaration.New false (defaultLoc, GlobalCallable fullName, idType, false), decl.TypeParameters
 
         let addDiagnosticForSymbol code args =
@@ -330,12 +328,12 @@ type SymbolTracker(globals: NamespaceManager, sourceFile, parent: QsQualifiedNam
                 let decl = dict.[sym]
 
                 let properties =
-                    (defaultLoc,
-                     LocalVariable sym,
-                     decl.Type |> StripPositionInfo.Apply,
-                     decl.InferredInformation.HasLocalQuantumDependency)
+                    defaultLoc,
+                    LocalVariable sym,
+                    decl.Type |> ResolvedType.withAllRanges qsSym.Range,
+                    decl.InferredInformation.HasLocalQuantumDependency
 
-                properties |> LocalVariableDeclaration.New decl.InferredInformation.IsMutable, ImmutableArray<_>.Empty
+                properties |> LocalVariableDeclaration.New decl.InferredInformation.IsMutable, ImmutableArray.Empty
             | Null -> globalCallableWithName (None, sym) |> resolveGlobal (None, sym)
 
         match qsSym.Symbol with
@@ -395,64 +393,3 @@ type SymbolTracker(globals: NamespaceManager, sourceFile, parent: QsQualifiedNam
                 | _ ->
                     addError (ErrorCode.UnknownItemName, [ udt.Name; name ])
                     InvalidType |> ResolvedType.New
-
-/// The context used for symbol resolution and type checking within the scope of a callable.
-type ScopeContext =
-    // TODO: RELEASE 2021-04: Remove IsInIfCondition and WithinIfCondition.
-    {
-        /// The namespace manager for global symbols.
-        Globals: NamespaceManager
-
-        /// The symbol tracker for the parent callable.
-        Symbols: SymbolTracker
-
-        /// True if the parent callable for the current scope is an operation.
-        IsInOperation: bool
-
-        /// True if the current expression is contained within the condition of an if- or elif-statement.
-        [<Obsolete>]
-        IsInIfCondition: bool
-
-        /// The return type of the parent callable for the current scope.
-        ReturnType: ResolvedType
-
-        /// The runtime capability of the compilation unit.
-        Capability: RuntimeCapability
-
-        /// The name of the processor architecture for the compilation unit.
-        ProcessorArchitecture: string
-    }
-
-    /// <summary>
-    /// Creates a scope context for the specialization.
-    ///
-    /// The symbol tracker in the context does not make a copy of the given namespace manager. Instead, it throws an
-    /// <see cref="InvalidOperationException"/> if the namespace manager has been modified (i.e. the version number of
-    /// the namespace manager has changed).
-    /// </summary>
-    /// <exception cref="ArgumentException">
-    /// Thrown if the given namespace manager does not contain all resolutions or if the specialization's parent does
-    /// not exist in the given namespace manager.
-    /// </exception>
-    static member Create (nsManager: NamespaceManager)
-                         capability
-                         processorArchitecture
-                         (spec: SpecializationDeclarationHeader)
-                         =
-        match nsManager.TryGetCallable spec.Parent (spec.Parent.Namespace, Source.assemblyOrCodeFile spec.Source) with
-        | Found declaration ->
-            {
-                Globals = nsManager
-                Symbols = SymbolTracker(nsManager, Source.assemblyOrCodeFile spec.Source, spec.Parent)
-                IsInOperation = declaration.Kind = Operation
-                IsInIfCondition = false
-                ReturnType = StripPositionInfo.Apply declaration.Signature.ReturnType
-                Capability = capability
-                ProcessorArchitecture = processorArchitecture
-            }
-        | _ -> raise <| ArgumentException "The specialization's parent callable does not exist."
-
-    /// Returns a new scope context for an expression that is contained within the condition of an if- or
-    /// elif-statement.
-    [<Obsolete>]
-    member this.WithinIfCondition = { this with IsInIfCondition = true }

--- a/src/QsCompiler/SyntaxProcessor/SymbolTracker.fs
+++ b/src/QsCompiler/SyntaxProcessor/SymbolTracker.fs
@@ -297,7 +297,10 @@ type SymbolTracker(globals: NamespaceManager, sourceFile, parent: QsQualifiedNam
             let argType, returnType =
                 decl.ArgumentType |> StripPositionInfo.Apply, decl.ReturnType |> StripPositionInfo.Apply
 
-            let idType = kind ((argType, returnType), decl.Information) |> ResolvedType.create qsSym.Range
+            let idType =
+                kind ((argType, returnType), decl.Information)
+                |> ResolvedType.create (TypeRange.inferred qsSym.Range)
+
             LocalVariableDeclaration.New false (defaultLoc, GlobalCallable fullName, idType, false), decl.TypeParameters
 
         let addDiagnosticForSymbol code args =
@@ -330,7 +333,7 @@ type SymbolTracker(globals: NamespaceManager, sourceFile, parent: QsQualifiedNam
                 let properties =
                     defaultLoc,
                     LocalVariable sym,
-                    decl.Type |> ResolvedType.withAllRanges qsSym.Range,
+                    decl.Type |> ResolvedType.withAllRanges (TypeRange.inferred qsSym.Range),
                     decl.InferredInformation.HasLocalQuantumDependency
 
                 properties |> LocalVariableDeclaration.New decl.InferredInformation.IsMutable, ImmutableArray.Empty

--- a/src/QsCompiler/SyntaxProcessor/SyntaxProcessor.fsproj
+++ b/src/QsCompiler/SyntaxProcessor/SyntaxProcessor.fsproj
@@ -13,7 +13,12 @@
       <Link>DelaySign.fs</Link>
     </Compile>
     <Compile Include="VerificationTools.fs" />
-    <Compile Include="ScopeTools.fs" />
+    <Compile Include="SymbolTracker.fs" />
+    <Compile Include="TypeInference\Constraint.fsi" />
+    <Compile Include="TypeInference\Constraint.fs" />
+    <Compile Include="TypeInference\InferenceContext.fsi" />
+    <Compile Include="TypeInference\InferenceContext.fs" />
+    <Compile Include="ScopeContext.fs" />
     <Compile Include="CapabilityInference.fs" />
     <Compile Include="ContextVerification.fs" />
     <Compile Include="ExpressionVerification.fs" />

--- a/src/QsCompiler/SyntaxProcessor/SyntaxProcessor.fsproj
+++ b/src/QsCompiler/SyntaxProcessor/SyntaxProcessor.fsproj
@@ -14,6 +14,7 @@
     </Compile>
     <Compile Include="VerificationTools.fs" />
     <Compile Include="SymbolTracker.fs" />
+    <Content Include="TypeInference\README.md" />
     <Compile Include="TypeInference\Constraint.fsi" />
     <Compile Include="TypeInference\Constraint.fs" />
     <Compile Include="TypeInference\InferenceContext.fsi" />

--- a/src/QsCompiler/SyntaxProcessor/TreeVerification.fs
+++ b/src/QsCompiler/SyntaxProcessor/TreeVerification.fs
@@ -3,6 +3,8 @@
 
 module Microsoft.Quantum.QsCompiler.SyntaxProcessing.SyntaxTree
 
+#nowarn "44" // UserDefinedType.Range is deprecated.
+
 open System
 open System.Collections.Generic
 open System.Collections.Immutable

--- a/src/QsCompiler/SyntaxProcessor/TreeVerification.fs
+++ b/src/QsCompiler/SyntaxProcessor/TreeVerification.fs
@@ -3,8 +3,6 @@
 
 module Microsoft.Quantum.QsCompiler.SyntaxProcessing.SyntaxTree
 
-#nowarn "44" // UserDefinedType.Range is deprecated.
-
 open System
 open System.Collections.Generic
 open System.Collections.Immutable
@@ -177,7 +175,6 @@ let CheckDefinedTypesForCycles (definitions: ImmutableArray<TypeDeclarationHeade
                     (source,
                      (getLocation header).Range |> QsCompilerDiagnostic.Error(ErrorCode.TypeCannotContainItself, []))
                     |> diagnostics.Add
-
                 []
 
     let getTypes location (vtype: ResolvedType) (rootIndex: int option) =
@@ -196,10 +193,7 @@ let CheckDefinedTypesForCycles (definitions: ImmutableArray<TypeDeclarationHeade
             let queue = Queue()
 
             let parent =
-                (header.QualifiedName.Namespace,
-                 header.QualifiedName.Name,
-                 header.Location |> QsNullable<_>.Map(fun loc -> loc.Range))
-                |> UserDefinedType.New
+                UserDefinedType.New(header.QualifiedName.Namespace, header.QualifiedName.Name)
                 |> UserDefinedType
                 |> ResolvedType.New
 

--- a/src/QsCompiler/SyntaxProcessor/TypeInference/Constraint.fs
+++ b/src/QsCompiler/SyntaxProcessor/TypeInference/Constraint.fs
@@ -1,0 +1,37 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Microsoft.Quantum.QsCompiler.SyntaxProcessing.TypeInference
+
+open Microsoft.Quantum.QsCompiler.SyntaxTokens
+open Microsoft.Quantum.QsCompiler.SyntaxTree
+
+type internal Constraint =
+    | Adjointable
+    | Callable of input: ResolvedType * output: ResolvedType
+    | CanGenerateFunctors of functors: QsFunctor Set
+    | Controllable of controlled: ResolvedType
+    | Equatable
+    | HasPartialApplication of missing: ResolvedType * result: ResolvedType
+    | Indexed of index: ResolvedType * item: ResolvedType
+    | Integral
+    | Iterable of item: ResolvedType
+    | Numeric
+    | Semigroup
+    | Wrapped of item: ResolvedType
+
+module internal Constraint =
+    let types =
+        function
+        | Adjointable -> []
+        | Callable (input, output) -> [ input; output ]
+        | CanGenerateFunctors _ -> []
+        | Controllable controlled -> [ controlled ]
+        | Equatable -> []
+        | HasPartialApplication (missing, result) -> [ missing; result ]
+        | Indexed (index, item) -> [ index; item ]
+        | Integral -> []
+        | Iterable item -> [ item ]
+        | Numeric -> []
+        | Semigroup -> []
+        | Wrapped item -> [ item ]

--- a/src/QsCompiler/SyntaxProcessor/TypeInference/Constraint.fsi
+++ b/src/QsCompiler/SyntaxProcessor/TypeInference/Constraint.fsi
@@ -1,0 +1,67 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Microsoft.Quantum.QsCompiler.SyntaxProcessing.TypeInference
+
+open Microsoft.Quantum.QsCompiler.SyntaxTokens
+open Microsoft.Quantum.QsCompiler.SyntaxTree
+
+/// A type constraint is a set of types satisfying some property.
+type internal Constraint =
+    /// An adjointable operation.
+    | Adjointable
+
+    /// <summary>
+    /// A callable from <paramref name="input"/> to <paramref name="output"/>.
+    /// </summary>
+    | Callable of input: ResolvedType * output: ResolvedType
+
+    /// <summary>
+    /// A type that can be used in an operation that requires auto-generated specializations for the given
+    /// <paramref name="functors"/>.
+    /// </summary>
+    | CanGenerateFunctors of functors: QsFunctor Set
+
+    /// <summary>
+    /// A controllable operation that has the given <paramref name="controlled"/> type after the controlled functor is
+    /// applied.
+    /// </summary>
+    | Controllable of controlled: ResolvedType
+
+    /// A type that supports equality comparisons.
+    | Equatable
+
+    /// <summary>
+    /// A callable that can be partially applied such that, given the remaining inputs as an argument of type
+    /// <paramref name="missing"/>, it will yield an output of type <paramref name="result"/>.
+    /// </summary>
+    | HasPartialApplication of missing: ResolvedType * result: ResolvedType
+
+    /// <summary>
+    /// A type that can be accessed by an index of type <paramref name="index"/>, yielding an item of type
+    /// <paramref name="item"/>.
+    /// </summary>
+    | Indexed of index: ResolvedType * item: ResolvedType
+
+    /// A type that represents an integer.
+    | Integral
+
+    /// <summary>
+    /// A type that can be iterated over, yielding items of type <paramref name="item"/>.
+    /// </summary>
+    | Iterable of item: ResolvedType
+
+    /// A type that represents a number.
+    | Numeric
+
+    /// A type with the associative semigroup operator +.
+    | Semigroup
+
+    /// <summary>
+    /// A wrapped type that can be unwrapped to yield an item of type <paramref name="item"/>.
+    /// </summary>
+    | Wrapped of item: ResolvedType
+
+module internal Constraint =
+    /// The list of types contained in a constraint.
+    val types: Constraint -> ResolvedType list

--- a/src/QsCompiler/SyntaxProcessor/TypeInference/InferenceContext.fs
+++ b/src/QsCompiler/SyntaxProcessor/TypeInference/InferenceContext.fs
@@ -1,0 +1,559 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Microsoft.Quantum.QsCompiler.SyntaxProcessing.TypeInference
+
+open System
+open System.Collections.Generic
+open System.Collections.Immutable
+
+open Microsoft.Quantum.QsCompiler
+open Microsoft.Quantum.QsCompiler.DataTypes
+open Microsoft.Quantum.QsCompiler.Diagnostics
+open Microsoft.Quantum.QsCompiler.SyntaxExtensions
+open Microsoft.Quantum.QsCompiler.SyntaxProcessing
+open Microsoft.Quantum.QsCompiler.SyntaxProcessing.VerificationTools
+open Microsoft.Quantum.QsCompiler.SyntaxTokens
+open Microsoft.Quantum.QsCompiler.SyntaxTree
+open Microsoft.Quantum.QsCompiler.TextProcessing
+open Microsoft.Quantum.QsCompiler.Transformations.Core
+open Microsoft.Quantum.QsCompiler.Transformations.QsCodeOutput
+open Microsoft.Quantum.QsCompiler.Utils
+
+/// A placeholder type variable.
+type private Variable =
+    {
+        /// The substituted type.
+        Substitution: ResolvedType option
+
+        /// The list of constraints on the type of this variable.
+        Constraints: Constraint list
+
+        /// Whether this variable encountered a type inference error.
+        HasError: bool
+
+        /// The source range that this variable originated from.
+        Source: Range
+    }
+
+module private Variable =
+    /// Adds a type constraint to the type of the variable.
+    let constrain typeConstraint variable =
+        { variable with Constraints = typeConstraint :: variable.Constraints }
+
+/// An ordering comparison of two types.
+type private Ordering =
+    /// The type is a subtype of the other type.
+    | Subtype
+
+    /// The types are equal.
+    | Equal
+
+    /// The type is a supertype of the other type.
+    | Supertype
+
+module private Ordering =
+    /// Negates the direction of the ordering.
+    let not =
+        function
+        | Subtype -> Supertype
+        | Equal -> Equal
+        | Supertype -> Subtype
+
+/// Remembers context when recursively comparing two types side-by-side.
+type private TypeContext =
+    {
+        /// The left-hand type.
+        Left: ResolvedType
+
+        /// The right-hand type.
+        Right: ResolvedType
+
+        /// The most recent relevant ancestor of the left-hand type.
+        OriginalLeft: ResolvedType
+
+        /// The most recent relevant ancestor of the right-hand type.
+        OriginalRight: ResolvedType
+    }
+
+module private TypeContext =
+    /// <summary>
+    /// Creates a type context originating with <paramref name="left"/> and <paramref name="right"/>.
+    /// </summary>
+    let create left right =
+        {
+            Left = left
+            Right = right
+            OriginalLeft = left
+            OriginalRight = right
+        }
+
+    /// Descends into the respective children of each type, preserving the original types if the range of both the left
+    /// and the right types do not change.
+    let into (leftChild: ResolvedType) (rightChild: ResolvedType) context =
+        if leftChild.Range = context.Left.Range || rightChild.Range = context.Right.Range
+        then { context with Left = leftChild; Right = rightChild }
+        else create leftChild rightChild
+
+    /// Descends into the respective children of each type, preserving the original types if the range of the right type
+    /// does not change.
+    let intoRight leftChild (rightChild: ResolvedType) context =
+        if rightChild.Range = context.Right.Range
+        then { context with Left = leftChild; Right = rightChild }
+        else create leftChild rightChild
+
+    /// Swaps the left and right types.
+    let swap context =
+        {
+            Left = context.Right
+            Right = context.Left
+            OriginalLeft = context.OriginalRight
+            OriginalRight = context.OriginalLeft
+        }
+
+    /// The list of types in the context, in order: left, right, original left, original right.
+    let toList context =
+        [ context.Left; context.Right; context.OriginalLeft; context.OriginalRight ]
+
+/// Tools to help with type inference.
+module private Inference =
+    /// <summary>
+    /// True if <paramref name="info1"/> and <paramref name="info2"/> contain the same set of characteristics.
+    /// </summary>
+    let characteristicsEqual info1 info2 =
+        let chars1 = info1.Characteristics
+        let chars2 = info2.Characteristics
+        chars1.AreInvalid || chars2.AreInvalid || chars1.GetProperties().SetEquals(chars2.GetProperties())
+
+    /// <summary>
+    /// True if the characteristics of <paramref name="info1"/> are a subset of the characteristics of
+    /// <paramref name="info2"/>.
+    /// </summary>
+    let isSubset info1 info2 =
+        info1.Characteristics.GetProperties().IsSubsetOf(info2.Characteristics.GetProperties())
+
+    /// <summary>
+    /// True if the characteristics of <paramref name="info"/> contain the given <paramref name="functor"/>.
+    /// </summary>
+    let hasFunctor functor info =
+        info.Characteristics.SupportedFunctors
+        |> QsNullable.defaultValue ImmutableHashSet.Empty
+        |> fun functors -> functors.Contains functor
+
+    /// Shows the type as a string.
+    let showType: ResolvedType -> _ = SyntaxTreeToQsharp.Default.ToCode
+
+    /// Shows the functor as a string.
+    let showFunctor =
+        function
+        | Adjoint -> Keywords.qsAdjointFunctor.id
+        | Controlled -> Keywords.qsControlledFunctor.id
+
+    /// <summary>
+    /// Combines information from two callables such that the resulting callable information satisfies the given
+    /// <paramref name="ordering"/> with respect to both <paramref name="info1"/> and <paramref name="info2"/>.
+    /// </summary>
+    /// <returns><see cref="Some"/> information if a combination is possible; otherwise <see cref="None"/>.</returns>
+    let private combineCallableInfo ordering info1 info2 =
+        match ordering with
+        | Subtype ->
+            let chars = Union(info1.Characteristics, info2.Characteristics)
+
+            CallableInformation.New(ResolvedCharacteristics.New chars, InferredCallableInformation.NoInformation)
+            |> Some
+        | Equal when characteristicsEqual info1 info2 ->
+            let characteristics =
+                if info1.Characteristics.AreInvalid then info2.Characteristics else info1.Characteristics
+
+            let inferred =
+                [ info1.InferredInformation; info2.InferredInformation ] |> InferredCallableInformation.Common
+
+            CallableInformation.New(characteristics, inferred) |> Some
+        | Equal -> None
+        | Supertype -> [ info1; info2 ] |> CallableInformation.Common |> Some
+
+    /// <summary>
+    /// Combines two types such that the resulting type satisfies the given <paramref name="ordering"/> with respect to
+    /// both original types.
+    /// </summary>
+    let rec combine ordering types =
+        let range = QsNullable.Map2 Range.Span types.Left.Range types.Right.Range
+
+        let relation =
+            match ordering with
+            | Subtype -> "share a subtype with"
+            | Equal -> "equal"
+            | Supertype -> "share a base type with"
+
+        let error =
+            QsCompilerDiagnostic.Error
+                (ErrorCode.MissingBaseType, relation :: (TypeContext.toList types |> List.map showType))
+                (range |> QsNullable.defaultValue Range.Zero)
+
+        match types.Left.Resolution, types.Right.Resolution with
+        | ArrayType item1, ArrayType item2 ->
+            let combinedType, diagnostics = types |> TypeContext.into item1 item2 |> combine Equal
+            ArrayType combinedType |> ResolvedType.create range, diagnostics
+        | TupleType items1, TupleType items2 when items1.Length = items2.Length ->
+            let combinedTypes, diagnostics =
+                (items1, items2)
+                ||> Seq.map2 (fun item1 item2 -> types |> TypeContext.into item1 item2 |> combine ordering)
+                |> Seq.toList
+                |> List.unzip
+
+            ImmutableArray.CreateRange combinedTypes |> TupleType |> ResolvedType.create range, List.concat diagnostics
+        | QsTypeKind.Operation ((in1, out1), info1), QsTypeKind.Operation ((in2, out2), info2) ->
+            let input, inDiagnostics = types |> TypeContext.into in1 in2 |> combine (Ordering.not ordering)
+            let output, outDiagnostics = types |> TypeContext.into out1 out2 |> combine ordering
+
+            let info, infoDiagnostics =
+                match combineCallableInfo ordering info1 info2 with
+                | Some info -> info, []
+                | None ->
+                    CallableInformation.New
+                        (ResolvedCharacteristics.New InvalidSetExpr, InferredCallableInformation.NoInformation),
+                    [ error ]
+
+            QsTypeKind.Operation((input, output), info) |> ResolvedType.create range,
+            inDiagnostics @ outDiagnostics @ infoDiagnostics
+        | QsTypeKind.Function (in1, out1), QsTypeKind.Function (in2, out2) ->
+            let input, inDiagnostics = types |> TypeContext.into in1 in2 |> combine (Ordering.not ordering)
+            let output, outDiagnostics = types |> TypeContext.into out1 out2 |> combine ordering
+            QsTypeKind.Function(input, output) |> ResolvedType.create range, inDiagnostics @ outDiagnostics
+        | InvalidType, _
+        | _, InvalidType -> ResolvedType.create range InvalidType, []
+        | _ when types.Left = types.Right -> types.Left |> ResolvedType.withAllRanges range, []
+        | _ -> ResolvedType.create range InvalidType, [ error ]
+
+    /// <summary>
+    /// True if <paramref name="param"/> does not occur in <paramref name="resolvedType"/>.
+    /// </summary>
+    let occursCheck param (resolvedType: ResolvedType) =
+        TypeParameter param |> (=) |> resolvedType.Exists |> not
+
+    /// An infinite sequence of alphabetic strings of increasing length in alphabetical order.
+    let letters =
+        Seq.initInfinite ((+) 1)
+        |> Seq.collect (fun length ->
+            seq { 'a' .. 'z' }
+            |> Seq.map string
+            |> Seq.replicate length
+            |> Seq.reduce (fun strings -> Seq.allPairs strings >> Seq.map String.Concat))
+
+    /// <summary>
+    /// The set of type parameters contained in the given <paramref name="resolvedType"/>.
+    /// </summary>
+    let typeParameters resolvedType =
+        let mutable parameters = Set.empty
+
+        { new TypeTransformation() with
+            member this.OnTypeParameter param =
+                parameters <- parameters |> Set.add param
+                TypeParameter param
+        }.OnType resolvedType
+        |> ignore
+
+        parameters
+
+open Inference
+
+type InferenceContext(symbolTracker: SymbolTracker) =
+    let variables = Dictionary()
+
+    let mutable statementPosition = Position.Zero
+
+    let bind param substitution =
+        if occursCheck param substitution |> not then failwith "Occurs check failed."
+        let variable = variables.[param]
+
+        match variable.Substitution with
+        | Some substitution' when substitution <> substitution' ->
+            failwith "The type parameter is already bound to a different type."
+        | _ -> variables.[param] <- { variable with Substitution = Some substitution }
+
+    let rememberErrors types diagnostics =
+        if types |> Seq.contains (ResolvedType.New InvalidType) || List.isEmpty diagnostics |> not then
+            for param in types |> Seq.fold (fun params' -> typeParameters >> Set.union params') Set.empty do
+                match variables.TryGetValue param |> tryOption with
+                | Some variable -> variables.[param] <- { variable with HasError = true }
+                | None -> ()
+
+        diagnostics
+
+    member context.AmbiguousDiagnostics =
+        [
+            for variable in variables do
+                if not variable.Value.HasError && Option.isNone variable.Value.Substitution
+                then QsCompilerDiagnostic.Error (ErrorCode.AmbiguousTypeParameterResolution, []) variable.Value.Source
+        ]
+
+    member context.UseStatementPosition position = statementPosition <- position
+
+    member internal context.Fresh source =
+        let name = letters |> Seq.item variables.Count
+
+        let param =
+            Seq.initInfinite (fun i -> if i = 0 then name else name + string (i - 1))
+            |> Seq.map (fun name -> QsTypeParameter.New(symbolTracker.Parent, name, Null))
+            |> Seq.skipWhile (fun param ->
+                variables.ContainsKey param || symbolTracker.DefinedTypeParameters.Contains param.TypeName)
+            |> Seq.head
+
+        let variable =
+            {
+                Substitution = None
+                Constraints = []
+                HasError = false
+                Source = statementPosition + source
+            }
+
+        variables.Add(param, variable)
+        TypeParameter param |> ResolvedType.create (Value source)
+
+    member internal context.Unify(expected, actual) =
+        context.UnifyByOrdering(Supertype, TypeContext.create (context.Resolve expected) (context.Resolve actual))
+        |> rememberErrors [ expected; actual ]
+
+    member internal context.Intersect(left, right) =
+        context.UnifyByOrdering(Equal, TypeContext.create (context.Resolve left) (context.Resolve right))
+        |> ignore
+
+        let left = context.Resolve left
+        let right = context.Resolve right
+        let intersection, diagnostics = TypeContext.create left right |> combine Supertype
+        intersection, diagnostics |> rememberErrors [ left; right ]
+
+    member internal context.Constrain(resolvedType, typeConstraint) =
+        let resolvedType = context.Resolve resolvedType
+
+        match resolvedType.Resolution with
+        | TypeParameter param ->
+            match variables.TryGetValue param |> tryOption with
+            | Some variable ->
+                variables.[param] <- variable |> Variable.constrain typeConstraint
+                []
+            | None -> context.ApplyConstraint(typeConstraint, resolvedType)
+        | _ -> context.ApplyConstraint(typeConstraint, resolvedType)
+        |> rememberErrors (resolvedType :: Constraint.types typeConstraint)
+
+    member internal context.Resolve resolvedType =
+        let resolveWithRange type' =
+            let type' = context.Resolve type'
+            type' |> ResolvedType.withRange (type'.Range |> QsNullable.orElse resolvedType.Range)
+
+        match resolvedType.Resolution with
+        | TypeParameter param ->
+            tryOption (variables.TryGetValue param)
+            |> Option.bind (fun variable -> variable.Substitution)
+            |> Option.map resolveWithRange
+            |> Option.defaultValue resolvedType
+        | ArrayType array -> resolvedType |> ResolvedType.withKind (context.Resolve array |> ArrayType)
+        | TupleType tuple ->
+            resolvedType
+            |> ResolvedType.withKind (tuple |> Seq.map context.Resolve |> ImmutableArray.CreateRange |> TupleType)
+        | QsTypeKind.Operation ((inType, outType), info) ->
+            resolvedType
+            |> ResolvedType.withKind (QsTypeKind.Operation((context.Resolve inType, context.Resolve outType), info))
+        | QsTypeKind.Function (inType, outType) ->
+            resolvedType
+            |> ResolvedType.withKind (QsTypeKind.Function(context.Resolve inType, context.Resolve outType))
+        | _ -> resolvedType
+
+    /// <summary>
+    /// Unifies two types given that the left-hand type must satisfy the <paramref name="ordering"/> relation relative
+    /// to the right-hand type.
+    /// </summary>
+    member private context.UnifyByOrdering(ordering, types) =
+        let error =
+            QsCompilerDiagnostic.Error
+                (ErrorCode.TypeMismatch, TypeContext.toList types |> List.map showType)
+                (types.Right.Range |> QsNullable.defaultValue Range.Zero)
+
+        match types.Left.Resolution, types.Right.Resolution with
+        | _ when types.Left = types.Right -> []
+        | TypeParameter param, _ when variables.ContainsKey param ->
+            bind param types.Right
+            context.ApplyConstraints(param, types.Right)
+        | _, TypeParameter param when variables.ContainsKey param ->
+            bind param types.Left
+            context.ApplyConstraints(param, types.Left)
+        | ArrayType item1, ArrayType item2 -> context.UnifyByOrdering(Equal, types |> TypeContext.intoRight item1 item2)
+        | TupleType items1, TupleType items2 ->
+            [
+                if items1.Length <> items2.Length then error
+                for item1, item2 in Seq.zip items1 items2 do
+                    let types = types |> TypeContext.intoRight (context.Resolve item1) (context.Resolve item2)
+                    yield! context.UnifyByOrdering(ordering, types)
+            ]
+        | QsTypeKind.Operation ((in1, out1), info1), QsTypeKind.Operation ((in2, out2), info2) ->
+            let errors =
+                if ordering = Equal && not (characteristicsEqual info1 info2)
+                   || ordering = Supertype && not (isSubset info1 info2)
+                   || ordering = Subtype && not (isSubset info2 info1) then
+                    [ error ]
+                else
+                    []
+
+            context.UnifyByOrdering(ordering, types |> TypeContext.swap |> TypeContext.intoRight in2 in1)
+            @ context.UnifyByOrdering
+                (ordering, types |> TypeContext.intoRight (context.Resolve out1) (context.Resolve out2))
+              @ errors
+        | QsTypeKind.Function (in1, out1), QsTypeKind.Function (in2, out2) ->
+            context.UnifyByOrdering(ordering, types |> TypeContext.swap |> TypeContext.intoRight in2 in1)
+            @ context.UnifyByOrdering
+                (ordering, types |> TypeContext.intoRight (context.Resolve out1) (context.Resolve out2))
+        | QsTypeKind.Operation ((in1, out1), _), QsTypeKind.Function (in2, out2)
+        | QsTypeKind.Function (in1, out1), QsTypeKind.Operation ((in2, out2), _) ->
+            error
+            :: context.UnifyByOrdering(ordering, types |> TypeContext.swap |> TypeContext.intoRight in2 in1)
+            @ context.UnifyByOrdering
+                (ordering, types |> TypeContext.intoRight (context.Resolve out1) (context.Resolve out2))
+        | InvalidType, _
+        | MissingType, _
+        | _, InvalidType
+        | _, MissingType -> []
+        | _ -> [ error ]
+
+    /// <summary>
+    /// Applies the <paramref name="typeConstraint"/> to the given <paramref name="resolvedType"/>.
+    /// </summary>
+    member private context.ApplyConstraint(typeConstraint, resolvedType) =
+        let range = resolvedType.Range |> QsNullable.defaultValue Range.Zero
+
+        match typeConstraint with
+        | _ when resolvedType.Resolution = InvalidType -> []
+        | Constraint.Adjointable ->
+            match resolvedType.Resolution with
+            | QsTypeKind.Operation (_, info) when hasFunctor Adjoint info -> []
+            | _ -> [ QsCompilerDiagnostic.Error (ErrorCode.InvalidAdjointApplication, []) range ]
+        | Callable (input, output) ->
+            match resolvedType.Resolution with
+            | QsTypeKind.Operation _ ->
+                let operationType = QsTypeKind.Operation((input, output), CallableInformation.NoInformation)
+                context.Unify(ResolvedType.New operationType, resolvedType)
+            | QsTypeKind.Function _ ->
+                context.Unify(QsTypeKind.Function(input, output) |> ResolvedType.New, resolvedType)
+            | _ ->
+                [
+                    QsCompilerDiagnostic.Error (ErrorCode.ExpectingCallableExpr, [ showType resolvedType ]) range
+                ]
+        | CanGenerateFunctors functors ->
+            match resolvedType.Resolution with
+            | QsTypeKind.Operation (_, info) ->
+                let supported = info.Characteristics.SupportedFunctors.ValueOr ImmutableHashSet.Empty
+                let missing = Set.difference functors (Set.ofSeq supported)
+
+                let error =
+                    ErrorCode.MissingFunctorForAutoGeneration, [ missing |> Seq.map showFunctor |> String.concat "," ]
+
+                [
+                    if not info.Characteristics.AreInvalid && Set.isEmpty missing |> not
+                    then QsCompilerDiagnostic.Error error range
+                ]
+            | _ -> []
+        | Constraint.Controllable controlled ->
+            let error = QsCompilerDiagnostic.Error (ErrorCode.InvalidControlledApplication, []) range
+
+            match resolvedType.Resolution with
+            | QsTypeKind.Operation ((input, output), info) ->
+                let actualControlled =
+                    QsTypeKind.Operation((SyntaxGenerator.AddControlQubits input, output), info) |> ResolvedType.New
+
+                [
+                    if info |> hasFunctor Controlled |> not then error
+                    yield! context.Unify(controlled, actualControlled)
+                ]
+            | QsTypeKind.Function (input, output) ->
+                let actualControlled =
+                    QsTypeKind.Operation((SyntaxGenerator.AddControlQubits input, output), CallableInformation.Invalid)
+                    |> ResolvedType.New
+
+                error :: context.Unify(controlled, actualControlled)
+            | _ -> [ error ]
+        | Equatable ->
+            [
+                if Option.isNone resolvedType.supportsEqualityComparison
+                then QsCompilerDiagnostic.Error
+                         (ErrorCode.InvalidTypeInEqualityComparison, [ showType resolvedType ])
+                         range
+            ]
+        | HasPartialApplication (missing, result) ->
+            match resolvedType.Resolution with
+            | QsTypeKind.Function (_, output) ->
+                context.Unify(result, QsTypeKind.Function(missing, output) |> ResolvedType.New)
+            | QsTypeKind.Operation ((_, output), info) ->
+                context.Unify(result, QsTypeKind.Operation((missing, output), info) |> ResolvedType.New)
+            | _ ->
+                [
+                    QsCompilerDiagnostic.Error (ErrorCode.ExpectingCallableExpr, [ showType resolvedType ]) range
+                ]
+        | Indexed (index, item) ->
+            let index = context.Resolve index
+
+            match resolvedType.Resolution, index.Resolution with
+            | ArrayType actualItem, Int -> context.Unify(item, actualItem)
+            | ArrayType _, Range -> context.Unify(item, resolvedType)
+            | ArrayType _, _ ->
+                [
+                    QsCompilerDiagnostic.Error
+                        (ErrorCode.InvalidArrayItemIndex, [ showType index ])
+                        (index.Range |> QsNullable.defaultValue Range.Zero)
+                ]
+            | _ ->
+                [
+                    QsCompilerDiagnostic.Error (ErrorCode.ItemAccessForNonArray, [ showType resolvedType ]) range
+                ]
+        | Integral ->
+            [
+                if resolvedType.Resolution <> Int && resolvedType.Resolution <> BigInt
+                then QsCompilerDiagnostic.Error (ErrorCode.ExpectingIntegralExpr, [ showType resolvedType ]) range
+            ]
+        | Iterable item ->
+            match resolvedType.supportsIteration with
+            | Some actualItem -> context.Unify(item, actualItem)
+            | None ->
+                [
+                    QsCompilerDiagnostic.Error (ErrorCode.ExpectingIterableExpr, [ showType resolvedType ]) range
+                ]
+        | Numeric ->
+            [
+                if Option.isNone resolvedType.supportsArithmetic
+                then QsCompilerDiagnostic.Error (ErrorCode.InvalidTypeInArithmeticExpr, [ showType resolvedType ]) range
+            ]
+        | Semigroup ->
+            [
+                if Option.isNone resolvedType.supportsConcatenation && Option.isNone resolvedType.supportsArithmetic
+                then QsCompilerDiagnostic.Error (ErrorCode.InvalidTypeForConcatenation, [ showType resolvedType ]) range
+            ]
+        | Wrapped item ->
+            match resolvedType.Resolution with
+            | UserDefinedType udt ->
+                let actualItem = symbolTracker.GetUnderlyingType (fun _ -> ()) udt
+                context.Unify(item, actualItem)
+            | _ ->
+                [
+                    QsCompilerDiagnostic.Error (ErrorCode.ExpectingUserDefinedType, [ showType resolvedType ]) range
+                ]
+
+    /// <summary>
+    /// Applies all of the constraints for <paramref name="param"/>, given that it has just been bound to
+    /// <paramref name="resolvedType"/>.
+    /// </summary>
+    member private context.ApplyConstraints(param, resolvedType) =
+        match variables.TryGetValue param |> tryOption with
+        | Some variable ->
+            let diagnostics = variable.Constraints |> List.collect (fun c -> context.ApplyConstraint(c, resolvedType))
+            variables.[param] <- { variable with Constraints = [] }
+            diagnostics
+        | None -> []
+
+module InferenceContext =
+    [<CompiledName "Resolver">]
+    let resolver (context: InferenceContext) =
+        let types =
+            { new TypeTransformation() with
+                member this.OnTypeParameter param =
+                    (TypeParameter param |> ResolvedType.New |> context.Resolve).Resolution
+            }
+
+        SyntaxTreeTransformation(Types = types)

--- a/src/QsCompiler/SyntaxProcessor/TypeInference/InferenceContext.fs
+++ b/src/QsCompiler/SyntaxProcessor/TypeInference/InferenceContext.fs
@@ -266,10 +266,10 @@ type InferenceContext(symbolTracker: SymbolTracker) =
         if occursCheck param substitution |> not then failwith "Occurs check failed."
         let variable = variables.[param]
 
-        match variable.Substitution with
-        | Some substitution' when substitution <> substitution' ->
-            failwith "The type parameter is already bound to a different type."
-        | _ -> variables.[param] <- { variable with Substitution = Some substitution }
+        if Option.isSome variable.Substitution
+        then failwith "Type parameter is already bound."
+
+        variables.[param] <- { variable with Substitution = Some substitution }
 
     let rememberErrors types diagnostics =
         if types |> Seq.contains (ResolvedType.New InvalidType) || List.isEmpty diagnostics |> not then

--- a/src/QsCompiler/SyntaxProcessor/TypeInference/InferenceContext.fs
+++ b/src/QsCompiler/SyntaxProcessor/TypeInference/InferenceContext.fs
@@ -295,7 +295,7 @@ type InferenceContext(symbolTracker: SymbolTracker) =
 
         let param =
             Seq.initInfinite (fun i -> if i = 0 then name else name + string (i - 1))
-            |> Seq.map (fun name -> QsTypeParameter.New(symbolTracker.Parent, name, Null))
+            |> Seq.map (fun name -> QsTypeParameter.New(symbolTracker.Parent, name))
             |> Seq.skipWhile (fun param ->
                 variables.ContainsKey param || symbolTracker.DefinedTypeParameters.Contains param.TypeName)
             |> Seq.head

--- a/src/QsCompiler/SyntaxProcessor/TypeInference/InferenceContext.fs
+++ b/src/QsCompiler/SyntaxProcessor/TypeInference/InferenceContext.fs
@@ -177,7 +177,9 @@ module private Inference =
     /// both original types.
     /// </summary>
     let rec combine ordering types =
-        let range = QsNullable.Map2 Range.Span types.Left.Range types.Right.Range
+        let range =
+            QsNullable.Map2 Range.Span (TypeRange.tryRange types.Left.Range) (TypeRange.tryRange types.Right.Range)
+            |> TypeRange.inferred
 
         let relation =
             match ordering with
@@ -188,7 +190,7 @@ module private Inference =
         let error =
             QsCompilerDiagnostic.Error
                 (ErrorCode.MissingBaseType, relation :: (TypeContext.toList types |> List.map showType))
-                (range |> QsNullable.defaultValue Range.Zero)
+                (TypeRange.tryRange range |> QsNullable.defaultValue Range.Zero)
 
         match types.Left.Resolution, types.Right.Resolution with
         | ArrayType item1, ArrayType item2 ->
@@ -268,7 +270,6 @@ type InferenceContext(symbolTracker: SymbolTracker) =
 
         if Option.isSome variable.Substitution
         then failwith "Type parameter is already bound."
-
         variables.[param] <- { variable with Substitution = Some substitution }
 
     let rememberErrors types diagnostics =
@@ -308,7 +309,7 @@ type InferenceContext(symbolTracker: SymbolTracker) =
             }
 
         variables.Add(param, variable)
-        TypeParameter param |> ResolvedType.create (Value source)
+        TypeParameter param |> ResolvedType.create (Inferred source)
 
     member internal context.Unify(expected, actual) =
         context.UnifyByOrdering(Supertype, TypeContext.create (context.Resolve expected) (context.Resolve actual))
@@ -339,7 +340,7 @@ type InferenceContext(symbolTracker: SymbolTracker) =
     member internal context.Resolve resolvedType =
         let resolveWithRange type' =
             let type' = context.Resolve type'
-            type' |> ResolvedType.withRange (type'.Range |> QsNullable.orElse resolvedType.Range)
+            type' |> ResolvedType.withRange (type'.Range |> TypeRange.orElse resolvedType.Range)
 
         match resolvedType.Resolution with
         | TypeParameter param ->
@@ -367,7 +368,7 @@ type InferenceContext(symbolTracker: SymbolTracker) =
         let error =
             QsCompilerDiagnostic.Error
                 (ErrorCode.TypeMismatch, TypeContext.toList types |> List.map showType)
-                (types.Right.Range |> QsNullable.defaultValue Range.Zero)
+                (TypeRange.tryRange types.Right.Range |> QsNullable.defaultValue Range.Zero)
 
         match types.Left.Resolution, types.Right.Resolution with
         | _ when types.Left = types.Right -> []
@@ -418,7 +419,7 @@ type InferenceContext(symbolTracker: SymbolTracker) =
     /// Applies the <paramref name="typeConstraint"/> to the given <paramref name="resolvedType"/>.
     /// </summary>
     member private context.ApplyConstraint(typeConstraint, resolvedType) =
-        let range = resolvedType.Range |> QsNullable.defaultValue Range.Zero
+        let range = TypeRange.tryRange resolvedType.Range |> QsNullable.defaultValue Range.Zero
 
         match typeConstraint with
         | _ when resolvedType.Resolution = InvalidType -> []
@@ -497,7 +498,7 @@ type InferenceContext(symbolTracker: SymbolTracker) =
                 [
                     QsCompilerDiagnostic.Error
                         (ErrorCode.InvalidArrayItemIndex, [ showType index ])
-                        (index.Range |> QsNullable.defaultValue Range.Zero)
+                        (TypeRange.tryRange index.Range |> QsNullable.defaultValue Range.Zero)
                 ]
             | _ ->
                 [

--- a/src/QsCompiler/SyntaxProcessor/TypeInference/InferenceContext.fsi
+++ b/src/QsCompiler/SyntaxProcessor/TypeInference/InferenceContext.fsi
@@ -1,0 +1,56 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Microsoft.Quantum.QsCompiler.SyntaxProcessing.TypeInference
+
+open Microsoft.Quantum.QsCompiler.DataTypes
+open Microsoft.Quantum.QsCompiler.SyntaxProcessing
+open Microsoft.Quantum.QsCompiler.SyntaxTree
+open Microsoft.Quantum.QsCompiler.Transformations.Core
+
+/// The inference context is an implementation of Hindley-Milner type inference. It is a source of fresh type parameters
+/// and can unify types containing them.
+type InferenceContext =
+    /// <summary>
+    /// Creates a new inference context using the given <see cref="SymbolTracker"/>.
+    /// </summary>
+    new: symbolTracker:SymbolTracker -> InferenceContext
+
+    /// Diagnostics for all type variables that are missing substitutions.
+    member AmbiguousDiagnostics: QsCompilerDiagnostic list
+
+    /// Updates the position of the statement in which types are currently being inferred.
+    member UseStatementPosition: position:Position -> unit
+
+    /// <summary>
+    /// Creates a fresh type parameter originating from the given <paramref name="source"/> range.
+    /// </summary>
+    member internal Fresh: source:Range -> ResolvedType
+
+    /// <summary>
+    /// Unifies the <paramref name="expected"/> type with the <paramref name="actual"/> type.
+    /// </summary>
+    member internal Unify: expected:ResolvedType * actual:ResolvedType -> QsCompilerDiagnostic list
+
+    /// <summary>
+    /// The intersection of types <paramref name="left"/> and <paramref name="right"/>.
+    /// </summary>
+    member internal Intersect: left:ResolvedType * right:ResolvedType -> ResolvedType * QsCompilerDiagnostic list
+
+    /// <summary>
+    /// Constrains the given <paramref name="resolvedType"/> to satisfy the <paramref name="typeConstraint"/>.
+    /// </summary>
+    member internal Constrain: resolvedType:ResolvedType * typeConstraint:Constraint -> QsCompilerDiagnostic list
+
+    /// <summary>
+    /// Replaces each placeholder type parameter in the given <paramref name="resolvedType"/> with its substitution if
+    /// one exists.
+    /// </summary>
+    member internal Resolve: resolvedType:ResolvedType -> ResolvedType
+
+module InferenceContext =
+    /// <summary>
+    /// A syntax tree transformation that resolves types using the given inference <paramref name="context"/>.
+    /// </summary>
+    [<CompiledName "Resolver">]
+    val resolver: context:InferenceContext -> SyntaxTreeTransformation

--- a/src/QsCompiler/SyntaxProcessor/TypeInference/InferenceContext.fsi
+++ b/src/QsCompiler/SyntaxProcessor/TypeInference/InferenceContext.fsi
@@ -28,16 +28,15 @@ type InferenceContext =
     member internal Fresh: source:Range -> ResolvedType
 
     /// <summary>
-    /// Unifies the <paramref name="expected"/> type with the <paramref name="actual"/> type.
+    /// Unifies the <paramref name="expected"/> type with the <paramref name="actual"/> type. Fails if
+    /// <paramref name="actual"/> is not a subtype of <paramref name="expected"/>.
     /// </summary>
     member internal Unify: expected:ResolvedType * actual:ResolvedType -> QsCompilerDiagnostic list
 
     /// <summary>
-    /// The intersection of types <paramref name="left"/> and <paramref name="right"/>.
+    /// Returns a type that is a supertype of both types <paramref name="left"/> and <paramref name="right"/>, and that
+    /// has a <see cref="TypeRange.Generated"/> range.
     /// </summary>
-    /// <returns>
-    /// The intersecting type with a <see cref="TypeRange.Generated"/> range.
-    /// </returns>
     member internal Intersect: left:ResolvedType * right:ResolvedType -> ResolvedType * QsCompilerDiagnostic list
 
     /// <summary>

--- a/src/QsCompiler/SyntaxProcessor/TypeInference/InferenceContext.fsi
+++ b/src/QsCompiler/SyntaxProcessor/TypeInference/InferenceContext.fsi
@@ -35,6 +35,9 @@ type InferenceContext =
     /// <summary>
     /// The intersection of types <paramref name="left"/> and <paramref name="right"/>.
     /// </summary>
+    /// <returns>
+    /// The intersecting type with a <see cref="TypeRange.Generated"/> range.
+    /// </returns>
     member internal Intersect: left:ResolvedType * right:ResolvedType -> ResolvedType * QsCompilerDiagnostic list
 
     /// <summary>

--- a/src/QsCompiler/SyntaxProcessor/TypeInference/README.md
+++ b/src/QsCompiler/SyntaxProcessor/TypeInference/README.md
@@ -1,0 +1,66 @@
+﻿# Q# type inference
+
+Q# uses a type inference algorithm based on the [Hindley-Milner type inference algorithm](https://en.wikipedia.org/wiki/Hindley%E2%80%93Milner_type_system#An_inference_algorithm).
+The core ideas are:
+
+1. *Instantiation.* When a type is used, any universal quantifiers are *instantiated* as fresh type variables with unique names.
+2. *Unification.* When two types must match, they are *unified* by comparing each type side-by-side.
+   If an instantiated type variable is encountered in one type, it is bound to the other type.
+
+For example, consider the identity function:
+
+```qsharp
+function Identity<'a>(x : 'a) : 'a {
+    return x;
+}
+```
+
+When the identity function is referenced, its type parameters are instantiated to type variables with previously unused names.
+
+```qsharp
+// Identity.'a is instantiated to a fresh variable, like 'a0.
+// f is of type 'a0 -> 'a0.
+let f = Identity;
+```
+
+When the function is applied, the argument type is unified with the input of the function type.
+To apply a function to an argument of type Int, the function type must match `Int -> 'b0`, where `'b0` is another freshly instantiated type variable.
+
+```qsharp
+// Int -> 'b0
+// must unify with
+// 'a0 -> 'a0
+//
+// f(7) is of type 'b0.
+f(7);
+```
+
+Unification yields `'a0 ↦ Int` and `'b0 ↦ 'a0`.
+We can conclude that `'b0 ↦ Int`, so `f(7)` is of type `Int`, as expected.
+
+Hindley-Milner type inference normally performs *generalization*, the opposite of instantiation, when a `let` binding is encountered.
+However, since `let` bindings are monomorphic in Q#, generalization is not supported.
+A special case of generalization exists for polymorphic top-level callables, like `Identity`, but this is not part of the type inference algorithm.
+
+## Extensions
+
+Q#'s type system has two additional features that extend the Hindley-Milner type system: type constraints (a limited form of bounded polymorphism), and subtyping of operation characteristics.
+
+### Constraints
+
+Constraints are used to require that some types satisfy certain properties.
+For example, using the `==` operator requires that the type supports equality comparisons, and using `for` loop requires that the type supports iteration.
+Constraints are not themselves first-class types in Q#, so all constrained types must resolve to a specific type that satisfies the constraint.
+
+### Subtyping
+
+Q# operation types have subtyping over their characteristics.
+For example, `Qubit => Unit is Adj + Ctl` is a subtype of `Qubit => Unit is Adj`, which is a subtype of `Qubit => Unit`.
+The subtyping relationship extends to compound types containing operation types, so that `(Qubit => Unit is Adj, Int)` is a subtype of `(Qubit => Unit, Int)`.
+
+Since Q#'s subtyping is limited, unification is still very similar to standard Hindley-Milner unification.
+However, an additional *ordering* is given that states whether one type should be a supertype of, equal to, or a subtype of the other type.
+Unification fails if the ordering is not satisfied.
+
+Some expressions, like binary operators or array literals, have a type that is the *intersection* or *greatest common base type* of its constituent types.
+For simplicity, an intersection is computed using only typing information known up to the point where the intersection is requested.

--- a/src/QsCompiler/SyntaxProcessor/TypeInference/README.md
+++ b/src/QsCompiler/SyntaxProcessor/TypeInference/README.md
@@ -31,12 +31,12 @@ To apply a function to an argument of type Int, the function type must match `In
 // must unify with
 // 'a0 -> 'a0
 //
-// f(7) is of type 'b0.
-f(7);
+// result is of type 'b0.
+let result = f(7);
 ```
 
 Unification yields `'a0 ↦ Int` and `'b0 ↦ 'a0`.
-We can conclude that `'b0 ↦ Int`, so `f(7)` is of type `Int`, as expected.
+We can conclude that `'b0 ↦ Int`, so `result` is of type `Int`, as expected.
 
 Hindley-Milner type inference normally performs *generalization*, the opposite of instantiation, when a `let` binding is encountered.
 However, since `let` bindings are monomorphic in Q#, generalization is not supported.

--- a/src/QsCompiler/SyntaxProcessor/TypeInference/README.md
+++ b/src/QsCompiler/SyntaxProcessor/TypeInference/README.md
@@ -24,7 +24,7 @@ let f = Identity;
 ```
 
 When the function is applied, the argument type is unified with the input of the function type.
-To apply a function to an argument of type Int, the function type must match `Int -> 'b0`, where `'b0` is another freshly instantiated type variable.
+To apply a function to an argument of type `Int`, the function type must match `Int -> 'b0`, where `'b0` is another freshly instantiated type variable.
 
 ```qsharp
 // Int -> 'b0
@@ -37,6 +37,7 @@ let result = f(7);
 
 Unification yields `'a0 ↦ Int` and `'b0 ↦ 'a0`.
 We can conclude that `'b0 ↦ Int`, so `result` is of type `Int`, as expected.
+By the same reasoning, we have also learned that `f` is of type `Int -> Int`.
 
 Hindley-Milner type inference normally performs *generalization*, the opposite of instantiation, when a `let` binding is encountered.
 However, since `let` bindings are monomorphic in Q#, generalization is not supported.
@@ -49,7 +50,7 @@ Q#'s type system has two additional features that extend the Hindley-Milner type
 ### Constraints
 
 Constraints are used to require that some types satisfy certain properties.
-For example, using the `==` operator requires that the type supports equality comparisons, and using `for` loop requires that the type supports iteration.
+For example, using the `==` operator requires that the type supports equality comparisons, and using a `for` loop requires that the type supports iteration.
 Constraints are not themselves first-class types in Q#, so all constrained types must resolve to a specific type that satisfies the constraint.
 
 ### Subtyping

--- a/src/QsCompiler/Tests.Compiler/SerializationTests.fs
+++ b/src/QsCompiler/Tests.Compiler/SerializationTests.fs
@@ -4,6 +4,8 @@
 // mock-up for the purpose of testing
 namespace Microsoft.Quantum.Simulation.Core
 
+#nowarn "44" // UserDefinedType.Range is deprecated.
+
 open System
 
 [<AttributeUsage(AttributeTargets.Assembly, AllowMultiple = true)>]

--- a/src/QsCompiler/Tests.Compiler/SerializationTests.fs
+++ b/src/QsCompiler/Tests.Compiler/SerializationTests.fs
@@ -4,8 +4,6 @@
 // mock-up for the purpose of testing
 namespace Microsoft.Quantum.Simulation.Core
 
-#nowarn "44" // UserDefinedType.Range is deprecated.
-
 open System
 
 [<AttributeUsage(AttributeTargets.Assembly, AllowMultiple = true)>]
@@ -81,15 +79,8 @@ module SerializationTests =
     let qualifiedName ns name = { Namespace = ns; Name = name }
 
     let udt name =
-        let range = Range.Create (Position.Create 4 9) (Position.Create 4 9) |> Value
         let fullName = qualifiedName "Microsoft.Quantum" name
-
-        {
-            Namespace = fullName.Namespace
-            Name = fullName.Name
-            Range = range
-        }
-        |> UserDefinedType
+        UserDefinedType.New(fullName.Namespace, fullName.Name) |> UserDefinedType
 
     let udtPair = udt "Pair"
 

--- a/src/QsCompiler/Tests.Compiler/SymbolManagementTests.fs
+++ b/src/QsCompiler/Tests.Compiler/SymbolManagementTests.fs
@@ -3,6 +3,8 @@
 
 module Microsoft.Quantum.QsCompiler.Testing.SymbolManagementTests
 
+#nowarn "44" // TypeParameter.Range and UserDefinedType.Range are deprecated.
+
 open System.Collections.Immutable
 open Microsoft.Quantum.QsCompiler.DataTypes
 open Microsoft.Quantum.QsCompiler.SymbolManagement

--- a/src/QsCompiler/Tests.Compiler/TestUtils/Signatures.fs
+++ b/src/QsCompiler/Tests.Compiler/TestUtils/Signatures.fs
@@ -3,6 +3,8 @@
 
 module Microsoft.Quantum.QsCompiler.Testing.Signatures
 
+#nowarn "44" // TypeParameter.Range and UserDefinedType.Range are deprecated.
+
 open System.Collections.Generic
 open System.Collections.Immutable
 open Microsoft.Quantum.QsCompiler

--- a/src/QsCompiler/Tests.Compiler/TestUtils/Signatures.fs
+++ b/src/QsCompiler/Tests.Compiler/TestUtils/Signatures.fs
@@ -3,15 +3,13 @@
 
 module Microsoft.Quantum.QsCompiler.Testing.Signatures
 
-#nowarn "44" // TypeParameter.Range and UserDefinedType.Range are deprecated.
-
-open System.Collections.Generic
-open System.Collections.Immutable
 open Microsoft.Quantum.QsCompiler
-open Microsoft.Quantum.QsCompiler.DataTypes
-open Microsoft.Quantum.QsCompiler.Transformations.QsCodeOutput
+open Microsoft.Quantum.QsCompiler.SyntaxExtensions
 open Microsoft.Quantum.QsCompiler.SyntaxTokens
 open Microsoft.Quantum.QsCompiler.SyntaxTree
+open Microsoft.Quantum.QsCompiler.Transformations.QsCodeOutput
+open System.Collections.Generic
+open System.Collections.Immutable
 open Xunit
 
 let private _BaseTypes =
@@ -52,12 +50,7 @@ let private _MakeSignatures sigs =
 
 let _MakeTypeParam originNs originName paramName =
     originName + "." + paramName,
-    {
-        Origin = { Namespace = originNs; Name = originName }
-        TypeName = paramName
-        Range = Null
-    }
-    |> TypeParameter
+    QsTypeParameter.New({ Namespace = originNs; Name = originName }, paramName) |> TypeParameter
 
 /// For all given namespaces in checkedNamespaces, checks that there are exactly
 /// the callables specified with targetSignatures in the given compilation.
@@ -194,13 +187,10 @@ let public MonomorphizationSignatures =
     |> _MakeSignatures
 
 let private _IntrinsicResolutionTypes =
-    _MakeTypeMap [| "TestType",
-                    {
-                        Namespace = "Microsoft.Quantum.Testing.IntrinsicResolution"
-                        Name = "TestType"
-                        Range = Null
-                    }
-                    |> UserDefinedType |]
+    [|
+        "TestType", UserDefinedType.New("Microsoft.Quantum.Testing.IntrinsicResolution", "TestType") |> UserDefinedType
+    |]
+    |> _MakeTypeMap
 
 /// Expected callable signatures to be found when running Intrinsic Resolution tests
 let public IntrinsicResolutionSignatures =

--- a/src/QsCompiler/Tests.Compiler/TypeParameterTests.fs
+++ b/src/QsCompiler/Tests.Compiler/TypeParameterTests.fs
@@ -27,7 +27,7 @@ type TypeParameterTests() =
         Assert.True(pieces.Length = 2)
         let parent = qualifiedName pieces.[0]
         let name = pieces.[1]
-        QsTypeParameter.New(parent, name, Null)
+        QsTypeParameter.New(parent, name)
 
     let FooA = typeParameter "Foo.A"
     let FooB = typeParameter "Foo.B"

--- a/src/QsCompiler/Transformations/ContentLifting.cs
+++ b/src/QsCompiler/Transformations/ContentLifting.cs
@@ -439,7 +439,9 @@ namespace Microsoft.Quantum.QsCompiler.Transformations.ContentLifting
                     // Reroute a type parameter's origin to the newly generated operation
                     if (!this.SharedState.IsRecursiveIdentifier && this.SharedState.OldName.Equals(tp.Origin))
                     {
+#pragma warning disable 618 // QsTypeParameter.Range is obsolete.
                         tp = new QsTypeParameter(this.SharedState.NewName, tp.TypeName, tp.Range);
+#pragma warning restore 618
                     }
 
                     return base.OnTypeParameter(tp);

--- a/src/QsCompiler/Transformations/ContentLifting.cs
+++ b/src/QsCompiler/Transformations/ContentLifting.cs
@@ -434,18 +434,11 @@ namespace Microsoft.Quantum.QsCompiler.Transformations.ContentLifting
                 {
                 }
 
-                public override ResolvedTypeKind OnTypeParameter(QsTypeParameter tp)
-                {
+                public override ResolvedTypeKind OnTypeParameter(QsTypeParameter tp) =>
                     // Reroute a type parameter's origin to the newly generated operation
-                    if (!this.SharedState.IsRecursiveIdentifier && this.SharedState.OldName.Equals(tp.Origin))
-                    {
-#pragma warning disable 618 // QsTypeParameter.Range is obsolete.
-                        tp = new QsTypeParameter(this.SharedState.NewName, tp.TypeName, tp.Range);
-#pragma warning restore 618
-                    }
-
-                    return base.OnTypeParameter(tp);
-                }
+                    !this.SharedState.IsRecursiveIdentifier && this.SharedState.OldName.Equals(tp.Origin)
+                        ? base.OnTypeParameter(tp.WithOrigin(this.SharedState.NewName))
+                        : base.OnTypeParameter(tp);
             }
         }
     }

--- a/src/QsCompiler/Transformations/SearchAndReplace.cs
+++ b/src/QsCompiler/Transformations/SearchAndReplace.cs
@@ -230,7 +230,9 @@ namespace Microsoft.Quantum.QsCompiler.Transformations.SearchAndReplace
             public override QsTypeKind OnUserDefinedType(UserDefinedType udt)
             {
                 var id = Identifier.NewGlobalCallable(new QsQualifiedName(udt.Namespace, udt.Name));
+#pragma warning disable 618 // UserDefinedType.Range is obsolete.
                 this.SharedState.LogIdentifierLocation(id, udt.Range);
+#pragma warning restore 618
                 return QsTypeKind.NewUserDefinedType(udt);
             }
 
@@ -238,7 +240,9 @@ namespace Microsoft.Quantum.QsCompiler.Transformations.SearchAndReplace
             {
                 var resT = ResolvedType.New(QsTypeKind.NewTypeParameter(tp));
                 var id = Identifier.NewLocalVariable(SyntaxTreeToQsharp.Default.ToCode(resT) ?? "");
+#pragma warning disable 618 // QsTypeParameter.Range is obsolete.
                 this.SharedState.LogIdentifierLocation(id, tp.Range);
+#pragma warning restore 618
                 return resT.Resolution;
             }
         }
@@ -605,7 +609,9 @@ namespace Microsoft.Quantum.QsCompiler.Transformations.SearchAndReplace
             internal UserDefinedType RenameUdt(UserDefinedType udt)
             {
                 var newName = this.GetNewName(new QsQualifiedName(udt.Namespace, udt.Name));
+#pragma warning disable 618 // UserDefinedType.Range is obsolete.
                 return new UserDefinedType(newName.Namespace, newName.Name, udt.Range);
+#pragma warning restore 618
             }
         }
 
@@ -702,7 +708,9 @@ namespace Microsoft.Quantum.QsCompiler.Transformations.SearchAndReplace
                 QsTypeKind.NewUserDefinedType(this.state.RenameUdt(udt));
 
             public override QsTypeKind OnTypeParameter(QsTypeParameter tp) =>
+#pragma warning disable 618 // QsTypeParameter.Range is obsolete.
                 QsTypeKind.NewTypeParameter(new QsTypeParameter(this.state.GetNewName(tp.Origin), tp.TypeName, tp.Range));
+#pragma warning restore 618
         }
 
         private class ExpressionKindTransformation : Core.ExpressionKindTransformation


### PR DESCRIPTION
This PR splits out the HM type inference module from #884, as well as additional changes that the module requires. The new module is not used by the compiler, so there's no change to type inference behavior yet (there will be another PR for that).

Additional changes:

* Added a range field to `ResolvedType` so that the HM module can generate diagnostics with accurate locations.
* Split ScopeTools.fs into two files so that the HM module can reference SymbolTracker, and ScopeContext can reference the HM module.
* Removed `WithinIfCondition` field from `ScopeContext` that has been deprecated for 6 months.