### PR TITLE
Updating ClassicalControl rewrite to use new namespace

### DIFF
--- a/src/QsCompiler/Core/Dependencies.fs
+++ b/src/QsCompiler/Core/Dependencies.fs
@@ -24,7 +24,7 @@ type BuiltIn =
     }
 
     static member CanonNamespace = "Microsoft.Quantum.Canon"
-    static member ClassicallyControlledNamespace = "Microsoft.Quantum.Simulation.QuantumProcessor.Extensions"
+    static member ClassicallyControlledNamespace = "Microsoft.Quantum.ClassicalControl"
     static member CoreNamespace = "Microsoft.Quantum.Core"
     static member DiagnosticsNamespace = "Microsoft.Quantum.Diagnostics"
     static member IntrinsicNamespace = "Microsoft.Quantum.Intrinsic"
@@ -261,7 +261,7 @@ type BuiltIn =
             Kind = Function(TypeParameters = ImmutableArray.Empty)
         }
 
-    // dependencies in Microsoft.Quantum.Simulation.QuantumProcessor.Extensions
+    // dependencies in Microsoft.Quantum.ClassicalControl
 
     // This is expected to have type <'T, 'U>((Result[], Result[], (('T => Unit), 'T) , (('U => Unit), 'U)) => Unit)
     static member ApplyConditionally =

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestTargeting.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestTargeting.ll
@@ -9,7 +9,7 @@ entry:
   %5 = call %Callable* @__quantum__rt__callable_create([4 x void (%Tuple*, %Tuple*, %Tuple*)*]* @Microsoft__Quantum__Testing__QIR_____GUID___NoArgs, [2 x void (%Tuple*, i32)*]* null, %Tuple* null)
   store %Callable* %5, %Callable** %3, align 8
   store %Qubit* %q, %Qubit** %4, align 8
-  call void @Microsoft__Quantum__Simulation__QuantumProcessor__Extensions_____GUID___ApplyIfOne__body(%Result* %0, { %Callable*, %Qubit* }* %2)
+  call void @Microsoft__Quantum__ClassicalControl_____GUID___ApplyIfOne__body(%Result* %0, { %Callable*, %Qubit* }* %2)
   call void @__quantum__rt__result_update_reference_count(%Result* %0, i32 -1)
   call void @__quantum__rt__capture_update_reference_count(%Callable* %5, i32 -1)
   call void @__quantum__rt__callable_update_reference_count(%Callable* %5, i32 -1)

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestTargeting.qs
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestTargeting.qs
@@ -24,7 +24,7 @@ namespace Microsoft.Quantum.Canon {
     operation NoOp<'T>(arg : 'T) : Unit is Adj + Ctl { }
 }
 
-namespace Microsoft.Quantum.Simulation.QuantumProcessor.Extensions {
+namespace Microsoft.Quantum.ClassicalControl {
 
     operation ApplyIfZero<'T>(measurementResult : Result, (onResultZeroOp : ('T => Unit), zeroArg : 'T)) : Unit { }
     operation ApplyIfZeroA<'T>(measurementResult : Result, (onResultZeroOp : ('T => Unit is Adj), zeroArg : 'T)) : Unit is Adj { }


### PR DESCRIPTION
This change takes advantage of the update done in https://github.com/microsoft/qsharp-runtime/pull/692 to use the new namespaces for Classical Control operations.