### PR TITLE
Improve HM type inference diagnostic messages

### DIFF
--- a/src/QsCompiler/Core/SyntaxGenerator.fs
+++ b/src/QsCompiler/Core/SyntaxGenerator.fs
@@ -18,6 +18,9 @@ open Microsoft.Quantum.QsCompiler.Transformations.Core
 
 type private StripPositionInfoFromType(parent: StripPositionInfo) =
     inherit TypeTransformation(parent)
+
+    override this.OnTypeRange _ = TypeRange.Generated
+
     override this.OnRangeInformation _ = Null
 
 and private StripPositionInfoFromExpression(parent: StripPositionInfo) =

--- a/src/QsCompiler/DataStructures/Diagnostics.fs
+++ b/src/QsCompiler/DataStructures/Diagnostics.fs
@@ -461,9 +461,9 @@ type DiagnosticItem =
             DiagnosticItem.ApplyArguments args
             << function
             | ErrorCode.TypeMismatch ->
-                "The expected type {0} does not match the actual type {1}.\nExpected type: {2}\n  Actual type: {3}"
+                "The type {1} does not match the type {0}. Actual type: {3}. Expected type: {2}."
             | ErrorCode.MissingBaseType ->
-                "The type {3} cannot be used with the type {4}, because {1} does not {0} {2}."
+                "The type {1} does not {0} the type {2}. Left-hand type: {3}. Right-hand type: {4}."
 
             | ErrorCode.ExcessBracketError -> "No matching opening bracket for this closing bracket."
             | ErrorCode.MissingBracketError -> "An opening bracket has not been closed."

--- a/src/QsCompiler/DataStructures/Diagnostics.fs
+++ b/src/QsCompiler/DataStructures/Diagnostics.fs
@@ -769,7 +769,10 @@ type DiagnosticItem =
                 "The type of the given argument does not match the expected type. Got an argument of type {0}, expecting one of type {1} instead."
             | ErrorCode.UnexpectedTupleArgument -> "Unexpected argument tuple. Expecting an argument of type {0}."
             | ErrorCode.AmbiguousTypeParameterResolution ->
-                "The type parameter resolution for the expression is ambiguous. Please provide explicit type arguments, e.g. Op<Int, Double>(arg)."
+                "The type parameter {0} is ambiguous. More type annotations or usage context may be necessary."
+                + if Seq.item 1 args |> String.IsNullOrWhiteSpace
+                  then ""
+                  else " Note: {0} has constraints {1}."
             | ErrorCode.ConstrainsTypeParameter -> "The given expression constrains the type parameter(s) {0}."
             | ErrorCode.GlobalTypeAlreadyExists -> "A type with the name \"{0}\" already exists."
             | ErrorCode.GlobalCallableAlreadyExists -> "A callable with the name \"{0}\" already exists."

--- a/src/QsCompiler/DataStructures/Diagnostics.fs
+++ b/src/QsCompiler/DataStructures/Diagnostics.fs
@@ -461,9 +461,9 @@ type DiagnosticItem =
             DiagnosticItem.ApplyArguments args
             << function
             | ErrorCode.TypeMismatch ->
-                "The type {1} does not match the type {0}. Actual type: {3}. Expected type: {2}."
+                "The type {1} does not match the type {0}.\nActual type:   {3}\nExpected type: {2}"
             | ErrorCode.MissingBaseType ->
-                "The type {1} does not {0} the type {2}. Left-hand type: {3}. Right-hand type: {4}."
+                "The type {1} does not {0} the type {2}.\nLeft-hand type:  {3}\nRight-hand type: {4}"
 
             | ErrorCode.ExcessBracketError -> "No matching opening bracket for this closing bracket."
             | ErrorCode.MissingBracketError -> "An opening bracket has not been closed."

--- a/src/QsCompiler/SyntaxProcessor/TypeInference/Constraint.fs
+++ b/src/QsCompiler/SyntaxProcessor/TypeInference/Constraint.fs
@@ -5,6 +5,7 @@ namespace Microsoft.Quantum.QsCompiler.SyntaxProcessing.TypeInference
 
 open Microsoft.Quantum.QsCompiler.SyntaxTokens
 open Microsoft.Quantum.QsCompiler.SyntaxTree
+open Microsoft.Quantum.QsCompiler.Transformations.QsCodeOutput
 
 type internal Constraint =
     | Adjointable
@@ -21,6 +22,9 @@ type internal Constraint =
     | Wrapped of item: ResolvedType
 
 module internal Constraint =
+    /// Pretty prints a type.
+    let private prettyType: ResolvedType -> _ = SyntaxTreeToQsharp.Default.ToCode
+
     let types =
         function
         | Adjointable -> []
@@ -35,3 +39,20 @@ module internal Constraint =
         | Numeric -> []
         | Semigroup -> []
         | Wrapped item -> [ item ]
+
+    let pretty =
+        function
+        | Adjointable -> "Adjointable"
+        | Callable (input, output) -> sprintf "Callable(%s, %s)" (prettyType input) (prettyType output)
+        | CanGenerateFunctors functors ->
+            sprintf "CanGenerateFunctors(%s)" (functors |> Seq.map string |> String.concat ", ")
+        | Controllable controlled -> sprintf "Controllable(%s)" (prettyType controlled)
+        | Equatable -> "Equatable"
+        | HasPartialApplication (missing, result) ->
+            sprintf "HasPartialApplication(%s, %s)" (prettyType missing) (prettyType result)
+        | Indexed (index, item) -> sprintf "Indexed(%s, %s)" (prettyType index) (prettyType item)
+        | Integral -> "Integral"
+        | Iterable item -> sprintf "Iterable(%s)" (prettyType item)
+        | Numeric -> "Numeric"
+        | Semigroup -> "Semigroup"
+        | Wrapped item -> sprintf "Wrapped(%s)" (prettyType item)

