### PR TITLE
Mark all non-entrypoint functions in QIR as internal

### DIFF
--- a/src/QsCompiler/QirGeneration/QIR/Constants.cs
+++ b/src/QsCompiler/QirGeneration/QIR/Constants.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Quantum.QIR
         internal Constants(Context context, BitcodeModule module, Types types)
         {
             Value CreatePauli(string name, ulong idx) =>
-                module.AddGlobal(types.Pauli, true, Linkage.External, context.CreateConstant(types.Pauli, idx, false), name);
+                module.AddGlobal(types.Pauli, true, Linkage.Internal, context.CreateConstant(types.Pauli, idx, false), name);
 
             this.UnitValue = types.Tuple.GetNullValue();
             this.PauliI = CreatePauli("PauliI", 0);

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestAliasCounts.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestAliasCounts.ll
@@ -1,4 +1,4 @@
-define void @Microsoft__Quantum__Testing__QIR__TestAliasCounts__ctl(%Array* %__controlQubits__, { %Array*, { %Array* }* }* %0) {
+define internal void @Microsoft__Quantum__Testing__QIR__TestAliasCounts__ctl(%Array* %__controlQubits__, { %Array*, { %Array* }* }* %0) {
 entry:
   call void @__quantum__rt__array_update_alias_count(%Array* %__controlQubits__, i32 1)
   %1 = getelementptr inbounds { %Array*, { %Array* }* }, { %Array*, { %Array* }* }* %0, i32 0, i32 0

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestArrayLoop.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestArrayLoop.ll
@@ -1,4 +1,4 @@
-define { i64, i64 }* @Microsoft__Quantum__Testing__QIR__TestArrayLoop__body(%Array* %a) {
+define internal { i64, i64 }* @Microsoft__Quantum__Testing__QIR__TestArrayLoop__body(%Array* %a) {
 entry:
   %0 = call i64 @__quantum__rt__array_get_size_1d(%Array* %a)
   %1 = sub i64 %0, 1

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestArrayUpdate1.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestArrayUpdate1.ll
@@ -1,4 +1,4 @@
-define %Array* @Microsoft__Quantum__Testing__QIR__TestArrayUpdate1__body(%String* %even) {
+define internal %Array* @Microsoft__Quantum__Testing__QIR__TestArrayUpdate1__body(%String* %even) {
 entry:
   %0 = call %String* @__quantum__rt__string_create(i8* null)
   %1 = call %Array* @__quantum__rt__array_create_1d(i32 8, i64 10)

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestArrayUpdate2.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestArrayUpdate2.ll
@@ -1,4 +1,4 @@
-define %Array* @Microsoft__Quantum__Testing__QIR__TestArrayUpdate2__body(%Array* %array, %String* %even) {
+define internal %Array* @Microsoft__Quantum__Testing__QIR__TestArrayUpdate2__body(%Array* %array, %String* %even) {
 entry:
   call void @__quantum__rt__array_update_alias_count(%Array* %array, i32 1)
   %arr = alloca %Array*, align 8

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestArrayUpdate3.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestArrayUpdate3.ll
@@ -1,4 +1,4 @@
-define %Array* @Microsoft__Quantum__Testing__QIR__TestArrayUpdate3__body(%Array* %y, %String* %b) {
+define internal %Array* @Microsoft__Quantum__Testing__QIR__TestArrayUpdate3__body(%Array* %y, %String* %b) {
 entry:
   call void @__quantum__rt__array_update_alias_count(%Array* %y, i32 1)
   %x = alloca %Array*, align 8

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestArrayUpdate4.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestArrayUpdate4.ll
@@ -1,4 +1,4 @@
-define %Array* @Microsoft__Quantum__Testing__QIR__TestArrayUpdate4__body(%Array* %array) {
+define internal %Array* @Microsoft__Quantum__Testing__QIR__TestArrayUpdate4__body(%Array* %array) {
 entry:
   call void @__quantum__rt__array_update_alias_count(%Array* %array, i32 1)
   %item = call %String* @__quantum__rt__string_create(i8* getelementptr inbounds ([6 x i8], [6 x i8]* @3, i32 0, i32 0))

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestArrayUpdate5.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestArrayUpdate5.ll
@@ -1,4 +1,4 @@
-define %Array* @Microsoft__Quantum__Testing__QIR__TestArrayUpdate5__body(i1 %cond, %Array* %array) {
+define internal %Array* @Microsoft__Quantum__Testing__QIR__TestArrayUpdate5__body(i1 %cond, %Array* %array) {
 entry:
   %0 = call i64 @__quantum__rt__array_get_size_1d(%Array* %array)
   %1 = sub i64 %0, 1

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestBigInts.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestBigInts.ll
@@ -1,4 +1,4 @@
-define %BigInt* @Microsoft__Quantum__Testing__QIR__TestBigInts__body(%BigInt* %a, %BigInt* %b) {
+define internal %BigInt* @Microsoft__Quantum__Testing__QIR__TestBigInts__body(%BigInt* %a, %BigInt* %b) {
 entry:
   %0 = call i1 @__quantum__rt__bigint_greater(%BigInt* %a, %BigInt* %b)
   %c = select i1 %0, %BigInt* %a, %BigInt* %b

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestBools.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestBools.ll
@@ -1,4 +1,4 @@
-define i1 @Microsoft__Quantum__Testing__QIR__TestBools__body(i1 %a, i1 %b) {
+define internal i1 @Microsoft__Quantum__Testing__QIR__TestBools__body(i1 %a, i1 %b) {
 entry:
   %0 = icmp eq i1 %a, %b
   %c = select i1 %0, i1 %a, i1 %b

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestBuiltIn.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestBuiltIn.ll
@@ -1,4 +1,4 @@
-define { double, i64, %BigInt*, i64 }* @Microsoft__Quantum__Testing__QIR__TestBuiltIn__body(i64 %arg) {
+define internal { double, i64, %BigInt*, i64 }* @Microsoft__Quantum__Testing__QIR__TestBuiltIn__body(i64 %arg) {
 entry:
   %d = sitofp i64 %arg to double
   %i = fptosi double %d to i64

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestBuiltInIntrinsics1.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestBuiltInIntrinsics1.ll
@@ -1,4 +1,4 @@
-define void @Microsoft__Quantum__Testing__QIR__TestBuiltInIntrinsics__body() {
+define internal void @Microsoft__Quantum__Testing__QIR__TestBuiltInIntrinsics__body() {
 entry:
   %0 = call { %Callable* }* @Microsoft__Quantum__Testing__QIR__DefaultOptions__body()
   %1 = bitcast { %Callable* }* %0 to %Tuple*

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestBuiltInIntrinsics2.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestBuiltInIntrinsics2.ll
@@ -1,4 +1,4 @@
-define void @Microsoft__Quantum__Intrinsic_____GUID___Message__body__wrapper(%Tuple* %capture-tuple, %Tuple* %arg-tuple, %Tuple* %result-tuple) {
+define internal void @Microsoft__Quantum__Intrinsic_____GUID___Message__body__wrapper(%Tuple* %capture-tuple, %Tuple* %arg-tuple, %Tuple* %result-tuple) {
 entry:
   %0 = bitcast %Tuple* %arg-tuple to { %String* }*
   %1 = getelementptr inbounds { %String* }, { %String* }* %0, i32 0, i32 0

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestCaching1.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestCaching1.ll
@@ -1,4 +1,4 @@
-define i64 @Microsoft__Quantum__Testing__QIR__TestCaching__body(%Array* %arr) {
+define internal i64 @Microsoft__Quantum__Testing__QIR__TestCaching__body(%Array* %arr) {
 entry:
   call void @__quantum__rt__array_update_alias_count(%Array* %arr, i32 1)
   %q = call %Qubit* @__quantum__rt__qubit_allocate()

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestCaching2.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestCaching2.ll
@@ -1,4 +1,4 @@
-define %Array* @Microsoft__Quantum__Testing__QIR__LengthCaching__body(%Array* %vals) {
+define internal %Array* @Microsoft__Quantum__Testing__QIR__LengthCaching__body(%Array* %vals) {
 entry:
   call void @__quantum__rt__array_update_alias_count(%Array* %vals, i32 1)
   br i1 false, label %condTrue__1, label %condFalse__1

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestCaching3.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestCaching3.ll
@@ -1,4 +1,4 @@
-define { double, double }* @Microsoft__Quantum__Testing__QIR__Conditional__body(%Result* %res, { double, double }* %0) {
+define internal { double, double }* @Microsoft__Quantum__Testing__QIR__Conditional__body(%Result* %res, { double, double }* %0) {
 entry:
   %1 = getelementptr inbounds { double, double }, { double, double }* %0, i32 0, i32 0
   %x = load double, double* %1, align 8

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestConditional1.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestConditional1.ll
@@ -1,4 +1,4 @@
-﻿define i64 @Microsoft__Quantum__Testing__QIR__ReturnInt__body({ %Array* }* %arg) {
+﻿define internal i64 @Microsoft__Quantum__Testing__QIR__ReturnInt__body({ %Array* }* %arg) {
 entry:
   %0 = getelementptr inbounds { %Array* }, { %Array* }* %arg, i32 0, i32 0
   %arg__1 = load %Array*, %Array** %0, align 8

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestConditional2.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestConditional2.ll
@@ -1,4 +1,4 @@
-﻿define %Array* @Microsoft__Quantum__Testing__QIR__Hello__body(i1 %withPunctuation) {
+﻿define internal %Array* @Microsoft__Quantum__Testing__QIR__Hello__body(i1 %withPunctuation) {
 entry:
   %arr = call %Array* @__quantum__rt__array_create_1d(i32 8, i64 3)
   %0 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %arr, i64 0)

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestConditional3.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestConditional3.ll
@@ -1,4 +1,4 @@
-define i64 @Microsoft__Quantum__Testing__QIR__ReturnFromNested__body(i1 %branch1, i1 %branch2) {
+define internal i64 @Microsoft__Quantum__Testing__QIR__ReturnFromNested__body(i1 %branch1, i1 %branch2) {
 entry:
   br i1 %branch1, label %then0__1, label %else__1
 

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestControlled1.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestControlled1.ll
@@ -1,4 +1,4 @@
-﻿define void @Lifted__PartialApplication__1__ctl__wrapper(%Tuple* %capture-tuple, %Tuple* %arg-tuple, %Tuple* %result-tuple) {
+﻿define internal void @Lifted__PartialApplication__1__ctl__wrapper(%Tuple* %capture-tuple, %Tuple* %arg-tuple, %Tuple* %result-tuple) {
 entry:
   %0 = bitcast %Tuple* %arg-tuple to { %Array*, %Qubit* }*
   %1 = getelementptr inbounds { %Array*, %Qubit* }, { %Array*, %Qubit* }* %0, i32 0, i32 0

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestControlled2.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestControlled2.ll
@@ -1,4 +1,4 @@
-﻿define void @Microsoft__Quantum__Intrinsic__K__ctl__wrapper(%Tuple* %capture-tuple, %Tuple* %arg-tuple, %Tuple* %result-tuple) {
+﻿define internal void @Microsoft__Quantum__Intrinsic__K__ctl__wrapper(%Tuple* %capture-tuple, %Tuple* %arg-tuple, %Tuple* %result-tuple) {
 entry:
   %0 = bitcast %Tuple* %arg-tuple to { %Array*, { %Qubit*, i64 }* }*
   %1 = getelementptr inbounds { %Array*, { %Qubit*, i64 }* }, { %Array*, { %Qubit*, i64 }* }* %0, i32 0, i32 0

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestDeclarations1.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestDeclarations1.ll
@@ -1,10 +1,10 @@
-define void @Microsoft__Quantum__Testing__QIR__SelfAdjointIntrinsic__adj() {
+define internal void @Microsoft__Quantum__Testing__QIR__SelfAdjointIntrinsic__adj() {
 entry:
   call void @__quantum__qis__selfadjointintrinsic__body()
   ret void
 }
 
-define void @Microsoft__Quantum__Testing__QIR__SelfAdjointIntrinsic__ctl(%Array* %__controlQubits__, %Tuple* %__unitArg__) {
+define internal void @Microsoft__Quantum__Testing__QIR__SelfAdjointIntrinsic__ctl(%Array* %__controlQubits__, %Tuple* %__unitArg__) {
 entry:
   call void @__quantum__rt__array_update_alias_count(%Array* %__controlQubits__, i32 1)
   call void @__quantum__qis__selfadjointintrinsic__ctl(%Array* %__controlQubits__, %Tuple* %__unitArg__)

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestDeclarations2.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestDeclarations2.ll
@@ -1,4 +1,4 @@
-define void @Microsoft__Quantum__Testing__QIR__SelfAdjointIntrinsic__ctladj(%Array* %__controlQubits__, %Tuple* %__unitArg__) {
+define internal void @Microsoft__Quantum__Testing__QIR__SelfAdjointIntrinsic__ctladj(%Array* %__controlQubits__, %Tuple* %__unitArg__) {
 entry:
   call void @__quantum__rt__array_update_alias_count(%Array* %__controlQubits__, i32 1)
   call void @__quantum__qis__selfadjointintrinsic__ctl(%Array* %__controlQubits__, %Tuple* %__unitArg__)

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestDeclarations3.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestDeclarations3.ll
@@ -1,4 +1,4 @@
-define void @Microsoft__Quantum__Testing__QIR__SelfAdjointOp__body() {
+define internal void @Microsoft__Quantum__Testing__QIR__SelfAdjointOp__body() {
 entry:
   ret void
 }

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestDeclarations4.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestDeclarations4.ll
@@ -1,4 +1,4 @@
-define void @Microsoft__Quantum__Testing__QIR__SelfAdjointOp__adj() {
+define internal void @Microsoft__Quantum__Testing__QIR__SelfAdjointOp__adj() {
 entry:
   call void @Microsoft__Quantum__Testing__QIR__SelfAdjointOp__body()
   ret void

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestDeclarations5.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestDeclarations5.ll
@@ -1,4 +1,4 @@
-define void @Microsoft__Quantum__Testing__QIR__SelfAdjointOp__ctl(%Array* %__controlQubits__, %Tuple* %__unitArg__) {
+define internal void @Microsoft__Quantum__Testing__QIR__SelfAdjointOp__ctl(%Array* %__controlQubits__, %Tuple* %__unitArg__) {
 entry:
   call void @__quantum__rt__array_update_alias_count(%Array* %__controlQubits__, i32 1)
   call void @__quantum__rt__array_update_alias_count(%Array* %__controlQubits__, i32 -1)

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestDeclarations6.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestDeclarations6.ll
@@ -1,4 +1,4 @@
-define void @Microsoft__Quantum__Testing__QIR__SelfAdjointOp__ctladj(%Array* %__controlQubits__, %Tuple* %__unitArg__) {
+define internal void @Microsoft__Quantum__Testing__QIR__SelfAdjointOp__ctladj(%Array* %__controlQubits__, %Tuple* %__unitArg__) {
 entry:
   call void @__quantum__rt__array_update_alias_count(%Array* %__controlQubits__, i32 1)
   call void @Microsoft__Quantum__Testing__QIR__SelfAdjointOp__ctl(%Array* %__controlQubits__, %Tuple* %__unitArg__)

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestDeconstruct.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestDeconstruct.ll
@@ -1,4 +1,4 @@
-define i64 @Microsoft__Quantum__Testing__QIR__TestDeconstruct__body(i64 %0, { i64, i64 }* %1) {
+define internal i64 @Microsoft__Quantum__Testing__QIR__TestDeconstruct__body(i64 %0, { i64, i64 }* %1) {
 entry:
   %2 = call %Tuple* @__quantum__rt__tuple_create(i64 ptrtoint ({ i64, { i64, i64 }* }* getelementptr ({ i64, { i64, i64 }* }, { i64, { i64, i64 }* }* null, i32 1) to i64))
   %a = bitcast %Tuple* %2 to { i64, { i64, i64 }* }*

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestDoubles.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestDoubles.ll
@@ -1,4 +1,4 @@
-define double @Microsoft__Quantum__Testing__QIR__TestDouble__body(double %x, double %y) {
+define internal double @Microsoft__Quantum__Testing__QIR__TestDouble__body(double %x, double %y) {
 entry:
   %0 = fadd double %x, %y
   %a = fsub double %0, 2.000000e+00

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestForLoop.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestForLoop.ll
@@ -1,4 +1,4 @@
-define { double, %String* }* @Microsoft__Quantum__Testing__QIR__TestNestedLoops__body() {
+define internal { double, %String* }* @Microsoft__Quantum__Testing__QIR__TestNestedLoops__body() {
 entry:
   %name = call %String* @__quantum__rt__string_create(i8* getelementptr inbounds ([7 x i8], [7 x i8]* @0, i32 0, i32 0))
   %0 = call %String* @__quantum__rt__string_create(i8* null)

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestFunctors.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestFunctors.ll
@@ -1,4 +1,4 @@
-define i64 @Microsoft__Quantum__Testing__QIR__TestControlled__body() {
+define internal i64 @Microsoft__Quantum__Testing__QIR__TestControlled__body() {
 entry:
   %0 = call %Tuple* @__quantum__rt__tuple_create(i64 ptrtoint ({ %Callable*, i64 }* getelementptr ({ %Callable*, i64 }, { %Callable*, i64 }* null, i32 1) to i64))
   %1 = bitcast %Tuple* %0 to { %Callable*, i64 }*

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestGenerics1.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestGenerics1.ll
@@ -1,4 +1,4 @@
-define void @Microsoft__Quantum__Testing__QIR__DumpMachineTest__body() {
+define internal void @Microsoft__Quantum__Testing__QIR__DumpMachineTest__body() {
 entry:
   call void @__quantum__qis__dumpmachine__body(i8* null)
   ret void

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestGenerics2.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestGenerics2.ll
@@ -1,4 +1,4 @@
-define void @Microsoft__Quantum__Testing__QIR__DumpMachineToFileTest__body(%String* %filePath) {
+define internal void @Microsoft__Quantum__Testing__QIR__DumpMachineToFileTest__body(%String* %filePath) {
 entry:
   %0 = bitcast %String* %filePath to i8*
   call void @__quantum__qis__dumpmachine__body(i8* %0)

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestGenerics3.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestGenerics3.ll
@@ -1,4 +1,4 @@
-define void @Microsoft__Quantum__Testing__QIR__DumpRegisterTest__body() {
+define internal void @Microsoft__Quantum__Testing__QIR__DumpRegisterTest__body() {
 entry:
   %q2 = call %Array* @__quantum__rt__qubit_allocate_array(i64 2)
   call void @__quantum__rt__array_update_alias_count(%Array* %q2, i32 1)

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestGenerics4.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestGenerics4.ll
@@ -1,4 +1,4 @@
-define void @Microsoft__Quantum__Testing__QIR__DumpRegisterToFileTest__body(%String* %filePath) {
+define internal void @Microsoft__Quantum__Testing__QIR__DumpRegisterToFileTest__body(%String* %filePath) {
 entry:
   %q2 = call %Array* @__quantum__rt__qubit_allocate_array(i64 2)
   call void @__quantum__rt__array_update_alias_count(%Array* %q2, i32 1)

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestInline.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestInline.ll
@@ -1,4 +1,4 @@
-define { double, double }* @Microsoft__Quantum__Testing__QIR__TestInline__body() {
+define internal { double, double }* @Microsoft__Quantum__Testing__QIR__TestInline__body() {
 entry:
   %x = alloca double, align 8
   store double 0.000000e+00, double* %x, align 8

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestIntegers.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestIntegers.ll
@@ -1,4 +1,4 @@
-define i64 @Microsoft__Quantum__Testing__QIR__TestInts__body(i64 %a, i64 %b) {
+define internal i64 @Microsoft__Quantum__Testing__QIR__TestInts__body(i64 %a, i64 %b) {
 entry:
   %0 = icmp sgt i64 %a, %b
   %c = select i1 %0, i64 %a, i64 %b

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestLocalCallables1.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestLocalCallables1.ll
@@ -1,4 +1,4 @@
-﻿define { %String*, double }* @Microsoft__Quantum__Testing__QIR__TestLocalCallables__body() {
+﻿define internal { %String*, double }* @Microsoft__Quantum__Testing__QIR__TestLocalCallables__body() {
 entry:
   %arr = call %Array* @__quantum__rt__array_create_1d(i32 8, i64 1)
   %0 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %arr, i64 0)

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestLocalCallables2.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestLocalCallables2.ll
@@ -1,4 +1,4 @@
-﻿define void @Microsoft__Quantum__Testing__QIR__ReturnTuple__body__wrapper(%Tuple* %capture-tuple, %Tuple* %arg-tuple, %Tuple* %result-tuple) {
+﻿define internal void @Microsoft__Quantum__Testing__QIR__ReturnTuple__body__wrapper(%Tuple* %capture-tuple, %Tuple* %arg-tuple, %Tuple* %result-tuple) {
 entry:
   %0 = bitcast %Tuple* %arg-tuple to { %String* }*
   %1 = getelementptr inbounds { %String* }, { %String* }* %0, i32 0, i32 0

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestOpArgument.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestOpArgument.ll
@@ -1,4 +1,4 @@
-define %String* @Microsoft__Quantum__Testing__QIR__TestOpArgument__body() {
+define internal %String* @Microsoft__Quantum__Testing__QIR__TestOpArgument__body() {
 entry:
   %q1 = call %Qubit* @__quantum__rt__qubit_allocate()
   %q2 = call %Qubit* @__quantum__rt__qubit_allocate()

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestOpCall1.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestOpCall1.ll
@@ -1,4 +1,4 @@
-define void @Microsoft__Quantum__Testing__QIR__TestOperationCalls__body() {
+define internal void @Microsoft__Quantum__Testing__QIR__TestOperationCalls__body() {
 entry:
   %doNothing = call %Callable* @Microsoft__Quantum__Testing__QIR__ReturnDoNothing__body(i64 1)
   call void @__quantum__rt__capture_update_alias_count(%Callable* %doNothing, i32 1)

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestOpCall2.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestOpCall2.ll
@@ -1,4 +1,4 @@
-define void @Microsoft__Quantum__Testing__QIR__CNOT__ctl(%Array* %__controlQubits__, { %Qubit*, %Qubit* }* %0) {
+define internal void @Microsoft__Quantum__Testing__QIR__CNOT__ctl(%Array* %__controlQubits__, { %Qubit*, %Qubit* }* %0) {
 entry:
   call void @__quantum__rt__array_update_alias_count(%Array* %__controlQubits__, i32 1)
   %1 = getelementptr inbounds { %Qubit*, %Qubit* }, { %Qubit*, %Qubit* }* %0, i32 0, i32 0

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestPartials1.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestPartials1.ll
@@ -1,4 +1,4 @@
-﻿define i1 @Microsoft__Quantum__Testing__QIR__TestPartials__body(i64 %a, double %b) {
+﻿define internal i1 @Microsoft__Quantum__Testing__QIR__TestPartials__body(i64 %a, double %b) {
 entry:
   %0 = call %Tuple* @__quantum__rt__tuple_create(i64 ptrtoint ({ %Callable*, double }* getelementptr ({ %Callable*, double }, { %Callable*, double }* null, i32 1) to i64))
   %1 = bitcast %Tuple* %0 to { %Callable*, double }*

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestPartials2.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestPartials2.ll
@@ -1,4 +1,4 @@
-﻿define void @Microsoft__Quantum__Intrinsic__Rz__body__wrapper(%Tuple* %capture-tuple, %Tuple* %arg-tuple, %Tuple* %result-tuple) {
+﻿define internal void @Microsoft__Quantum__Intrinsic__Rz__body__wrapper(%Tuple* %capture-tuple, %Tuple* %arg-tuple, %Tuple* %result-tuple) {
 entry:
   %0 = bitcast %Tuple* %arg-tuple to { double, %Qubit* }*
   %1 = getelementptr inbounds { double, %Qubit* }, { double, %Qubit* }* %0, i32 0, i32 0
@@ -9,7 +9,7 @@ entry:
   ret void
 }
 
-define void @Microsoft__Quantum__Intrinsic__Rz__adj__wrapper(%Tuple* %capture-tuple, %Tuple* %arg-tuple, %Tuple* %result-tuple) {
+define internal void @Microsoft__Quantum__Intrinsic__Rz__adj__wrapper(%Tuple* %capture-tuple, %Tuple* %arg-tuple, %Tuple* %result-tuple) {
 entry:
   %0 = bitcast %Tuple* %arg-tuple to { double, %Qubit* }*
   %1 = getelementptr inbounds { double, %Qubit* }, { double, %Qubit* }* %0, i32 0, i32 0
@@ -20,7 +20,7 @@ entry:
   ret void
 }
 
-define void @Microsoft__Quantum__Intrinsic__Rz__ctl__wrapper(%Tuple* %capture-tuple, %Tuple* %arg-tuple, %Tuple* %result-tuple) {
+define internal void @Microsoft__Quantum__Intrinsic__Rz__ctl__wrapper(%Tuple* %capture-tuple, %Tuple* %arg-tuple, %Tuple* %result-tuple) {
 entry:
   %0 = bitcast %Tuple* %arg-tuple to { %Array*, { double, %Qubit* }* }*
   %1 = getelementptr inbounds { %Array*, { double, %Qubit* }* }, { %Array*, { double, %Qubit* }* }* %0, i32 0, i32 0
@@ -31,7 +31,7 @@ entry:
   ret void
 }
 
-define void @Microsoft__Quantum__Intrinsic__Rz__ctladj__wrapper(%Tuple* %capture-tuple, %Tuple* %arg-tuple, %Tuple* %result-tuple) {
+define internal void @Microsoft__Quantum__Intrinsic__Rz__ctladj__wrapper(%Tuple* %capture-tuple, %Tuple* %arg-tuple, %Tuple* %result-tuple) {
 entry:
   %0 = bitcast %Tuple* %arg-tuple to { %Array*, { double, %Qubit* }* }*
   %1 = getelementptr inbounds { %Array*, { double, %Qubit* }* }, { %Array*, { double, %Qubit* }* }* %0, i32 0, i32 0

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestPartials3.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestPartials3.ll
@@ -1,4 +1,4 @@
-﻿define void @Lifted__PartialApplication__2__body__wrapper(%Tuple* %capture-tuple, %Tuple* %arg-tuple, %Tuple* %result-tuple) {
+﻿define internal void @Lifted__PartialApplication__2__body__wrapper(%Tuple* %capture-tuple, %Tuple* %arg-tuple, %Tuple* %result-tuple) {
 entry:
   %0 = bitcast %Tuple* %capture-tuple to { %Callable*, { i64, double }* }*
   %1 = getelementptr inbounds { %Callable*, { i64, double }* }, { %Callable*, { i64, double }* }* %0, i32 0, i32 1

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestPartials4.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestPartials4.ll
@@ -1,4 +1,4 @@
-﻿define void @Lifted__PartialApplication__2__adj__wrapper(%Tuple* %capture-tuple, %Tuple* %arg-tuple, %Tuple* %result-tuple) {
+﻿define internal void @Lifted__PartialApplication__2__adj__wrapper(%Tuple* %capture-tuple, %Tuple* %arg-tuple, %Tuple* %result-tuple) {
 entry:
   %0 = bitcast %Tuple* %capture-tuple to { %Callable*, { i64, double }* }*
   %1 = getelementptr inbounds { %Callable*, { i64, double }* }, { %Callable*, { i64, double }* }* %0, i32 0, i32 1
@@ -22,7 +22,7 @@ entry:
   ret void
 }
 
-define void @Lifted__PartialApplication__2__ctl__wrapper(%Tuple* %capture-tuple, %Tuple* %arg-tuple, %Tuple* %result-tuple) {
+define internal void @Lifted__PartialApplication__2__ctl__wrapper(%Tuple* %capture-tuple, %Tuple* %arg-tuple, %Tuple* %result-tuple) {
 entry:
   %0 = bitcast %Tuple* %arg-tuple to { %Array*, { %String*, %Qubit* }* }*
   %1 = getelementptr inbounds { %Array*, { %String*, %Qubit* }* }, { %Array*, { %String*, %Qubit* }* }* %0, i32 0, i32 0
@@ -57,7 +57,7 @@ entry:
   ret void
 }
 
-define void @Lifted__PartialApplication__2__ctladj__wrapper(%Tuple* %capture-tuple, %Tuple* %arg-tuple, %Tuple* %result-tuple) {
+define internal void @Lifted__PartialApplication__2__ctladj__wrapper(%Tuple* %capture-tuple, %Tuple* %arg-tuple, %Tuple* %result-tuple) {
 entry:
   %0 = bitcast %Tuple* %arg-tuple to { %Array*, { %String*, %Qubit* }* }*
   %1 = getelementptr inbounds { %Array*, { %String*, %Qubit* }* }, { %Array*, { %String*, %Qubit* }* }* %0, i32 0, i32 0

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestPartials5.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestPartials5.ll
@@ -1,4 +1,4 @@
-﻿define void @MemoryManagement__2__RefCount(%Tuple* %capture-tuple, i32 %count-change) {
+﻿define internal void @MemoryManagement__2__RefCount(%Tuple* %capture-tuple, i32 %count-change) {
 entry:
   %0 = bitcast %Tuple* %capture-tuple to { %Callable*, { i64, double }* }*
   %1 = getelementptr inbounds { %Callable*, { i64, double }* }, { %Callable*, { i64, double }* }* %0, i32 0, i32 0
@@ -13,7 +13,7 @@ entry:
   ret void
 }
 
-define void @MemoryManagement__2__AliasCount(%Tuple* %capture-tuple, i32 %count-change) {
+define internal void @MemoryManagement__2__AliasCount(%Tuple* %capture-tuple, i32 %count-change) {
 entry:
   %0 = bitcast %Tuple* %capture-tuple to { %Callable*, { i64, double }* }*
   %1 = getelementptr inbounds { %Callable*, { i64, double }* }, { %Callable*, { i64, double }* }* %0, i32 0, i32 0

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestPartials6.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestPartials6.ll
@@ -1,4 +1,4 @@
-﻿define void @Lifted__PartialApplication__6__body__wrapper(%Tuple* %capture-tuple, %Tuple* %arg-tuple, %Tuple* %result-tuple) {
+﻿define internal void @Lifted__PartialApplication__6__body__wrapper(%Tuple* %capture-tuple, %Tuple* %arg-tuple, %Tuple* %result-tuple) {
 entry:
   %0 = bitcast %Tuple* %capture-tuple to { %Callable*, %Callable* }*
   %1 = getelementptr inbounds { %Callable*, %Callable* }, { %Callable*, %Callable* }* %0, i32 0, i32 1
@@ -17,7 +17,7 @@ entry:
   ret void
 }
 
-define void @Lifted__PartialApplication__6__adj__wrapper(%Tuple* %capture-tuple, %Tuple* %arg-tuple, %Tuple* %result-tuple) {
+define internal void @Lifted__PartialApplication__6__adj__wrapper(%Tuple* %capture-tuple, %Tuple* %arg-tuple, %Tuple* %result-tuple) {
 entry:
   %0 = bitcast %Tuple* %capture-tuple to { %Callable*, %Callable* }*
   %1 = getelementptr inbounds { %Callable*, %Callable* }, { %Callable*, %Callable* }* %0, i32 0, i32 1
@@ -41,7 +41,7 @@ entry:
   ret void
 }
 
-define void @Lifted__PartialApplication__6__ctl__wrapper(%Tuple* %capture-tuple, %Tuple* %arg-tuple, %Tuple* %result-tuple) {
+define internal void @Lifted__PartialApplication__6__ctl__wrapper(%Tuple* %capture-tuple, %Tuple* %arg-tuple, %Tuple* %result-tuple) {
 entry:
   %0 = bitcast %Tuple* %arg-tuple to { %Array*, { %Array* }* }*
   %1 = getelementptr inbounds { %Array*, { %Array* }* }, { %Array*, { %Array* }* }* %0, i32 0, i32 0
@@ -76,7 +76,7 @@ entry:
   ret void
 }
 
-define void @Lifted__PartialApplication__6__ctladj__wrapper(%Tuple* %capture-tuple, %Tuple* %arg-tuple, %Tuple* %result-tuple) {
+define internal void @Lifted__PartialApplication__6__ctladj__wrapper(%Tuple* %capture-tuple, %Tuple* %arg-tuple, %Tuple* %result-tuple) {
 entry:
   %0 = bitcast %Tuple* %arg-tuple to { %Array*, { %Array* }* }*
   %1 = getelementptr inbounds { %Array*, { %Array* }* }, { %Array*, { %Array* }* }* %0, i32 0, i32 0

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestPaulis.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestPaulis.ll
@@ -1,4 +1,4 @@
-define i2 @Microsoft__Quantum__Testing__QIR__TestPaulis__body(i2 %a, i2 %b) {
+define internal i2 @Microsoft__Quantum__Testing__QIR__TestPaulis__body(i2 %a, i2 %b) {
 entry:
   %0 = load i2, i2* @PauliX, align 1
   %1 = icmp eq i2 %a, %0

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestRange.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestRange.ll
@@ -1,4 +1,4 @@
-define %Range @Microsoft__Quantum__Testing__QIR__TestRange__body() {
+define internal %Range @Microsoft__Quantum__Testing__QIR__TestRange__body() {
 entry:
   %0 = load %Range, %Range* @EmptyRange, align 4
   %1 = insertvalue %Range %0, i64 0, 0

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestReferenceCounts1.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestReferenceCounts1.ll
@@ -1,4 +1,4 @@
-define void @Microsoft__Quantum__Testing__QIR__TestRefCountsForItemUpdate__body(i1 %cond) {
+define internal void @Microsoft__Quantum__Testing__QIR__TestRefCountsForItemUpdate__body(i1 %cond) {
 entry:
   %0 = call %Array* @__quantum__rt__array_create_1d(i32 8, i64 0)
   %1 = call %Array* @__quantum__rt__array_create_1d(i32 8, i64 5)

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestReferenceCounts2.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestReferenceCounts2.ll
@@ -1,4 +1,4 @@
-define { %String*, %Array* }* @Microsoft__Quantum__Testing__QIR__TestPendingRefCountIncreases__body(i1 %cond) {
+define internal { %String*, %Array* }* @Microsoft__Quantum__Testing__QIR__TestPendingRefCountIncreases__body(i1 %cond) {
 entry:
   %0 = call %String* @__quantum__rt__string_create(i8* getelementptr inbounds ([2 x i8], [2 x i8]* @0, i32 0, i32 0))
   %1 = call %Array* @__quantum__rt__array_create_1d(i32 8, i64 1)

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestRepeat.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestRepeat.ll
@@ -1,4 +1,4 @@
-define i64 @Microsoft__Quantum__Testing__QIR__TestRepeat__body(%Qubit* %q) {
+define internal i64 @Microsoft__Quantum__Testing__QIR__TestRepeat__body(%Qubit* %q) {
 entry:
   %n = alloca i64, align 8
   store i64 0, i64* %n, align 4

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestResults.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestResults.ll
@@ -1,4 +1,4 @@
-define %Result* @Microsoft__Quantum__Testing__QIR__TestResults__body(%Result* %a, %Result* %b) {
+define internal %Result* @Microsoft__Quantum__Testing__QIR__TestResults__body(%Result* %a, %Result* %b) {
 entry:
   %0 = call i1 @__quantum__rt__result_equal(%Result* %a, %Result* %b)
   br i1 %0, label %then0__1, label %test1__1

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestScoping.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestScoping.ll
@@ -1,4 +1,4 @@
-define i64 @Microsoft__Quantum__Testing__QIR__TestScoping__body(%Array* %a) {
+define internal i64 @Microsoft__Quantum__Testing__QIR__TestScoping__body(%Array* %a) {
 entry:
   call void @__quantum__rt__array_update_alias_count(%Array* %a, i32 1)
   %sum = alloca i64, align 8

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestShortCircuiting.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestShortCircuiting.ll
@@ -1,4 +1,4 @@
-define { i1, i1 }* @Microsoft__Quantum__Testing__QIR__TestShortCircuiting__body() {
+define internal { i1, i1 }* @Microsoft__Quantum__Testing__QIR__TestShortCircuiting__body() {
 entry:
   %0 = call i1 @__quantum__qis__getrandombool__body(i64 1)
   br i1 %0, label %condTrue__1, label %condContinue__1

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestStrings.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestStrings.ll
@@ -1,4 +1,4 @@
-define %String* @Microsoft__Quantum__Testing__QIR__TestStrings__body(i64 %a, i64 %b, %Array* %arr) {
+define internal %String* @Microsoft__Quantum__Testing__QIR__TestStrings__body(i64 %a, i64 %b, %Array* %arr) {
 entry:
   call void @__quantum__rt__array_update_alias_count(%Array* %arr, i32 1)
   %0 = call %String* @__quantum__rt__string_create(i8* getelementptr inbounds ([6 x i8], [6 x i8]* @0, i32 0, i32 0))

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestTargeting.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestTargeting.ll
@@ -1,4 +1,4 @@
-define void @Microsoft__Quantum__Testing__QIR__NoArgs__body() {
+define internal void @Microsoft__Quantum__Testing__QIR__NoArgs__body() {
 entry:
   %q = call %Qubit* @__quantum__rt__qubit_allocate()
   %0 = call %Result* @__quantum__qis__mz(%Qubit* %q)

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestUdt.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestUdt.ll
@@ -1,4 +1,4 @@
-define { { i2, i64 }*, double }* @Microsoft__Quantum__Testing__QIR__TestType__body({ i2, i64 }* %0, double %D) {
+define internal { { i2, i64 }*, double }* @Microsoft__Quantum__Testing__QIR__TestType__body({ i2, i64 }* %0, double %D) {
 entry:
   %1 = call %Tuple* @__quantum__rt__tuple_create(i64 ptrtoint ({ { i2, i64 }*, double }* getelementptr ({ { i2, i64 }*, double }, { { i2, i64 }*, double }* null, i32 1) to i64))
   %2 = bitcast %Tuple* %1 to { { i2, i64 }*, double }*

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestUdtAccessor.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestUdtAccessor.ll
@@ -1,4 +1,4 @@
-define i64 @Microsoft__Quantum__Testing__QIR__TestAccessors__body() {
+define internal i64 @Microsoft__Quantum__Testing__QIR__TestAccessors__body() {
 entry:
   %0 = call %Tuple* @__quantum__rt__tuple_create(i64 ptrtoint ({ i2, i64 }* getelementptr ({ i2, i64 }, { i2, i64 }* null, i32 1) to i64))
   %1 = bitcast %Tuple* %0 to { i2, i64 }*
@@ -24,7 +24,7 @@ entry:
   ret i64 %y
 }
 
-define { { i2, i64 }*, double }* @Microsoft__Quantum__Testing__QIR__TestType__body({ i2, i64 }* %0, double %D) {
+define internal { { i2, i64 }*, double }* @Microsoft__Quantum__Testing__QIR__TestType__body({ i2, i64 }* %0, double %D) {
 entry:
   %1 = call %Tuple* @__quantum__rt__tuple_create(i64 ptrtoint ({ { i2, i64 }*, double }* getelementptr ({ { i2, i64 }*, double }, { { i2, i64 }*, double }* null, i32 1) to i64))
   %2 = bitcast %Tuple* %1 to { { i2, i64 }*, double }*

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestUdtArgument.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestUdtArgument.ll
@@ -1,4 +1,4 @@
-define { i64, { i2, i64 }* }* @Microsoft__Quantum__Testing__QIR__TestUdtArgument__body() {
+define internal { i64, { i2, i64 }* }* @Microsoft__Quantum__Testing__QIR__TestUdtArgument__body() {
 entry:
   %0 = call %Callable* @__quantum__rt__callable_create([4 x void (%Tuple*, %Tuple*, %Tuple*)*]* @Microsoft__Quantum__Testing__QIR__TestType1, [2 x void (%Tuple*, i32)*]* null, %Tuple* null)
   %udt1 = call { i64 }* @Microsoft__Quantum__Testing__QIR_____GUID___Build__body(%Callable* %0)

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestUdtConstruction.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestUdtConstruction.ll
@@ -1,4 +1,4 @@
-define { { i2, i64 }*, double }* @Microsoft__Quantum__Testing__QIR__TestUdtConstructor__body() {
+define internal { { i2, i64 }*, double }* @Microsoft__Quantum__Testing__QIR__TestUdtConstructor__body() {
 entry:
   %0 = call %Tuple* @__quantum__rt__tuple_create(i64 mul nuw (i64 ptrtoint (double* getelementptr (double, double* null, i32 1) to i64), i64 2))
   %args = bitcast %Tuple* %0 to { double, double }*

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestUdtUpdate1.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestUdtUpdate1.ll
@@ -1,4 +1,4 @@
-define { { double, %String* }*, i64 }* @Microsoft__Quantum__Testing__QIR__TestUdtUpdate1__body(%String* %a, i64 %b) {
+define internal { { double, %String* }*, i64 }* @Microsoft__Quantum__Testing__QIR__TestUdtUpdate1__body(%String* %a, i64 %b) {
 entry:
   %0 = call %Tuple* @__quantum__rt__tuple_create(i64 ptrtoint ({ double, %String* }* getelementptr ({ double, %String* }, { double, %String* }* null, i32 1) to i64))
   %1 = bitcast %Tuple* %0 to { double, %String* }*

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestUdtUpdate2.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestUdtUpdate2.ll
@@ -1,4 +1,4 @@
-define { %String*, { double, double }*, { double, double }* }* @Microsoft__Quantum__Testing__QIR__TestUdtUpdate2__body(i1 %cond, { %String*, { double, double }*, { double, double }* }* %arg) {
+define internal { %String*, { double, double }*, { double, double }* }* @Microsoft__Quantum__Testing__QIR__TestUdtUpdate2__body(i1 %cond, { %String*, { double, double }*, { double, double }* }* %arg) {
 entry:
   %0 = getelementptr inbounds { %String*, { double, double }*, { double, double }* }, { %String*, { double, double }*, { double, double }* }* %arg, i32 0, i32 1
   %1 = load { double, double }*, { double, double }** %0, align 8

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestUsing1.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestUsing1.ll
@@ -1,4 +1,4 @@
-define void @Microsoft__Quantum__Testing__QIR__TestUsing__body() {
+define internal void @Microsoft__Quantum__Testing__QIR__TestUsing__body() {
 entry:
   %q = call %Qubit* @__quantum__rt__qubit_allocate()
   call void @Microsoft__Quantum__Testing__QIR__ArbitraryAllocation__body(i64 3, %Qubit* %q)

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestUsing2.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestUsing2.ll
@@ -1,4 +1,4 @@
-define void @Microsoft__Quantum__Testing__QIR__ArbitraryAllocation__body(i64 %max, %Qubit* %q) {
+define internal void @Microsoft__Quantum__Testing__QIR__ArbitraryAllocation__body(i64 %max, %Qubit* %q) {
 entry:
   %a = call %Qubit* @__quantum__rt__qubit_allocate()
   %b = call %Array* @__quantum__rt__qubit_allocate_array(i64 %max)

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestWhile.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestWhile.ll
@@ -1,4 +1,4 @@
-define i64 @Microsoft__Quantum__Testing__QIR__TestWhile__body(i64 %a, i64 %b) {
+define internal i64 @Microsoft__Quantum__Testing__QIR__TestWhile__body(i64 %a, i64 %b) {
 entry:
   %n = alloca i64, align 8
   store i64 %a, i64* %n, align 4


### PR DESCRIPTION
This change updates the QirGeneration rewrite step to always mark the linkage type of functions internal except when they are the generated functions for an EntryPoint (the `_Interop` variant and the message based variant). This better allows for LLVM passes to perform optimization, inling, and dead code elimination across these functions. Note that in LLVM, any global variable or function definition is considered `external` by default when no linkage is provided.