### PR TITLE
Support for sized array in qir generation and package number update

### DIFF
--- a/build/ci.yml
+++ b/build/ci.yml
@@ -2,7 +2,7 @@ name: $(Build.Major).$(Build.Minor).$(date:yyMM).$(DayOfMonth)$(rev:rr)
 
 variables:
   Build.Major: 0
-  Build.Minor: 15
+  Build.Minor: 16
   Assembly.Version: $(Build.BuildNumber)
   Assembly.Constants: ''
   Drops.Dir: $(Build.ArtifactStagingDirectory)/drops

--- a/examples/QIR/Development/Development.csproj
+++ b/examples/QIR/Development/Development.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.Quantum.Sdk/0.15.2103133969">
+﻿<Project Sdk="Microsoft.Quantum.Sdk/0.16.210426130-alpha">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-	<!-- The following references need to be removed once the Sdk version number is updated. -->
+    <!-- These packages are included by the Sdk if QIR generation is enabled. -->
     <PackageReference Condition="$([MSBuild]::IsOsPlatform('Windows'))"
                       Include="libLLVM.runtime.win-x64" Version="11.0.0"
                       PrivateAssets="All" GeneratePathProperty="true" />
@@ -57,16 +57,6 @@
 
   <Target Name="BeforeQSharpCompile" DependsOnTargets="QSharpClean">
     <Message Text="Removed files from prior compilation." Importance="High" />
-	<!-- The following lines need to be removed once the Sdk version number is updated. -->
-    <PropertyGroup Condition="'$(LlvmLibsPath)' == ''">
-      <LlvmLibsPath Condition="$([MSBuild]::IsOsPlatform('OSX'))">$(PkglibLLVM_runtime_osx-x64)</LlvmLibsPath>
-      <LlvmLibsPath Condition="$([MSBuild]::IsOsPlatform('Windows'))">$(PkglibLLVM_runtime_win-x64)</LlvmLibsPath>
-      <LlvmLibsPath Condition="$([MSBuild]::IsOsPlatform('Linux')) And '$(UbuntuVersion)' == '18.04'">$(PkglibLLVM_runtime_ubuntu_18_04-x64)</LlvmLibsPath>
-      <LlvmLibsPath Condition="$([MSBuild]::IsOsPlatform('Linux')) And '$(UbuntuVersion)' != '18.04'">$(PkglibLLVM_runtime_ubuntu_20_04-x64)</LlvmLibsPath>
-    </PropertyGroup>
-    <PropertyGroup>
-      <AdditionalQscArguments>--llvm-libs $(LlvmLibsPath)/</AdditionalQscArguments>
-    </PropertyGroup>
   </Target>
 
   <Target Name="BeforeCSharpCompile">

--- a/examples/QIR/Emission/Emission.csproj
+++ b/examples/QIR/Emission/Emission.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.Quantum.Sdk/0.15.2103133969">
+﻿<Project Sdk="Microsoft.Quantum.Sdk/0.16.210426130-alpha">
 
   <PropertyGroup>
     <QscVerbosity>Detailed</QscVerbosity>

--- a/src/QsCompiler/QirGeneration/README.md
+++ b/src/QsCompiler/QirGeneration/README.md
@@ -13,7 +13,7 @@ To enable QIR emission, open the project file in a text editor and add the follo
 ```
 If the project builds successfully, the .ll file containing QIR can be found in `qir` folder in the project folder. Alternatively, the folder path can be specified via the `QirOutputPath` project property. The project file should look similar to this:
 ```
-<Project Sdk="Microsoft.Quantum.Sdk/0.15.210324373-alpha">
+<Project Sdk="Microsoft.Quantum.Sdk/0.16.210426130-alpha">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>

--- a/src/QsCompiler/TestTargets/Libraries/Library1/Library1.csproj
+++ b/src/QsCompiler/TestTargets/Libraries/Library1/Library1.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Simulators" Version="0.15.2102128704-alpha" />
+    <PackageReference Include="Microsoft.Quantum.Simulators" Version="0.16.210426130-alpha" />
   </ItemGroup>
 
   <Import Project="$(MSBuildThisFileDirectory)../build/Library.props" />

--- a/src/QsCompiler/TestTargets/Libraries/Library2/Library2.csproj
+++ b/src/QsCompiler/TestTargets/Libraries/Library2/Library2.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk" InitialTargets="RecompileOnChange">
+﻿<Project Sdk="Microsoft.NET.Sdk" InitialTargets="RecompileOnChange">
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Simulators" Version="0.15.2102128704-alpha" />
+    <PackageReference Include="Microsoft.Quantum.Simulators" Version="0.16.210426130-alpha" />
   </ItemGroup>
 
   <Import Project="$(MSBuildThisFileDirectory)../build/Library.props" />

--- a/src/QsCompiler/TestTargets/Simulation/Example/Example.csproj
+++ b/src/QsCompiler/TestTargets/Simulation/Example/Example.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.Quantum.Sdk/0.15.2102128704-alpha">
+﻿<Project Sdk="Microsoft.Quantum.Sdk/0.16.210426130-alpha">
   <PropertyGroup>
     <QscVerbosity>Detailed</QscVerbosity>
     <OutputType>Exe</OutputType>