--- a/src/QsCompiler/SyntaxProcessor/TypeInference/Constraint.fsi
+++ b/src/QsCompiler/SyntaxProcessor/TypeInference/Constraint.fsi
@@ -65,3 +65,6 @@ type internal Constraint =
 module internal Constraint =
     /// The list of types contained in a constraint.
     val types: Constraint -> ResolvedType list
+
+    /// Pretty prints a constraint.
+    val pretty: Constraint -> string

--- a/src/QsCompiler/SyntaxProcessor/TypeInference/InferenceContext.fs
+++ b/src/QsCompiler/SyntaxProcessor/TypeInference/InferenceContext.fs
@@ -143,12 +143,6 @@ module private Inference =
     /// Shows the type as a string.
     let showType: ResolvedType -> _ = SyntaxTreeToQsharp.Default.ToCode
 
-    /// Shows the functor as a string.
-    let showFunctor =
-        function
-        | Adjoint -> Keywords.qsAdjointFunctor.id
-        | Controlled -> Keywords.qsControlledFunctor.id
-
     /// <summary>
     /// Combines information from two callables such that the resulting callable information satisfies the given
     /// <paramref name="ordering"/> with respect to both <paramref name="info1"/> and <paramref name="info2"/>.
@@ -456,7 +450,7 @@ type InferenceContext(symbolTracker: SymbolTracker) =
                 let missing = Set.difference functors (Set.ofSeq supported)
 
                 let error =
-                    ErrorCode.MissingFunctorForAutoGeneration, [ missing |> Seq.map showFunctor |> String.concat "," ]
+                    ErrorCode.MissingFunctorForAutoGeneration, [ missing |> Seq.map string |> String.concat "," ]
 
                 [
                     if not info.Characteristics.AreInvalid && Set.isEmpty missing |> not

--- a/src/QsCompiler/Tests.Compiler/LocalVerificationTests.fs
+++ b/src/QsCompiler/Tests.Compiler/LocalVerificationTests.fs
@@ -92,6 +92,11 @@ type LocalVerificationTests() =
         this.Expect "TypeArgumentsInference40" []
         this.Expect "TypeArgumentsInference41" [ Error ErrorCode.TypeMismatch ]
         this.Expect "TypeArgumentsInference42" [ Error ErrorCode.TypeMismatch ]
+        this.Expect "TypeArgumentsInference43" []
+        this.Expect "TypeArgumentsInference44" [ Error ErrorCode.AmbiguousTypeParameterResolution ]
+        this.Expect "TypeArgumentsInference45" [ Error ErrorCode.AmbiguousTypeParameterResolution ]
+        this.Expect "TypeArgumentsInference46" [ Error ErrorCode.AmbiguousTypeParameterResolution ]
+        this.Expect "TypeArgumentsInference47" []
 
 
     [<Fact>]

--- a/src/QsCompiler/Tests.Compiler/TestCases/LocalVerification.qs
+++ b/src/QsCompiler/Tests.Compiler/TestCases/LocalVerification.qs
@@ -3,11 +3,15 @@
 
 /// This namespace contains test cases for expression and statement verification
 namespace Microsoft.Quantum.Testing.LocalVerification {
-
     open Microsoft.Quantum.Diagnostics;
     open Microsoft.Quantum.Testing.General;
     open Microsoft.Quantum.Testing.TypeChecking;
 
+    function UnusedTypeParam<'a>() : Unit {}
+
+    operation Sequence<'a, 'b>(f : 'a => Unit, g : 'b => Unit) : ('a, 'b) => Unit {
+        fail "Not implemented.";
+    }
 
     // type argument inference
 
@@ -222,6 +226,25 @@ namespace Microsoft.Quantum.Testing.LocalVerification {
         TypeArgumentsInference23<'A, 'A>(a, b);
     }
 
+    function TypeArgumentsInference43() : Unit {
+        Default();
+    }
+
+    function TypeArgumentsInference44() : Unit {
+        let _ = Default();
+    }
+
+    function TypeArgumentsInference45() : Unit {
+        UnusedTypeParam();
+    }
+
+    function TypeArgumentsInference46() : Unit {
+        let _ = GenericFunction(Default);
+    }
+
+    operation TypeArgumentsInference47() : Unit {
+        Sequence(GenericOperation, GenericOperation)("Foo", 3);
+    }
 
     // variable declarations
 


### PR DESCRIPTION
* Fix incorrect diagnostic ranges caused by `StripPositionInfoFromType` not stripping ranges from `TypeRange`.
* Improve phrasing and give more information in type mismatch, missing base type, and ambiguous type parameter diagnostic:
  - For ambiguous type parameter diagnostics, show the constraints applied to the type parameter.
  - Call attention to type mismatches with explicitly bound type parameters (i.e., an alternative to the original "constrains type parameter" error).
* Add test cases for issues #573 and #662 that are fixed by HM.

Note: @cesarzc reported an issue where multi-line diagnostic messages were cut off after the first line in Visual Studio, but I can't reproduce the issue. Here is what they look like for me:

![image](https://user-images.githubusercontent.com/33814365/115311839-2ca7fa00-a125-11eb-80b5-fc20ef98773d.png)