### PR TITLE
Splitting out general purpose helpers for branches and loops that yield values

### DIFF
--- a/src/QsCompiler/QirGeneration/Subtransformations/ExpressionKindTransformation.cs
+++ b/src/QsCompiler/QirGeneration/Subtransformations/ExpressionKindTransformation.cs
@@ -539,12 +539,9 @@ namespace Microsoft.Quantum.QsCompiler.QIR
 
                     for (var idx = 0; idx < tupleElements.Length; ++idx)
                     {
-                        if (idx == 0)
+                        if (idx > 0)
                         {
-                            comma = CreateConstantString(", ");
-                        }
-                        else
-                        {
+                            comma ??= CreateConstantString(", ");
                             str = DoAppend(str, comma!, unreferenceNext: false);
                         }
                         str = DoAppend(str, ExpressionToString(tupleElements[idx]));

--- a/src/QsCompiler/QirGeneration/Subtransformations/ExpressionKindTransformation.cs
+++ b/src/QsCompiler/QirGeneration/Subtransformations/ExpressionKindTransformation.cs
@@ -550,12 +550,12 @@ namespace Microsoft.Quantum.QsCompiler.QIR
                         str = DoAppend(str, ExpressionToString(tupleElements[idx]));
                     }
 
+                    str = DoAppend(str, CreateConstantString(")"), unreferenceNext: true);
                     if (comma != null)
                     {
                         UpdateStringRefCount(comma, -1);
                     }
 
-                    str = DoAppend(str, CreateConstantString(")"), unreferenceNext: true);
                     return str;
                 }
 

--- a/src/QsCompiler/QirGeneration/Subtransformations/ExpressionKindTransformation.cs
+++ b/src/QsCompiler/QirGeneration/Subtransformations/ExpressionKindTransformation.cs
@@ -539,22 +539,23 @@ namespace Microsoft.Quantum.QsCompiler.QIR
 
                     for (var idx = 0; idx < tupleElements.Length; ++idx)
                     {
-                        str = DoAppend(str, ExpressionToString(tupleElements[idx]));
-                        if (idx == tupleElements.Length - 1)
+                        if (idx == 0)
                         {
-                            str = DoAppend(str, CreateConstantString(")"), unreferenceNext: true);
+                            comma = CreateConstantString(", ");
                         }
                         else
                         {
-                            comma ??= CreateConstantString(", ");
-                            str = DoAppend(str, comma, unreferenceNext: false);
+                            str = DoAppend(str, comma!, unreferenceNext: false);
                         }
+                        str = DoAppend(str, ExpressionToString(tupleElements[idx]));
                     }
 
                     if (comma != null)
                     {
                         UpdateStringRefCount(comma, -1);
                     }
+
+                    str = DoAppend(str, CreateConstantString(")"), unreferenceNext: true);
                     return str;
                 }
 

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestArrayUpdate1.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestArrayUpdate1.ll
@@ -46,7 +46,7 @@ exit__2:                                          ; preds = %header__2
   br label %header__3
 
 header__3:                                        ; preds = %exiting__3, %exit__2
-  %i = phi i64 [ 0, %exit__2 ], [ %23, %exiting__3 ]
+  %i = phi i64 [ 0, %exit__2 ], [ %22, %exiting__3 ]
   %13 = icmp sle i64 %i, 9
   br i1 %13, label %body__3, label %exit__3
 
@@ -68,29 +68,28 @@ condContinue__1:                                  ; preds = %condFalse__1, %cond
   %17 = load %Array*, %Array** %arr, align 8
   call void @__quantum__rt__array_update_alias_count(%Array* %17, i32 -1)
   %18 = call %Array* @__quantum__rt__array_copy(%Array* %17, i1 false)
-  %19 = icmp ne %Array* %17, %18
-  %20 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %18, i64 %i)
-  %21 = bitcast i8* %20 to %String**
+  %19 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %18, i64 %i)
+  %20 = bitcast i8* %19 to %String**
   call void @__quantum__rt__string_update_reference_count(%String* %str, i32 1)
-  %22 = load %String*, %String** %21, align 8
-  store %String* %str, %String** %21, align 8
+  %21 = load %String*, %String** %20, align 8
+  store %String* %str, %String** %20, align 8
   call void @__quantum__rt__array_update_reference_count(%Array* %18, i32 1)
   call void @__quantum__rt__array_update_alias_count(%Array* %18, i32 1)
   store %Array* %18, %Array** %arr, align 8
   call void @__quantum__rt__string_update_reference_count(%String* %str, i32 -1)
   call void @__quantum__rt__array_update_reference_count(%Array* %17, i32 -1)
-  call void @__quantum__rt__string_update_reference_count(%String* %22, i32 -1)
+  call void @__quantum__rt__string_update_reference_count(%String* %21, i32 -1)
   call void @__quantum__rt__array_update_reference_count(%Array* %18, i32 -1)
   br label %exiting__3
 
 exiting__3:                                       ; preds = %condContinue__1
-  %23 = add i64 %i, 1
+  %22 = add i64 %i, 1
   br label %header__3
 
 exit__3:                                          ; preds = %header__3
-  %24 = load %Array*, %Array** %arr, align 8
-  call void @__quantum__rt__array_update_alias_count(%Array* %24, i32 -1)
+  %23 = load %Array*, %Array** %arr, align 8
+  call void @__quantum__rt__array_update_alias_count(%Array* %23, i32 -1)
   call void @__quantum__rt__array_update_reference_count(%Array* %0, i32 -1)
   call void @__quantum__rt__string_update_reference_count(%String* %1, i32 -1)
-  ret %Array* %24
+  ret %Array* %23
 }

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestArrayUpdate2.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestArrayUpdate2.ll
@@ -29,7 +29,7 @@ exit__1:                                          ; preds = %header__1
   br label %header__2
 
 header__2:                                        ; preds = %exiting__2, %exit__1
-  %i = phi i64 [ 0, %exit__1 ], [ %18, %exiting__2 ]
+  %i = phi i64 [ 0, %exit__1 ], [ %17, %exiting__2 ]
   %8 = icmp sle i64 %i, 9
   br i1 %8, label %body__2, label %exit__2
 
@@ -51,28 +51,27 @@ condContinue__1:                                  ; preds = %condFalse__1, %cond
   %12 = load %Array*, %Array** %arr, align 8
   call void @__quantum__rt__array_update_alias_count(%Array* %12, i32 -1)
   %13 = call %Array* @__quantum__rt__array_copy(%Array* %12, i1 false)
-  %14 = icmp ne %Array* %12, %13
-  %15 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %13, i64 %i)
-  %16 = bitcast i8* %15 to %String**
+  %14 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %13, i64 %i)
+  %15 = bitcast i8* %14 to %String**
   call void @__quantum__rt__string_update_reference_count(%String* %str, i32 1)
-  %17 = load %String*, %String** %16, align 8
-  store %String* %str, %String** %16, align 8
+  %16 = load %String*, %String** %15, align 8
+  store %String* %str, %String** %15, align 8
   call void @__quantum__rt__array_update_reference_count(%Array* %13, i32 1)
   call void @__quantum__rt__array_update_alias_count(%Array* %13, i32 1)
   store %Array* %13, %Array** %arr, align 8
   call void @__quantum__rt__string_update_reference_count(%String* %str, i32 -1)
   call void @__quantum__rt__array_update_reference_count(%Array* %12, i32 -1)
-  call void @__quantum__rt__string_update_reference_count(%String* %17, i32 -1)
+  call void @__quantum__rt__string_update_reference_count(%String* %16, i32 -1)
   call void @__quantum__rt__array_update_reference_count(%Array* %13, i32 -1)
   br label %exiting__2
 
 exiting__2:                                       ; preds = %condContinue__1
-  %18 = add i64 %i, 1
+  %17 = add i64 %i, 1
   br label %header__2
 
 exit__2:                                          ; preds = %header__2
-  %19 = load %Array*, %Array** %arr, align 8
+  %18 = load %Array*, %Array** %arr, align 8
   call void @__quantum__rt__array_update_alias_count(%Array* %array, i32 -1)
-  call void @__quantum__rt__array_update_alias_count(%Array* %19, i32 -1)
-  ret %Array* %19
+  call void @__quantum__rt__array_update_alias_count(%Array* %18, i32 -1)
+  ret %Array* %18
 }

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestArrayUpdate3.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestArrayUpdate3.ll
@@ -28,193 +28,190 @@ exit__1:                                          ; preds = %header__1
   call void @__quantum__rt__array_update_reference_count(%Array* %y, i32 1)
   call void @__quantum__rt__array_update_alias_count(%Array* %y, i32 -1)
   %8 = call %Array* @__quantum__rt__array_copy(%Array* %y, i1 false)
-  %9 = icmp ne %Array* %y, %8
-  %10 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %8, i64 0)
-  %11 = bitcast i8* %10 to %String**
+  %9 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %8, i64 0)
+  %10 = bitcast i8* %9 to %String**
   call void @__quantum__rt__string_update_reference_count(%String* %b, i32 1)
-  %12 = load %String*, %String** %11, align 8
-  store %String* %b, %String** %11, align 8
+  %11 = load %String*, %String** %10, align 8
+  store %String* %b, %String** %10, align 8
   call void @__quantum__rt__array_update_reference_count(%Array* %8, i32 1)
   call void @__quantum__rt__array_update_alias_count(%Array* %8, i32 1)
   store %Array* %8, %Array** %x, align 8
   call void @__quantum__rt__array_update_alias_count(%Array* %8, i32 -1)
-  %13 = call %Array* @__quantum__rt__array_copy(%Array* %8, i1 false)
-  %14 = icmp ne %Array* %8, %13
-  %15 = call %String* @__quantum__rt__string_create(i8* getelementptr inbounds ([6 x i8], [6 x i8]* @2, i32 0, i32 0))
-  %16 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %13, i64 1)
-  %17 = bitcast i8* %16 to %String**
-  call void @__quantum__rt__string_update_reference_count(%String* %15, i32 1)
-  %18 = load %String*, %String** %17, align 8
-  store %String* %15, %String** %17, align 8
-  call void @__quantum__rt__array_update_reference_count(%Array* %13, i32 1)
-  call void @__quantum__rt__array_update_alias_count(%Array* %13, i32 1)
-  store %Array* %13, %Array** %x, align 8
-  %19 = call %Array* @__quantum__rt__array_create_1d(i32 8, i64 10)
-  %20 = call %Tuple* @__quantum__rt__tuple_create(i64 mul nuw (i64 ptrtoint (i64* getelementptr (i64, i64* null, i32 1) to i64), i64 2))
-  %21 = bitcast %Tuple* %20 to { i64, i64 }*
-  %22 = getelementptr inbounds { i64, i64 }, { i64, i64 }* %21, i32 0, i32 0
-  %23 = getelementptr inbounds { i64, i64 }, { i64, i64 }* %21, i32 0, i32 1
-  store i64 0, i64* %22, align 4
-  store i64 0, i64* %23, align 4
+  %12 = call %Array* @__quantum__rt__array_copy(%Array* %8, i1 false)
+  %13 = call %String* @__quantum__rt__string_create(i8* getelementptr inbounds ([6 x i8], [6 x i8]* @2, i32 0, i32 0))
+  %14 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %12, i64 1)
+  %15 = bitcast i8* %14 to %String**
+  call void @__quantum__rt__string_update_reference_count(%String* %13, i32 1)
+  %16 = load %String*, %String** %15, align 8
+  store %String* %13, %String** %15, align 8
+  call void @__quantum__rt__array_update_reference_count(%Array* %12, i32 1)
+  call void @__quantum__rt__array_update_alias_count(%Array* %12, i32 1)
+  store %Array* %12, %Array** %x, align 8
+  %17 = call %Array* @__quantum__rt__array_create_1d(i32 8, i64 10)
+  %18 = call %Tuple* @__quantum__rt__tuple_create(i64 mul nuw (i64 ptrtoint (i64* getelementptr (i64, i64* null, i32 1) to i64), i64 2))
+  %19 = bitcast %Tuple* %18 to { i64, i64 }*
+  %20 = getelementptr inbounds { i64, i64 }, { i64, i64 }* %19, i32 0, i32 0
+  %21 = getelementptr inbounds { i64, i64 }, { i64, i64 }* %19, i32 0, i32 1
+  store i64 0, i64* %20, align 4
+  store i64 0, i64* %21, align 4
   br label %header__2
 
 header__2:                                        ; preds = %exiting__2, %exit__1
-  %24 = phi i64 [ 0, %exit__1 ], [ %28, %exiting__2 ]
-  %25 = icmp sle i64 %24, 9
-  br i1 %25, label %body__2, label %exit__2
+  %22 = phi i64 [ 0, %exit__1 ], [ %26, %exiting__2 ]
+  %23 = icmp sle i64 %22, 9
+  br i1 %23, label %body__2, label %exit__2
 
 body__2:                                          ; preds = %header__2
-  %26 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %19, i64 %24)
-  %27 = bitcast i8* %26 to { i64, i64 }**
-  store { i64, i64 }* %21, { i64, i64 }** %27, align 8
+  %24 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %17, i64 %22)
+  %25 = bitcast i8* %24 to { i64, i64 }**
+  store { i64, i64 }* %19, { i64, i64 }** %25, align 8
   br label %exiting__2
 
 exiting__2:                                       ; preds = %body__2
-  %28 = add i64 %24, 1
+  %26 = add i64 %22, 1
   br label %header__2
 
 exit__2:                                          ; preds = %header__2
   %arr = alloca %Array*, align 8
-  store %Array* %19, %Array** %arr, align 8
+  store %Array* %17, %Array** %arr, align 8
   br label %header__3
 
 header__3:                                        ; preds = %exiting__3, %exit__2
-  %29 = phi i64 [ 0, %exit__2 ], [ %35, %exiting__3 ]
-  %30 = icmp sle i64 %29, 9
-  br i1 %30, label %body__3, label %exit__3
+  %27 = phi i64 [ 0, %exit__2 ], [ %33, %exiting__3 ]
+  %28 = icmp sle i64 %27, 9
+  br i1 %28, label %body__3, label %exit__3
 
 body__3:                                          ; preds = %header__3