--- a/src/QsCompiler/TestTargets/Simulation/Target/Simulation.csproj
+++ b/src/QsCompiler/TestTargets/Simulation/Target/Simulation.csproj
@@ -12,7 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.CSharpGeneration" Version="0.15.2102128704-alpha" />
+    <PackageReference Include="Microsoft.Quantum.CSharpGeneration" Version="0.16.210426130-alpha" />
   </ItemGroup>
   
 </Project>

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestArrayUpdate.qs
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestArrayUpdate.qs
@@ -8,7 +8,7 @@ namespace Microsoft.Quantum.Testing.QIR
     function TestArrayUpdate1(even : String) : String[]
     {
         mutable arr = new String[10];
-        for (i in 0 .. 9)
+        for i in 0 .. 9
         {
             let str = i % 2 != 0 ? "odd" | even;
             set arr w/= i <- str; 
@@ -20,7 +20,7 @@ namespace Microsoft.Quantum.Testing.QIR
     function TestArrayUpdate2(array : String[], even : String) : String[]
     {
         mutable arr = array;
-        for (i in 0 .. 9)
+        for i in 0 .. 9
         {
             let str = i % 2 != 0 ? "odd" | even;
             set arr w/= i <- str; 
@@ -35,8 +35,8 @@ namespace Microsoft.Quantum.Testing.QIR
         set x w/= 0 <- b;
         set x w/= 1 <- "Hello";
 
-        mutable arr = new (Int, Int)[10];
-        for (i in 0 .. 9)
+        mutable arr = [(0,0), size = 10];
+        for i in 0 .. 9
         {
             set arr w/= i <- (i, i + 1); 
         }
@@ -50,7 +50,7 @@ namespace Microsoft.Quantum.Testing.QIR
         mutable arr = new String[0];
         set arr = array;
 
-        for (i in 0 .. 9)
+        for i in 0 .. 9
         {
             set arr w/= i <- item; 
         }
@@ -62,7 +62,7 @@ namespace Microsoft.Quantum.Testing.QIR
     {
         let item = Complex(0.,0.);
         mutable arr = array;
-        for (i in 0 .. 2 .. Length(arr) - 1)
+        for i in 0 .. 2 .. Length(arr) - 1
         {
             set arr w/= i <- arr[i % 2]; 
             if (cond)

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestArrayUpdate1.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestArrayUpdate1.ll
@@ -1,28 +1,29 @@
 define %Array* @Microsoft__Quantum__Testing__QIR__TestArrayUpdate1__body(%String* %even) {
 entry:
-  %0 = call %Array* @__quantum__rt__array_create_1d(i32 8, i64 10)
+  %0 = call %String* @__quantum__rt__string_create(i8* null)
+  %1 = call %Array* @__quantum__rt__array_create_1d(i32 8, i64 10)
   br label %header__1
 
 header__1:                                        ; preds = %exiting__1, %entry
-  %1 = phi i64 [ 0, %entry ], [ %6, %exiting__1 ]
-  %2 = icmp sle i64 %1, 9
-  br i1 %2, label %body__1, label %exit__1
+  %2 = phi i64 [ 0, %entry ], [ %6, %exiting__1 ]
+  %3 = icmp sle i64 %2, 9
+  br i1 %3, label %body__1, label %exit__1
 
 body__1:                                          ; preds = %header__1
-  %3 = call %String* @__quantum__rt__string_create(i8* null)
-  %4 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %0, i64 %1)
+  %4 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %1, i64 %2)
   %5 = bitcast i8* %4 to %String**
-  store %String* %3, %String** %5, align 8
+  store %String* %0, %String** %5, align 8
+  call void @__quantum__rt__string_update_reference_count(%String* %0, i32 1)
   br label %exiting__1
 
 exiting__1:                                       ; preds = %body__1
-  %6 = add i64 %1, 1
+  %6 = add i64 %2, 1
   br label %header__1
 
 exit__1:                                          ; preds = %header__1
   %arr = alloca %Array*, align 8
-  store %Array* %0, %Array** %arr, align 8
-  call void @__quantum__rt__array_update_alias_count(%Array* %0, i32 1)
+  store %Array* %1, %Array** %arr, align 8
+  call void @__quantum__rt__array_update_alias_count(%Array* %1, i32 1)
   br label %header__2
 
 header__2:                                        ; preds = %exiting__2, %exit__1
@@ -31,7 +32,7 @@ header__2:                                        ; preds = %exiting__2, %exit__
   br i1 %8, label %body__2, label %exit__2
 
 body__2:                                          ; preds = %header__2
-  %9 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %0, i64 %7)
+  %9 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %1, i64 %7)
   %10 = bitcast i8* %9 to %String**
   %11 = load %String*, %String** %10, align 8
   call void @__quantum__rt__string_update_reference_count(%String* %11, i32 1)
@@ -42,7 +43,7 @@ exiting__2:                                       ; preds = %body__2
   br label %header__2
 
 exit__2:                                          ; preds = %header__2
-  call void @__quantum__rt__array_update_reference_count(%Array* %0, i32 1)
+  call void @__quantum__rt__array_update_reference_count(%Array* %1, i32 1)
   br label %header__3
 
 header__3:                                        ; preds = %exiting__3, %exit__2
@@ -98,6 +99,7 @@ exiting__3:                                       ; preds = %condContinue__2
 exit__3:                                          ; preds = %header__3
   %24 = load %Array*, %Array** %arr, align 8
   call void @__quantum__rt__array_update_alias_count(%Array* %24, i32 -1)
+  call void @__quantum__rt__string_update_reference_count(%String* %0, i32 -1)
   br label %header__4
 
 header__4:                                        ; preds = %exiting__4, %exit__3
@@ -106,7 +108,7 @@ header__4:                                        ; preds = %exiting__4, %exit__
   br i1 %26, label %body__4, label %exit__4
 
 body__4:                                          ; preds = %header__4
-  %27 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %0, i64 %25)
+  %27 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %1, i64 %25)
   %28 = bitcast i8* %27 to %String**
   %29 = load %String*, %String** %28, align 8
   call void @__quantum__rt__string_update_reference_count(%String* %29, i32 -1)
@@ -117,6 +119,6 @@ exiting__4:                                       ; preds = %body__4
   br label %header__4
 
 exit__4:                                          ; preds = %header__4
-  call void @__quantum__rt__array_update_reference_count(%Array* %0, i32 -1)
+  call void @__quantum__rt__array_update_reference_count(%Array* %1, i32 -1)
   ret %Array* %24
 }

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestArrayUpdate3.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestArrayUpdate3.ll
@@ -65,33 +65,34 @@ condContinue__2:                                  ; preds = %condFalse__2, %cond
   call void @__quantum__rt__array_update_reference_count(%Array* %13, i32 1)
   call void @__quantum__rt__array_update_alias_count(%Array* %13, i32 1)
   store %Array* %13, %Array** %x, align 8
-  %19 = call %Array* @__quantum__rt__array_create_1d(i32 8, i64 10)
+  %19 = call %Tuple* @__quantum__rt__tuple_create(i64 mul nuw (i64 ptrtoint (i64* getelementptr (i64, i64* null, i32 1) to i64), i64 2))
+  %20 = bitcast %Tuple* %19 to { i64, i64 }*
+  %21 = getelementptr inbounds { i64, i64 }, { i64, i64 }* %20, i32 0, i32 0
+  %22 = getelementptr inbounds { i64, i64 }, { i64, i64 }* %20, i32 0, i32 1
+  store i64 0, i64* %21, align 4
+  store i64 0, i64* %22, align 4
+  %23 = call %Array* @__quantum__rt__array_create_1d(i32 8, i64 10)
   br label %header__2
 
 header__2:                                        ; preds = %exiting__2, %condContinue__2
