### PR TITLE
Generate namespace summaries as Markdown.

### DIFF
--- a/src/Documentation/DocumentationGenerator/DocumentationGeneration.cs
+++ b/src/Documentation/DocumentationGenerator/DocumentationGeneration.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using Microsoft.CodeAnalysis;
 using Microsoft.Quantum.QsCompiler;
 using Microsoft.Quantum.QsCompiler.SyntaxTree;
+using QsAssemblyConstants = Microsoft.Quantum.QsCompiler.ReservedKeywords.AssemblyConstants;
 
 namespace Microsoft.Quantum.Documentation
 {
@@ -50,36 +51,42 @@ namespace Microsoft.Quantum.Documentation
         /// <inheritdoc/>
         public bool PreconditionVerification(QsCompilation compilation)
         {
-            if (this.AssemblyConstants.TryGetValue(QsCompiler.ReservedKeywords.AssemblyConstants.DocsOutputPath, out var path) && path != null)
-            {
-                this.docsOutputPath = path;
-            }
-
-            var preconditionPassed = string.IsNullOrEmpty(this.docsOutputPath);
-            if (preconditionPassed)
-            {
-                // Diagnostics with severity Info or lower usually won't be displayed to the user.
-                // If the severity is Error or Warning the diagnostic is shown to the user like any other compiler diagnostic,
-                // and if the Source property is set to the absolute path of an existing file,
-                // the user will be directed to the file when double clicking the diagnostics.
-                this.diagnostics.Add(new IRewriteStep.Diagnostic
-                {
-                    Severity = DiagnosticSeverity.Info,
-                    Message = $"Precondition for {this.Name} was satisfied.",
-                    Stage = IRewriteStep.Stage.PreconditionVerification,
-                });
-            }
-            else
+            if (!this.AssemblyConstants.TryGetValue(QsAssemblyConstants.DocsOutputPath, out var path))
             {
                 this.diagnostics.Add(new IRewriteStep.Diagnostic
                 {
                     Severity = DiagnosticSeverity.Warning,
-                    Message = $"Precondition for {this.Name} was not satisfied: Missing assembly property DocsOutputPath.",
+                    Message = $"Documentation generation was enabled, but precondition for {this.Name} was not satisfied: Missing assembly property {QsAssemblyConstants.DocsOutputPath}.",
                     Stage = IRewriteStep.Stage.PreconditionVerification,
                 });
+                return false;
             }
 
-            return preconditionPassed;
+            if (string.IsNullOrEmpty(path))
+            {
+                this.diagnostics.Add(new IRewriteStep.Diagnostic
+                {
+                    Severity = DiagnosticSeverity.Warning,
+                    Message = $"Documentation generation was enabled, but precondition for {this.Name} was not satisfied: Assembly property {QsAssemblyConstants.DocsOutputPath} was found, but was empty.",
+                    Stage = IRewriteStep.Stage.PreconditionVerification,
+                });
+                return false;
+            }
+
+            this.docsOutputPath = path;
+
+            // Diagnostics with severity Info or lower usually won't be displayed to the user.
+            // If the severity is Error or Warning the diagnostic is shown to the user like any other compiler diagnostic,
+            // and if the Source property is set to the absolute path of an existing file,
+            // the user will be directed to the file when double clicking the diagnostics.
+            this.diagnostics.Add(new IRewriteStep.Diagnostic
+            {
+                Severity = DiagnosticSeverity.Info,
+                Message = $"Documentation generation was enabled, and precondition for {this.Name} was satisfied, writing docs to {this.docsOutputPath}.",
+                Stage = IRewriteStep.Stage.PreconditionVerification,
+            });
+
+            return true;
         }
 
         /// <inheritdoc/>
@@ -87,7 +94,7 @@ namespace Microsoft.Quantum.Documentation
         {
             var docProcessor = new ProcessDocComments(
                 this.docsOutputPath,
-                this.AssemblyConstants.TryGetValue(QsCompiler.ReservedKeywords.AssemblyConstants.DocsPackageId, out var packageName)
+                this.AssemblyConstants.TryGetValue(QsAssemblyConstants.DocsPackageId, out var packageName)
                 ? packageName
                 : null);
 

--- a/src/Documentation/Summarizer/summarize_documentation.py
+++ b/src/Documentation/Summarizer/summarize_documentation.py
@@ -66,8 +66,6 @@ def summaries_table(namespace : Namespace, kind : str, header : str) -> str:
         return lines[0] if lines else ""
 
     items = items_of_kind(namespace.items, kind)
-    print(items)
-    print(namespace.items)
     return (
         table_header + "\n".join(
             f"|[{item['name']}](xref:{item['uid']}) |{first_line(item['summary'])} |"

--- a/src/Documentation/Summarizer/summarize_documentation.py
+++ b/src/Documentation/Summarizer/summarize_documentation.py
@@ -61,9 +61,13 @@ def summaries_table(namespace, kind, header):
 | Name | Summary |
 |------|---------|
 """
+    def first_line(summary):
+        lines = summary.splitlines()
+        return lines[0] if lines else ""
+
     return (
         table_header + "\n".join(
-            f"|[{item['name']}](xref:{item['uid']}) |{item['summary']}"
+            f"|[{item['name']}](xref:{item['uid']}) |{first_line(item['summary'])} |"
             for item in namespace[kind]
         )
         if kind in namespace and namespace[kind]
@@ -94,7 +98,7 @@ def write_namespace_summary(target_file : Path, namespace):
         # If it does exist, look for <!-- summaries --> and <!-- /summaries -->
         # comments, and if they exist, replace inside that section.
         if begin_region in contents:
-            contents[contents.index(begin_region):contents.index(end_region) + len(end_region)] = summaries
+            contents = contents[:contents.index(begin_region)] + summaries + contents[contents.index(end_region) + len(end_region):]
         else:
             contents += "\n" + summaries
 

--- a/src/QsCompiler/Compiler/LoadedStep.cs
+++ b/src/QsCompiler/Compiler/LoadedStep.cs
@@ -124,7 +124,11 @@ namespace Microsoft.Quantum.QsCompiler
                 Message = $"{stageAnnotation}{diagnostic.Message}",
                 Source = diagnostic.Source,
                 Range = diagnostic.Source is null || diagnostic.Range is null
-                        ? new VisualStudio.LanguageServer.Protocol.Range()
+                        ? new VisualStudio.LanguageServer.Protocol.Range
+                          {
+                              Start = new Position(0, 0),
+                              End = new Position(0, 0),
+                          }
                         : diagnostic.Range.ToLsp()
             };
         }

--- a/src/QuantumSdk/Sdk/Sdk.targets
+++ b/src/QuantumSdk/Sdk/Sdk.targets
@@ -98,7 +98,7 @@
       <_QscCommandPredefinedAssemblyProperties Condition="'$(ExposeReferencesViaTestNames)'">$(_QscCommandPredefinedAssemblyProperties)$(_NewLineIndent)ExposeReferencesViaTestNames:true</_QscCommandPredefinedAssemblyProperties>
       <_QscCommandPredefinedAssemblyProperties Condition="'$(_QscDocsPackageId)' != ''">$(_QscCommandPredefinedAssemblyProperties)$(_NewLineIndent)DocsPackageId:$(_QscDocsPackageId)</_QscCommandPredefinedAssemblyProperties>
       <_QscCommandPredefinedAssemblyProperties Condition="'$(QirGeneration)'">$(_QscCommandPredefinedAssemblyProperties)$(_NewLineIndent)QirOutputPath:"$(QirOutputPath)"</_QscCommandPredefinedAssemblyProperties>
-      <_QscCommandPredefinedAssemblyProperties Condition="'$(QsharpDocsGeneration)'">$(_QscCommandPredefinedAssemblyProperties)$(_NewLineIndent)DocsOutputPath:"$(QsharpDocsOutputPath)"</_QscCommandPredefinedAssemblyProperties>
+      <_QscCommandPredefinedAssemblyProperties Condition="'$(QSharpDocsGeneration)'">$(_QscCommandPredefinedAssemblyProperties)$(_NewLineIndent)DocsOutputPath:"$(QSharpDocsOutputPath)"</_QscCommandPredefinedAssemblyProperties>
       <_QscCommandPredefinedAssemblyProperties Condition="'$(PerfDataGeneration)'">$(_QscCommandPredefinedAssemblyProperties)$(_NewLineIndent)PerfDataOutputPath:"$(PerfDataOutputPath)"</_QscCommandPredefinedAssemblyProperties>
       <_QscCommandPredefinedAssemblyProperties Condition="'$(GenerateConcreteIntrinsic)'">$(_QscCommandPredefinedAssemblyProperties)$(_NewLineIndent)GenerateConcreteIntrinsic:$(GenerateConcreteIntrinsic)</_QscCommandPredefinedAssemblyProperties>
       <_QscCommandAssemblyPropertiesFlag>$(_NewLine)--assembly-properties$(_QscCommandPredefinedAssemblyProperties)</_QscCommandAssemblyPropertiesFlag>


### PR DESCRIPTION
This PR fixes an issue reported offline by @tcNickolas by removing YAML versions of namespace summaries in favor of pure-Markdown summaries.