-  %31 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %19, i64 %29)
-  %32 = bitcast i8* %31 to { i64, i64 }**
-  %33 = load { i64, i64 }*, { i64, i64 }** %32, align 8
-  %34 = bitcast { i64, i64 }* %33 to %Tuple*
-  call void @__quantum__rt__tuple_update_alias_count(%Tuple* %34, i32 1)
+  %29 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %17, i64 %27)
+  %30 = bitcast i8* %29 to { i64, i64 }**
+  %31 = load { i64, i64 }*, { i64, i64 }** %30, align 8
+  %32 = bitcast { i64, i64 }* %31 to %Tuple*
+  call void @__quantum__rt__tuple_update_alias_count(%Tuple* %32, i32 1)
   br label %exiting__3
 
 exiting__3:                                       ; preds = %body__3
-  %35 = add i64 %29, 1
+  %33 = add i64 %27, 1
   br label %header__3
 
 exit__3:                                          ; preds = %header__3
-  call void @__quantum__rt__array_update_alias_count(%Array* %19, i32 1)
+  call void @__quantum__rt__array_update_alias_count(%Array* %17, i32 1)
   br label %header__4
 
 header__4:                                        ; preds = %exiting__4, %exit__3
-  %36 = phi i64 [ 0, %exit__3 ], [ %42, %exiting__4 ]
-  %37 = icmp sle i64 %36, 9
-  br i1 %37, label %body__4, label %exit__4
+  %34 = phi i64 [ 0, %exit__3 ], [ %40, %exiting__4 ]
+  %35 = icmp sle i64 %34, 9
+  br i1 %35, label %body__4, label %exit__4
 
 body__4:                                          ; preds = %header__4
-  %38 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %19, i64 %36)
-  %39 = bitcast i8* %38 to { i64, i64 }**
-  %40 = load { i64, i64 }*, { i64, i64 }** %39, align 8
-  %41 = bitcast { i64, i64 }* %40 to %Tuple*
-  call void @__quantum__rt__tuple_update_reference_count(%Tuple* %41, i32 1)
+  %36 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %17, i64 %34)
+  %37 = bitcast i8* %36 to { i64, i64 }**
+  %38 = load { i64, i64 }*, { i64, i64 }** %37, align 8
+  %39 = bitcast { i64, i64 }* %38 to %Tuple*
+  call void @__quantum__rt__tuple_update_reference_count(%Tuple* %39, i32 1)
   br label %exiting__4
 
 exiting__4:                                       ; preds = %body__4
-  %42 = add i64 %36, 1
+  %40 = add i64 %34, 1
   br label %header__4
 
 exit__4:                                          ; preds = %header__4
-  call void @__quantum__rt__array_update_reference_count(%Array* %19, i32 1)
+  call void @__quantum__rt__array_update_reference_count(%Array* %17, i32 1)
   br label %header__5
 
 header__5:                                        ; preds = %exiting__5, %exit__4
-  %i = phi i64 [ 0, %exit__4 ], [ %56, %exiting__5 ]
-  %43 = icmp sle i64 %i, 9
-  br i1 %43, label %body__5, label %exit__5
+  %i = phi i64 [ 0, %exit__4 ], [ %53, %exiting__5 ]
+  %41 = icmp sle i64 %i, 9
+  br i1 %41, label %body__5, label %exit__5
 
 body__5:                                          ; preds = %header__5
-  %44 = load %Array*, %Array** %arr, align 8
-  call void @__quantum__rt__array_update_alias_count(%Array* %44, i32 -1)
-  %45 = call %Array* @__quantum__rt__array_copy(%Array* %44, i1 false)
-  %46 = icmp ne %Array* %44, %45
-  %47 = add i64 %i, 1
-  %48 = call %Tuple* @__quantum__rt__tuple_create(i64 mul nuw (i64 ptrtoint (i64* getelementptr (i64, i64* null, i32 1) to i64), i64 2))
-  %49 = bitcast %Tuple* %48 to { i64, i64 }*
-  %50 = getelementptr inbounds { i64, i64 }, { i64, i64 }* %49, i32 0, i32 0
-  %51 = getelementptr inbounds { i64, i64 }, { i64, i64 }* %49, i32 0, i32 1
-  store i64 %i, i64* %50, align 4
-  store i64 %47, i64* %51, align 4
-  %52 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %45, i64 %i)
-  %53 = bitcast i8* %52 to { i64, i64 }**
-  call void @__quantum__rt__tuple_update_reference_count(%Tuple* %48, i32 1)
-  call void @__quantum__rt__tuple_update_alias_count(%Tuple* %48, i32 1)
-  %54 = load { i64, i64 }*, { i64, i64 }** %53, align 8
-  %55 = bitcast { i64, i64 }* %54 to %Tuple*
-  call void @__quantum__rt__tuple_update_alias_count(%Tuple* %55, i32 -1)
-  store { i64, i64 }* %49, { i64, i64 }** %53, align 8
-  call void @__quantum__rt__array_update_reference_count(%Array* %45, i32 1)
-  call void @__quantum__rt__array_update_alias_count(%Array* %45, i32 1)
-  store %Array* %45, %Array** %arr, align 8
-  call void @__quantum__rt__array_update_reference_count(%Array* %44, i32 -1)
-  call void @__quantum__rt__tuple_update_reference_count(%Tuple* %48, i32 -1)
-  call void @__quantum__rt__tuple_update_reference_count(%Tuple* %55, i32 -1)
-  call void @__quantum__rt__array_update_reference_count(%Array* %45, i32 -1)
+  %42 = load %Array*, %Array** %arr, align 8
+  call void @__quantum__rt__array_update_alias_count(%Array* %42, i32 -1)
+  %43 = call %Array* @__quantum__rt__array_copy(%Array* %42, i1 false)
+  %44 = add i64 %i, 1
+  %45 = call %Tuple* @__quantum__rt__tuple_create(i64 mul nuw (i64 ptrtoint (i64* getelementptr (i64, i64* null, i32 1) to i64), i64 2))
+  %46 = bitcast %Tuple* %45 to { i64, i64 }*
+  %47 = getelementptr inbounds { i64, i64 }, { i64, i64 }* %46, i32 0, i32 0
+  %48 = getelementptr inbounds { i64, i64 }, { i64, i64 }* %46, i32 0, i32 1
+  store i64 %i, i64* %47, align 4
+  store i64 %44, i64* %48, align 4
+  %49 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %43, i64 %i)
+  %50 = bitcast i8* %49 to { i64, i64 }**
+  call void @__quantum__rt__tuple_update_reference_count(%Tuple* %45, i32 1)
+  call void @__quantum__rt__tuple_update_alias_count(%Tuple* %45, i32 1)
+  %51 = load { i64, i64 }*, { i64, i64 }** %50, align 8
+  %52 = bitcast { i64, i64 }* %51 to %Tuple*
+  call void @__quantum__rt__tuple_update_alias_count(%Tuple* %52, i32 -1)
+  store { i64, i64 }* %46, { i64, i64 }** %50, align 8
+  call void @__quantum__rt__array_update_reference_count(%Array* %43, i32 1)
+  call void @__quantum__rt__array_update_alias_count(%Array* %43, i32 1)
+  store %Array* %43, %Array** %arr, align 8
+  call void @__quantum__rt__array_update_reference_count(%Array* %42, i32 -1)
+  call void @__quantum__rt__tuple_update_reference_count(%Tuple* %45, i32 -1)
+  call void @__quantum__rt__tuple_update_reference_count(%Tuple* %52, i32 -1)
+  call void @__quantum__rt__array_update_reference_count(%Array* %43, i32 -1)
   br label %exiting__5
 
 exiting__5:                                       ; preds = %body__5
-  %56 = add i64 %i, 1
+  %53 = add i64 %i, 1
   br label %header__5
 
 exit__5:                                          ; preds = %header__5
-  %57 = load %Array*, %Array** %arr, align 8
+  %54 = load %Array*, %Array** %arr, align 8
   call void @__quantum__rt__array_update_alias_count(%Array* %y, i32 -1)
-  call void @__quantum__rt__array_update_alias_count(%Array* %13, i32 -1)
-  %58 = call i64 @__quantum__rt__array_get_size_1d(%Array* %57)
-  %59 = sub i64 %58, 1
+  call void @__quantum__rt__array_update_alias_count(%Array* %12, i32 -1)
+  %55 = call i64 @__quantum__rt__array_get_size_1d(%Array* %54)
+  %56 = sub i64 %55, 1
   br label %header__6
 
 header__6:                                        ; preds = %exiting__6, %exit__5
-  %60 = phi i64 [ 0, %exit__5 ], [ %66, %exiting__6 ]
-  %61 = icmp sle i64 %60, %59
-  br i1 %61, label %body__6, label %exit__6
+  %57 = phi i64 [ 0, %exit__5 ], [ %63, %exiting__6 ]
+  %58 = icmp sle i64 %57, %56
+  br i1 %58, label %body__6, label %exit__6
 
 body__6:                                          ; preds = %header__6
-  %62 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %57, i64 %60)
-  %63 = bitcast i8* %62 to { i64, i64 }**
-  %64 = load { i64, i64 }*, { i64, i64 }** %63, align 8
-  %65 = bitcast { i64, i64 }* %64 to %Tuple*
-  call void @__quantum__rt__tuple_update_alias_count(%Tuple* %65, i32 -1)
+  %59 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %54, i64 %57)
+  %60 = bitcast i8* %59 to { i64, i64 }**
+  %61 = load { i64, i64 }*, { i64, i64 }** %60, align 8
+  %62 = bitcast { i64, i64 }* %61 to %Tuple*
+  call void @__quantum__rt__tuple_update_alias_count(%Tuple* %62, i32 -1)
   br label %exiting__6
 
 exiting__6:                                       ; preds = %body__6
-  %66 = add i64 %60, 1
+  %63 = add i64 %57, 1
   br label %header__6
 
 exit__6:                                          ; preds = %header__6
-  call void @__quantum__rt__array_update_alias_count(%Array* %57, i32 -1)
+  call void @__quantum__rt__array_update_alias_count(%Array* %54, i32 -1)
   call void @__quantum__rt__array_update_reference_count(%Array* %y, i32 -1)
-  call void @__quantum__rt__string_update_reference_count(%String* %12, i32 -1)
+  call void @__quantum__rt__string_update_reference_count(%String* %11, i32 -1)
   call void @__quantum__rt__array_update_reference_count(%Array* %8, i32 -1)
   call void @__quantum__rt__array_update_reference_count(%Array* %8, i32 -1)
-  call void @__quantum__rt__string_update_reference_count(%String* %15, i32 -1)
-  call void @__quantum__rt__string_update_reference_count(%String* %18, i32 -1)
-  call void @__quantum__rt__array_update_reference_count(%Array* %13, i32 -1)
-  call void @__quantum__rt__array_update_reference_count(%Array* %19, i32 -1)
-  call void @__quantum__rt__tuple_update_reference_count(%Tuple* %20, i32 -1)
-  %67 = sub i64 %58, 1
+  call void @__quantum__rt__string_update_reference_count(%String* %13, i32 -1)
+  call void @__quantum__rt__string_update_reference_count(%String* %16, i32 -1)
+  call void @__quantum__rt__array_update_reference_count(%Array* %12, i32 -1)
+  call void @__quantum__rt__array_update_reference_count(%Array* %17, i32 -1)
+  call void @__quantum__rt__tuple_update_reference_count(%Tuple* %18, i32 -1)
+  %64 = sub i64 %55, 1
   br label %header__7
 
 header__7:                                        ; preds = %exiting__7, %exit__6
-  %68 = phi i64 [ 0, %exit__6 ], [ %74, %exiting__7 ]
-  %69 = icmp sle i64 %68, %67
-  br i1 %69, label %body__7, label %exit__7
+  %65 = phi i64 [ 0, %exit__6 ], [ %71, %exiting__7 ]
+  %66 = icmp sle i64 %65, %64
+  br i1 %66, label %body__7, label %exit__7
 
 body__7:                                          ; preds = %header__7
-  %70 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %57, i64 %68)
-  %71 = bitcast i8* %70 to { i64, i64 }**
-  %72 = load { i64, i64 }*, { i64, i64 }** %71, align 8
-  %73 = bitcast { i64, i64 }* %72 to %Tuple*
-  call void @__quantum__rt__tuple_update_reference_count(%Tuple* %73, i32 -1)
+  %67 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %54, i64 %65)
+  %68 = bitcast i8* %67 to { i64, i64 }**
+  %69 = load { i64, i64 }*, { i64, i64 }** %68, align 8
+  %70 = bitcast { i64, i64 }* %69 to %Tuple*
+  call void @__quantum__rt__tuple_update_reference_count(%Tuple* %70, i32 -1)
   br label %exiting__7
 
 exiting__7:                                       ; preds = %body__7
-  %74 = add i64 %68, 1
+  %71 = add i64 %65, 1
   br label %header__7
 
 exit__7:                                          ; preds = %header__7
-  call void @__quantum__rt__array_update_reference_count(%Array* %57, i32 -1)
-  ret %Array* %13
+  call void @__quantum__rt__array_update_reference_count(%Array* %54, i32 -1)
+  ret %Array* %12
 }

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestArrayUpdate4.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestArrayUpdate4.ll
@@ -35,7 +35,7 @@ exit__1:                                          ; preds = %header__1
   br label %header__2
 
 header__2:                                        ; preds = %exiting__2, %exit__1
-  %i = phi i64 [ 0, %exit__1 ], [ %16, %exiting__2 ]
+  %i = phi i64 [ 0, %exit__1 ], [ %15, %exiting__2 ]
   %9 = icmp sle i64 %i, 9
   br i1 %9, label %body__2, label %exit__2
 
@@ -43,30 +43,29 @@ body__2:                                          ; preds = %header__2
   %10 = load %Array*, %Array** %arr, align 8
   call void @__quantum__rt__array_update_alias_count(%Array* %10, i32 -1)
   %11 = call %Array* @__quantum__rt__array_copy(%Array* %10, i1 false)
-  %12 = icmp ne %Array* %10, %11
-  %13 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %11, i64 %i)
-  %14 = bitcast i8* %13 to %String**
+  %12 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %11, i64 %i)
+  %13 = bitcast i8* %12 to %String**
   call void @__quantum__rt__string_update_reference_count(%String* %item, i32 1)