-  %20 = phi i64 [ 0, %condContinue__2 ], [ %28, %exiting__2 ]
-  %21 = icmp sle i64 %20, 9
-  br i1 %21, label %body__2, label %exit__2
+  %24 = phi i64 [ 0, %condContinue__2 ], [ %28, %exiting__2 ]
+  %25 = icmp sle i64 %24, 9
+  br i1 %25, label %body__2, label %exit__2
 
 body__2:                                          ; preds = %header__2
-  %22 = call %Tuple* @__quantum__rt__tuple_create(i64 mul nuw (i64 ptrtoint (i64* getelementptr (i64, i64* null, i32 1) to i64), i64 2))
-  %23 = bitcast %Tuple* %22 to { i64, i64 }*
-  %24 = getelementptr inbounds { i64, i64 }, { i64, i64 }* %23, i32 0, i32 0
-  %25 = getelementptr inbounds { i64, i64 }, { i64, i64 }* %23, i32 0, i32 1
-  store i64 0, i64* %24, align 4
-  store i64 0, i64* %25, align 4
-  %26 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %19, i64 %20)
+  %26 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %23, i64 %24)
   %27 = bitcast i8* %26 to { i64, i64 }**
-  store { i64, i64 }* %23, { i64, i64 }** %27, align 8
+  store { i64, i64 }* %20, { i64, i64 }** %27, align 8
+  call void @__quantum__rt__tuple_update_reference_count(%Tuple* %19, i32 1)
   br label %exiting__2
 
 exiting__2:                                       ; preds = %body__2
-  %28 = add i64 %20, 1
+  %28 = add i64 %24, 1
   br label %header__2
 
 exit__2:                                          ; preds = %header__2
   %arr = alloca %Array*, align 8
-  store %Array* %19, %Array** %arr, align 8
+  store %Array* %23, %Array** %arr, align 8
   br label %header__3
 
 header__3:                                        ; preds = %exiting__3, %exit__2
@@ -100,7 +101,7 @@ header__3:                                        ; preds = %exiting__3, %exit__
   br i1 %30, label %body__3, label %exit__3
 
 body__3:                                          ; preds = %header__3
-  %31 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %19, i64 %29)
+  %31 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %23, i64 %29)
   %32 = bitcast i8* %31 to { i64, i64 }**
   %33 = load { i64, i64 }*, { i64, i64 }** %32, align 8
   %34 = bitcast { i64, i64 }* %33 to %Tuple*
@@ -112,7 +113,7 @@ exiting__3:                                       ; preds = %body__3
   br label %header__3
 
 exit__3:                                          ; preds = %header__3
-  call void @__quantum__rt__array_update_alias_count(%Array* %19, i32 1)
+  call void @__quantum__rt__array_update_alias_count(%Array* %23, i32 1)
   br label %header__4
 
 header__4:                                        ; preds = %exiting__4, %exit__3
@@ -121,7 +122,7 @@ header__4:                                        ; preds = %exiting__4, %exit__
   br i1 %37, label %body__4, label %exit__4
 
 body__4:                                          ; preds = %header__4
-  %38 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %19, i64 %36)
+  %38 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %23, i64 %36)
   %39 = bitcast i8* %38 to { i64, i64 }**
   %40 = load { i64, i64 }*, { i64, i64 }** %39, align 8
   %41 = bitcast { i64, i64 }* %40 to %Tuple*
@@ -133,7 +134,7 @@ exiting__4:                                       ; preds = %body__4
   br label %header__4
 
 exit__4:                                          ; preds = %header__4
-  call void @__quantum__rt__array_update_reference_count(%Array* %19, i32 1)
+  call void @__quantum__rt__array_update_reference_count(%Array* %23, i32 1)
   br label %header__5
 
 header__5:                                        ; preds = %exiting__5, %exit__4
@@ -216,6 +217,7 @@ exit__6:                                          ; preds = %header__6
   call void @__quantum__rt__string_update_reference_count(%String* %15, i32 -1)
   call void @__quantum__rt__string_update_reference_count(%String* %18, i32 -1)
   call void @__quantum__rt__array_update_reference_count(%Array* %13, i32 -1)
+  call void @__quantum__rt__tuple_update_reference_count(%Tuple* %19, i32 -1)
   br label %header__7
 
 header__7:                                        ; preds = %exiting__7, %exit__6
@@ -224,7 +226,7 @@ header__7:                                        ; preds = %exiting__7, %exit__
   br i1 %68, label %body__7, label %exit__7
 
 body__7:                                          ; preds = %header__7
-  %69 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %19, i64 %67)
+  %69 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %23, i64 %67)
   %70 = bitcast i8* %69 to { i64, i64 }**
   %71 = load { i64, i64 }*, { i64, i64 }** %70, align 8
   %72 = bitcast { i64, i64 }* %71 to %Tuple*
@@ -236,7 +238,7 @@ exiting__7:                                       ; preds = %body__7
   br label %header__7
 
 exit__7:                                          ; preds = %header__7
-  call void @__quantum__rt__array_update_reference_count(%Array* %19, i32 -1)
+  call void @__quantum__rt__array_update_reference_count(%Array* %23, i32 -1)
   %74 = sub i64 %58, 1
   br label %header__8
 

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestArrayUpdate4.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestArrayUpdate4.ll
@@ -2,79 +2,81 @@ define %Array* @Microsoft__Quantum__Testing__QIR__TestArrayUpdate4__body(%Array*
 entry:
   call void @__quantum__rt__array_update_alias_count(%Array* %array, i32 1)
   %item = call %String* @__quantum__rt__string_create(i8* getelementptr inbounds ([6 x i8], [6 x i8]* @3, i32 0, i32 0))
-  %0 = call %Array* @__quantum__rt__array_create_1d(i32 8, i64 0)
+  %0 = call %String* @__quantum__rt__string_create(i8* null)
+  %1 = call %Array* @__quantum__rt__array_create_1d(i32 8, i64 0)
   %arr = alloca %Array*, align 8
-  store %Array* %0, %Array** %arr, align 8
-  call void @__quantum__rt__array_update_alias_count(%Array* %0, i32 1)
-  call void @__quantum__rt__array_update_reference_count(%Array* %0, i32 1)
-  %1 = call i64 @__quantum__rt__array_get_size_1d(%Array* %array)
-  %2 = sub i64 %1, 1
+  store %Array* %1, %Array** %arr, align 8
+  call void @__quantum__rt__array_update_alias_count(%Array* %1, i32 1)
+  call void @__quantum__rt__array_update_reference_count(%Array* %1, i32 1)
+  %2 = call i64 @__quantum__rt__array_get_size_1d(%Array* %array)
+  %3 = sub i64 %2, 1
   br label %header__1
 
 header__1:                                        ; preds = %exiting__1, %entry
-  %3 = phi i64 [ 0, %entry ], [ %8, %exiting__1 ]
-  %4 = icmp sle i64 %3, %2
-  br i1 %4, label %body__1, label %exit__1
+  %4 = phi i64 [ 0, %entry ], [ %9, %exiting__1 ]
+  %5 = icmp sle i64 %4, %3
+  br i1 %5, label %body__1, label %exit__1
 
 body__1:                                          ; preds = %header__1
-  %5 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %array, i64 %3)
-  %6 = bitcast i8* %5 to %String**
-  %7 = load %String*, %String** %6, align 8
-  call void @__quantum__rt__string_update_reference_count(%String* %7, i32 1)
+  %6 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %array, i64 %4)
+  %7 = bitcast i8* %6 to %String**
+  %8 = load %String*, %String** %7, align 8
+  call void @__quantum__rt__string_update_reference_count(%String* %8, i32 1)
   br label %exiting__1
 
 exiting__1:                                       ; preds = %body__1
