### PR TITLE
Make interfaces public for development

### DIFF
--- a/src/QsCompiler/BondSchemas/EntryPoint/Extensions.cs
+++ b/src/QsCompiler/BondSchemas/EntryPoint/Extensions.cs
@@ -9,12 +9,12 @@ namespace Microsoft.Quantum.QsCompiler.BondSchemas.EntryPoint
     /// <summary>
     /// This class provides extension methods for objects in the Microsoft.Quantum.QsCompiler.BondSchemas.EntryPoint namespace.
     /// </summary>
-    internal static class Extensions
+    public static class Extensions
     {
         /// <summary>
         /// Determine whether the values of two object instances are equal.
         /// </summary>
-        public static bool ValueEquals(this EntryPointOperation entryPointA, EntryPointOperation entryPointB)
+        internal static bool ValueEquals(this EntryPointOperation entryPointA, EntryPointOperation entryPointB)
         {
             if (!entryPointA.Name.Equals(entryPointB.Name))
             {

--- a/src/QsCompiler/BondSchemas/EntryPoint/Protocols.cs
+++ b/src/QsCompiler/BondSchemas/EntryPoint/Protocols.cs
@@ -10,12 +10,12 @@ namespace Microsoft.Quantum.QsCompiler.BondSchemas.EntryPoint
     /// <summary>
     /// This class provides methods for serialization/deserialization of objects in the Microsoft.Quantum.QsCompiler.BondSchemas.EntryPoint namespace.
     /// </summary>
-    internal static class Protocols
+    public static class Protocols
     {
         /// <summary>
         /// Deserializes an EntryPointOperation object from its JSON representation.
         /// </summary>
-        public static EntryPointOperation DeserializeFromJson(Stream stream)
+        internal static EntryPointOperation DeserializeFromJson(Stream stream)
         {
             var reader = new SimpleJsonReader(stream);
             var deserializer = new Deserializer<SimpleJsonReader>(typeof(EntryPointOperation));
@@ -26,7 +26,7 @@ namespace Microsoft.Quantum.QsCompiler.BondSchemas.EntryPoint
         /// <summary>
         /// Serializes an EntryPointOperation object to its JSON representation.
         /// </summary>
-        public static void SerializeToJson(EntryPointOperation entryPoint, Stream stream)
+        internal static void SerializeToJson(EntryPointOperation entryPoint, Stream stream)
         {
             var writer = new SimpleJsonWriter(stream);
             var serializer = new Serializer<SimpleJsonWriter>(typeof(EntryPointOperation));

--- a/src/QsCompiler/Compiler/QirDriverGeneration.cs
+++ b/src/QsCompiler/Compiler/QirDriverGeneration.cs
@@ -8,7 +8,7 @@ using Microsoft.Quantum.QsCompiler.Templates;
 
 namespace Microsoft.Quantum.QsCompiler
 {
-    internal static class QirDriverGeneration
+    public static class QirDriverGeneration
     {
         public static void GenerateQirDriverCpp(EntryPointOperation entryPointOperation, Stream stream)
         {


### PR DESCRIPTION
This change makes some interfaces public such that the QIR controller being developed in the qsharp-runtime repo can make use of the available methods.