-  %15 = load %String*, %String** %14, align 8
-  store %String* %item, %String** %14, align 8
+  %14 = load %String*, %String** %13, align 8
+  store %String* %item, %String** %13, align 8
   call void @__quantum__rt__array_update_reference_count(%Array* %11, i32 1)
   call void @__quantum__rt__array_update_alias_count(%Array* %11, i32 1)
   store %Array* %11, %Array** %arr, align 8
   call void @__quantum__rt__array_update_reference_count(%Array* %10, i32 -1)
-  call void @__quantum__rt__string_update_reference_count(%String* %15, i32 -1)
+  call void @__quantum__rt__string_update_reference_count(%String* %14, i32 -1)
   call void @__quantum__rt__array_update_reference_count(%Array* %11, i32 -1)
   br label %exiting__2
 
 exiting__2:                                       ; preds = %body__2
-  %16 = add i64 %i, 1
+  %15 = add i64 %i, 1
   br label %header__2
 
 exit__2:                                          ; preds = %header__2
-  %17 = load %Array*, %Array** %arr, align 8
+  %16 = load %Array*, %Array** %arr, align 8
   call void @__quantum__rt__array_update_alias_count(%Array* %array, i32 -1)
-  call void @__quantum__rt__array_update_alias_count(%Array* %17, i32 -1)
+  call void @__quantum__rt__array_update_alias_count(%Array* %16, i32 -1)
   call void @__quantum__rt__string_update_reference_count(%String* %item, i32 -1)
   call void @__quantum__rt__array_update_reference_count(%Array* %0, i32 -1)
   call void @__quantum__rt__array_update_reference_count(%Array* %0, i32 -1)
-  ret %Array* %17
+  ret %Array* %16
 }

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestArrayUpdate5.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestArrayUpdate5.ll
@@ -79,7 +79,7 @@ preheader__1:                                     ; preds = %exit__3
   br label %header__4
 
 header__4:                                        ; preds = %exiting__4, %preheader__1
-  %i = phi i64 [ 0, %preheader__1 ], [ %50, %exiting__4 ]
+  %i = phi i64 [ 0, %preheader__1 ], [ %48, %exiting__4 ]
   %27 = icmp sle i64 %i, %26
   %28 = icmp sge i64 %i, %26
   %29 = select i1 true, i1 %27, i1 %28
@@ -89,105 +89,103 @@ body__4:                                          ; preds = %header__4
   %30 = load %Array*, %Array** %arr, align 8
   call void @__quantum__rt__array_update_alias_count(%Array* %30, i32 -1)
   %31 = call %Array* @__quantum__rt__array_copy(%Array* %30, i1 false)
-  %32 = icmp ne %Array* %30, %31
-  %33 = srem i64 %i, 2
-  %34 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %30, i64 %33)
-  %35 = bitcast i8* %34 to { double, double }**
-  %36 = load { double, double }*, { double, double }** %35, align 8
-  %37 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %31, i64 %i)
-  %38 = bitcast i8* %37 to { double, double }**
-  %39 = bitcast { double, double }* %36 to %Tuple*
-  call void @__quantum__rt__tuple_update_reference_count(%Tuple* %39, i32 1)
-  call void @__quantum__rt__tuple_update_alias_count(%Tuple* %39, i32 1)
-  %40 = load { double, double }*, { double, double }** %38, align 8
-  %41 = bitcast { double, double }* %40 to %Tuple*
-  call void @__quantum__rt__tuple_update_alias_count(%Tuple* %41, i32 -1)
-  store { double, double }* %36, { double, double }** %38, align 8
+  %32 = srem i64 %i, 2
+  %33 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %30, i64 %32)
+  %34 = bitcast i8* %33 to { double, double }**
+  %35 = load { double, double }*, { double, double }** %34, align 8
+  %36 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %31, i64 %i)
+  %37 = bitcast i8* %36 to { double, double }**
+  %38 = bitcast { double, double }* %35 to %Tuple*
+  call void @__quantum__rt__tuple_update_reference_count(%Tuple* %38, i32 1)
+  call void @__quantum__rt__tuple_update_alias_count(%Tuple* %38, i32 1)
+  %39 = load { double, double }*, { double, double }** %37, align 8
+  %40 = bitcast { double, double }* %39 to %Tuple*
+  call void @__quantum__rt__tuple_update_alias_count(%Tuple* %40, i32 -1)
+  store { double, double }* %35, { double, double }** %37, align 8
   call void @__quantum__rt__array_update_reference_count(%Array* %31, i32 1)
   call void @__quantum__rt__array_update_alias_count(%Array* %31, i32 1)
   store %Array* %31, %Array** %arr, align 8
   br i1 %cond, label %then0__1, label %continue__1
 
 then0__1:                                         ; preds = %body__4
-  %42 = load %Array*, %Array** %arr, align 8
-  call void @__quantum__rt__array_update_alias_count(%Array* %42, i32 -1)
-  %43 = call %Array* @__quantum__rt__array_copy(%Array* %42, i1 false)
-  %44 = icmp ne %Array* %42, %43
-  %45 = srem i64 %i, 2
-  %46 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %43, i64 %45)
-  %47 = bitcast i8* %46 to { double, double }**
+  %41 = load %Array*, %Array** %arr, align 8
+  call void @__quantum__rt__array_update_alias_count(%Array* %41, i32 -1)
+  %42 = call %Array* @__quantum__rt__array_copy(%Array* %41, i1 false)
+  %43 = srem i64 %i, 2
+  %44 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %42, i64 %43)
+  %45 = bitcast i8* %44 to { double, double }**
   call void @__quantum__rt__tuple_update_reference_count(%Tuple* %9, i32 1)
   call void @__quantum__rt__tuple_update_alias_count(%Tuple* %9, i32 1)
-  %48 = load { double, double }*, { double, double }** %47, align 8
-  %49 = bitcast { double, double }* %48 to %Tuple*
-  call void @__quantum__rt__tuple_update_alias_count(%Tuple* %49, i32 -1)
-  store { double, double }* %item, { double, double }** %47, align 8
-  call void @__quantum__rt__array_update_reference_count(%Array* %43, i32 1)
-  call void @__quantum__rt__array_update_alias_count(%Array* %43, i32 1)
-  store %Array* %43, %Array** %arr, align 8
+  %46 = load { double, double }*, { double, double }** %45, align 8
+  %47 = bitcast { double, double }* %46 to %Tuple*
+  call void @__quantum__rt__tuple_update_alias_count(%Tuple* %47, i32 -1)
+  store { double, double }* %item, { double, double }** %45, align 8
+  call void @__quantum__rt__array_update_reference_count(%Array* %42, i32 1)
+  call void @__quantum__rt__array_update_alias_count(%Array* %42, i32 1)
+  store %Array* %42, %Array** %arr, align 8
+  call void @__quantum__rt__array_update_reference_count(%Array* %41, i32 -1)
+  call void @__quantum__rt__tuple_update_reference_count(%Tuple* %47, i32 -1)
   call void @__quantum__rt__array_update_reference_count(%Array* %42, i32 -1)
-  call void @__quantum__rt__tuple_update_reference_count(%Tuple* %49, i32 -1)
-  call void @__quantum__rt__array_update_reference_count(%Array* %43, i32 -1)
   br label %continue__1
 
 continue__1:                                      ; preds = %then0__1, %body__4
   call void @__quantum__rt__array_update_reference_count(%Array* %30, i32 -1)
-  call void @__quantum__rt__tuple_update_reference_count(%Tuple* %41, i32 -1)
+  call void @__quantum__rt__tuple_update_reference_count(%Tuple* %40, i32 -1)
   call void @__quantum__rt__array_update_reference_count(%Array* %31, i32 -1)
   br label %exiting__4
 
 exiting__4:                                       ; preds = %continue__1
-  %50 = add i64 %i, 2
+  %48 = add i64 %i, 2
   br label %header__4
 
 exit__4:                                          ; preds = %header__4
-  %51 = load %Array*, %Array** %arr, align 8
-  %52 = sub i64 %0, 1
+  %49 = load %Array*, %Array** %arr, align 8
+  %50 = sub i64 %0, 1
   br label %header__5
 
 header__5:                                        ; preds = %exiting__5, %exit__4
-  %53 = phi i64 [ 0, %exit__4 ], [ %59, %exiting__5 ]
-  %54 = icmp sle i64 %53, %52
-  br i1 %54, label %body__5, label %exit__5
+  %51 = phi i64 [ 0, %exit__4 ], [ %57, %exiting__5 ]
+  %52 = icmp sle i64 %51, %50
+  br i1 %52, label %body__5, label %exit__5
 
 body__5:                                          ; preds = %header__5
-  %55 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %array, i64 %53)
-  %56 = bitcast i8* %55 to { double, double }**
-  %57 = load { double, double }*, { double, double }** %56, align 8
-  %58 = bitcast { double, double }* %57 to %Tuple*
-  call void @__quantum__rt__tuple_update_alias_count(%Tuple* %58, i32 -1)
+  %53 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %array, i64 %51)
+  %54 = bitcast i8* %53 to { double, double }**
+  %55 = load { double, double }*, { double, double }** %54, align 8
+  %56 = bitcast { double, double }* %55 to %Tuple*
+  call void @__quantum__rt__tuple_update_alias_count(%Tuple* %56, i32 -1)
   br label %exiting__5
 
 exiting__5:                                       ; preds = %body__5
-  %59 = add i64 %53, 1
+  %57 = add i64 %51, 1
   br label %header__5
 
 exit__5:                                          ; preds = %header__5
   call void @__quantum__rt__array_update_alias_count(%Array* %array, i32 -1)
   call void @__quantum__rt__tuple_update_alias_count(%Tuple* %9, i32 -1)
-  %60 = call i64 @__quantum__rt__array_get_size_1d(%Array* %51)
-  %61 = sub i64 %60, 1
+  %58 = call i64 @__quantum__rt__array_get_size_1d(%Array* %49)
+  %59 = sub i64 %58, 1
   br label %header__6
 
 header__6:                                        ; preds = %exiting__6, %exit__5
-  %62 = phi i64 [ 0, %exit__5 ], [ %68, %exiting__6 ]
-  %63 = icmp sle i64 %62, %61
-  br i1 %63, label %body__6, label %exit__6
+  %60 = phi i64 [ 0, %exit__5 ], [ %66, %exiting__6 ]
+  %61 = icmp sle i64 %60, %59
+  br i1 %61, label %body__6, label %exit__6
 
 body__6:                                          ; preds = %header__6
-  %64 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %51, i64 %62)
-  %65 = bitcast i8* %64 to { double, double }**
-  %66 = load { double, double }*, { double, double }** %65, align 8
-  %67 = bitcast { double, double }* %66 to %Tuple*
-  call void @__quantum__rt__tuple_update_alias_count(%Tuple* %67, i32 -1)
+  %62 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %49, i64 %60)
+  %63 = bitcast i8* %62 to { double, double }**
+  %64 = load { double, double }*, { double, double }** %63, align 8
+  %65 = bitcast { double, double }* %64 to %Tuple*
+  call void @__quantum__rt__tuple_update_alias_count(%Tuple* %65, i32 -1)
   br label %exiting__6
 
 exiting__6:                                       ; preds = %body__6
-  %68 = add i64 %62, 1
+  %66 = add i64 %60, 1
   br label %header__6
 
 exit__6:                                          ; preds = %header__6
-  call void @__quantum__rt__array_update_alias_count(%Array* %51, i32 -1)
+  call void @__quantum__rt__array_update_alias_count(%Array* %49, i32 -1)
   call void @__quantum__rt__tuple_update_reference_count(%Tuple* %9, i32 -1)
-  ret %Array* %51
+  ret %Array* %49
 }

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestConditional2.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestConditional2.ll
@@ -21,38 +21,37 @@ condTrue__1:                                      ; preds = %entry
 
 condFalse__1:                                     ; preds = %entry
   %9 = call %Array* @__quantum__rt__array_copy(%Array* %arr, i1 false)
-  %10 = icmp ne %Array* %arr, %9
-  %11 = call %String* @__quantum__rt__string_create(i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0))
-  %12 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %9, i64 2)
-  %13 = bitcast i8* %12 to %String**
-  store %String* %11, %String** %13, align 8
-  %14 = call i64 @__quantum__rt__array_get_size_1d(%Array* %9)
-  %15 = sub i64 %14, 1
+  %10 = call %String* @__quantum__rt__string_create(i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0))
+  %11 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %9, i64 2)
+  %12 = bitcast i8* %11 to %String**
+  store %String* %10, %String** %12, align 8
+  %13 = call i64 @__quantum__rt__array_get_size_1d(%Array* %9)
+  %14 = sub i64 %13, 1
   br label %header__2
 
 condContinue__1:                                  ; preds = %exit__2, %exit__1
-  %16 = phi %Array* [ %arr, %exit__1 ], [ %9, %exit__2 ]
+  %15 = phi %Array* [ %arr, %exit__1 ], [ %9, %exit__2 ]
   call void @__quantum__rt__array_update_alias_count(%Array* %arr, i32 -1)
   call void @__quantum__rt__string_update_reference_count(%String* %0, i32 -1)
   call void @__quantum__rt__string_update_reference_count(%String* %1, i32 -1)
   call void @__quantum__rt__string_update_reference_count(%String* %2, i32 -1)
   call void @__quantum__rt__array_update_reference_count(%Array* %arr, i32 -1)
-  ret %Array* %16
+  ret %Array* %15
 
 header__1:                                        ; preds = %exiting__1, %condTrue__1
-  %17 = phi i64 [ 0, %condTrue__1 ], [ %22, %exiting__1 ]
-  %18 = icmp sle i64 %17, 2
-  br i1 %18, label %body__1, label %exit__1
+  %16 = phi i64 [ 0, %condTrue__1 ], [ %21, %exiting__1 ]
+  %17 = icmp sle i64 %16, 2
+  br i1 %17, label %body__1, label %exit__1
 
 body__1:                                          ; preds = %header__1
-  %19 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %arr, i64 %17)
-  %20 = bitcast i8* %19 to %String**
-  %21 = load %String*, %String** %20, align 8
-  call void @__quantum__rt__string_update_reference_count(%String* %21, i32 1)
+  %18 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %arr, i64 %16)
+  %19 = bitcast i8* %18 to %String**
+  %20 = load %String*, %String** %19, align 8
+  call void @__quantum__rt__string_update_reference_count(%String* %20, i32 1)
   br label %exiting__1
 
 exiting__1:                                       ; preds = %body__1
