### PR TITLE
Update use of deprecated range field in UserDefinedType and QsTypeParameter

### DIFF
--- a/src/QsCompiler/BondSchemas/CompilerObjectTranslator.cs
+++ b/src/QsCompiler/BondSchemas/CompilerObjectTranslator.cs
@@ -250,6 +250,7 @@ namespace Microsoft.Quantum.QsCompiler.BondSchemas
                 typeId: bondQsDeclarationAttribute.TypeId != null ?
                     bondQsDeclarationAttribute.TypeId.ToCompilerObject().ToQsNullableGeneric() :
                     QsNullable<SyntaxTree.UserDefinedType>.Null,
+                typeIdRange: QsNullable<DataTypes.Range>.Null,
                 argument: bondQsDeclarationAttribute.Argument.ToCompilerObject(),
                 offset: bondQsDeclarationAttribute.Offset.ToCompilerObject(),
                 comments: bondQsDeclarationAttribute.Comments.ToCompilerObject());

--- a/src/QsCompiler/CompilationManager/CompilationUnit.cs
+++ b/src/QsCompiler/CompilationManager/CompilationUnit.cs
@@ -112,8 +112,10 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
                 var attArg = SyntaxGenerator.StringLiteral(
                     originalName.ToString(),
                     ImmutableArray<TypedExpression>.Empty);
+
                 return new QsDeclarationAttribute(
                     QsNullable<UserDefinedType>.NewValue(attName),
+                    QsNullable<Range>.Null,
                     attArg,
                     declLocation,
                     QsComments.Empty);