-  %8 = add i64 %3, 1
+  %9 = add i64 %4, 1
   br label %header__1
 
 exit__1:                                          ; preds = %header__1
   call void @__quantum__rt__array_update_reference_count(%Array* %array, i32 1)
   call void @__quantum__rt__array_update_alias_count(%Array* %array, i32 1)
-  call void @__quantum__rt__array_update_alias_count(%Array* %0, i32 -1)
+  call void @__quantum__rt__array_update_alias_count(%Array* %1, i32 -1)
   store %Array* %array, %Array** %arr, align 8
   br label %header__2
 
 header__2:                                        ; preds = %exiting__2, %exit__1
-  %i = phi i64 [ 0, %exit__1 ], [ %16, %exiting__2 ]
-  %9 = icmp sle i64 %i, 9
-  br i1 %9, label %body__2, label %exit__2
+  %i = phi i64 [ 0, %exit__1 ], [ %17, %exiting__2 ]
+  %10 = icmp sle i64 %i, 9
+  br i1 %10, label %body__2, label %exit__2
 
 body__2:                                          ; preds = %header__2
-  %10 = load %Array*, %Array** %arr, align 8
-  call void @__quantum__rt__array_update_alias_count(%Array* %10, i32 -1)
-  %11 = call %Array* @__quantum__rt__array_copy(%Array* %10, i1 false)
-  %12 = icmp ne %Array* %10, %11
-  %13 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %11, i64 %i)
-  %14 = bitcast i8* %13 to %String**
+  %11 = load %Array*, %Array** %arr, align 8
+  call void @__quantum__rt__array_update_alias_count(%Array* %11, i32 -1)
+  %12 = call %Array* @__quantum__rt__array_copy(%Array* %11, i1 false)
+  %13 = icmp ne %Array* %11, %12
+  %14 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %12, i64 %i)
+  %15 = bitcast i8* %14 to %String**
   call void @__quantum__rt__string_update_reference_count(%String* %item, i32 1)
-  %15 = load %String*, %String** %14, align 8
-  br i1 %12, label %condContinue__1, label %condFalse__1
+  %16 = load %String*, %String** %15, align 8
+  br i1 %13, label %condContinue__1, label %condFalse__1
 
 condFalse__1:                                     ; preds = %body__2
   call void @__quantum__rt__string_update_reference_count(%String* %item, i32 1)
-  call void @__quantum__rt__string_update_reference_count(%String* %15, i32 -1)
+  call void @__quantum__rt__string_update_reference_count(%String* %16, i32 -1)
   br label %condContinue__1
 
 condContinue__1:                                  ; preds = %condFalse__1, %body__2
-  store %String* %item, %String** %14, align 8
-  call void @__quantum__rt__array_update_reference_count(%Array* %11, i32 1)
-  call void @__quantum__rt__array_update_alias_count(%Array* %11, i32 1)
-  store %Array* %11, %Array** %arr, align 8
-  call void @__quantum__rt__array_update_reference_count(%Array* %10, i32 -1)
-  call void @__quantum__rt__string_update_reference_count(%String* %15, i32 -1)
+  store %String* %item, %String** %15, align 8
+  call void @__quantum__rt__array_update_reference_count(%Array* %12, i32 1)
+  call void @__quantum__rt__array_update_alias_count(%Array* %12, i32 1)
+  store %Array* %12, %Array** %arr, align 8
   call void @__quantum__rt__array_update_reference_count(%Array* %11, i32 -1)
+  call void @__quantum__rt__string_update_reference_count(%String* %16, i32 -1)
+  call void @__quantum__rt__array_update_reference_count(%Array* %12, i32 -1)
   br label %exiting__2
 
 exiting__2:                                       ; preds = %condContinue__1
-  %16 = add i64 %i, 1
+  %17 = add i64 %i, 1
   br label %header__2
 
 exit__2:                                          ; preds = %header__2
-  %17 = load %Array*, %Array** %arr, align 8
+  %18 = load %Array*, %Array** %arr, align 8
   call void @__quantum__rt__array_update_alias_count(%Array* %array, i32 -1)
-  call void @__quantum__rt__array_update_alias_count(%Array* %17, i32 -1)
+  call void @__quantum__rt__array_update_alias_count(%Array* %18, i32 -1)
   call void @__quantum__rt__string_update_reference_count(%String* %item, i32 -1)
-  call void @__quantum__rt__array_update_reference_count(%Array* %0, i32 -1)
-  call void @__quantum__rt__array_update_reference_count(%Array* %0, i32 -1)
-  ret %Array* %17
+  call void @__quantum__rt__string_update_reference_count(%String* %0, i32 -1)
+  call void @__quantum__rt__array_update_reference_count(%Array* %1, i32 -1)
+  call void @__quantum__rt__array_update_reference_count(%Array* %1, i32 -1)
+  ret %Array* %18
 }

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestExpressions.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestExpressions.ll
@@ -48,114 +48,137 @@ entry:
   %45 = call i1 @Microsoft__Quantum__Testing__QIR__ReturnNot__body()
   %46 = call i64 @Microsoft__Quantum__Testing__QIR__ReturnBNot__body()
   %47 = call double @Microsoft__Quantum__Testing__QIR__ReturnNegative__body(double 3.000000e+00)