-  %22 = add i64 %17, 1
+  %21 = add i64 %16, 1
   br label %header__1
 
 exit__1:                                          ; preds = %header__1
@@ -60,24 +59,24 @@ exit__1:                                          ; preds = %header__1
   br label %condContinue__1
 
 header__2:                                        ; preds = %exiting__2, %condFalse__1
-  %23 = phi i64 [ 0, %condFalse__1 ], [ %28, %exiting__2 ]
-  %24 = icmp sle i64 %23, %15
-  br i1 %24, label %body__2, label %exit__2
+  %22 = phi i64 [ 0, %condFalse__1 ], [ %27, %exiting__2 ]
+  %23 = icmp sle i64 %22, %14
+  br i1 %23, label %body__2, label %exit__2
 
 body__2:                                          ; preds = %header__2
-  %25 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %9, i64 %23)
-  %26 = bitcast i8* %25 to %String**
-  %27 = load %String*, %String** %26, align 8
-  call void @__quantum__rt__string_update_reference_count(%String* %27, i32 1)
+  %24 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %9, i64 %22)
+  %25 = bitcast i8* %24 to %String**
+  %26 = load %String*, %String** %25, align 8
+  call void @__quantum__rt__string_update_reference_count(%String* %26, i32 1)
   br label %exiting__2
 
 exiting__2:                                       ; preds = %body__2
-  %28 = add i64 %23, 1
+  %27 = add i64 %22, 1
   br label %header__2
 
 exit__2:                                          ; preds = %header__2
   call void @__quantum__rt__array_update_reference_count(%Array* %9, i32 1)
-  call void @__quantum__rt__string_update_reference_count(%String* %11, i32 -1)
+  call void @__quantum__rt__string_update_reference_count(%String* %10, i32 -1)
   call void @__quantum__rt__array_update_reference_count(%Array* %9, i32 -1)
   br label %condContinue__1
 }

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestEntryPoint2.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestEntryPoint2.ll
@@ -64,103 +64,112 @@ exit__1:                                          ; preds = %header__1
   %46 = load %Result*, %Result** %41, align 8
   %47 = load %Range, %Range* %42, align 4
   %48 = load { i64, i1 }*, { i64, i1 }** %43, align 8
-  %49 = call %String* @__quantum__rt__string_create(i8* getelementptr inbounds ([2 x i8], [2 x i8]* @1, i32 0, i32 0))
+  %49 = call %String* @__quantum__rt__string_create(i8* getelementptr inbounds ([3 x i8], [3 x i8]* @1, i32 0, i32 0))
   %50 = call %String* @__quantum__rt__string_create(i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0))
-  %51 = call %String* @__quantum__rt__string_create(i8* getelementptr inbounds ([2 x i8], [2 x i8]* @3, i32 0, i32 0))
-  %52 = call i64 @__quantum__rt__array_get_size_1d(%Array* %44)
-  %53 = sub i64 %52, 1
+  %51 = call i64 @__quantum__rt__array_get_size_1d(%Array* %44)
+  %52 = sub i64 %51, 1
   br label %header__2
 
 header__2:                                        ; preds = %exiting__2, %exit__1
-  %54 = phi i64 [ 0, %exit__1 ], [ %62, %exiting__2 ]
-  %55 = icmp sle i64 %54, %53
+  %53 = phi %String* [ %50, %exit__1 ], [ %63, %exiting__2 ]
+  %54 = phi i64 [ 0, %exit__1 ], [ %64, %exiting__2 ]
+  %55 = icmp sle i64 %54, %52
   br i1 %55, label %body__2, label %exit__2
 
 body__2:                                          ; preds = %header__2
   %56 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %44, i64 %54)
   %57 = bitcast i8* %56 to i2*
   %58 = load i2, i2* %57, align 1
-  %59 = call %String* @__quantum__rt__pauli_to_string(i2 %58)
-  %60 = call %String* @__quantum__rt__string_concatenate(%String* %49, %String* %59)
-  call void @__quantum__rt__string_update_reference_count(%String* %49, i32 -1)
-  call void @__quantum__rt__string_update_reference_count(%String* %59, i32 -1)
-  %61 = call %String* @__quantum__rt__string_concatenate(%String* %60, %String* %50)
-  call void @__quantum__rt__string_update_reference_count(%String* %60, i32 -1)
+  %59 = icmp ne %String* %53, %50
+  br i1 %59, label %condTrue__1, label %condContinue__1
+
+condTrue__1:                                      ; preds = %body__2
+  %60 = call %String* @__quantum__rt__string_concatenate(%String* %53, %String* %49)
+  call void @__quantum__rt__string_update_reference_count(%String* %53, i32 -1)
+  br label %condContinue__1
+
+condContinue__1:                                  ; preds = %condTrue__1, %body__2
+  %61 = phi %String* [ %60, %condTrue__1 ], [ %53, %body__2 ]
+  %62 = call %String* @__quantum__rt__pauli_to_string(i2 %58)
+  %63 = call %String* @__quantum__rt__string_concatenate(%String* %61, %String* %62)
+  call void @__quantum__rt__string_update_reference_count(%String* %61, i32 -1)
+  call void @__quantum__rt__string_update_reference_count(%String* %62, i32 -1)
   br label %exiting__2
 
-exiting__2:                                       ; preds = %body__2
-  %62 = add i64 %54, 1
+exiting__2:                                       ; preds = %condContinue__1
+  %64 = add i64 %54, 1
   br label %header__2
 
 exit__2:                                          ; preds = %header__2
-  %63 = call %String* @__quantum__rt__string_concatenate(%String* %61, %String* %51)
-  call void @__quantum__rt__string_update_reference_count(%String* %61, i32 -1)
-  call void @__quantum__rt__string_update_reference_count(%String* %51, i32 -1)
-  call void @__quantum__rt__string_update_reference_count(%String* %50, i32 -1)
-  %64 = call %String* @__quantum__rt__string_concatenate(%String* %38, %String* %63)
+  %65 = call %String* @__quantum__rt__string_create(i8* getelementptr inbounds ([2 x i8], [2 x i8]* @3, i32 0, i32 0))
+  %66 = call %String* @__quantum__rt__string_concatenate(%String* %53, %String* %65)
+  call void @__quantum__rt__string_update_reference_count(%String* %53, i32 -1)
+  call void @__quantum__rt__string_update_reference_count(%String* %65, i32 -1)
+  call void @__quantum__rt__string_update_reference_count(%String* %49, i32 -1)
+  %67 = call %String* @__quantum__rt__string_concatenate(%String* %38, %String* %66)
   call void @__quantum__rt__string_update_reference_count(%String* %38, i32 -1)
-  call void @__quantum__rt__string_update_reference_count(%String* %63, i32 -1)
-  %65 = call %String* @__quantum__rt__string_create(i8* getelementptr inbounds ([2 x i8], [2 x i8]* @4, i32 0, i32 0))
-  %66 = call %String* @__quantum__rt__string_concatenate(%String* %64, %String* %65)
-  call void @__quantum__rt__string_update_reference_count(%String* %64, i32 -1)
-  call void @__quantum__rt__string_update_reference_count(%String* %45, i32 1)
-  %67 = call %String* @__quantum__rt__string_concatenate(%String* %66, %String* %45)
   call void @__quantum__rt__string_update_reference_count(%String* %66, i32 -1)
-  call void @__quantum__rt__string_update_reference_count(%String* %45, i32 -1)
-  %68 = call %String* @__quantum__rt__string_concatenate(%String* %67, %String* %65)
+  %68 = call %String* @__quantum__rt__string_create(i8* getelementptr inbounds ([3 x i8], [3 x i8]* @4, i32 0, i32 0))
+  %69 = call %String* @__quantum__rt__string_concatenate(%String* %67, %String* %68)
   call void @__quantum__rt__string_update_reference_count(%String* %67, i32 -1)
-  %69 = call %String* @__quantum__rt__result_to_string(%Result* %46)
-  %70 = call %String* @__quantum__rt__string_concatenate(%String* %68, %String* %69)
-  call void @__quantum__rt__string_update_reference_count(%String* %68, i32 -1)
+  call void @__quantum__rt__string_update_reference_count(%String* %45, i32 1)
+  %70 = call %String* @__quantum__rt__string_concatenate(%String* %69, %String* %45)
   call void @__quantum__rt__string_update_reference_count(%String* %69, i32 -1)
-  %71 = call %String* @__quantum__rt__string_concatenate(%String* %70, %String* %65)
+  call void @__quantum__rt__string_update_reference_count(%String* %45, i32 -1)
+  %71 = call %String* @__quantum__rt__string_concatenate(%String* %70, %String* %68)
   call void @__quantum__rt__string_update_reference_count(%String* %70, i32 -1)
-  %72 = call %String* @__quantum__rt__range_to_string(%Range %47)
+  %72 = call %String* @__quantum__rt__result_to_string(%Result* %46)
   %73 = call %String* @__quantum__rt__string_concatenate(%String* %71, %String* %72)
   call void @__quantum__rt__string_update_reference_count(%String* %71, i32 -1)
   call void @__quantum__rt__string_update_reference_count(%String* %72, i32 -1)
-  %74 = call %String* @__quantum__rt__string_concatenate(%String* %73, %String* %65)
+  %74 = call %String* @__quantum__rt__string_concatenate(%String* %73, %String* %68)
   call void @__quantum__rt__string_update_reference_count(%String* %73, i32 -1)
-  %75 = call %String* @__quantum__rt__string_create(i8* getelementptr inbounds ([2 x i8], [2 x i8]* @5, i32 0, i32 0))
-  %76 = getelementptr inbounds { i64, i1 }, { i64, i1 }* %48, i32 0, i32 0
-  %77 = getelementptr inbounds { i64, i1 }, { i64, i1 }* %48, i32 0, i32 1
-  %78 = load i64, i64* %76, align 4
-  %79 = load i1, i1* %77, align 1
-  %80 = call %String* @__quantum__rt__int_to_string(i64 %78)
-  %81 = call %String* @__quantum__rt__string_concatenate(%String* %75, %String* %80)
-  call void @__quantum__rt__string_update_reference_count(%String* %75, i32 -1)
-  call void @__quantum__rt__string_update_reference_count(%String* %80, i32 -1)
-  %82 = call %String* @__quantum__rt__string_create(i8* getelementptr inbounds ([2 x i8], [2 x i8]* @6, i32 0, i32 0))
-  %83 = call %String* @__quantum__rt__string_concatenate(%String* %81, %String* %82)
-  call void @__quantum__rt__string_update_reference_count(%String* %81, i32 -1)
-  %84 = call %String* @__quantum__rt__bool_to_string(i1 %79)
-  %85 = call %String* @__quantum__rt__string_concatenate(%String* %83, %String* %84)
-  call void @__quantum__rt__string_update_reference_count(%String* %83, i32 -1)
-  call void @__quantum__rt__string_update_reference_count(%String* %84, i32 -1)
-  %86 = call %String* @__quantum__rt__string_create(i8* getelementptr inbounds ([2 x i8], [2 x i8]* @7, i32 0, i32 0))
-  %87 = call %String* @__quantum__rt__string_concatenate(%String* %85, %String* %86)
-  call void @__quantum__rt__string_update_reference_count(%String* %85, i32 -1)
-  call void @__quantum__rt__string_update_reference_count(%String* %86, i32 -1)
-  call void @__quantum__rt__string_update_reference_count(%String* %82, i32 -1)
-  %88 = call %String* @__quantum__rt__string_concatenate(%String* %74, %String* %87)
+  %75 = call %String* @__quantum__rt__range_to_string(%Range %47)
+  %76 = call %String* @__quantum__rt__string_concatenate(%String* %74, %String* %75)
   call void @__quantum__rt__string_update_reference_count(%String* %74, i32 -1)
+  call void @__quantum__rt__string_update_reference_count(%String* %75, i32 -1)
+  %77 = call %String* @__quantum__rt__string_concatenate(%String* %76, %String* %68)
+  call void @__quantum__rt__string_update_reference_count(%String* %76, i32 -1)
+  %78 = call %String* @__quantum__rt__string_create(i8* getelementptr inbounds ([2 x i8], [2 x i8]* @5, i32 0, i32 0))
+  %79 = getelementptr inbounds { i64, i1 }, { i64, i1 }* %48, i32 0, i32 0
+  %80 = getelementptr inbounds { i64, i1 }, { i64, i1 }* %48, i32 0, i32 1
+  %81 = load i64, i64* %79, align 4
+  %82 = load i1, i1* %80, align 1
+  %83 = call %String* @__quantum__rt__int_to_string(i64 %81)
+  %84 = call %String* @__quantum__rt__string_concatenate(%String* %78, %String* %83)
+  call void @__quantum__rt__string_update_reference_count(%String* %78, i32 -1)
+  call void @__quantum__rt__string_update_reference_count(%String* %83, i32 -1)
+  %85 = call %String* @__quantum__rt__string_create(i8* getelementptr inbounds ([3 x i8], [3 x i8]* @6, i32 0, i32 0))
+  %86 = call %String* @__quantum__rt__string_concatenate(%String* %84, %String* %85)
+  call void @__quantum__rt__string_update_reference_count(%String* %84, i32 -1)
+  %87 = call %String* @__quantum__rt__bool_to_string(i1 %82)
+  %88 = call %String* @__quantum__rt__string_concatenate(%String* %86, %String* %87)
+  call void @__quantum__rt__string_update_reference_count(%String* %86, i32 -1)
   call void @__quantum__rt__string_update_reference_count(%String* %87, i32 -1)
-  %89 = call %String* @__quantum__rt__string_create(i8* getelementptr inbounds ([2 x i8], [2 x i8]* @8, i32 0, i32 0))
+  %89 = call %String* @__quantum__rt__string_create(i8* getelementptr inbounds ([2 x i8], [2 x i8]* @7, i32 0, i32 0))
   %90 = call %String* @__quantum__rt__string_concatenate(%String* %88, %String* %89)
   call void @__quantum__rt__string_update_reference_count(%String* %88, i32 -1)
   call void @__quantum__rt__string_update_reference_count(%String* %89, i32 -1)
