### PR TITLE
Always generate function for QIR Interop

### DIFF
--- a/src/QsCompiler/QirGeneration/Interop.cs
+++ b/src/QsCompiler/QirGeneration/Interop.cs
@@ -463,42 +463,34 @@ namespace Microsoft.Quantum.QsCompiler.QIR
                 wrapperReturnType ?? this.sharedState.Context.VoidType,
                 argItems.Select(sym => this.MapToInteropType(sym.Type)!));
 
-            if (wrapperSignature.Equals(implementation.Signature))
-            {
-                this.sharedState.Module.AddAlias(implementation, wrapperName).Linkage = Linkage.External;
-                return implementation;
-            }
-            else
-            {
-                var wrapperFunc = this.sharedState.Module.CreateFunction(wrapperName, wrapperSignature);
-                var argNames = argItems.Select(arg => arg.VariableName is QsLocalSymbol.ValidName name ? name.Item : null).ToArray();
+            var wrapperFunc = this.sharedState.Module.CreateFunction(wrapperName, wrapperSignature);
+            var argNames = argItems.Select(arg => arg.VariableName is QsLocalSymbol.ValidName name ? name.Item : null).ToArray();
 
-                this.sharedState.GenerateFunction(wrapperFunc, argNames, parameters =>
+            this.sharedState.GenerateFunction(wrapperFunc, argNames, parameters =>
+            {
+                var argValueList = this.ProcessArguments(argumentTuple, parameters);
+                var evaluatedValue = this.sharedState.CurrentBuilder.Call(implementation, argValueList);
+                var result = this.sharedState.Values.From(evaluatedValue, returnType);
+                this.sharedState.ScopeMgr.RegisterValue(result);
+
+                if (wrapperSignature.ReturnType.IsVoid)
                 {
-                    var argValueList = this.ProcessArguments(argumentTuple, parameters);
-                    var evaluatedValue = this.sharedState.CurrentBuilder.Call(implementation, argValueList);
-                    var result = this.sharedState.Values.From(evaluatedValue, returnType);
-                    this.sharedState.ScopeMgr.RegisterValue(result);
+                    this.sharedState.AddReturn(this.sharedState.Values.Unit, true);
+                }
+                else if (wrapperSignature.ReturnType.Equals(result.LlvmType))
+                {
+                    this.sharedState.AddReturn(result, false);
+                }
+                else
+                {
+                    // ProcessReturnValue makes sure the memory for the returned value isn't freed
+                    var returnValue = this.ProcessReturnValue(result)!;
+                    this.sharedState.ScopeMgr.ExitFunction(this.sharedState.Values.Unit);
+                    this.sharedState.CurrentBuilder.Return(returnValue);
+                }
+            });
 
-                    if (wrapperSignature.ReturnType.IsVoid)
-                    {
-                        this.sharedState.AddReturn(this.sharedState.Values.Unit, true);
-                    }
-                    else if (wrapperSignature.ReturnType.Equals(result.LlvmType))
-                    {
-                        this.sharedState.AddReturn(result, false);
-                    }
-                    else
-                    {
-                        // ProcessReturnValue makes sure the memory for the returned value isn't freed
-                        var returnValue = this.ProcessReturnValue(result)!;
-                        this.sharedState.ScopeMgr.ExitFunction(this.sharedState.Values.Unit);
-                        this.sharedState.CurrentBuilder.Return(returnValue);
-                    }
-                });
-
-                return wrapperFunc;
-            }
+            return wrapperFunc;
         }
 
         /// <summary>

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestBuiltInIntrinsics1.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestBuiltInIntrinsics1.ll
@@ -1,4 +1,4 @@
-define void @Microsoft__Quantum__Testing__QIR__TestBuiltInIntrinsics__body() #0 {
+define void @Microsoft__Quantum__Testing__QIR__TestBuiltInIntrinsics__body() {
 entry:
   %0 = call { %Callable* }* @Microsoft__Quantum__Testing__QIR__DefaultOptions__body()
   %1 = bitcast { %Callable* }* %0 to %Tuple*

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestFunctors.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestFunctors.ll
@@ -1,4 +1,4 @@
-define i64 @Microsoft__Quantum__Testing__QIR__TestControlled__body() #0 {
+define i64 @Microsoft__Quantum__Testing__QIR__TestControlled__body() {
 entry:
   %0 = call %Tuple* @__quantum__rt__tuple_create(i64 ptrtoint ({ %Callable*, i64 }* getelementptr ({ %Callable*, i64 }, { %Callable*, i64 }* null, i32 1) to i64))
   %1 = bitcast %Tuple* %0 to { %Callable*, i64 }*

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestGenerics1.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestGenerics1.ll
@@ -1,4 +1,4 @@
-define void @Microsoft__Quantum__Testing__QIR__DumpMachineTest__body() #0 {
+define void @Microsoft__Quantum__Testing__QIR__DumpMachineTest__body() {
 entry:
   call void @__quantum__qis__dumpmachine__body(i8* null)
   ret void

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestGenerics3.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestGenerics3.ll
@@ -1,4 +1,4 @@
-define void @Microsoft__Quantum__Testing__QIR__DumpRegisterTest__body() #0 {
+define void @Microsoft__Quantum__Testing__QIR__DumpRegisterTest__body() {
 entry:
   %q2 = call %Array* @__quantum__rt__qubit_allocate_array(i64 2)
   call void @__quantum__rt__array_update_alias_count(%Array* %q2, i32 1)

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestInline.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestInline.ll
@@ -1,4 +1,4 @@
-define { double, double }* @Microsoft__Quantum__Testing__QIR__TestInline__body() #0 {
+define { double, double }* @Microsoft__Quantum__Testing__QIR__TestInline__body() {
 entry:
   %x = alloca double, align 8
   store double 0.000000e+00, double* %x, align 8

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestOpCall1.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestOpCall1.ll
@@ -1,4 +1,4 @@
-define void @Microsoft__Quantum__Testing__QIR__TestOperationCalls__body() #0 {
+define void @Microsoft__Quantum__Testing__QIR__TestOperationCalls__body() {
 entry:
   %doNothing = call %Callable* @Microsoft__Quantum__Testing__QIR__ReturnDoNothing__body(i64 1)
   call void @__quantum__rt__capture_update_alias_count(%Callable* %doNothing, i32 1)

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestUsing1.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestUsing1.ll
@@ -1,4 +1,4 @@
-define void @Microsoft__Quantum__Testing__QIR__TestUsing__body() #0 {
+define void @Microsoft__Quantum__Testing__QIR__TestUsing__body() {
 entry:
   %q = call %Qubit* @__quantum__rt__qubit_allocate()
   call void @Microsoft__Quantum__Testing__QIR__ArbitraryAllocation__body(i64 3, %Qubit* %q)


### PR DESCRIPTION
Because aliases are a little hard to work with during JIT, we should always generate a full function for entry point interop, even when the signature matches exactly. This will also help differentiate when we use different linkages between functions for specializations and interop.