### PR TITLE
Target both Net5.0 and 3.1 for core compiler and runtime assemblies.

### DIFF
--- a/src/QsCompiler/CommandLineTool/CommandLineTool.csproj
+++ b/src/QsCompiler/CommandLineTool/CommandLineTool.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <AssemblyName>qsc</AssemblyName>
     <AssemblyTitle>Microsoft Q# compiler command line tool.</AssemblyTitle>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0;netcoreapp3.1</TargetFramework>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
 

--- a/src/QsCompiler/CommandLineTool/CommandLineTool.csproj
+++ b/src/QsCompiler/CommandLineTool/CommandLineTool.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <AssemblyName>qsc</AssemblyName>
     <AssemblyTitle>Microsoft Q# compiler command line tool.</AssemblyTitle>
-    <TargetFramework>net5.0;netcoreapp3.1</TargetFramework>
+    <TargetFrameworks>net5.0;netcoreapp3.1</TargetFrameworks>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
 

--- a/src/QsCompiler/LanguageServer/LanguageServer.csproj
+++ b/src/QsCompiler/LanguageServer/LanguageServer.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <AssemblyName>Microsoft.Quantum.QsLanguageServer</AssemblyName>
-    <TargetFramework>net5.0;netcoreapp3.1</TargetFramework>
+    <TargetFrameworks>net5.0;netcoreapp3.1</TargetFrameworks>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
 

--- a/src/QsCompiler/LanguageServer/LanguageServer.csproj
+++ b/src/QsCompiler/LanguageServer/LanguageServer.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <AssemblyName>Microsoft.Quantum.QsLanguageServer</AssemblyName>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0;netcoreapp3.1</TargetFramework>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
 

--- a/src/QsFmt/App/App.fsproj
+++ b/src/QsFmt/App/App.fsproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0;netcoreapp3.1</TargetFramework>
     <AssemblyName>qsfmt</AssemblyName>
     <RootNamespace>Microsoft.Quantum.QsFmt.App</RootNamespace>
   </PropertyGroup>

--- a/src/QsFmt/App/App.fsproj
+++ b/src/QsFmt/App/App.fsproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0;netcoreapp3.1</TargetFramework>
+    <TargetFrameworks>net5.0;netcoreapp3.1</TargetFrameworks>
     <AssemblyName>qsfmt</AssemblyName>
     <RootNamespace>Microsoft.Quantum.QsFmt.App</RootNamespace>
   </PropertyGroup>

--- a/src/QuantumSdk/Tools/BuildConfiguration/BuildConfiguration.csproj
+++ b/src/QuantumSdk/Tools/BuildConfiguration/BuildConfiguration.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0;netcoreapp3.1</TargetFramework>
+    <TargetFrameworks>net5.0;netcoreapp3.1</TargetFrameworks>
     <AssemblyName>Microsoft.Quantum.Sdk.BuildConfiguration</AssemblyName>
     <AssemblyTitle>Build configuration tools included in the Microsoft Quantum Sdk.</AssemblyTitle>
   </PropertyGroup>

--- a/src/QuantumSdk/Tools/BuildConfiguration/BuildConfiguration.csproj
+++ b/src/QuantumSdk/Tools/BuildConfiguration/BuildConfiguration.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0;netcoreapp3.1</TargetFramework>
     <AssemblyName>Microsoft.Quantum.Sdk.BuildConfiguration</AssemblyName>
     <AssemblyTitle>Build configuration tools included in the Microsoft Quantum Sdk.</AssemblyTitle>
   </PropertyGroup>

--- a/src/QuantumSdk/Tools/DefaultEntryPoint/DefaultEntryPoint.csproj
+++ b/src/QuantumSdk/Tools/DefaultEntryPoint/DefaultEntryPoint.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net5.0;netcoreapp3.1</TargetFramework>
         <AssemblyName>Microsoft.Quantum.Sdk.DefaultEntryPoint.Generation</AssemblyName>
         <AssemblyTitle>Build tool to generate a minimal C# entry point when no C# files are included in the compilation.</AssemblyTitle>
     </PropertyGroup>

--- a/src/QuantumSdk/Tools/DefaultEntryPoint/DefaultEntryPoint.csproj
+++ b/src/QuantumSdk/Tools/DefaultEntryPoint/DefaultEntryPoint.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net5.0;netcoreapp3.1</TargetFramework>
+        <TargetFrameworks>net5.0;netcoreapp3.1</TargetFrameworks>
         <AssemblyName>Microsoft.Quantum.Sdk.DefaultEntryPoint.Generation</AssemblyName>
         <AssemblyTitle>Build tool to generate a minimal C# entry point when no C# files are included in the compilation.</AssemblyTitle>
     </PropertyGroup>


### PR DESCRIPTION
Cross-repo change to add limited support for users that only have .Net5 installed.