-  call void @__quantum__rt__string_update_reference_count(%String* %65, i32 -1)
-  call void @__quantum__rt__message(%String* %90)
+  call void @__quantum__rt__string_update_reference_count(%String* %85, i32 -1)
+  %91 = call %String* @__quantum__rt__string_concatenate(%String* %77, %String* %90)
+  call void @__quantum__rt__string_update_reference_count(%String* %77, i32 -1)
+  call void @__quantum__rt__string_update_reference_count(%String* %90, i32 -1)
+  %92 = call %String* @__quantum__rt__string_create(i8* getelementptr inbounds ([2 x i8], [2 x i8]* @8, i32 0, i32 0))
+  %93 = call %String* @__quantum__rt__string_concatenate(%String* %91, %String* %92)
+  call void @__quantum__rt__string_update_reference_count(%String* %91, i32 -1)
+  call void @__quantum__rt__string_update_reference_count(%String* %92, i32 -1)
+  call void @__quantum__rt__string_update_reference_count(%String* %68, i32 -1)
+  call void @__quantum__rt__message(%String* %93)
   call void @__quantum__rt__array_update_reference_count(%Array* %4, i32 -1)
   call void @__quantum__rt__string_update_reference_count(%String* %17, i32 -1)
   call void @__quantum__rt__tuple_update_reference_count(%Tuple* %33, i32 -1)
   call void @__quantum__rt__array_update_reference_count(%Array* %44, i32 -1)
   call void @__quantum__rt__string_update_reference_count(%String* %45, i32 -1)
   call void @__quantum__rt__result_update_reference_count(%Result* %46, i32 -1)
-  %91 = bitcast { i64, i1 }* %48 to %Tuple*
-  call void @__quantum__rt__tuple_update_reference_count(%Tuple* %91, i32 -1)
-  %92 = bitcast { %Array*, %String*, %Result*, %Range, { i64, i1 }* }* %37 to %Tuple*
-  call void @__quantum__rt__tuple_update_reference_count(%Tuple* %92, i32 -1)
-  call void @__quantum__rt__string_update_reference_count(%String* %90, i32 -1)
+  %94 = bitcast { i64, i1 }* %48 to %Tuple*
+  call void @__quantum__rt__tuple_update_reference_count(%Tuple* %94, i32 -1)
+  %95 = bitcast { %Array*, %String*, %Result*, %Range, { i64, i1 }* }* %37 to %Tuple*
+  call void @__quantum__rt__tuple_update_reference_count(%Tuple* %95, i32 -1)
+  call void @__quantum__rt__string_update_reference_count(%String* %93, i32 -1)
   ret void
 }

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestForLoop.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestForLoop.ll
@@ -13,71 +13,69 @@ entry:
   call void @__quantum__rt__tuple_update_reference_count(%Tuple* %2, i32 1)
   call void @__quantum__rt__tuple_update_alias_count(%Tuple* %2, i32 -1)
   %5 = call %Tuple* @__quantum__rt__tuple_copy(%Tuple* %2, i1 false)
-  %6 = icmp ne %Tuple* %2, %5
-  %7 = bitcast %Tuple* %5 to { double, %String* }*
-  %8 = getelementptr inbounds { double, %String* }, { double, %String* }* %7, i32 0, i32 1
+  %6 = bitcast %Tuple* %5 to { double, %String* }*
+  %7 = getelementptr inbounds { double, %String* }, { double, %String* }* %6, i32 0, i32 1
   call void @__quantum__rt__string_update_reference_count(%String* %name, i32 1)
-  %9 = load %String*, %String** %8, align 8
-  store %String* %name, %String** %8, align 8
+  %8 = load %String*, %String** %7, align 8
+  store %String* %name, %String** %7, align 8
   call void @__quantum__rt__tuple_update_reference_count(%Tuple* %5, i32 1)
   call void @__quantum__rt__tuple_update_alias_count(%Tuple* %5, i32 1)
-  store { double, %String* }* %7, { double, %String* }** %res, align 8
+  store { double, %String* }* %6, { double, %String* }** %res, align 8
   %energy = alloca double, align 8
   store double 0.000000e+00, double* %energy, align 8
   br label %header__1
 
 header__1:                                        ; preds = %exiting__1, %entry
-  %10 = phi i64 [ 0, %entry ], [ %12, %exiting__1 ]
-  %11 = icmp sle i64 %10, 10
-  br i1 %11, label %body__1, label %exit__1
+  %9 = phi i64 [ 0, %entry ], [ %11, %exiting__1 ]
+  %10 = icmp sle i64 %9, 10
+  br i1 %10, label %body__1, label %exit__1
 
 body__1:                                          ; preds = %header__1
   br label %preheader__1
 
 exiting__1:                                       ; preds = %exit__2
-  %12 = add i64 %10, 1
+  %11 = add i64 %9, 1
   br label %header__1
 
 exit__1:                                          ; preds = %header__1
-  %13 = call %Tuple* @__quantum__rt__tuple_copy(%Tuple* %5, i1 false)
-  %14 = icmp ne %Tuple* %5, %13
-  %15 = bitcast %Tuple* %13 to { double, %String* }*
-  %16 = getelementptr inbounds { double, %String* }, { double, %String* }* %15, i32 0, i32 0
-  %17 = load double, double* %energy, align 8
-  store double %17, double* %16, align 8
-  %18 = getelementptr inbounds { double, %String* }, { double, %String* }* %15, i32 0, i32 1
-  %19 = load %String*, %String** %18, align 8
-  call void @__quantum__rt__string_update_reference_count(%String* %19, i32 1)
+  %12 = call %Tuple* @__quantum__rt__tuple_copy(%Tuple* %5, i1 false)
+  %13 = bitcast %Tuple* %12 to { double, %String* }*
+  %14 = getelementptr inbounds { double, %String* }, { double, %String* }* %13, i32 0, i32 0
+  %15 = load double, double* %energy, align 8
+  store double %15, double* %14, align 8
+  %16 = getelementptr inbounds { double, %String* }, { double, %String* }* %13, i32 0, i32 1
+  %17 = load %String*, %String** %16, align 8
+  call void @__quantum__rt__string_update_reference_count(%String* %17, i32 1)
   call void @__quantum__rt__tuple_update_alias_count(%Tuple* %5, i32 -1)
   call void @__quantum__rt__string_update_reference_count(%String* %name, i32 -1)
   call void @__quantum__rt__string_update_reference_count(%String* %0, i32 -1)
   call void @__quantum__rt__string_update_reference_count(%String* %4, i32 -1)
   call void @__quantum__rt__tuple_update_reference_count(%Tuple* %2, i32 -1)
   call void @__quantum__rt__tuple_update_reference_count(%Tuple* %2, i32 -1)
-  call void @__quantum__rt__string_update_reference_count(%String* %9, i32 -1)
+  call void @__quantum__rt__string_update_reference_count(%String* %8, i32 -1)
   call void @__quantum__rt__tuple_update_reference_count(%Tuple* %5, i32 -1)
   call void @__quantum__rt__string_update_reference_count(%String* %name, i32 -1)
   call void @__quantum__rt__tuple_update_reference_count(%Tuple* %5, i32 -1)
-  ret { double, %String* }* %15
+  ret { double, %String* }* %13
 
 preheader__1:                                     ; preds = %body__1
   br label %header__2
 
 header__2:                                        ; preds = %exiting__2, %preheader__1
-  %j = phi i64 [ 5, %preheader__1 ], [ %25, %exiting__2 ]
-  %20 = icmp sle i64 %j, 0
-  %21 = icmp sge i64 %j, 0
-  %22 = select i1 false, i1 %20, i1 %21
-  br i1 %22, label %body__2, label %exit__2
+  %j = phi i64 [ 5, %preheader__1 ], [ %23, %exiting__2 ]
+  %18 = icmp sle i64 %j, 0
+  %19 = icmp sge i64 %j, 0
+  %20 = select i1 false, i1 %18, i1 %19
+  br i1 %20, label %body__2, label %exit__2
 
 body__2:                                          ; preds = %header__2
-  %23 = load double, double* %energy, align 8
-  %24 = fadd double %23, 5.000000e-01
-  store double %24, double* %energy, align 8
+  %21 = load double, double* %energy, align 8
+  %22 = fadd double %21, 5.000000e-01
+  store double %22, double* %energy, align 8
   br label %exiting__2
 
 exiting__2:                                       ; preds = %body__2
-  %25 = add i64 %j, -1
+  %23 = add i64 %j, -1
   br label %header__2
 
 exit__2:                                          ; preds = %header__2

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestReferenceCounts.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestReferenceCounts.ll
@@ -67,88 +67,87 @@ exit__3:                                          ; preds = %header__3
 then0__1:                                         ; preds = %exit__3
   call void @__quantum__rt__array_update_alias_count(%Array* %0, i32 -1)
   %19 = call %Array* @__quantum__rt__array_copy(%Array* %0, i1 false)
-  %20 = icmp ne %Array* %0, %19
-  %21 = call %Array* @__quantum__rt__array_create_1d(i32 8, i64 3)
+  %20 = call %Array* @__quantum__rt__array_create_1d(i32 8, i64 3)
   br label %header__4
 
 continue__1:                                      ; preds = %exit__4, %exit__3
-  %22 = load %Array*, %Array** %ops, align 8
-  %23 = call i64 @__quantum__rt__array_get_size_1d(%Array* %22)
-  %24 = sub i64 %23, 1
+  %21 = load %Array*, %Array** %ops, align 8
+  %22 = call i64 @__quantum__rt__array_get_size_1d(%Array* %21)
+  %23 = sub i64 %22, 1
   br label %header__5
 
 header__4:                                        ; preds = %exiting__4, %then0__1
-  %25 = phi i64 [ 0, %then0__1 ], [ %29, %exiting__4 ]
-  %26 = icmp sle i64 %25, 2
-  br i1 %26, label %body__4, label %exit__4
+  %24 = phi i64 [ 0, %then0__1 ], [ %28, %exiting__4 ]
+  %25 = icmp sle i64 %24, 2
+  br i1 %25, label %body__4, label %exit__4
 
 body__4:                                          ; preds = %header__4
-  %27 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %21, i64 %25)
-  %28 = bitcast i8* %27 to i64*
-  store i64 0, i64* %28, align 4
+  %26 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %20, i64 %24)
+  %27 = bitcast i8* %26 to i64*
+  store i64 0, i64* %27, align 4
   br label %exiting__4
 
 exiting__4:                                       ; preds = %body__4
-  %29 = add i64 %25, 1
+  %28 = add i64 %24, 1
   br label %header__4
 
 exit__4:                                          ; preds = %header__4
-  %30 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %19, i64 0)
-  %31 = bitcast i8* %30 to %Array**
-  call void @__quantum__rt__array_update_reference_count(%Array* %21, i32 1)
-  call void @__quantum__rt__array_update_alias_count(%Array* %21, i32 1)
-  %32 = load %Array*, %Array** %31, align 8
-  call void @__quantum__rt__array_update_alias_count(%Array* %32, i32 -1)
-  store %Array* %21, %Array** %31, align 8
+  %29 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %19, i64 0)
+  %30 = bitcast i8* %29 to %Array**
+  call void @__quantum__rt__array_update_reference_count(%Array* %20, i32 1)
+  call void @__quantum__rt__array_update_alias_count(%Array* %20, i32 1)
+  %31 = load %Array*, %Array** %30, align 8
+  call void @__quantum__rt__array_update_alias_count(%Array* %31, i32 -1)
+  store %Array* %20, %Array** %30, align 8
   call void @__quantum__rt__array_update_reference_count(%Array* %19, i32 1)
   call void @__quantum__rt__array_update_alias_count(%Array* %19, i32 1)
   store %Array* %19, %Array** %ops, align 8
   call void @__quantum__rt__array_update_reference_count(%Array* %0, i32 -1)
-  call void @__quantum__rt__array_update_reference_count(%Array* %21, i32 -1)
-  call void @__quantum__rt__array_update_reference_count(%Array* %32, i32 -1)
+  call void @__quantum__rt__array_update_reference_count(%Array* %20, i32 -1)
+  call void @__quantum__rt__array_update_reference_count(%Array* %31, i32 -1)
   call void @__quantum__rt__array_update_reference_count(%Array* %19, i32 -1)
   br label %continue__1
 
 header__5:                                        ; preds = %exiting__5, %continue__1
-  %33 = phi i64 [ 0, %continue__1 ], [ %38, %exiting__5 ]
-  %34 = icmp sle i64 %33, %24
-  br i1 %34, label %body__5, label %exit__5
+  %32 = phi i64 [ 0, %continue__1 ], [ %37, %exiting__5 ]
+  %33 = icmp sle i64 %32, %23
+  br i1 %33, label %body__5, label %exit__5
 
 body__5:                                          ; preds = %header__5
-  %35 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %22, i64 %33)
-  %36 = bitcast i8* %35 to %Array**
-  %37 = load %Array*, %Array** %36, align 8
-  call void @__quantum__rt__array_update_alias_count(%Array* %37, i32 -1)
+  %34 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %21, i64 %32)
+  %35 = bitcast i8* %34 to %Array**
+  %36 = load %Array*, %Array** %35, align 8
+  call void @__quantum__rt__array_update_alias_count(%Array* %36, i32 -1)
   br label %exiting__5
 
 exiting__5:                                       ; preds = %body__5
-  %38 = add i64 %33, 1
+  %37 = add i64 %32, 1
   br label %header__5
 
 exit__5:                                          ; preds = %header__5
-  call void @__quantum__rt__array_update_alias_count(%Array* %22, i32 -1)
+  call void @__quantum__rt__array_update_alias_count(%Array* %21, i32 -1)
   call void @__quantum__rt__array_update_reference_count(%Array* %0, i32 -1)
   call void @__quantum__rt__array_update_reference_count(%Array* %1, i32 -1)
-  %39 = sub i64 %23, 1
+  %38 = sub i64 %22, 1
   br label %header__6
 
 header__6:                                        ; preds = %exiting__6, %exit__5