-  %48 = getelementptr inbounds { { i2, i64 }*, double }, { { i2, i64 }*, double }* %5, i32 0, i32 0
-  %49 = load { i2, i64 }*, { i2, i64 }** %48, align 8
-  %50 = getelementptr inbounds { i64, { %Callable*, %String* }* }, { i64, { %Callable*, %String* }* }* %8, i32 0, i32 1
-  %51 = load { %Callable*, %String* }*, { %Callable*, %String* }** %50, align 8
-  %52 = getelementptr inbounds { %Callable*, %String* }, { %Callable*, %String* }* %51, i32 0, i32 0
-  %53 = load %Callable*, %Callable** %52, align 8
-  %54 = getelementptr inbounds { %Callable*, %String* }, { %Callable*, %String* }* %51, i32 0, i32 1
-  %55 = load %String*, %String** %54, align 8
-  %56 = getelementptr inbounds { { i2, i64 }*, double }, { { i2, i64 }*, double }* %16, i32 0, i32 0
-  %57 = load { i2, i64 }*, { i2, i64 }** %56, align 8
+  %48 = call %Array* @Microsoft__Quantum__Testing__QIR__ReturnSizedArray__body()
+  %49 = getelementptr inbounds { { i2, i64 }*, double }, { { i2, i64 }*, double }* %5, i32 0, i32 0
+  %50 = load { i2, i64 }*, { i2, i64 }** %49, align 8
+  %51 = getelementptr inbounds { i64, { %Callable*, %String* }* }, { i64, { %Callable*, %String* }* }* %8, i32 0, i32 1
+  %52 = load { %Callable*, %String* }*, { %Callable*, %String* }** %51, align 8
+  %53 = getelementptr inbounds { %Callable*, %String* }, { %Callable*, %String* }* %52, i32 0, i32 0
+  %54 = load %Callable*, %Callable** %53, align 8
+  %55 = getelementptr inbounds { %Callable*, %String* }, { %Callable*, %String* }* %52, i32 0, i32 1
+  %56 = load %String*, %String** %55, align 8
+  %57 = getelementptr inbounds { { i2, i64 }*, double }, { { i2, i64 }*, double }* %16, i32 0, i32 0
+  %58 = load { i2, i64 }*, { i2, i64 }** %57, align 8
   call void @__quantum__rt__capture_update_reference_count(%Callable* %0, i32 -1)
   call void @__quantum__rt__callable_update_reference_count(%Callable* %0, i32 -1)
   call void @__quantum__rt__capture_update_reference_count(%Callable* %1, i32 -1)
   call void @__quantum__rt__callable_update_reference_count(%Callable* %1, i32 -1)
   call void @__quantum__rt__capture_update_reference_count(%Callable* %4, i32 -1)
   call void @__quantum__rt__callable_update_reference_count(%Callable* %4, i32 -1)
-  %58 = bitcast { i2, i64 }* %49 to %Tuple*
-  call void @__quantum__rt__tuple_update_reference_count(%Tuple* %58, i32 -1)
-  %59 = bitcast { { i2, i64 }*, double }* %5 to %Tuple*
+  %59 = bitcast { i2, i64 }* %50 to %Tuple*
   call void @__quantum__rt__tuple_update_reference_count(%Tuple* %59, i32 -1)
+  %60 = bitcast { { i2, i64 }*, double }* %5 to %Tuple*
+  call void @__quantum__rt__tuple_update_reference_count(%Tuple* %60, i32 -1)
   call void @__quantum__rt__capture_update_reference_count(%Callable* %6, i32 -1)
   call void @__quantum__rt__callable_update_reference_count(%Callable* %6, i32 -1)
   call void @__quantum__rt__capture_update_reference_count(%Callable* %7, i32 -1)
   call void @__quantum__rt__callable_update_reference_count(%Callable* %7, i32 -1)
-  call void @__quantum__rt__capture_update_reference_count(%Callable* %53, i32 -1)
-  call void @__quantum__rt__callable_update_reference_count(%Callable* %53, i32 -1)
-  call void @__quantum__rt__string_update_reference_count(%String* %55, i32 -1)
-  %60 = bitcast { %Callable*, %String* }* %51 to %Tuple*
-  call void @__quantum__rt__tuple_update_reference_count(%Tuple* %60, i32 -1)
-  %61 = bitcast { i64, { %Callable*, %String* }* }* %8 to %Tuple*
+  call void @__quantum__rt__capture_update_reference_count(%Callable* %54, i32 -1)
+  call void @__quantum__rt__callable_update_reference_count(%Callable* %54, i32 -1)
+  call void @__quantum__rt__string_update_reference_count(%String* %56, i32 -1)
+  %61 = bitcast { %Callable*, %String* }* %52 to %Tuple*
   call void @__quantum__rt__tuple_update_reference_count(%Tuple* %61, i32 -1)
+  %62 = bitcast { i64, { %Callable*, %String* }* }* %8 to %Tuple*
+  call void @__quantum__rt__tuple_update_reference_count(%Tuple* %62, i32 -1)
   call void @__quantum__rt__string_update_reference_count(%String* %9, i32 -1)
-  %62 = call i64 @__quantum__rt__array_get_size_1d(%Array* %11)
-  %63 = sub i64 %62, 1
+  %63 = call i64 @__quantum__rt__array_get_size_1d(%Array* %11)
+  %64 = sub i64 %63, 1
   br label %header__1
 
 header__1:                                        ; preds = %exiting__1, %entry
-  %64 = phi i64 [ 0, %entry ], [ %69, %exiting__1 ]
-  %65 = icmp sle i64 %64, %63
-  br i1 %65, label %body__1, label %exit__1
+  %65 = phi i64 [ 0, %entry ], [ %70, %exiting__1 ]
+  %66 = icmp sle i64 %65, %64
+  br i1 %66, label %body__1, label %exit__1
 
 body__1:                                          ; preds = %header__1
-  %66 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %11, i64 %64)
-  %67 = bitcast i8* %66 to %String**
-  %68 = load %String*, %String** %67, align 8
-  call void @__quantum__rt__string_update_reference_count(%String* %68, i32 -1)
+  %67 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %11, i64 %65)
+  %68 = bitcast i8* %67 to %String**
+  %69 = load %String*, %String** %68, align 8
+  call void @__quantum__rt__string_update_reference_count(%String* %69, i32 -1)
   br label %exiting__1
 
 exiting__1:                                       ; preds = %body__1
