### PR TITLE
Fix #949.

### DIFF
--- a/src/Documentation/DocumentationGenerator/Extensions.cs
+++ b/src/Documentation/DocumentationGenerator/Extensions.cs
@@ -306,6 +306,7 @@ namespace Microsoft.Quantum.Documentation
                         ResolvedTypeKind.Tags.Range => "[Range](xref:microsoft.quantum.qsharp.valueliterals#range-literals)",
                         ResolvedTypeKind.Tags.String => "[String](xref:microsoft.quantum.qsharp.valueliterals#string-literals)",
                         ResolvedTypeKind.Tags.UnitType => "[Unit](xref:microsoft.quantum.qsharp.valueliterals#unit-literal)",
+                        ResolvedTypeKind.Tags.Result => "[Unit](xref:microsoft.quantum.qsharp.valueliterals#result-literal)",
                         ResolvedTypeKind.Tags.InvalidType => "__invalid__",
                         _ => $"__invalid<{type.Resolution.ToString()}>__",
                     },

--- a/src/Documentation/DocumentationGenerator/Extensions.cs
+++ b/src/Documentation/DocumentationGenerator/Extensions.cs
@@ -306,7 +306,7 @@ namespace Microsoft.Quantum.Documentation
                         ResolvedTypeKind.Tags.Range => "[Range](xref:microsoft.quantum.qsharp.valueliterals#range-literals)",
                         ResolvedTypeKind.Tags.String => "[String](xref:microsoft.quantum.qsharp.valueliterals#string-literals)",
                         ResolvedTypeKind.Tags.UnitType => "[Unit](xref:microsoft.quantum.qsharp.valueliterals#unit-literal)",
-                        ResolvedTypeKind.Tags.Result => "[Unit](xref:microsoft.quantum.qsharp.valueliterals#result-literal)",
+                        ResolvedTypeKind.Tags.Result => "[Result](xref:microsoft.quantum.qsharp.valueliterals#result-literal)",
                         ResolvedTypeKind.Tags.InvalidType => "__invalid__",
                         _ => $"__invalid<{type.Resolution.ToString()}>__",
                     },


### PR DESCRIPTION
This PR fixes a regression in the documentation generation pipeline that causes some inputs of type `Result` to be formatted as `invalid` instead (#949).