-  %40 = phi i64 [ 0, %exit__5 ], [ %45, %exiting__6 ]
-  %41 = icmp sle i64 %40, %39
-  br i1 %41, label %body__6, label %exit__6
+  %39 = phi i64 [ 0, %exit__5 ], [ %44, %exiting__6 ]
+  %40 = icmp sle i64 %39, %38
+  br i1 %40, label %body__6, label %exit__6
 
 body__6:                                          ; preds = %header__6
-  %42 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %22, i64 %40)
-  %43 = bitcast i8* %42 to %Array**
-  %44 = load %Array*, %Array** %43, align 8
-  call void @__quantum__rt__array_update_reference_count(%Array* %44, i32 -1)
+  %41 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %21, i64 %39)
+  %42 = bitcast i8* %41 to %Array**
+  %43 = load %Array*, %Array** %42, align 8
+  call void @__quantum__rt__array_update_reference_count(%Array* %43, i32 -1)
   br label %exiting__6
 
 exiting__6:                                       ; preds = %body__6
-  %45 = add i64 %40, 1
+  %44 = add i64 %39, 1
   br label %header__6
 
 exit__6:                                          ; preds = %header__6
-  call void @__quantum__rt__array_update_reference_count(%Array* %22, i32 -1)
+  call void @__quantum__rt__array_update_reference_count(%Array* %21, i32 -1)
   ret void
 }

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestRepeat.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestRepeat.ll
@@ -22,90 +22,88 @@ repeat__1:                                        ; preds = %continue__1, %entry
   call void @__quantum__rt__tuple_update_reference_count(%Tuple* %2, i32 1)
   call void @__quantum__rt__tuple_update_alias_count(%Tuple* %2, i32 -1)
   %5 = call %Tuple* @__quantum__rt__tuple_copy(%Tuple* %2, i1 false)
-  %6 = icmp ne %Tuple* %2, %5
-  %7 = bitcast %Tuple* %5 to { double, %String* }*
-  %8 = getelementptr inbounds { double, %String* }, { double, %String* }* %7, i32 0, i32 1
+  %6 = bitcast %Tuple* %5 to { double, %String* }*
+  %7 = getelementptr inbounds { double, %String* }, { double, %String* }* %6, i32 0, i32 1
   call void @__quantum__rt__string_update_reference_count(%String* %name, i32 1)
-  %9 = load %String*, %String** %8, align 8
-  store %String* %name, %String** %8, align 8
+  %8 = load %String*, %String** %7, align 8
+  store %String* %name, %String** %7, align 8
   call void @__quantum__rt__tuple_update_reference_count(%Tuple* %5, i32 1)
   call void @__quantum__rt__tuple_update_alias_count(%Tuple* %5, i32 1)
-  store { double, %String* }* %7, { double, %String* }** %res, align 8
-  %10 = load i64, i64* %n, align 4
-  %11 = add i64 %10, 1
-  store i64 %11, i64* %n, align 4
+  store { double, %String* }* %6, { double, %String* }** %res, align 8
+  %9 = load i64, i64* %n, align 4
+  %10 = add i64 %9, 1
+  store i64 %10, i64* %n, align 4
   br label %until__1
 
 until__1:                                         ; preds = %repeat__1
-  %12 = call %Result* @__quantum__qis__mz(%Qubit* %q)
-  %13 = call %Result* @__quantum__rt__result_get_zero()
-  %14 = call i1 @__quantum__rt__result_equal(%Result* %12, %Result* %13)
+  %11 = call %Result* @__quantum__qis__mz(%Qubit* %q)
+  %12 = call %Result* @__quantum__rt__result_get_zero()
+  %13 = call i1 @__quantum__rt__result_equal(%Result* %11, %Result* %12)
   call void @__quantum__rt__string_update_reference_count(%String* %name, i32 1)
   call void @__quantum__rt__tuple_update_reference_count(%Tuple* %5, i32 1)
-  br i1 %14, label %rend__1, label %fixup__1
+  br i1 %13, label %rend__1, label %fixup__1
 
 fixup__1:                                         ; preds = %until__1
-  %15 = icmp sgt i64 %11, 100
-  br i1 %15, label %then0__1, label %continue__1
+  %14 = icmp sgt i64 %10, 100
+  br i1 %14, label %then0__1, label %continue__1
 
 then0__1:                                         ; preds = %fixup__1
-  %16 = call %String* @__quantum__rt__string_create(i8* getelementptr inbounds ([20 x i8], [20 x i8]* @1, i32 0, i32 0))
-  %17 = load %String*, %String** %3, align 8
-  %18 = load %String*, %String** %8, align 8
-  %19 = load { double, %String* }*, { double, %String* }** %res, align 8
-  %20 = bitcast { double, %String* }* %19 to %Tuple*
-  call void @__quantum__rt__tuple_update_alias_count(%Tuple* %20, i32 -1)
+  %15 = call %String* @__quantum__rt__string_create(i8* getelementptr inbounds ([20 x i8], [20 x i8]* @1, i32 0, i32 0))
+  %16 = load %String*, %String** %3, align 8
+  %17 = load %String*, %String** %7, align 8
+  %18 = load { double, %String* }*, { double, %String* }** %res, align 8
+  %19 = bitcast { double, %String* }* %18 to %Tuple*
+  call void @__quantum__rt__tuple_update_alias_count(%Tuple* %19, i32 -1)
   call void @__quantum__rt__string_update_reference_count(%String* %name, i32 -1)
   call void @__quantum__rt__string_update_reference_count(%String* %0, i32 -1)
+  call void @__quantum__rt__string_update_reference_count(%String* %16, i32 -1)
+  call void @__quantum__rt__tuple_update_reference_count(%Tuple* %2, i32 -1)
+  call void @__quantum__rt__tuple_update_reference_count(%Tuple* %2, i32 -1)
   call void @__quantum__rt__string_update_reference_count(%String* %17, i32 -1)
-  call void @__quantum__rt__tuple_update_reference_count(%Tuple* %2, i32 -1)
-  call void @__quantum__rt__tuple_update_reference_count(%Tuple* %2, i32 -1)
-  call void @__quantum__rt__string_update_reference_count(%String* %18, i32 -1)
   call void @__quantum__rt__tuple_update_reference_count(%Tuple* %5, i32 -1)
-  call void @__quantum__rt__string_update_reference_count(%String* %9, i32 -1)
+  call void @__quantum__rt__string_update_reference_count(%String* %8, i32 -1)
   call void @__quantum__rt__tuple_update_reference_count(%Tuple* %5, i32 -1)
-  call void @__quantum__rt__result_update_reference_count(%Result* %12, i32 -1)
-  %21 = getelementptr inbounds { double, %String* }, { double, %String* }* %19, i32 0, i32 1
-  %22 = load %String*, %String** %21, align 8
-  call void @__quantum__rt__string_update_reference_count(%String* %22, i32 -1)
-  call void @__quantum__rt__tuple_update_reference_count(%Tuple* %20, i32 -1)
-  call void @__quantum__rt__fail(%String* %16)
+  call void @__quantum__rt__result_update_reference_count(%Result* %11, i32 -1)
+  %20 = getelementptr inbounds { double, %String* }, { double, %String* }* %18, i32 0, i32 1
+  %21 = load %String*, %String** %20, align 8
+  call void @__quantum__rt__string_update_reference_count(%String* %21, i32 -1)
+  call void @__quantum__rt__tuple_update_reference_count(%Tuple* %19, i32 -1)
+  call void @__quantum__rt__fail(%String* %15)
   unreachable
 
 continue__1:                                      ; preds = %fixup__1
-  %23 = load { double, %String* }*, { double, %String* }** %res, align 8
-  %24 = bitcast { double, %String* }* %23 to %Tuple*
+  %22 = load { double, %String* }*, { double, %String* }** %res, align 8
+  %23 = bitcast { double, %String* }* %22 to %Tuple*
+  call void @__quantum__rt__tuple_update_alias_count(%Tuple* %23, i32 -1)
+  %24 = call %Tuple* @__quantum__rt__tuple_copy(%Tuple* %23, i1 false)
+  %25 = bitcast %Tuple* %24 to { double, %String* }*
+  %26 = getelementptr inbounds { double, %String* }, { double, %String* }* %25, i32 0, i32 1
+  %27 = call %String* @__quantum__rt__string_create(i8* null)
+  call void @__quantum__rt__string_update_reference_count(%String* %27, i32 1)
+  %28 = load %String*, %String** %26, align 8
+  store %String* %27, %String** %26, align 8
+  call void @__quantum__rt__tuple_update_reference_count(%Tuple* %24, i32 1)
+  call void @__quantum__rt__tuple_update_alias_count(%Tuple* %24, i32 1)
+  store { double, %String* }* %25, { double, %String* }** %res, align 8
+  %29 = load %String*, %String** %3, align 8
+  %30 = load %String*, %String** %7, align 8
   call void @__quantum__rt__tuple_update_alias_count(%Tuple* %24, i32 -1)
-  %25 = call %Tuple* @__quantum__rt__tuple_copy(%Tuple* %24, i1 false)
-  %26 = icmp ne %Tuple* %24, %25
-  %27 = bitcast %Tuple* %25 to { double, %String* }*
-  %28 = getelementptr inbounds { double, %String* }, { double, %String* }* %27, i32 0, i32 1
-  %29 = call %String* @__quantum__rt__string_create(i8* null)
-  call void @__quantum__rt__string_update_reference_count(%String* %29, i32 1)
-  %30 = load %String*, %String** %28, align 8
-  store %String* %29, %String** %28, align 8
-  call void @__quantum__rt__tuple_update_reference_count(%Tuple* %25, i32 1)
-  call void @__quantum__rt__tuple_update_alias_count(%Tuple* %25, i32 1)
-  store { double, %String* }* %27, { double, %String* }** %res, align 8
-  %31 = load %String*, %String** %3, align 8
-  %32 = load %String*, %String** %8, align 8
-  call void @__quantum__rt__tuple_update_alias_count(%Tuple* %25, i32 -1)
   call void @__quantum__rt__string_update_reference_count(%String* %name, i32 -1)
   call void @__quantum__rt__string_update_reference_count(%String* %0, i32 -1)
-  call void @__quantum__rt__string_update_reference_count(%String* %31, i32 -1)
-  call void @__quantum__rt__tuple_update_reference_count(%Tuple* %2, i32 -1)
-  call void @__quantum__rt__tuple_update_reference_count(%Tuple* %2, i32 -1)
-  call void @__quantum__rt__string_update_reference_count(%String* %32, i32 -1)
-  call void @__quantum__rt__tuple_update_reference_count(%Tuple* %5, i32 -1)
-  call void @__quantum__rt__string_update_reference_count(%String* %9, i32 -1)
-  call void @__quantum__rt__tuple_update_reference_count(%Tuple* %5, i32 -1)
-  call void @__quantum__rt__result_update_reference_count(%Result* %12, i32 -1)
-  call void @__quantum__rt__tuple_update_reference_count(%Tuple* %24, i32 -1)
   call void @__quantum__rt__string_update_reference_count(%String* %29, i32 -1)
+  call void @__quantum__rt__tuple_update_reference_count(%Tuple* %2, i32 -1)
+  call void @__quantum__rt__tuple_update_reference_count(%Tuple* %2, i32 -1)
   call void @__quantum__rt__string_update_reference_count(%String* %30, i32 -1)
-  call void @__quantum__rt__tuple_update_reference_count(%Tuple* %25, i32 -1)
-  call void @__quantum__rt__string_update_reference_count(%String* %29, i32 -1)
-  call void @__quantum__rt__tuple_update_reference_count(%Tuple* %25, i32 -1)
+  call void @__quantum__rt__tuple_update_reference_count(%Tuple* %5, i32 -1)
+  call void @__quantum__rt__string_update_reference_count(%String* %8, i32 -1)
+  call void @__quantum__rt__tuple_update_reference_count(%Tuple* %5, i32 -1)
+  call void @__quantum__rt__result_update_reference_count(%Result* %11, i32 -1)
+  call void @__quantum__rt__tuple_update_reference_count(%Tuple* %23, i32 -1)
+  call void @__quantum__rt__string_update_reference_count(%String* %27, i32 -1)
+  call void @__quantum__rt__string_update_reference_count(%String* %28, i32 -1)
+  call void @__quantum__rt__tuple_update_reference_count(%Tuple* %24, i32 -1)
+  call void @__quantum__rt__string_update_reference_count(%String* %27, i32 -1)
+  call void @__quantum__rt__tuple_update_reference_count(%Tuple* %24, i32 -1)
   br label %repeat__1
 
 rend__1:                                          ; preds = %until__1
@@ -117,11 +115,11 @@ rend__1:                                          ; preds = %until__1
   call void @__quantum__rt__tuple_update_reference_count(%Tuple* %2, i32 -1)
   call void @__quantum__rt__string_update_reference_count(%String* %name, i32 -1)
   call void @__quantum__rt__tuple_update_reference_count(%Tuple* %5, i32 -1)
-  call void @__quantum__rt__string_update_reference_count(%String* %9, i32 -1)
+  call void @__quantum__rt__string_update_reference_count(%String* %8, i32 -1)
   call void @__quantum__rt__tuple_update_reference_count(%Tuple* %5, i32 -1)
-  call void @__quantum__rt__result_update_reference_count(%Result* %12, i32 -1)
+  call void @__quantum__rt__result_update_reference_count(%Result* %11, i32 -1)
   call void @__quantum__rt__string_update_reference_count(%String* %name, i32 -1)
   call void @__quantum__rt__tuple_update_reference_count(%Tuple* %5, i32 -1)
-  %33 = load i64, i64* %n, align 4
-  ret i64 %33
+  %31 = load i64, i64* %n, align 4
+  ret i64 %31
 }

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestShortCircuiting.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestShortCircuiting.ll
@@ -10,19 +10,20 @@ condTrue__1:                                      ; preds = %entry
 condContinue__1:                                  ; preds = %condTrue__1, %entry
   %rand = phi i1 [ %1, %condTrue__1 ], [ %0, %entry ]
   %2 = call i1 @__quantum__qis__getrandombool__body(i64 3)
-  br i1 %2, label %condContinue__2, label %condFalse__1
+  %3 = xor i1 %2, true
+  br i1 %3, label %condTrue__2, label %condContinue__2
 