-  %69 = add i64 %64, 1
+  %70 = add i64 %65, 1
   br label %header__1
 
 exit__1:                                          ; preds = %header__1
   call void @__quantum__rt__array_update_reference_count(%Array* %11, i32 -1)
-  %70 = call i64 @__quantum__rt__array_get_size_1d(%Array* %12)
-  %71 = sub i64 %70, 1
+  %71 = call i64 @__quantum__rt__array_get_size_1d(%Array* %12)
+  %72 = sub i64 %71, 1
   br label %header__2
 
 header__2:                                        ; preds = %exiting__2, %exit__1
-  %72 = phi i64 [ 0, %exit__1 ], [ %77, %exiting__2 ]
-  %73 = icmp sle i64 %72, %71
-  br i1 %73, label %body__2, label %exit__2
+  %73 = phi i64 [ 0, %exit__1 ], [ %78, %exiting__2 ]
+  %74 = icmp sle i64 %73, %72
+  br i1 %74, label %body__2, label %exit__2
 
 body__2:                                          ; preds = %header__2
-  %74 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %12, i64 %72)
-  %75 = bitcast i8* %74 to %Result**
-  %76 = load %Result*, %Result** %75, align 8
-  call void @__quantum__rt__result_update_reference_count(%Result* %76, i32 -1)
+  %75 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %12, i64 %73)
+  %76 = bitcast i8* %75 to %Result**
+  %77 = load %Result*, %Result** %76, align 8
+  call void @__quantum__rt__result_update_reference_count(%Result* %77, i32 -1)
   br label %exiting__2
 
 exiting__2:                                       ; preds = %body__2
-  %77 = add i64 %72, 1
+  %78 = add i64 %73, 1
   br label %header__2
 
 exit__2:                                          ; preds = %header__2
   call void @__quantum__rt__array_update_reference_count(%Array* %12, i32 -1)
   call void @__quantum__rt__string_update_reference_count(%String* %13, i32 -1)
-  %78 = call i64 @__quantum__rt__array_get_size_1d(%Array* %15)
-  %79 = sub i64 %78, 1
+  %79 = call i64 @__quantum__rt__array_get_size_1d(%Array* %15)
+  %80 = sub i64 %79, 1
   br label %header__3
 
 header__3:                                        ; preds = %exiting__3, %exit__2
-  %80 = phi i64 [ 0, %exit__2 ], [ %85, %exiting__3 ]
-  %81 = icmp sle i64 %80, %79
-  br i1 %81, label %body__3, label %exit__3
+  %81 = phi i64 [ 0, %exit__2 ], [ %86, %exiting__3 ]
+  %82 = icmp sle i64 %81, %80
+  br i1 %82, label %body__3, label %exit__3
 
 body__3:                                          ; preds = %header__3
-  %82 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %15, i64 %80)
-  %83 = bitcast i8* %82 to %Result**
-  %84 = load %Result*, %Result** %83, align 8
-  call void @__quantum__rt__result_update_reference_count(%Result* %84, i32 -1)
+  %83 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %15, i64 %81)
+  %84 = bitcast i8* %83 to %Result**
+  %85 = load %Result*, %Result** %84, align 8
+  call void @__quantum__rt__result_update_reference_count(%Result* %85, i32 -1)
   br label %exiting__3
 
 exiting__3:                                       ; preds = %body__3
-  %85 = add i64 %80, 1
+  %86 = add i64 %81, 1
   br label %header__3
 
 exit__3:                                          ; preds = %header__3
   call void @__quantum__rt__array_update_reference_count(%Array* %15, i32 -1)
-  %86 = bitcast { i2, i64 }* %57 to %Tuple*
-  call void @__quantum__rt__tuple_update_reference_count(%Tuple* %86, i32 -1)
-  %87 = bitcast { { i2, i64 }*, double }* %16 to %Tuple*
+  %87 = bitcast { i2, i64 }* %58 to %Tuple*
   call void @__quantum__rt__tuple_update_reference_count(%Tuple* %87, i32 -1)
+  %88 = bitcast { { i2, i64 }*, double }* %16 to %Tuple*
+  call void @__quantum__rt__tuple_update_reference_count(%Tuple* %88, i32 -1)
   call void @__quantum__rt__bigint_update_reference_count(%BigInt* %17, i32 -1)
   call void @__quantum__rt__bigint_update_reference_count(%BigInt* %32, i32 -1)
   call void @__quantum__rt__result_update_reference_count(%Result* %35, i32 -1)
   call void @__quantum__rt__bigint_update_reference_count(%BigInt* %39, i32 -1)
   call void @__quantum__rt__bigint_update_reference_count(%BigInt* %41, i32 -1)
   call void @__quantum__rt__bigint_update_reference_count(%BigInt* %44, i32 -1)
