### PR TITLE
Only allow QIR Generation on Exe projects

### DIFF
--- a/src/QuantumSdk/DefaultItems/DefaultItems.targets
+++ b/src/QuantumSdk/DefaultItems/DefaultItems.targets
@@ -59,9 +59,9 @@
   <PropertyGroup>
     <DefaultEntryPointGeneration>dotnet "$(MSBuildThisFileDirectory)../tools/utils/Microsoft.Quantum.Sdk.DefaultEntryPoint.Generation.dll"</DefaultEntryPointGeneration>
     <!-- true/false optional properties -->
-    <Warning Condition="'$(QirGeneration)' == 'true' And '$(ResolvedQSharpOutputType)' == 'QSharpLibrary'" Text="QIR Generation 'true' is not supported on library projects, returning to default behavior." />
+    <Warning Condition="'$(QirGeneration)' == 'true' And '$(ResolvedQSharpOutputType)' != 'QSharpExe'" Text="QIR Generation 'true' is not supported on library projects, returning to default behavior." />
     <QirGeneration Condition="'$(QirOutputPath)' != '' And '$(QirGeneration)' == 'default' And '$(ResolvedQSharpOutputType)' == 'QSharpExe'">true</QirGeneration>
-    <QirGeneration Condition="('$(QirOutputPath)' == '' And '$(QirGeneration)' == 'default') Or '$(ResolvedQSharpOutputType)' == 'QSharpLibrary'">false</QirGeneration>
+    <QirGeneration Condition="('$(QirOutputPath)' == '' And '$(QirGeneration)' == 'default') Or '$(ResolvedQSharpOutputType)' != 'QSharpExe'">false</QirGeneration>
     <PerfDataGeneration Condition="'$(PerfDataOutputPath)' != '' And '$(PerfDataGeneration)' == 'default'">true</PerfDataGeneration>
     <PerfDataGeneration Condition="'$(PerfDataOutputPath)' == '' And '$(PerfDataGeneration)' == 'default'">false</PerfDataGeneration>
     <QSharpDocsGeneration Condition="'$(QSharpDocsOutputPath)' != '' And '$(QSharpDocsGeneration)' == 'default'">true</QSharpDocsGeneration>

--- a/src/QuantumSdk/DefaultItems/DefaultItems.targets
+++ b/src/QuantumSdk/DefaultItems/DefaultItems.targets
@@ -59,7 +59,6 @@
   <PropertyGroup>
     <DefaultEntryPointGeneration>dotnet "$(MSBuildThisFileDirectory)../tools/utils/Microsoft.Quantum.Sdk.DefaultEntryPoint.Generation.dll"</DefaultEntryPointGeneration>
     <!-- true/false optional properties -->
-    <Warning Condition="'$(QirGeneration)' == 'true' And '$(ResolvedQSharpOutputType)' != 'QSharpExe'" Text="QIR Generation 'true' is not supported on library projects, returning to default behavior." />
     <QirGeneration Condition="'$(QirOutputPath)' != '' And '$(QirGeneration)' == 'default' And '$(ResolvedQSharpOutputType)' == 'QSharpExe'">true</QirGeneration>
     <QirGeneration Condition="('$(QirOutputPath)' == '' And '$(QirGeneration)' == 'default') Or '$(ResolvedQSharpOutputType)' != 'QSharpExe'">false</QirGeneration>
     <PerfDataGeneration Condition="'$(PerfDataOutputPath)' != '' And '$(PerfDataGeneration)' == 'default'">true</PerfDataGeneration>

--- a/src/QuantumSdk/DefaultItems/DefaultItems.targets
+++ b/src/QuantumSdk/DefaultItems/DefaultItems.targets
@@ -59,8 +59,9 @@
   <PropertyGroup>
     <DefaultEntryPointGeneration>dotnet "$(MSBuildThisFileDirectory)../tools/utils/Microsoft.Quantum.Sdk.DefaultEntryPoint.Generation.dll"</DefaultEntryPointGeneration>
     <!-- true/false optional properties -->
-    <QirGeneration Condition="'$(QirOutputPath)' != '' And '$(QirGeneration)' == 'default'">true</QirGeneration>
-    <QirGeneration Condition="'$(QirOutputPath)' == '' And '$(QirGeneration)' == 'default'">false</QirGeneration>
+    <Warning Condition="'$(QirGeneration)' == 'true' And '$(ResolvedQSharpOutputType)' == 'QSharpLibrary'" Text="QIR Generation 'true' is not supported on library projects, returning to default behavior." />
+    <QirGeneration Condition="'$(QirOutputPath)' != '' And '$(QirGeneration)' == 'default' And '$(ResolvedQSharpOutputType)' == 'QSharpExe'">true</QirGeneration>
+    <QirGeneration Condition="('$(QirOutputPath)' == '' And '$(QirGeneration)' == 'default') Or '$(ResolvedQSharpOutputType)' == 'QSharpLibrary'">false</QirGeneration>
     <PerfDataGeneration Condition="'$(PerfDataOutputPath)' != '' And '$(PerfDataGeneration)' == 'default'">true</PerfDataGeneration>
     <PerfDataGeneration Condition="'$(PerfDataOutputPath)' == '' And '$(PerfDataGeneration)' == 'default'">false</PerfDataGeneration>
     <QSharpDocsGeneration Condition="'$(QSharpDocsOutputPath)' != '' And '$(QSharpDocsGeneration)' == 'default'">true</QSharpDocsGeneration>


### PR DESCRIPTION
This change suppresses QIR Generation for library projects. This is needed to unblok the pipeline now that we are testing QIR Generation for samples.