### PR TITLE
Remove comment in EntryPoint Bond schema

### DIFF
--- a/src/QsCompiler/BondSchemas/EntryPoint/EntryPoint.bond
+++ b/src/QsCompiler/BondSchemas/EntryPoint/EntryPoint.bond
@@ -105,6 +105,4 @@ struct EntryPointOperation
     5: string Name;
 
     10: vector<Argument> Arguments;
-
-    // TODO: Needs to be expanded to include return information.
 }


### PR DESCRIPTION
This change removes a comment in the EntryPoint Bond schema since the TODO it describes no longer needs to be done.