+  %89 = call i64 @__quantum__rt__array_get_size_1d(%Array* %48)
+  %90 = sub i64 %89, 1
+  br label %header__4
+
+header__4:                                        ; preds = %exiting__4, %exit__3
+  %91 = phi i64 [ 0, %exit__3 ], [ %96, %exiting__4 ]
+  %92 = icmp sle i64 %91, %90
+  br i1 %92, label %body__4, label %exit__4
+
+body__4:                                          ; preds = %header__4
+  %93 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %48, i64 %91)
+  %94 = bitcast i8* %93 to %Result**
+  %95 = load %Result*, %Result** %94, align 8
+  call void @__quantum__rt__result_update_reference_count(%Result* %95, i32 -1)
+  br label %exiting__4
+
+exiting__4:                                       ; preds = %body__4
+  %96 = add i64 %91, 1
+  br label %header__4
+
+exit__4:                                          ; preds = %header__4
+  call void @__quantum__rt__array_update_reference_count(%Array* %48, i32 -1)
   ret void
 }

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestExpressions.qs
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestExpressions.qs
@@ -58,6 +58,7 @@ namespace Microsoft.Quantum.Testing.QIR {
         let _ = ReturnNot();
         let _ = ReturnBNot();
         let _ = ReturnNegative(3.);
+        let _ = ReturnSizedArray();
     }
 
     function ReturnGlobalId() : (Unit => Unit) {
@@ -114,6 +115,10 @@ namespace Microsoft.Quantum.Testing.QIR {
 
     function ReturnNewArray() : Result[] {
         return new Result[5];
+    }
+
+    function ReturnSizedArray() : Result[] {
+        return [Zero, size = 5];
     }
 
     function ReturnString() : String {

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestReferenceCounts1.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestReferenceCounts1.ll
@@ -1,27 +1,28 @@
 define void @Microsoft__Quantum__Testing__QIR__TestRefCountsForItemUpdate__body(i1 %cond) {
 entry:
-  %0 = call %Array* @__quantum__rt__array_create_1d(i32 8, i64 5)
+  %0 = call %Array* @__quantum__rt__array_create_1d(i32 8, i64 0)
+  %1 = call %Array* @__quantum__rt__array_create_1d(i32 8, i64 5)
   br label %header__1
 
 header__1:                                        ; preds = %exiting__1, %entry
-  %1 = phi i64 [ 0, %entry ], [ %6, %exiting__1 ]
-  %2 = icmp sle i64 %1, 4
-  br i1 %2, label %body__1, label %exit__1
+  %2 = phi i64 [ 0, %entry ], [ %6, %exiting__1 ]
+  %3 = icmp sle i64 %2, 4
+  br i1 %3, label %body__1, label %exit__1
 
 body__1:                                          ; preds = %header__1
-  %3 = call %Array* @__quantum__rt__array_create_1d(i32 8, i64 0)
-  %4 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %0, i64 %1)
+  %4 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %1, i64 %2)
   %5 = bitcast i8* %4 to %Array**
-  store %Array* %3, %Array** %5, align 8
+  store %Array* %0, %Array** %5, align 8
+  call void @__quantum__rt__array_update_reference_count(%Array* %0, i32 1)
   br label %exiting__1
 
 exiting__1:                                       ; preds = %body__1
-  %6 = add i64 %1, 1
+  %6 = add i64 %2, 1
   br label %header__1
 
 exit__1:                                          ; preds = %header__1
   %ops = alloca %Array*, align 8
-  store %Array* %0, %Array** %ops, align 8
+  store %Array* %1, %Array** %ops, align 8
   br label %header__2
 
 header__2:                                        ; preds = %exiting__2, %exit__1
@@ -30,7 +31,7 @@ header__2:                                        ; preds = %exiting__2, %exit__
   br i1 %8, label %body__2, label %exit__2
 
 body__2:                                          ; preds = %header__2
-  %9 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %0, i64 %7)
+  %9 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %1, i64 %7)
   %10 = bitcast i8* %9 to %Array**
   %11 = load %Array*, %Array** %10, align 8
   call void @__quantum__rt__array_update_alias_count(%Array* %11, i32 1)
@@ -41,7 +42,7 @@ exiting__2:                                       ; preds = %body__2
   br label %header__2
 
 exit__2:                                          ; preds = %header__2
-  call void @__quantum__rt__array_update_alias_count(%Array* %0, i32 1)
+  call void @__quantum__rt__array_update_alias_count(%Array* %1, i32 1)
   br label %header__3
 
 header__3:                                        ; preds = %exiting__3, %exit__2
@@ -50,7 +51,7 @@ header__3:                                        ; preds = %exiting__3, %exit__
   br i1 %14, label %body__3, label %exit__3
 
 body__3:                                          ; preds = %header__3
-  %15 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %0, i64 %13)
+  %15 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %1, i64 %13)
   %16 = bitcast i8* %15 to %Array**
   %17 = load %Array*, %Array** %16, align 8
   call void @__quantum__rt__array_update_reference_count(%Array* %17, i32 1)
@@ -61,13 +62,13 @@ exiting__3:                                       ; preds = %body__3
   br label %header__3
 
 exit__3:                                          ; preds = %header__3
-  call void @__quantum__rt__array_update_reference_count(%Array* %0, i32 1)
+  call void @__quantum__rt__array_update_reference_count(%Array* %1, i32 1)
   br i1 %cond, label %then0__1, label %continue__1
 
 then0__1:                                         ; preds = %exit__3
-  call void @__quantum__rt__array_update_alias_count(%Array* %0, i32 -1)
-  %19 = call %Array* @__quantum__rt__array_copy(%Array* %0, i1 false)
-  %20 = icmp ne %Array* %0, %19
+  call void @__quantum__rt__array_update_alias_count(%Array* %1, i32 -1)
+  %19 = call %Array* @__quantum__rt__array_copy(%Array* %1, i1 false)
+  %20 = icmp ne %Array* %1, %19
   %21 = call %Array* @__quantum__rt__array_create_1d(i32 8, i64 3)
   br label %header__4
 
@@ -111,7 +112,7 @@ condContinue__1:                                  ; preds = %condFalse__1, %exit
   call void @__quantum__rt__array_update_reference_count(%Array* %19, i32 1)
   call void @__quantum__rt__array_update_alias_count(%Array* %19, i32 1)
   store %Array* %19, %Array** %ops, align 8
-  call void @__quantum__rt__array_update_reference_count(%Array* %0, i32 -1)
+  call void @__quantum__rt__array_update_reference_count(%Array* %1, i32 -1)
   call void @__quantum__rt__array_update_reference_count(%Array* %21, i32 -1)
   call void @__quantum__rt__array_update_reference_count(%Array* %32, i32 -1)
   call void @__quantum__rt__array_update_reference_count(%Array* %19, i32 -1)
@@ -135,6 +136,7 @@ exiting__5:                                       ; preds = %body__5
 
 exit__5:                                          ; preds = %header__5
   call void @__quantum__rt__array_update_alias_count(%Array* %22, i32 -1)
+  call void @__quantum__rt__array_update_reference_count(%Array* %0, i32 -1)
   br label %header__6
 
 header__6:                                        ; preds = %exiting__6, %exit__5
@@ -143,7 +145,7 @@ header__6:                                        ; preds = %exiting__6, %exit__
   br i1 %40, label %body__6, label %exit__6
 
 body__6:                                          ; preds = %header__6
-  %41 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %0, i64 %39)
+  %41 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %1, i64 %39)
   %42 = bitcast i8* %41 to %Array**
   %43 = load %Array*, %Array** %42, align 8
   call void @__quantum__rt__array_update_reference_count(%Array* %43, i32 -1)
@@ -154,7 +156,7 @@ exiting__6:                                       ; preds = %body__6
   br label %header__6
 
 exit__6:                                          ; preds = %header__6
-  call void @__quantum__rt__array_update_reference_count(%Array* %0, i32 -1)
+  call void @__quantum__rt__array_update_reference_count(%Array* %1, i32 -1)
   %45 = sub i64 %23, 1
   br label %header__7
 

--- a/src/QuantumSdk/Sdk/Sdk.props
+++ b/src/QuantumSdk/Sdk/Sdk.props
@@ -23,27 +23,27 @@
   <!-- Q# package references included by default. -->
   <ItemGroup>
     <!-- Packages and libraries included for all execution targets. -->