--- a/src/QsCompiler/CompilationManager/CompilationUnit.cs
+++ b/src/QsCompiler/CompilationManager/CompilationUnit.cs
@@ -105,13 +105,10 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
 
             static QsDeclarationAttribute Renamed(QsQualifiedName originalName, Position declLocation)
             {
-                var attName = new UserDefinedType(
-                    GeneratedAttributes.Namespace,
-                    GeneratedAttributes.LoadedViaTestNameInsteadOf,
-                    QsNullable<Range>.Null);
-                var attArg = SyntaxGenerator.StringLiteral(
-                    originalName.ToString(),
-                    ImmutableArray<TypedExpression>.Empty);
+                var attName =
+                    UserDefinedType.New(GeneratedAttributes.Namespace, GeneratedAttributes.LoadedViaTestNameInsteadOf);
+                var attArg =
+                    SyntaxGenerator.StringLiteral(originalName.ToString(), ImmutableArray<TypedExpression>.Empty);
 
                 return new QsDeclarationAttribute(
                     QsNullable<UserDefinedType>.NewValue(attName),

--- a/src/QsCompiler/Core/ConstructorExtensions.fs
+++ b/src/QsCompiler/Core/ConstructorExtensions.fs
@@ -248,11 +248,17 @@ type QsCustomType with
         }
 
 type QsDeclarationAttribute with
+    // TODO: RELEASE 2021-10: Remove member.
+    [<Obsolete "Use the overload of New with 5 parameters.">]
     static member New(typeId, arg, pos, comments) =
+        QsDeclarationAttribute.New(typeId, Null, arg, pos, comments)
+
+    static member New(typeId, typeIdRange, argument, offset, comments) =
         {
             TypeId = typeId
-            Argument = arg
-            Offset = pos
+            TypeIdRange = typeIdRange
+            Argument = argument
+            Offset = offset
             Comments = comments
         }
 

--- a/src/QsCompiler/Core/ConstructorExtensions.fs
+++ b/src/QsCompiler/Core/ConstructorExtensions.fs
@@ -19,13 +19,7 @@ type QsQualifiedName with
     static member New(nsName, cName) = { Namespace = nsName; Name = cName }
 
 type UserDefinedType with
-    static member New(ns, name) =
-        {
-            Namespace = ns
-            Name = name
-            Range = Null
-        }
-
+    // TODO: RELEASE 2021-10: Remove member.
     [<Obsolete "Use UserDefinedType.New(string, string) instead.">]
     static member New(nsName, tName, range) =
         {
@@ -35,13 +29,7 @@ type UserDefinedType with
         }
 
 type QsTypeParameter with
-    static member New(origin, name) =
-        {
-            Origin = origin
-            TypeName = name
-            Range = Null
-        }
-
+    // TODO: RELEASE 2021-10: Remove member.
     [<Obsolete "Use QsTypeParameter.New(string, string) instead.">]
     static member New(origin, tName, range) =
         {
@@ -251,14 +239,11 @@ type QsDeclarationAttribute with
     // TODO: RELEASE 2021-10: Remove member.
     [<Obsolete "Use the overload of New with 5 parameters.">]
     static member New(typeId, arg, pos, comments) =
-        QsDeclarationAttribute.New(typeId, Null, arg, pos, comments)
-
-    static member New(typeId, typeIdRange, argument, offset, comments) =
         {
             TypeId = typeId
-            TypeIdRange = typeIdRange
-            Argument = argument
-            Offset = offset
+            TypeIdRange = Null
+            Argument = arg
+            Offset = pos
             Comments = comments
         }
 

--- a/src/QsCompiler/Core/SymbolResolution.fs
+++ b/src/QsCompiler/Core/SymbolResolution.fs
@@ -747,6 +747,7 @@ module SymbolResolution =
         let buildAttribute id =
             {
                 TypeId = id
+                TypeIdRange = attribute.Id.Range
                 Argument = resArg
                 Offset = attribute.Position
                 Comments = attribute.Comments

--- a/src/QsCompiler/Core/SymbolTable/NamespaceManager.fs
+++ b/src/QsCompiler/Core/SymbolTable/NamespaceManager.fs
@@ -242,10 +242,9 @@ type NamespaceManager(syncRoot: IReaderWriterLock,
     /// </summary>
     /// <exception cref="NotSupportedException"><paramref name="qsType"/> contains a <see cref="MissingType"/>.</exception>
     let resolveType (parent: QsQualifiedName, tpNames, source) qsType checkUdt =
-        let processUDT =
-            tryResolveTypeName (parent.Namespace, source)
-            >> function
-            | Some (udt, _, access), errs -> UserDefinedType udt, Array.append errs (checkUdt (udt, access))
+        let processUDT (name, range) =
+            match tryResolveTypeName (parent.Namespace, source) (name, range) with
+            | Some (udt, _, access), errs -> UserDefinedType udt, Array.append errs (checkUdt (udt, range, access))
             | None, errs -> InvalidType, errs
 
         let processTP (symName, symRange) =
@@ -274,10 +273,12 @@ type NamespaceManager(syncRoot: IReaderWriterLock,
     /// Compares the accessibility of the parent declaration with the accessibility of the UDT being referenced. If the
     /// accessibility of a referenced type is less than the accessibility of the parent, returns a diagnostic using the
     /// given error code. Otherwise, returns an empty array.
-    let checkUdtAccess code (parent, parentAccess) (udt: UserDefinedType, udtAccess) =
+    let checkUdtAccess code (parent, parentAccess) (udt: UserDefinedType, udtRange, udtAccess) =
+        let udtRange = udtRange |> QsNullable.defaultValue Range.Zero
+
         [|
             if udtAccess < parentAccess
-            then yield QsCompilerDiagnostic.Error (code, [ udt.Name; parent ]) (udt.Range.ValueOr Range.Zero)
+            then yield QsCompilerDiagnostic.Error (code, [ udt.Name; parent ]) udtRange
         |]
 
     /// <summary>
@@ -498,7 +499,7 @@ type NamespaceManager(syncRoot: IReaderWriterLock,
                 // the attribute is a duplication of another attribute on this declaration
                 if alreadyDefined.Contains attributeHash then
                     (att.Offset,
-                     tId.Range
+                     att.TypeIdRange
                      |> orDefault
                      |> QsCompilerDiagnostic.Warning(WarningCode.DuplicateAttribute, [ tId.Name ]))
                     |> Seq.singleton
@@ -506,7 +507,7 @@ type NamespaceManager(syncRoot: IReaderWriterLock,
 
                 // the attribute marks an entry point
                 elif tId |> isBuiltIn BuiltIn.EntryPoint then
-                    let register, msgs = validateEntryPoint parent (att.Offset, tId.Range) decl
+                    let register, msgs = validateEntryPoint parent (att.Offset, att.TypeIdRange) decl
                     errs.AddRange msgs
 
                     if register
@@ -550,7 +551,7 @@ type NamespaceManager(syncRoot: IReaderWriterLock,
                             |> returnInvalid
                     | _ ->
                         (att.Offset,
-                         tId.Range
+                         att.TypeIdRange
                          |> orDefault
                          |> QsCompilerDiagnostic.Error(ErrorCode.InvalidTestAttributePlacement, []))
                         |> Seq.singleton
@@ -563,7 +564,7 @@ type NamespaceManager(syncRoot: IReaderWriterLock,
                     match box decl.Defined with
                     | :? QsSpecializationGenerator ->
                         (att.Offset,
-                         tId.Range
+                         att.TypeIdRange
                          |> orDefault
                          |> QsCompilerDiagnostic.Error(ErrorCode.AttributeInvalidOnSpecialization, [ tId.Name ]))
                         |> Seq.singleton
@@ -572,7 +573,7 @@ type NamespaceManager(syncRoot: IReaderWriterLock,
                         attributeHash :: alreadyDefined, att :: resAttr
                     | _ ->
                         (att.Offset,
-                         tId.Range
+                         att.TypeIdRange
                          |> orDefault
                          |> QsCompilerDiagnostic.Error(ErrorCode.ExpectingFullNameAsAttributeArgument, [ tId.Name ]))
                         |> Seq.singleton
@@ -583,14 +584,14 @@ type NamespaceManager(syncRoot: IReaderWriterLock,
                     match box decl.Defined with
                     | :? CallableSignature ->
                         (att.Offset,
-                         tId.Range
+                         att.TypeIdRange
                          |> orDefault
                          |> QsCompilerDiagnostic.Error(ErrorCode.AttributeInvalidOnCallable, [ tId.Name ]))
                         |> Seq.singleton
                         |> returnInvalid
                     | :? QsSpecializationGenerator ->
                         (att.Offset,
-                         tId.Range
+                         att.TypeIdRange
                          |> orDefault
                          |> QsCompilerDiagnostic.Error(ErrorCode.AttributeInvalidOnSpecialization, [ tId.Name ]))
                         |> Seq.singleton
@@ -602,7 +603,7 @@ type NamespaceManager(syncRoot: IReaderWriterLock,
                     match box decl.Defined with
                     | :? QsSpecializationGenerator ->
                         (att.Offset,
-                         tId.Range
+                         att.TypeIdRange
                          |> orDefault
                          |> QsCompilerDiagnostic.Error(ErrorCode.AttributeInvalidOnSpecialization, [ tId.Name ]))
                         |> Seq.singleton

--- a/src/QsCompiler/Core/Transformations/TypeTransformation.fs
+++ b/src/QsCompiler/Core/Transformations/TypeTransformation.fs
@@ -126,7 +126,8 @@ type TypeTransformationBase(options: TransformationOptions) =
 
     // transformation root called on each node
 
-    member this.OnType(t: ResolvedType) =
+    abstract OnType: ResolvedType -> ResolvedType
+    default this.OnType(t: ResolvedType) =
         if not options.Enable then
             t
         else

--- a/src/QsCompiler/DataStructures/SyntaxTree.fs
+++ b/src/QsCompiler/DataStructures/SyntaxTree.fs
@@ -162,6 +162,16 @@ type QsTypeParameter =
             Range = defaultArg range param.Range
         }
 
+    /// <summary>
+    /// Creates a new <see cref="QsTypeParameter"/>.
+    /// </summary>
+    static member New(origin, name) =
+        {
+            Origin = origin
+            TypeName = name
+            Range = Null
+        }
+
 /// used to represent the use of a user defined type within a fully resolved Q# type
 [<CustomEquality>]
 [<CustomComparison>]
@@ -206,6 +216,16 @@ type UserDefinedType =
             Namespace = defaultArg ns udt.Namespace
             Name = defaultArg name udt.Name
             Range = defaultArg range udt.Range
+        }
+
+    /// <summary>
+    /// Creates a new <see cref="UserDefinedType"/>.
+    /// </summary>
+    static member New(ns, name) =
+        {
+            Namespace = ns
+            Name = name
+            Range = Null
         }
 
 /// Fully resolved operation characteristics used to describe the properties of a Q# callable.
@@ -913,6 +933,17 @@ type QsDeclarationAttribute =
         Comments: QsComments
     }
 
+    /// <summary>
+    /// Creates a new <see cref="QsDeclarationAttribute"/>.
+    /// </summary>
+    static member New(typeId, typeIdRange, argument, offset, comments) =
+        {
+            TypeId = typeId
+            TypeIdRange = typeIdRange
+            Argument = argument
+            Offset = offset
+            Comments = comments
+        }
 
 /// Fully resolved Q# callable signature
 type ResolvedSignature =

--- a/src/QsCompiler/DataStructures/SyntaxTree.fs
+++ b/src/QsCompiler/DataStructures/SyntaxTree.fs
@@ -151,9 +151,16 @@ type QsTypeParameter =
     override param.GetHashCode() = hash (param.Origin, param.TypeName)
 
     /// <summary>
-    /// Returns this type parameter with the given <paramref name="origin"/>.
+    /// Returns a copy of this <see cref="QsTypeParameter"/> with updated fields.
     /// </summary>
-    member param.WithOrigin origin = { param with Origin = origin }
+    member param.With([<Optional; DefaultParameterValue null>] ?origin,
+                      [<Optional; DefaultParameterValue null>] ?typeName,
+                      [<Optional; DefaultParameterValue null>] ?range) =
+        { param with
+            Origin = defaultArg origin param.Origin
+            TypeName = defaultArg typeName param.TypeName
+            Range = defaultArg range param.Range
+        }
 
 /// used to represent the use of a user defined type within a fully resolved Q# type
 [<CustomEquality>]
@@ -188,6 +195,18 @@ type UserDefinedType =
 
     member this.GetFullName() =
         { Namespace = this.Namespace; Name = this.Name }
+
+    /// <summary>
+    /// Returns a copy of this <see cref="UserDefinedType"/> with updated fields.
+    /// </summary>
+    member udt.With([<Optional; DefaultParameterValue null>] ?ns,
+                    [<Optional; DefaultParameterValue null>] ?name,
+                    [<Optional; DefaultParameterValue null>] ?range) =
+        { udt with
+            Namespace = defaultArg ns udt.Namespace
+            Name = defaultArg name udt.Name
+            Range = defaultArg range udt.Range
+        }
 
 /// Fully resolved operation characteristics used to describe the properties of a Q# callable.
 /// A resolved characteristic expression by construction never contains an empty or invalid set as inner expressions,

--- a/src/QsCompiler/DataStructures/SyntaxTree.fs
+++ b/src/QsCompiler/DataStructures/SyntaxTree.fs
@@ -871,13 +871,20 @@ type QsLocalSymbol =
 type QsDeclarationAttribute =
     {
         /// Identifies the user defined type that the attribute instantiates.
-        /// The range information describes the range occupied by the attribute identifier relative to the attribute offset.
         /// Is Null only if the correct attribute could not be determined. Attributes set to Null should be ignored.
         TypeId: QsNullable<UserDefinedType>
+
+        /// <summary>
+        /// The range of <see cref="TypeId"/> relative to <see cref="Offset"/>.
+        /// </summary>
+        TypeIdRange: QsNullable<Range>
+
         /// Contains the argument with which the attribute is instantiated.
         Argument: TypedExpression
+
         /// Represents the position in the source file where the attribute is used.
         Offset: Position
+
         /// contains comments in the code associated with the attached attribute
         Comments: QsComments
     }

--- a/src/QsCompiler/Transformations/Attributes.cs
+++ b/src/QsCompiler/Transformations/Attributes.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Quantum.QsCompiler.Transformations
         /// The attribute argument is set to an invalid expression if the given argument is null.
         /// </summary>
         public static QsDeclarationAttribute BuildAttribute(QsQualifiedName name, TypedExpression arg) =>
-            new QsDeclarationAttribute(BuildId(name), arg ?? SyntaxGenerator.InvalidExpression, Position.Zero, QsComments.Empty);
+            new QsDeclarationAttribute(BuildId(name), QsNullable<Range>.Null, arg, Position.Zero, QsComments.Empty);
 
         /// <summary>
         /// Builds a string literal with the given content that can be used as argument to a Q# attribute.

--- a/src/QsCompiler/Transformations/ContentLifting.cs
+++ b/src/QsCompiler/Transformations/ContentLifting.cs
@@ -437,7 +437,7 @@ namespace Microsoft.Quantum.QsCompiler.Transformations.ContentLifting
                 public override ResolvedTypeKind OnTypeParameter(QsTypeParameter tp) =>
                     // Reroute a type parameter's origin to the newly generated operation
                     !this.SharedState.IsRecursiveIdentifier && this.SharedState.OldName.Equals(tp.Origin)
-                        ? base.OnTypeParameter(tp.WithOrigin(this.SharedState.NewName))
+                        ? base.OnTypeParameter(tp.With(this.SharedState.NewName))
                         : base.OnTypeParameter(tp);
             }
         }

--- a/src/QsCompiler/Transformations/SearchAndReplace.cs
+++ b/src/QsCompiler/Transformations/SearchAndReplace.cs
@@ -25,8 +25,7 @@ namespace Microsoft.Quantum.QsCompiler.Transformations.SearchAndReplace
     /// Class that allows to walk the syntax tree and find all locations where a certain identifier occurs.
     /// If a set of source file names is given on initialization, the search is limited to callables and specializations in those files.
     /// </summary>
-    public class IdentifierReferences
-    : SyntaxTreeTransformation<IdentifierReferences.TransformationState>
+    public class IdentifierReferences : SyntaxTreeTransformation<IdentifierReferences.TransformationState>
     {
         public class Location : IEquatable<Location>
         {
@@ -171,7 +170,7 @@ namespace Microsoft.Quantum.QsCompiler.Transformations.SearchAndReplace
         }
 
         public IdentifierReferences(TransformationState state)
-        : base(state, TransformationOptions.NoRebuild)
+            : base(state, TransformationOptions.NoRebuild)
         {
             this.Types = new TypeTransformation(this);
             this.Expressions = new TypedExpressionWalker<TransformationState>(this.SharedState.LogIdentifierLocation, this);
@@ -180,12 +179,12 @@ namespace Microsoft.Quantum.QsCompiler.Transformations.SearchAndReplace
         }
 
         public IdentifierReferences(string idName, QsLocation? defaultOffset, IImmutableSet<string>? limitToSourceFiles = null)
-        : this(new TransformationState(id => id is Identifier.LocalVariable varName && varName.Item == idName, defaultOffset, limitToSourceFiles))
+            : this(new TransformationState(id => id is Identifier.LocalVariable varName && varName.Item == idName, defaultOffset, limitToSourceFiles))
         {
         }
 
         public IdentifierReferences(QsQualifiedName idName, QsLocation? defaultOffset, IImmutableSet<string>? limitToSourceFiles = null)
-        : this(new TransformationState(id => id is Identifier.GlobalCallable cName && cName.Item.Equals(idName), defaultOffset, limitToSourceFiles))
+            : this(new TransformationState(id => id is Identifier.GlobalCallable cName && cName.Item.Equals(idName), defaultOffset, limitToSourceFiles))
         {
         }
 
@@ -219,39 +218,35 @@ namespace Microsoft.Quantum.QsCompiler.Transformations.SearchAndReplace
 
         // helper classes
 
-        private class TypeTransformation
-        : TypeTransformation<TransformationState>
+        private class TypeTransformation : TypeTransformation<TransformationState>
         {
             public TypeTransformation(SyntaxTreeTransformation<TransformationState> parent)
-            : base(parent, TransformationOptions.NoRebuild)
+                : base(parent, TransformationOptions.NoRebuild)
             {
             }
 
-            public override QsTypeKind OnUserDefinedType(UserDefinedType udt)
+            public override ResolvedType OnType(ResolvedType type)
             {
-                var id = Identifier.NewGlobalCallable(new QsQualifiedName(udt.Namespace, udt.Name));
-#pragma warning disable 618 // UserDefinedType.Range is obsolete.
-                this.SharedState.LogIdentifierLocation(id, udt.Range);
-#pragma warning restore 618
-                return QsTypeKind.NewUserDefinedType(udt);
-            }
+                switch (type.Resolution)
+                {
+                    case QsTypeKind.UserDefinedType { Item: var udt }:
+                        var id = Identifier.NewGlobalCallable(new QsQualifiedName(udt.Namespace, udt.Name));
+                        this.SharedState.LogIdentifierLocation(id, TypeRangeModule.TryRange(type.Range));
+                        break;
+                    case QsTypeKind.TypeParameter _:
+                        id = Identifier.NewLocalVariable(SyntaxTreeToQsharp.Default.ToCode(type) ?? "");
+                        this.SharedState.LogIdentifierLocation(id, TypeRangeModule.TryRange(type.Range));
+                        break;
+                }
 
-            public override QsTypeKind OnTypeParameter(QsTypeParameter tp)
-            {
-                var resT = ResolvedType.New(QsTypeKind.NewTypeParameter(tp));
-                var id = Identifier.NewLocalVariable(SyntaxTreeToQsharp.Default.ToCode(resT) ?? "");
-#pragma warning disable 618 // QsTypeParameter.Range is obsolete.
-                this.SharedState.LogIdentifierLocation(id, tp.Range);
-#pragma warning restore 618
-                return resT.Resolution;
+                return base.OnType(type);
             }
         }
 
-        private class StatementTransformation
-        : StatementTransformation<TransformationState>
+        private class StatementTransformation : StatementTransformation<TransformationState>
         {
             public StatementTransformation(SyntaxTreeTransformation<TransformationState> parent)
-            : base(parent, TransformationOptions.NoRebuild)
+                : base(parent, TransformationOptions.NoRebuild)
             {
             }
 
@@ -262,11 +257,10 @@ namespace Microsoft.Quantum.QsCompiler.Transformations.SearchAndReplace
             }
         }
 
-        private class NamespaceTransformation
-        : NamespaceTransformation<TransformationState>
+        private class NamespaceTransformation : NamespaceTransformation<TransformationState>
         {
             public NamespaceTransformation(SyntaxTreeTransformation<TransformationState> parent)
-            : base(parent, TransformationOptions.NoRebuild)
+                : base(parent, TransformationOptions.NoRebuild)
             {
             }
 
@@ -337,8 +331,7 @@ namespace Microsoft.Quantum.QsCompiler.Transformations.SearchAndReplace
     /// The location information is relative to the root node, i.e. the start position of the containing specialization
     /// declaration.
     /// </remarks>
-    public class AccumulateIdentifiers
-    : SyntaxTreeTransformation<AccumulateIdentifiers.TransformationState>
+    public class AccumulateIdentifiers : SyntaxTreeTransformation<AccumulateIdentifiers.TransformationState>
     {
         public class TransformationState
         {
@@ -375,7 +368,7 @@ namespace Microsoft.Quantum.QsCompiler.Transformations.SearchAndReplace
         }
 
         public AccumulateIdentifiers()
-        : base(new TransformationState(), TransformationOptions.NoRebuild)
+            : base(new TransformationState(), TransformationOptions.NoRebuild)
         {
             this.Statements = new StatementTransformation(this);
             this.StatementKinds = new StatementKindTransformation(this);
@@ -385,11 +378,10 @@ namespace Microsoft.Quantum.QsCompiler.Transformations.SearchAndReplace
 
         // helper classes
 
-        private class StatementTransformation
-        : StatementTransformation<TransformationState>
+        private class StatementTransformation : StatementTransformation<TransformationState>
         {
             public StatementTransformation(SyntaxTreeTransformation<TransformationState> parent)
-            : base(parent, TransformationOptions.NoRebuild)
+                : base(parent, TransformationOptions.NoRebuild)
             {
             }
 
@@ -401,11 +393,10 @@ namespace Microsoft.Quantum.QsCompiler.Transformations.SearchAndReplace
             }
         }
 
-        private class StatementKindTransformation
-        : StatementKindTransformation<TransformationState>
+        private class StatementKindTransformation : StatementKindTransformation<TransformationState>
         {
             public StatementKindTransformation(SyntaxTreeTransformation<TransformationState> parent)
-            : base(parent, TransformationOptions.NoRebuild)
+                : base(parent, TransformationOptions.NoRebuild)
             {
             }
 
@@ -494,8 +485,7 @@ namespace Microsoft.Quantum.QsCompiler.Transformations.SearchAndReplace
     /// The original variable name can be recovered by using the static method StripUniqueName.
     /// This class is *not* threadsafe.
     /// </summary>
-    public class UniqueVariableNames
-    : SyntaxTreeTransformation<UniqueVariableNames.TransformationState>
+    public class UniqueVariableNames : SyntaxTreeTransformation<UniqueVariableNames.TransformationState>
     {
         public class TransformationState
         {
@@ -522,7 +512,7 @@ namespace Microsoft.Quantum.QsCompiler.Transformations.SearchAndReplace
         }
 
         public UniqueVariableNames()
-        : base(new TransformationState())
+            : base(new TransformationState())
         {
             this.Statements = new StatementTransformation(this);
             this.StatementKinds = new StatementKindTransformation(this);
@@ -538,11 +528,10 @@ namespace Microsoft.Quantum.QsCompiler.Transformations.SearchAndReplace
 
         // helper classes
 
-        private class StatementTransformation
-        : StatementTransformation<TransformationState>
+        private class StatementTransformation : StatementTransformation<TransformationState>
         {
             public StatementTransformation(SyntaxTreeTransformation<TransformationState> parent)
-            : base(parent)
+                : base(parent)
             {
             }
 
@@ -550,11 +539,10 @@ namespace Microsoft.Quantum.QsCompiler.Transformations.SearchAndReplace
                 this.SharedState.TryGetUniqueName(name, out var unique) ? unique : name;
         }
 
-        private class StatementKindTransformation
-        : StatementKindTransformation<TransformationState>
+        private class StatementKindTransformation : StatementKindTransformation<TransformationState>
         {
             public StatementKindTransformation(SyntaxTreeTransformation<TransformationState> parent)
-            : base(parent)
+                : base(parent)
             {
             }
 
@@ -566,11 +554,10 @@ namespace Microsoft.Quantum.QsCompiler.Transformations.SearchAndReplace
                     : syms;
         }
 
-        private class ExpressionKindTransformation
-        : ExpressionKindTransformation<TransformationState>
+        private class ExpressionKindTransformation : ExpressionKindTransformation<TransformationState>
         {
             public ExpressionKindTransformation(SyntaxTreeTransformation<TransformationState> parent)
-            : base(parent)
+                : base(parent)
             {
             }
 
@@ -609,9 +596,7 @@ namespace Microsoft.Quantum.QsCompiler.Transformations.SearchAndReplace
             internal UserDefinedType RenameUdt(UserDefinedType udt)
             {
                 var newName = this.GetNewName(new QsQualifiedName(udt.Namespace, udt.Name));
-#pragma warning disable 618 // UserDefinedType.Range is obsolete.
-                return new UserDefinedType(newName.Namespace, newName.Name, udt.Range);
-#pragma warning restore 618
+                return udt.With(newName.Namespace, newName.Name);
             }
         }
 
@@ -708,9 +693,7 @@ namespace Microsoft.Quantum.QsCompiler.Transformations.SearchAndReplace
                 QsTypeKind.NewUserDefinedType(this.state.RenameUdt(udt));
 
             public override QsTypeKind OnTypeParameter(QsTypeParameter tp) =>
-#pragma warning disable 618 // QsTypeParameter.Range is obsolete.
-                QsTypeKind.NewTypeParameter(new QsTypeParameter(this.state.GetNewName(tp.Origin), tp.TypeName, tp.Range));
-#pragma warning restore 618
+                QsTypeKind.NewTypeParameter(tp.With(this.state.GetNewName(tp.Origin)));
         }
 
         private class ExpressionKindTransformation : Core.ExpressionKindTransformation

--- a/src/QsCompiler/Transformations/SearchAndReplace.cs
+++ b/src/QsCompiler/Transformations/SearchAndReplace.cs
@@ -745,7 +745,9 @@ namespace Microsoft.Quantum.QsCompiler.Transformations.SearchAndReplace
                 var typeId = attribute.TypeId.IsValue
                     ? QsNullable<UserDefinedType>.NewValue(this.state.RenameUdt(attribute.TypeId.Item))
                     : attribute.TypeId;
-                return new QsDeclarationAttribute(typeId, argument, attribute.Offset, attribute.Comments);
+
+                return new QsDeclarationAttribute(
+                    typeId, attribute.TypeIdRange, argument, attribute.Offset, attribute.Comments);
             }
 
             public override QsCallable OnCallableDeclaration(QsCallable callable) =>

--- a/src/QsCompiler/Transformations/Transformations.csproj
+++ b/src/QsCompiler/Transformations/Transformations.csproj
@@ -5,6 +5,7 @@
     <OutputType>Library</OutputType>
     <TargetFramework>netstandard2.1</TargetFramework>
     <AssemblyName>Microsoft.Quantum.QsTransformations</AssemblyName>
+    <RootNamespace>Microsoft.Quantum.QsCompiler.Transformations</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Follow up from #917 to update usages of now-deprecated `UserDefinedType.Range` and `QsTypeParameter.Range`:

* Add `TypeIdRange` field to `QsAttributeDeclaration`.
* Make `TypeTransformationBase.OnType` virtual so that `IdentifierReferences` has access to both the UDT record and `ResolvedType.Range` at the same time.