-condFalse__1:                                     ; preds = %condContinue__1
-  %3 = call i1 @__quantum__qis__getrandombool__body(i64 4)
+condTrue__2:                                      ; preds = %condContinue__1
+  %4 = call i1 @__quantum__qis__getrandombool__body(i64 4)
   br label %condContinue__2
 
-condContinue__2:                                  ; preds = %condFalse__1, %condContinue__1
-  %ror = phi i1 [ %2, %condContinue__1 ], [ %3, %condFalse__1 ]
-  %4 = call %Tuple* @__quantum__rt__tuple_create(i64 mul nuw (i64 ptrtoint (i1* getelementptr (i1, i1* null, i32 1) to i64), i64 2))
-  %5 = bitcast %Tuple* %4 to { i1, i1 }*
-  %6 = getelementptr inbounds { i1, i1 }, { i1, i1 }* %5, i32 0, i32 0
-  %7 = getelementptr inbounds { i1, i1 }, { i1, i1 }* %5, i32 0, i32 1
-  store i1 %rand, i1* %6, align 1
-  store i1 %ror, i1* %7, align 1
-  ret { i1, i1 }* %5
+condContinue__2:                                  ; preds = %condTrue__2, %condContinue__1
+  %ror = phi i1 [ %4, %condTrue__2 ], [ %2, %condContinue__1 ]
+  %5 = call %Tuple* @__quantum__rt__tuple_create(i64 mul nuw (i64 ptrtoint (i1* getelementptr (i1, i1* null, i32 1) to i64), i64 2))
+  %6 = bitcast %Tuple* %5 to { i1, i1 }*
+  %7 = getelementptr inbounds { i1, i1 }, { i1, i1 }* %6, i32 0, i32 0
+  %8 = getelementptr inbounds { i1, i1 }, { i1, i1 }* %6, i32 0, i32 1
+  store i1 %rand, i1* %7, align 1
+  store i1 %ror, i1* %8, align 1
+  ret { i1, i1 }* %6
 }

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestStrings.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestStrings.ll
@@ -1,5 +1,6 @@
-define %String* @Microsoft__Quantum__Testing__QIR__TestStrings__body(i64 %a, i64 %b) {
+define %String* @Microsoft__Quantum__Testing__QIR__TestStrings__body(i64 %a, i64 %b, %Array* %arr) {
 entry:
+  call void @__quantum__rt__array_update_alias_count(%Array* %arr, i32 1)
   %0 = call %String* @__quantum__rt__string_create(i8* getelementptr inbounds ([6 x i8], [6 x i8]* @0, i32 0, i32 0))
   %1 = call %String* @__quantum__rt__int_to_string(i64 %a)
   %2 = call %String* @__quantum__rt__string_concatenate(%String* %0, %String* %1)
@@ -68,15 +69,59 @@ entry:
   %i = call %String* @__quantum__rt__string_concatenate(%String* %34, %String* %35)
   call void @__quantum__rt__string_update_reference_count(%String* %34, i32 -1)
   call void @__quantum__rt__string_update_reference_count(%String* %35, i32 -1)
-  %36 = call %String* @__quantum__rt__string_create(i8* getelementptr inbounds ([8 x i8], [8 x i8]* @9, i32 0, i32 0))
-  call void @__quantum__rt__string_update_reference_count(%String* %x, i32 1)
-  %37 = call %String* @__quantum__rt__string_concatenate(%String* %36, %String* %x)
+  %36 = call %String* @__quantum__rt__string_create(i8* getelementptr inbounds ([3 x i8], [3 x i8]* @9, i32 0, i32 0))
+  %37 = call %String* @__quantum__rt__string_create(i8* getelementptr inbounds ([2 x i8], [2 x i8]* @10, i32 0, i32 0))
+  %38 = call i64 @__quantum__rt__array_get_size_1d(%Array* %arr)
+  %39 = sub i64 %38, 1
+  br label %header__1
+
+header__1:                                        ; preds = %exiting__1, %entry
+  %40 = phi %String* [ %37, %entry ], [ %50, %exiting__1 ]
+  %41 = phi i64 [ 0, %entry ], [ %51, %exiting__1 ]
+  %42 = icmp sle i64 %41, %39
+  br i1 %42, label %body__1, label %exit__1
+
+body__1:                                          ; preds = %header__1
+  %43 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %arr, i64 %41)
+  %44 = bitcast i8* %43 to i64*
+  %45 = load i64, i64* %44, align 4
+  %46 = icmp ne %String* %40, %37
+  br i1 %46, label %condTrue__1, label %condContinue__1
+
+condTrue__1:                                      ; preds = %body__1
+  %47 = call %String* @__quantum__rt__string_concatenate(%String* %40, %String* %36)
+  call void @__quantum__rt__string_update_reference_count(%String* %40, i32 -1)
+  br label %condContinue__1
+
+condContinue__1:                                  ; preds = %condTrue__1, %body__1
+  %48 = phi %String* [ %47, %condTrue__1 ], [ %40, %body__1 ]
+  %49 = call %String* @__quantum__rt__int_to_string(i64 %45)
+  %50 = call %String* @__quantum__rt__string_concatenate(%String* %48, %String* %49)
+  call void @__quantum__rt__string_update_reference_count(%String* %48, i32 -1)
+  call void @__quantum__rt__string_update_reference_count(%String* %49, i32 -1)
+  br label %exiting__1
+
+exiting__1:                                       ; preds = %condContinue__1
+  %51 = add i64 %41, 1
+  br label %header__1
+
+exit__1:                                          ; preds = %header__1
+  %52 = call %String* @__quantum__rt__string_create(i8* getelementptr inbounds ([2 x i8], [2 x i8]* @11, i32 0, i32 0))
+  %data = call %String* @__quantum__rt__string_concatenate(%String* %40, %String* %52)
+  call void @__quantum__rt__string_update_reference_count(%String* %40, i32 -1)
+  call void @__quantum__rt__string_update_reference_count(%String* %52, i32 -1)
   call void @__quantum__rt__string_update_reference_count(%String* %36, i32 -1)
+  %53 = call %String* @__quantum__rt__string_create(i8* getelementptr inbounds ([8 x i8], [8 x i8]* @12, i32 0, i32 0))
+  call void @__quantum__rt__string_update_reference_count(%String* %x, i32 1)
+  %54 = call %String* @__quantum__rt__string_concatenate(%String* %53, %String* %x)
+  call void @__quantum__rt__string_update_reference_count(%String* %53, i32 -1)
   call void @__quantum__rt__string_update_reference_count(%String* %x, i32 -1)
+  call void @__quantum__rt__array_update_alias_count(%Array* %arr, i32 -1)
   call void @__quantum__rt__string_update_reference_count(%String* %x, i32 -1)
   call void @__quantum__rt__string_update_reference_count(%String* %y, i32 -1)
   call void @__quantum__rt__string_update_reference_count(%String* %y, i32 -1)
   call void @__quantum__rt__bigint_update_reference_count(%BigInt* %9, i32 -1)
   call void @__quantum__rt__string_update_reference_count(%String* %i, i32 -1)
-  ret %String* %37
+  call void @__quantum__rt__string_update_reference_count(%String* %data, i32 -1)
+  ret %String* %54
 }

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestStrings.qs
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestStrings.qs
@@ -3,12 +3,13 @@
 
 namespace Microsoft.Quantum.Testing.QIR
 {
-    function TestStrings(a : Int, b : Int) : String
+    function TestStrings(a : Int, b : Int, arr : Int[]) : String
     {
         let x = $"a is {a} \\ \r\n";
         let y = $"a+b is {a+b}";
         let z = $"{y}";
         let i = $"Constant double {1.2} bool {true} Pauli {PauliX} Result {One} BigInt {1L} Range {0..3}";
+        let data = $"{arr}";
         return $"a+b is {x}";
     }
 }

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestUdtUpdate1.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestUdtUpdate1.ll
@@ -22,37 +22,35 @@ entry:
   call void @__quantum__rt__tuple_update_reference_count(%Tuple* %8, i32 1)
   call void @__quantum__rt__tuple_update_alias_count(%Tuple* %8, i32 -1)
   %11 = call %Tuple* @__quantum__rt__tuple_copy(%Tuple* %8, i1 false)
-  %12 = icmp ne %Tuple* %8, %11
-  %13 = bitcast %Tuple* %11 to { { double, %String* }*, i64 }*
-  %14 = getelementptr inbounds { { double, %String* }*, i64 }, { { double, %String* }*, i64 }* %13, i32 0, i32 0
-  %15 = load { double, %String* }*, { double, %String* }** %14, align 8
-  %16 = bitcast { double, %String* }* %15 to %Tuple*
-  %17 = call %Tuple* @__quantum__rt__tuple_copy(%Tuple* %16, i1 false)
-  %18 = icmp ne %Tuple* %16, %17
-  call void @__quantum__rt__tuple_update_reference_count(%Tuple* %17, i32 1)
-  call void @__quantum__rt__tuple_update_alias_count(%Tuple* %17, i32 1)
-  call void @__quantum__rt__tuple_update_alias_count(%Tuple* %16, i32 -1)
-  %19 = bitcast %Tuple* %17 to { double, %String* }*
-  store { double, %String* }* %19, { double, %String* }** %14, align 8
-  %20 = getelementptr inbounds { double, %String* }, { double, %String* }* %19, i32 0, i32 1
-  %21 = call %String* @__quantum__rt__string_create(i8* getelementptr inbounds ([6 x i8], [6 x i8]* @0, i32 0, i32 0))
-  call void @__quantum__rt__string_update_reference_count(%String* %21, i32 1)
-  %22 = load %String*, %String** %20, align 8
-  store %String* %21, %String** %20, align 8
+  %12 = bitcast %Tuple* %11 to { { double, %String* }*, i64 }*
+  %13 = getelementptr inbounds { { double, %String* }*, i64 }, { { double, %String* }*, i64 }* %12, i32 0, i32 0
+  %14 = load { double, %String* }*, { double, %String* }** %13, align 8
+  %15 = bitcast { double, %String* }* %14 to %Tuple*
+  %16 = call %Tuple* @__quantum__rt__tuple_copy(%Tuple* %15, i1 false)
+  call void @__quantum__rt__tuple_update_reference_count(%Tuple* %16, i32 1)
+  call void @__quantum__rt__tuple_update_alias_count(%Tuple* %16, i32 1)
+  call void @__quantum__rt__tuple_update_alias_count(%Tuple* %15, i32 -1)
+  %17 = bitcast %Tuple* %16 to { double, %String* }*
+  store { double, %String* }* %17, { double, %String* }** %13, align 8
+  %18 = getelementptr inbounds { double, %String* }, { double, %String* }* %17, i32 0, i32 1
+  %19 = call %String* @__quantum__rt__string_create(i8* getelementptr inbounds ([6 x i8], [6 x i8]* @0, i32 0, i32 0))
+  call void @__quantum__rt__string_update_reference_count(%String* %19, i32 1)
+  %20 = load %String*, %String** %18, align 8
+  store %String* %19, %String** %18, align 8
   call void @__quantum__rt__tuple_update_reference_count(%Tuple* %11, i32 1)
   call void @__quantum__rt__tuple_update_alias_count(%Tuple* %11, i32 1)
-  store { { double, %String* }*, i64 }* %13, { { double, %String* }*, i64 }** %x, align 8
-  call void @__quantum__rt__tuple_update_alias_count(%Tuple* %17, i32 -1)
+  store { { double, %String* }*, i64 }* %12, { { double, %String* }*, i64 }** %x, align 8
+  call void @__quantum__rt__tuple_update_alias_count(%Tuple* %16, i32 -1)
   call void @__quantum__rt__tuple_update_alias_count(%Tuple* %11, i32 -1)
   call void @__quantum__rt__tuple_update_reference_count(%Tuple* %0, i32 -1)
   call void @__quantum__rt__string_update_reference_count(%String* %10, i32 -1)
   call void @__quantum__rt__tuple_update_reference_count(%Tuple* %7, i32 -1)
   call void @__quantum__rt__tuple_update_reference_count(%Tuple* %8, i32 -1)
   call void @__quantum__rt__tuple_update_reference_count(%Tuple* %8, i32 -1)
+  call void @__quantum__rt__tuple_update_reference_count(%Tuple* %15, i32 -1)
+  call void @__quantum__rt__string_update_reference_count(%String* %19, i32 -1)
+  call void @__quantum__rt__string_update_reference_count(%String* %20, i32 -1)
   call void @__quantum__rt__tuple_update_reference_count(%Tuple* %16, i32 -1)
-  call void @__quantum__rt__string_update_reference_count(%String* %21, i32 -1)
-  call void @__quantum__rt__string_update_reference_count(%String* %22, i32 -1)
-  call void @__quantum__rt__tuple_update_reference_count(%Tuple* %17, i32 -1)
   call void @__quantum__rt__tuple_update_reference_count(%Tuple* %11, i32 -1)
-  ret { { double, %String* }*, i64 }* %13
+  ret { { double, %String* }*, i64 }* %12
 }

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestUdtUpdate2.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestUdtUpdate2.ll
@@ -28,89 +28,86 @@ entry:
 then0__1:                                         ; preds = %entry
   call void @__quantum__rt__tuple_update_alias_count(%Tuple* %6, i32 -1)
   %11 = call %Tuple* @__quantum__rt__tuple_copy(%Tuple* %6, i1 false)
