### PR TITLE
Handle SizedArray in code output and optimizations

### DIFF
--- a/src/QsCompiler/Core/SymbolTable/NamespaceManager.fs
+++ b/src/QsCompiler/Core/SymbolTable/NamespaceManager.fs
@@ -1524,8 +1524,10 @@ type NamespaceManager(syncRoot: IReaderWriterLock,
         | StringLiteral (s, _) -> hash (6, s)
         | ValueTuple vs -> hash (7, (vs |> Seq.map NamespaceManager.ExpressionHash |> Seq.toList))
         | ValueArray vs -> hash (8, (vs |> Seq.map NamespaceManager.ExpressionHash |> Seq.toList))
-        | NewArray (bt, idx) -> hash (9, NamespaceManager.TypeHash bt, NamespaceManager.ExpressionHash idx)
-        | Identifier (GlobalCallable c, _) -> hash (10, c.Namespace, c.Name)
+        | SizedArray (value, size) ->
+            hash (9, NamespaceManager.ExpressionHash value, NamespaceManager.ExpressionHash size)
+        | NewArray (bt, idx) -> hash (10, NamespaceManager.TypeHash bt, NamespaceManager.ExpressionHash idx)
+        | Identifier (GlobalCallable c, _) -> hash (11, c.Namespace, c.Name)
         | kind -> JsonConvert.SerializeObject kind |> hash
 
     /// <summary>

--- a/src/QsCompiler/Core/Transformations/ExpressionTransformation.fs
+++ b/src/QsCompiler/Core/Transformations/ExpressionTransformation.fs
@@ -138,7 +138,7 @@ type ExpressionKindTransformationBase internal (options: TransformationOptions, 
         let bt, idx = this.Types.OnType bt, this.Expressions.OnTypedExpression idx
         NewArray |> Node.BuildOr InvalidExpr (bt, idx)
 
-    abstract OnSizedArray: TypedExpression * TypedExpression -> ExpressionKind
+    abstract OnSizedArray: value:TypedExpression * size:TypedExpression -> ExpressionKind
 
     default this.OnSizedArray(value, size) =
         let value = this.Expressions.OnTypedExpression value

--- a/src/QsCompiler/Optimizations/OptimizingTransformations/ConstantPropagation.fs
+++ b/src/QsCompiler/Optimizations/OptimizingTransformations/ConstantPropagation.fs
@@ -55,11 +55,48 @@ and private ConstantPropagationStatementKinds(parent: ConstantPropagation, calla
                 | ValueTuple _
                 | ValueArray _
                 | RangeLiteral _
+                | SizedArray _
                 | NewArray _ -> true
-                | CallLikeExpression ({ Expression = Identifier (GlobalCallable qualName, _) }, _) when (callables.[qualName])
+                | CallLikeExpression ({ Expression = Identifier (GlobalCallable name, _) }, _) when callables.[name]
                     .Kind = TypeConstructor -> true
-                | a when TypedExpression.IsPartialApplication a -> true
-                | _ -> false
+                | _ when TypedExpression.IsPartialApplication ex.Expression -> true
+                | UnitValue
+                | IntLiteral _
+                | BigIntLiteral _
+                | DoubleLiteral _
+                | BoolLiteral _
+                | StringLiteral _
+                | ResultLiteral _
+                | PauliLiteral _
+                | NEG _
+                | NOT _
+                | BNOT _
+                | ADD _
+                | SUB _
+                | MUL _
+                | DIV _
+                | MOD _
+                | POW _
+                | EQ _
+                | NEQ _
+                | LT _
+                | LTE _
+                | GT _
+                | GTE _
+                | AND _
+                | OR _
+                | BOR _
+                | BAND _
+                | BXOR _
+                | LSHIFT _
+                | RSHIFT _
+                | CONDITIONAL _
+                | CopyAndUpdate _
+                | AdjointApplication _
+                | ControlledApplication _
+                | CallLikeExpression _
+                | MissingExpr _
+                | InvalidExpr _ -> false
                 && Seq.forall id sub)
 
         expr.Fold folder

--- a/src/QsCompiler/Optimizations/Utils/HelperFunctions.fs
+++ b/src/QsCompiler/Optimizations/Utils/HelperFunctions.fs
@@ -228,10 +228,12 @@ let internal wrapStmt (stmt: QsStatementKind): QsStatement =
     QsStatement.New QsComments.Empty Null (stmt, LocalDeclarations.New symbolDecl)
 
 
-/// Returns a new array of the given type and length.
+/// <summary>
+/// Returns a new array containing the given value repeated <paramref name="length"/> times.
 /// Returns None if the type doesn't have a default value as an expression.
-let rec internal constructArray length value =
-    List.replicate length value |> ImmutableArray.CreateRange |> ValueArray
+/// </summary>
+let internal constructArray length =
+    List.replicate length >> ImmutableArray.CreateRange >> ValueArray
 
 /// Returns the default value for a given type (from Q# documentation).
 /// Returns None for types whose default values are not representable as expressions.

--- a/src/QsCompiler/Transformations/QsharpCodeOutput.cs
+++ b/src/QsCompiler/Transformations/QsharpCodeOutput.cs
@@ -802,6 +802,17 @@ namespace Microsoft.Quantum.QsCompiler.Transformations.QsCodeOutput
             }
 
             /// <inheritdoc/>
+            public override QsExpressionKind OnSizedArray(TypedExpression value, TypedExpression size)
+            {
+                var valueOutput = this.Recur(int.MinValue, value);
+                var sizeOutput = this.Recur(int.MinValue, size);
+                this.Output = $"[{valueOutput}, size = {sizeOutput}]";
+
+                this.currentPrecedence = int.MaxValue;
+                return QsExpressionKind.NewSizedArray(value, size);
+            }
+
+            /// <inheritdoc/>
             public override QsExpressionKind OnNewArray(ResolvedType bt, TypedExpression idx)
             {
                 this.Output = $"{Keywords.arrayDecl.id} {this.typeToQs(bt)}[{this.Recur(int.MinValue, idx)}]";


### PR DESCRIPTION
Addresses issues brought up in #884.

In some cases, I replaced a catch-all match case with every individual expression kind to make the match exhaustive, which should prevent these matches from being missed when new expression kinds are added in the future.