### PR TITLE
Restore icons of NuGet packages to current design

### DIFF
--- a/src/Documentation/DocumentationGenerator/DocumentationGenerator.csproj
+++ b/src/Documentation/DocumentationGenerator/DocumentationGenerator.csproj
@@ -13,7 +13,7 @@
     <PackageReleaseNotes>See: https://docs.microsoft.com/azure/quantum/qdk-relnotes/</PackageReleaseNotes>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/microsoft/qsharp-compiler</PackageProjectUrl>
-    <PackageIconUrl>https://secure.gravatar.com/avatar/bd1f02955b2853ba0a3b1cdc2434e8ec.png</PackageIconUrl>
+    <PackageIcon>qdk-nuget-icon.png</PackageIcon>
     <PackageTags>Quantum Q# QSharp</PackageTags>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
   </PropertyGroup>
@@ -27,6 +27,10 @@
       <Pack>true</Pack>
       <PackagePath>build\Microsoft.Quantum.DocumentationGenerator.props</PackagePath>
     </Content>
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="..\..\..\build\assets\qdk-nuget-icon.png" Pack="true" Visible="false" PackagePath="" />
   </ItemGroup>
 
 </Project>

--- a/src/ProjectTemplates/Microsoft.Quantum.ProjectTemplates.nuspec
+++ b/src/ProjectTemplates/Microsoft.Quantum.ProjectTemplates.nuspec
@@ -9,7 +9,7 @@
 
     <license type="expression">MIT</license>
     <projectUrl>https://docs.microsoft.com/azure/quantum</projectUrl>
-    <iconUrl>https://secure.gravatar.com/avatar/bd1f02955b2853ba0a3b1cdc2434e8ec.png</iconUrl>
+    <icon>images\qdk-nuget-icon.png</icon>
 
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>.NET Core templates pack for Q#, part of the Microsoft Quantum Development Kit.</description>
@@ -26,6 +26,7 @@
 
   <files>
     <file src="**" target="content" exclude="**\bin\**;**\obj\**;**\*.v.template;*.nuspec;*.png" />
+    <file src="..\..\build\assets\qdk-nuget-icon.png" target="images" />
   </files>
 
 </package>

--- a/src/QsCompiler/Compiler/Compiler.nuspec.template
+++ b/src/QsCompiler/Compiler/Compiler.nuspec.template
@@ -13,9 +13,12 @@
 
     <releaseNotes>See: https://docs.microsoft.com/azure/quantum/qdk-relnotes/</releaseNotes>
     <projectUrl>https://github.com/microsoft/qsharp-compiler</projectUrl>
-    <iconUrl>https://secure.gravatar.com/avatar/bd1f02955b2853ba0a3b1cdc2434e8ec.png</iconUrl>
+    <icon>images\qdk-nuget-icon.png</icon>
 
     <copyright>$copyright$</copyright>
     <tags>Quantum Q# QSharp</tags>
   </metadata>
+  <files>
+    <file src="..\..\..\build\assets\qdk-nuget-icon.png" target="images" />
+  </files>
 </package>

--- a/src/QsCompiler/QirGeneration/QirGeneration.nuspec.template
+++ b/src/QsCompiler/QirGeneration/QirGeneration.nuspec.template
@@ -13,7 +13,7 @@
 
     <releaseNotes>See: https://docs.microsoft.com/en-us/quantum/relnotes/</releaseNotes>
     <projectUrl>https://github.com/microsoft/qsharp-compiler</projectUrl>
-    <iconUrl>https://secure.gravatar.com/avatar/bd1f02955b2853ba0a3b1cdc2434e8ec.png</iconUrl>
+    <icon>images\qdk-nuget-icon.png</icon>
 
     <copyright>$copyright$</copyright>
     <tags>Quantum Q# QSharp QIR</tags>
@@ -21,5 +21,6 @@
   <files>
     <file src="QirGeneration.props" target="build\Microsoft.Quantum.QirGeneration.props" />
     <file src="..\LlvmBindings\bin\$Configuration$\netstandard2.1\publish\*.dll" target="lib\netstandard2.1" />
+    <file src="..\..\..\build\assets\qdk-nuget-icon.png" target="images" />
   </files>
 </package>

--- a/src/QuantumSdk/QuantumSdk.nuspec
+++ b/src/QuantumSdk/QuantumSdk.nuspec
@@ -11,7 +11,7 @@
     <description>The Microsoft Quantum Sdk for developing in Q#.</description>
     <releaseNotes>See: https://docs.microsoft.com/azure/quantum/qdk-relnotes/</releaseNotes>
     <projectUrl>https://github.com/microsoft/qsharp-compiler</projectUrl>
-    <iconUrl>https://secure.gravatar.com/avatar/bd1f02955b2853ba0a3b1cdc2434e8ec.png</iconUrl>
+    <icon>images\qdk-nuget-icon.png</icon>
     <copyright>© Microsoft Corporation. All rights reserved.</copyright>
     <tags>Quantum Q# QSharp</tags>
     <packageTypes>
@@ -25,5 +25,6 @@
     <file src="Tools\BuildConfiguration\bin\$Configuration$\netcoreapp3.1\publish\**" target="tools\utils" exclude="**\*.pdb" />
     <file src="Tools\DefaultEntryPoint\bin\$Configuration$\netcoreapp3.1\publish\**" target="tools\utils" exclude="**\*.pdb" />
     <file src="..\QsCompiler\CommandLineTool\bin\$Configuration$\netcoreapp3.1\publish\**" target="tools\qsc" />
+    <file src="..\..\build\assets\qdk-nuget-icon.png" target="images" />
   </files>
 </package>


### PR DESCRIPTION
This PR restores the icons used for NuGet packages which got reverted to the old logo in #923 