-  %12 = icmp ne %Tuple* %6, %11
-  %13 = bitcast %Tuple* %11 to { %String*, { double, double }*, { double, double }* }*
-  %14 = getelementptr inbounds { %String*, { double, double }*, { double, double }* }, { %String*, { double, double }*, { double, double }* }* %13, i32 0, i32 1
-  %15 = call { double, double }* @Microsoft__Quantum__Testing__QIR__Complex__body(double 0.000000e+00, double 0.000000e+00)
-  %16 = bitcast { double, double }* %15 to %Tuple*
-  call void @__quantum__rt__tuple_update_reference_count(%Tuple* %16, i32 1)
-  call void @__quantum__rt__tuple_update_alias_count(%Tuple* %16, i32 1)
-  %17 = load { double, double }*, { double, double }** %14, align 8
-  %18 = bitcast { double, double }* %17 to %Tuple*
-  call void @__quantum__rt__tuple_update_alias_count(%Tuple* %18, i32 -1)
-  store { double, double }* %15, { double, double }** %14, align 8
+  %12 = bitcast %Tuple* %11 to { %String*, { double, double }*, { double, double }* }*
+  %13 = getelementptr inbounds { %String*, { double, double }*, { double, double }* }, { %String*, { double, double }*, { double, double }* }* %12, i32 0, i32 1
+  %14 = call { double, double }* @Microsoft__Quantum__Testing__QIR__Complex__body(double 0.000000e+00, double 0.000000e+00)
+  %15 = bitcast { double, double }* %14 to %Tuple*
+  call void @__quantum__rt__tuple_update_reference_count(%Tuple* %15, i32 1)
+  call void @__quantum__rt__tuple_update_alias_count(%Tuple* %15, i32 1)
+  %16 = load { double, double }*, { double, double }** %13, align 8
+  %17 = bitcast { double, double }* %16 to %Tuple*
+  call void @__quantum__rt__tuple_update_alias_count(%Tuple* %17, i32 -1)
+  store { double, double }* %14, { double, double }** %13, align 8
   call void @__quantum__rt__tuple_update_reference_count(%Tuple* %11, i32 1)
   call void @__quantum__rt__tuple_update_alias_count(%Tuple* %11, i32 1)
-  store { %String*, { double, double }*, { double, double }* }* %13, { %String*, { double, double }*, { double, double }* }** %namedValue, align 8
+  store { %String*, { double, double }*, { double, double }* }* %12, { %String*, { double, double }*, { double, double }* }** %namedValue, align 8
   br i1 %cond, label %then0__2, label %continue__2
 
 then0__2:                                         ; preds = %then0__1
   call void @__quantum__rt__tuple_update_alias_count(%Tuple* %11, i32 -1)
-  %19 = call %Tuple* @__quantum__rt__tuple_copy(%Tuple* %11, i1 false)
-  %20 = icmp ne %Tuple* %11, %19
-  %21 = bitcast %Tuple* %19 to { %String*, { double, double }*, { double, double }* }*
-  %22 = getelementptr inbounds { %String*, { double, double }*, { double, double }* }, { %String*, { double, double }*, { double, double }* }* %21, i32 0, i32 1
-  %23 = call { double, double }* @Microsoft__Quantum__Testing__QIR__Complex__body(double 1.000000e+00, double 0.000000e+00)
+  %18 = call %Tuple* @__quantum__rt__tuple_copy(%Tuple* %11, i1 false)
+  %19 = bitcast %Tuple* %18 to { %String*, { double, double }*, { double, double }* }*
+  %20 = getelementptr inbounds { %String*, { double, double }*, { double, double }* }, { %String*, { double, double }*, { double, double }* }* %19, i32 0, i32 1
+  %21 = call { double, double }* @Microsoft__Quantum__Testing__QIR__Complex__body(double 1.000000e+00, double 0.000000e+00)
+  %22 = bitcast { double, double }* %21 to %Tuple*
+  call void @__quantum__rt__tuple_update_reference_count(%Tuple* %22, i32 1)
+  call void @__quantum__rt__tuple_update_alias_count(%Tuple* %22, i32 1)
+  %23 = load { double, double }*, { double, double }** %20, align 8
   %24 = bitcast { double, double }* %23 to %Tuple*
-  call void @__quantum__rt__tuple_update_reference_count(%Tuple* %24, i32 1)
-  call void @__quantum__rt__tuple_update_alias_count(%Tuple* %24, i32 1)
-  %25 = load { double, double }*, { double, double }** %22, align 8
-  %26 = bitcast { double, double }* %25 to %Tuple*
-  call void @__quantum__rt__tuple_update_alias_count(%Tuple* %26, i32 -1)
-  store { double, double }* %23, { double, double }** %22, align 8
-  call void @__quantum__rt__tuple_update_reference_count(%Tuple* %19, i32 1)
-  call void @__quantum__rt__tuple_update_alias_count(%Tuple* %19, i32 1)
-  store { %String*, { double, double }*, { double, double }* }* %21, { %String*, { double, double }*, { double, double }* }** %namedValue, align 8
+  call void @__quantum__rt__tuple_update_alias_count(%Tuple* %24, i32 -1)
+  store { double, double }* %21, { double, double }** %20, align 8
+  call void @__quantum__rt__tuple_update_reference_count(%Tuple* %18, i32 1)
+  call void @__quantum__rt__tuple_update_alias_count(%Tuple* %18, i32 1)
+  store { %String*, { double, double }*, { double, double }* }* %19, { %String*, { double, double }*, { double, double }* }** %namedValue, align 8
   call void @__quantum__rt__tuple_update_reference_count(%Tuple* %11, i32 -1)
+  call void @__quantum__rt__tuple_update_reference_count(%Tuple* %22, i32 -1)
   call void @__quantum__rt__tuple_update_reference_count(%Tuple* %24, i32 -1)
-  call void @__quantum__rt__tuple_update_reference_count(%Tuple* %26, i32 -1)
-  call void @__quantum__rt__tuple_update_reference_count(%Tuple* %19, i32 -1)
+  call void @__quantum__rt__tuple_update_reference_count(%Tuple* %18, i32 -1)
   br label %continue__2
 
 continue__2:                                      ; preds = %then0__2, %then0__1
-  %27 = load { %String*, { double, double }*, { double, double }* }*, { %String*, { double, double }*, { double, double }* }** %namedValue, align 8
-  %28 = bitcast { %String*, { double, double }*, { double, double }* }* %27 to %Tuple*
-  call void @__quantum__rt__tuple_update_alias_count(%Tuple* %28, i32 -1)
-  %29 = call %Tuple* @__quantum__rt__tuple_copy(%Tuple* %28, i1 false)
-  %30 = icmp ne %Tuple* %28, %29
-  %31 = bitcast %Tuple* %29 to { %String*, { double, double }*, { double, double }* }*
-  %32 = getelementptr inbounds { %String*, { double, double }*, { double, double }* }, { %String*, { double, double }*, { double, double }* }* %31, i32 0, i32 2
-  %33 = getelementptr inbounds { %String*, { double, double }*, { double, double }* }, { %String*, { double, double }*, { double, double }* }* %27, i32 0, i32 1
-  %34 = load { double, double }*, { double, double }** %33, align 8
-  %35 = bitcast { double, double }* %34 to %Tuple*
-  call void @__quantum__rt__tuple_update_reference_count(%Tuple* %35, i32 1)
-  call void @__quantum__rt__tuple_update_alias_count(%Tuple* %35, i32 1)
-  %36 = load { double, double }*, { double, double }** %32, align 8
-  %37 = bitcast { double, double }* %36 to %Tuple*
-  call void @__quantum__rt__tuple_update_alias_count(%Tuple* %37, i32 -1)
-  store { double, double }* %34, { double, double }** %32, align 8
-  call void @__quantum__rt__tuple_update_reference_count(%Tuple* %29, i32 1)
-  call void @__quantum__rt__tuple_update_alias_count(%Tuple* %29, i32 1)
-  store { %String*, { double, double }*, { double, double }* }* %31, { %String*, { double, double }*, { double, double }* }** %namedValue, align 8
+  %25 = load { %String*, { double, double }*, { double, double }* }*, { %String*, { double, double }*, { double, double }* }** %namedValue, align 8
+  %26 = bitcast { %String*, { double, double }*, { double, double }* }* %25 to %Tuple*
+  call void @__quantum__rt__tuple_update_alias_count(%Tuple* %26, i32 -1)
+  %27 = call %Tuple* @__quantum__rt__tuple_copy(%Tuple* %26, i1 false)
+  %28 = bitcast %Tuple* %27 to { %String*, { double, double }*, { double, double }* }*
+  %29 = getelementptr inbounds { %String*, { double, double }*, { double, double }* }, { %String*, { double, double }*, { double, double }* }* %28, i32 0, i32 2
+  %30 = getelementptr inbounds { %String*, { double, double }*, { double, double }* }, { %String*, { double, double }*, { double, double }* }* %25, i32 0, i32 1
+  %31 = load { double, double }*, { double, double }** %30, align 8
+  %32 = bitcast { double, double }* %31 to %Tuple*
+  call void @__quantum__rt__tuple_update_reference_count(%Tuple* %32, i32 1)
+  call void @__quantum__rt__tuple_update_alias_count(%Tuple* %32, i32 1)
+  %33 = load { double, double }*, { double, double }** %29, align 8
+  %34 = bitcast { double, double }* %33 to %Tuple*
+  call void @__quantum__rt__tuple_update_alias_count(%Tuple* %34, i32 -1)
+  store { double, double }* %31, { double, double }** %29, align 8
+  call void @__quantum__rt__tuple_update_reference_count(%Tuple* %27, i32 1)
+  call void @__quantum__rt__tuple_update_alias_count(%Tuple* %27, i32 1)
+  store { %String*, { double, double }*, { double, double }* }* %28, { %String*, { double, double }*, { double, double }* }** %namedValue, align 8
   call void @__quantum__rt__tuple_update_reference_count(%Tuple* %6, i32 -1)
-  call void @__quantum__rt__tuple_update_reference_count(%Tuple* %16, i32 -1)
-  call void @__quantum__rt__tuple_update_reference_count(%Tuple* %18, i32 -1)
+  call void @__quantum__rt__tuple_update_reference_count(%Tuple* %15, i32 -1)
+  call void @__quantum__rt__tuple_update_reference_count(%Tuple* %17, i32 -1)
   call void @__quantum__rt__tuple_update_reference_count(%Tuple* %11, i32 -1)
-  call void @__quantum__rt__tuple_update_reference_count(%Tuple* %28, i32 -1)
-  call void @__quantum__rt__tuple_update_reference_count(%Tuple* %37, i32 -1)
-  call void @__quantum__rt__tuple_update_reference_count(%Tuple* %29, i32 -1)
+  call void @__quantum__rt__tuple_update_reference_count(%Tuple* %26, i32 -1)
+  call void @__quantum__rt__tuple_update_reference_count(%Tuple* %34, i32 -1)
+  call void @__quantum__rt__tuple_update_reference_count(%Tuple* %27, i32 -1)
   br label %continue__1
 
 continue__1:                                      ; preds = %continue__2, %entry
-  %38 = load { %String*, { double, double }*, { double, double }* }*, { %String*, { double, double }*, { double, double }* }** %namedValue, align 8
+  %35 = load { %String*, { double, double }*, { double, double }* }*, { %String*, { double, double }*, { double, double }* }** %namedValue, align 8
   call void @__quantum__rt__tuple_update_alias_count(%Tuple* %2, i32 -1)
   call void @__quantum__rt__tuple_update_alias_count(%Tuple* %5, i32 -1)
   call void @__quantum__rt__tuple_update_alias_count(%Tuple* %6, i32 -1)
-  %39 = getelementptr inbounds { %String*, { double, double }*, { double, double }* }, { %String*, { double, double }*, { double, double }* }* %38, i32 0, i32 1
+  %36 = getelementptr inbounds { %String*, { double, double }*, { double, double }* }, { %String*, { double, double }*, { double, double }* }* %35, i32 0, i32 1
+  %37 = load { double, double }*, { double, double }** %36, align 8
+  %38 = bitcast { double, double }* %37 to %Tuple*
+  call void @__quantum__rt__tuple_update_alias_count(%Tuple* %38, i32 -1)
+  %39 = getelementptr inbounds { %String*, { double, double }*, { double, double }* }, { %String*, { double, double }*, { double, double }* }* %35, i32 0, i32 2
   %40 = load { double, double }*, { double, double }** %39, align 8
   %41 = bitcast { double, double }* %40 to %Tuple*
   call void @__quantum__rt__tuple_update_alias_count(%Tuple* %41, i32 -1)
-  %42 = getelementptr inbounds { %String*, { double, double }*, { double, double }* }, { %String*, { double, double }*, { double, double }* }* %38, i32 0, i32 2
-  %43 = load { double, double }*, { double, double }** %42, align 8
-  %44 = bitcast { double, double }* %43 to %Tuple*
-  call void @__quantum__rt__tuple_update_alias_count(%Tuple* %44, i32 -1)
-  %45 = bitcast { %String*, { double, double }*, { double, double }* }* %38 to %Tuple*
-  call void @__quantum__rt__tuple_update_alias_count(%Tuple* %45, i32 -1)
+  %42 = bitcast { %String*, { double, double }*, { double, double }* }* %35 to %Tuple*
+  call void @__quantum__rt__tuple_update_alias_count(%Tuple* %42, i32 -1)
   call void @__quantum__rt__string_update_reference_count(%String* %9, i32 -1)
-  ret { %String*, { double, double }*, { double, double }* }* %38
+  ret { %String*, { double, double }*, { double, double }* }* %35
 }

--- a/src/QsCompiler/Tests.Compiler/Tests.Compiler.fsproj
+++ b/src/QsCompiler/Tests.Compiler/Tests.Compiler.fsproj
@@ -268,28 +268,28 @@
     <Content Include="TestCases\QirTests\TestResults.qs">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
-    <Content Include="TestCases\QirTests\TestShortCircuiting.ll">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </Content>
-    <Content Include="TestCases\QirTests\TestShortCircuiting.qs">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </Content>
     <Content Include="TestCases\QirTests\TestScoping.ll">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
     <Content Include="TestCases\QirTests\TestScoping.qs">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
-    <Content Include="TestCases\QirTests\TestTargeting.ll">
+    <Content Include="TestCases\QirTests\TestShortCircuiting.ll">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
-    <Content Include="TestCases\QirTests\TestTargeting.qs">
+    <Content Include="TestCases\QirTests\TestShortCircuiting.qs">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
     <Content Include="TestCases\QirTests\TestStrings.ll">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
     <Content Include="TestCases\QirTests\TestStrings.qs">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="TestCases\QirTests\TestTargeting.ll">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="TestCases\QirTests\TestTargeting.qs">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
     <Content Include="TestCases\QirTests\TestUdt.ll">


### PR DESCRIPTION
Fixes https://github.com/microsoft/qsharp-compiler/issues/974.
As part of fixing https://github.com/microsoft/qsharp-compiler/issues/974, I decided to split out the necessary logic into some general purpose methods. 
I also decided to get rid of the final comma after all for array printing (as previously suggested by @kuzminrobin), though it does come at the cost of having to evaluate a branching in each loop iteration (I am still not sure whether that is preferable or not).