-    <PackageReference Condition="$(IncludeQSharpCorePackages)" Include="Microsoft.Quantum.QSharp.Core" Version="0.15.2101126940" />
-    <PackageReference Condition="$(IncludeQSharpCorePackages)" Include="Microsoft.Quantum.Standard" Version="0.15.2101126940" />
+    <PackageReference Condition="$(IncludeQSharpCorePackages)" Include="Microsoft.Quantum.QSharp.Core" Version="0.16.210426130-alpha" />
+    <PackageReference Condition="$(IncludeQSharpCorePackages)" Include="Microsoft.Quantum.Standard" Version="0.16.210426130-alpha" />
     <!-- Packages included for specific execution targets. -->
-    <PackageReference Condition="'$(ResolvedProcessorArchitecture)' == 'HoneywellProcessor' And $(IncludeProviderPackages)" Include="Microsoft.Quantum.Providers.Honeywell" Version="0.13.20102604" />
-    <PackageReference Condition="'$(ResolvedProcessorArchitecture)' == 'IonQProcessor' And $(IncludeProviderPackages)" Include="Microsoft.Quantum.Providers.IonQ" Version="0.13.20102604" />
-    <PackageReference Condition="'$(ResolvedProcessorArchitecture)' == 'QCIProcessor' And $(IncludeProviderPackages)" Include="Microsoft.Quantum.Providers.QCI" Version="0.13.20102604" />
+    <PackageReference Condition="'$(ResolvedProcessorArchitecture)' == 'HoneywellProcessor' And $(IncludeProviderPackages)" Include="Microsoft.Quantum.Providers.Honeywell" Version="0.16.210426130-alpha" />
+    <PackageReference Condition="'$(ResolvedProcessorArchitecture)' == 'IonQProcessor' And $(IncludeProviderPackages)" Include="Microsoft.Quantum.Providers.IonQ" Version="0.16.210426130-alpha" />
+    <PackageReference Condition="'$(ResolvedProcessorArchitecture)' == 'QCIProcessor' And $(IncludeProviderPackages)" Include="Microsoft.Quantum.Providers.QCI" Version="0.16.210426130-alpha" />
     <!-- TODO: uncomment once we are ready to use these packages.
-    <PackageReference Condition="'$(ResolvedQuantumIntrinsics)' == 'Type1'" Include="Microsoft.Quantum.Type1.Core" Version="0.11.2006.2118-beta" IsTargetPackage='true' />
-    <PackageReference Condition="'$(ResolvedQuantumIntrinsics)' == 'Type2'" Include="Microsoft.Quantum.Type2.Core" Version="0.11.2006.2118-beta" IsTargetPackage='true' />
-    <PackageReference Condition="'$(ResolvedQuantumIntrinsics)' == 'Type3'" Include="Microsoft.Quantum.Type3.Core" Version="0.11.2006.2118-beta" IsTargetPackage='true' />
+    <PackageReference Condition="'$(ResolvedQuantumIntrinsics)' == 'Type1'" Include="Microsoft.Quantum.Type1.Core" Version="0.16.210426130-alpha" IsTargetPackage='true' />
+    <PackageReference Condition="'$(ResolvedQuantumIntrinsics)' == 'Type2'" Include="Microsoft.Quantum.Type2.Core" Version="0.16.210426130-alpha" IsTargetPackage='true' />
+    <PackageReference Condition="'$(ResolvedQuantumIntrinsics)' == 'Type3'" Include="Microsoft.Quantum.Type3.Core" Version="0.16.210426130-alpha" IsTargetPackage='true' />
     -->  
     </ItemGroup>
 
   <!-- Include the qir generation and docs generation compiler extensions if needed. -->
   <ItemGroup>
     <PackageReference Condition="$(QSharpDocsGeneration)"
-                      Include="Microsoft.Quantum.DocumentationGenerator" Version="0.15.2101126940"
+                      Include="Microsoft.Quantum.DocumentationGenerator" Version="0.16.210426130-alpha"
                       IsImplicitlyDefined="true" 
                       IsQscReference="true" ExecutionTarget="Any" Priority="-1" PrivateAssets="All" />
     <PackageReference Condition="$(QirGeneration)"
-                      Include="Microsoft.Quantum.QirGeneration" Version="0.15.2101126940"
+                      Include="Microsoft.Quantum.QirGeneration" Version="0.16.210426130-alpha"
                       IsImplicitlyDefined="true" 
                       IsQscReference="true" ExecutionTarget="Any" Priority="-1" PrivateAssets="All" />
     <PackageReference Condition="$(QirGeneration) And $([MSBuild]::IsOsPlatform('Windows'))"
@@ -67,13 +67,13 @@
   <!-- Packages for execution on the simulation framework. -->
   <ItemGroup>
     <PackageReference Condition="$(CSharpGeneration) And '$(ResolvedQSharpOutputType)' == 'QSharpExe'" 
-                      Include="Microsoft.Quantum.Simulators" Version="0.15.2101126940" IsImplicitlyDefined="true" />
+                      Include="Microsoft.Quantum.Simulators" Version="0.16.210426130-alpha" IsImplicitlyDefined="true" />
     <PackageReference Condition="$(CSharpGeneration)" 
-                      Include="Microsoft.Quantum.Runtime.Core" Version="0.15.2101126940" IsImplicitlyDefined="true" />
+                      Include="Microsoft.Quantum.Runtime.Core" Version="0.16.210426130-alpha" IsImplicitlyDefined="true" />
     <PackageReference Condition="$(CSharpGeneration) And '$(ResolvedQSharpOutputType)' == 'QSharpExe'"
-                      Include="Microsoft.Quantum.EntryPointDriver" Version="0.15.2101126940" IsImplicitlyDefined="true" />
+                      Include="Microsoft.Quantum.EntryPointDriver" Version="0.16.210426130-alpha" IsImplicitlyDefined="true" />
     <PackageReference Condition="$(CSharpGeneration)"
-                      Include="Microsoft.Quantum.CSharpGeneration" Version="0.15.2101126940" IsImplicitlyDefined="true"
+                      Include="Microsoft.Quantum.CSharpGeneration" Version="0.16.210426130-alpha" IsImplicitlyDefined="true"
                       IsQscReference="true" ExecutionTarget="Any" Priority="-1" PrivateAssets="All" />
   </ItemGroup>
 


### PR DESCRIPTION
Taking care of some little things. The package number in the Sdk is set to the latest alpha package that contains the most recent bug fixes (only relevant for the local build).