### PR TITLE
Finish implementing the parser visitors for Type in QsFmt

### DIFF
--- a/src/QsFmt/Formatter.Tests/Examples.fs
+++ b/src/QsFmt/Formatter.Tests/Examples.fs
@@ -60,7 +60,7 @@ let ``Adds newlines and indents`` =
 [<Example>]
 let ``Removes extraneous spaces`` =
     """namespace     Foo {
-    function Bar() : Int {
+    function Bar() : Int [     ] {
         let x= // Newlines are preserved.
             (7 -   1) // Comments too.
             + 4;
@@ -69,7 +69,7 @@ let ``Removes extraneous spaces`` =
 }""",
 
     """namespace Foo {
-    function Bar() : Int {
+    function Bar() : Int [ ] {
         let x = // Newlines are preserved.
             (7 - 1) // Comments too.
             + 4;

--- a/src/QsFmt/Formatter.Tests/FixedPoints.fs
+++ b/src/QsFmt/Formatter.Tests/FixedPoints.fs
@@ -141,15 +141,15 @@ let ``Type parameter`` = """namespace Foo {
 
 [<FixedPoint>]
 let ``Tuple type`` = """namespace Foo {
-    function Bar (arg : (BigInt, Bool, (Double, Int))) : Unit {}
+    function Bar (arg : (BigInt, Bool, (Double, Int))) : Pauli {}
 }"""
 
 [<FixedPoint>]
 let ``Array type`` = """namespace Foo {
-    function Bar (arg : Pauli[]) : Unit {}
+    function Bar (arg : Qubit[]) : Range {}
 }"""
 
 [<FixedPoint>]
 let ``Function type`` = """namespace Foo {
-    function Bar (arg : Unit => Unit is Adj) : Unit {}
+    function Bar (arg : Result => String is Adj) : Unit {}
 }"""

--- a/src/QsFmt/Formatter.Tests/FixedPoints.fs
+++ b/src/QsFmt/Formatter.Tests/FixedPoints.fs
@@ -135,6 +135,11 @@ let ``Array literal`` = """namespace Foo {
 }"""
 
 [<FixedPoint>]
+let ``Missing type`` = """namespace Foo {
+    function Bar (arg : _) : Unit {}
+}"""
+
+[<FixedPoint>]
 let ``Type parameter`` = """namespace Foo {
     function Bar (arg : 't) : Unit {}
 }"""

--- a/src/QsFmt/Formatter.Tests/FixedPoints.fs
+++ b/src/QsFmt/Formatter.Tests/FixedPoints.fs
@@ -140,6 +140,11 @@ let ``Tuple type`` = """namespace Foo {
 }"""
 
 [<FixedPoint>]
+let ``Array type`` = """namespace Foo {
+    function Bar (arg : Pauli[]) : Unit {}
+}"""
+
+[<FixedPoint>]
 let ``Function type`` = """namespace Foo {
     function Bar (arg : Unit => Unit is Adj) : Unit {}
 }"""

--- a/src/QsFmt/Formatter.Tests/FixedPoints.fs
+++ b/src/QsFmt/Formatter.Tests/FixedPoints.fs
@@ -135,6 +135,11 @@ let ``Array literal`` = """namespace Foo {
 }"""
 
 [<FixedPoint>]
+let ``Type parameter`` = """namespace Foo {
+    function Bar (arg : 't) : Unit {}
+}"""
+
+[<FixedPoint>]
 let ``Tuple type`` = """namespace Foo {
     function Bar (arg : (BigInt, Bool, (Double, Int))) : Unit {}
 }"""

--- a/src/QsFmt/Formatter.Tests/FixedPoints.fs
+++ b/src/QsFmt/Formatter.Tests/FixedPoints.fs
@@ -133,3 +133,8 @@ let ``Array literal`` = """namespace Foo {
         let xs = [1, 2, 3];
     }
 }"""
+
+[<FixedPoint>]
+let ``Function type`` = """namespace Foo {
+    function Bar (arg : Unit => Unit is Adj) : Unit {}
+}"""

--- a/src/QsFmt/Formatter.Tests/FixedPoints.fs
+++ b/src/QsFmt/Formatter.Tests/FixedPoints.fs
@@ -135,6 +135,11 @@ let ``Array literal`` = """namespace Foo {
 }"""
 
 [<FixedPoint>]
+let ``Tuple type`` = """namespace Foo {
+    function Bar (arg : (BigInt, Bool, (Double, Int))) : Unit {}
+}"""
+
+[<FixedPoint>]
 let ``Function type`` = """namespace Foo {
     function Bar (arg : Unit => Unit is Adj) : Unit {}
 }"""

--- a/src/QsFmt/Formatter/ParseTree/Type.fs
+++ b/src/QsFmt/Formatter/ParseTree/Type.fs
@@ -74,6 +74,14 @@ type TypeVisitor(tokens) =
         }
         |> Type.Tuple
 
+    override visitor.VisitArrayType context =
+        {
+            ItemType = visitor.Visit context.item
+            OpenBracket = context.openBracket |> Node.toTerminal tokens
+            CloseBracket = context.closeBracket |> Node.toTerminal tokens
+        }
+        |> Array
+
     override visitor.VisitCallableType context =
         {
             FromType = visitor.Visit context.fromType

--- a/src/QsFmt/Formatter/ParseTree/Type.fs
+++ b/src/QsFmt/Formatter/ParseTree/Type.fs
@@ -56,6 +56,9 @@ type TypeVisitor(tokens) =
     override _.VisitChildren node =
         Node.toUnknown tokens node |> Type.Unknown
 
+    override _.VisitMissingType context =
+        context.Underscore().Symbol |> Node.toTerminal tokens |> Type.Missing
+
     override _.VisitBigIntType context =
         context.BigInt().Symbol |> Node.toTerminal tokens |> BuiltIn
 

--- a/src/QsFmt/Formatter/ParseTree/Type.fs
+++ b/src/QsFmt/Formatter/ParseTree/Type.fs
@@ -59,6 +59,9 @@ type TypeVisitor(tokens) =
     override _.VisitIntType context =
         context.Int().Symbol |> Node.toTerminal tokens |> BuiltIn
 
+    override _.VisitTypeParameter context =
+        context.typeParameter |> Node.toTerminal tokens |> Parameter
+
     override _.VisitUserDefinedType context =
         { Prefix = Node.prefix tokens context.name.Start.TokenIndex; Text = context.name.GetText() }
         |> UserDefined
@@ -76,7 +79,7 @@ type TypeVisitor(tokens) =
 
     override visitor.VisitArrayType context =
         {
-            ItemType = visitor.Visit context.item
+            ItemType = visitor.Visit context.itemType
             OpenBracket = context.openBracket |> Node.toTerminal tokens
             CloseBracket = context.closeBracket |> Node.toTerminal tokens
         }

--- a/src/QsFmt/Formatter/ParseTree/Type.fs
+++ b/src/QsFmt/Formatter/ParseTree/Type.fs
@@ -56,8 +56,35 @@ type TypeVisitor(tokens) =
     override _.VisitChildren node =
         Node.toUnknown tokens node |> Type.Unknown
 
+    override _.VisitBigIntType context =
+        context.BigInt().Symbol |> Node.toTerminal tokens |> BuiltIn
+
+    override _.VisitBoolType context =
+        context.Bool().Symbol |> Node.toTerminal tokens |> BuiltIn
+
+    override _.VisitDoubleType context =
+        context.Double().Symbol |> Node.toTerminal tokens |> BuiltIn
+
     override _.VisitIntType context =
         context.Int().Symbol |> Node.toTerminal tokens |> BuiltIn
+
+    override _.VisitPauliType context =
+        context.Pauli().Symbol |> Node.toTerminal tokens |> BuiltIn
+
+    override _.VisitQubitType context =
+        context.Qubit().Symbol |> Node.toTerminal tokens |> BuiltIn
+
+    override _.VisitRangeType context =
+        context.Range().Symbol |> Node.toTerminal tokens |> BuiltIn
+
+    override _.VisitResultType context =
+        context.Result().Symbol |> Node.toTerminal tokens |> BuiltIn
+
+    override _.VisitStringType context =
+        context.String().Symbol |> Node.toTerminal tokens |> BuiltIn
+
+    override _.VisitUnitType context =
+        context.Unit().Symbol |> Node.toTerminal tokens |> BuiltIn
 
     override _.VisitTypeParameter context =
         context.typeParameter |> Node.toTerminal tokens |> Parameter

--- a/src/QsFmt/Formatter/ParseTree/Type.fs
+++ b/src/QsFmt/Formatter/ParseTree/Type.fs
@@ -63,11 +63,22 @@ type TypeVisitor(tokens) =
         { Prefix = Node.prefix tokens context.name.Start.TokenIndex; Text = context.name.GetText() }
         |> UserDefined
 
+    override visitor.VisitTupleType context =
+        let items = context._items |> Seq.map visitor.Visit
+        let commas = context._commas |> Seq.map (Node.toTerminal tokens)
+
+        {
+            OpenParen = context.openParen |> Node.toTerminal tokens
+            Items = Node.tupleItems items commas
+            CloseParen = context.closeParen |> Node.toTerminal tokens
+        }
+        |> Type.Tuple
+
     override visitor.VisitCallableType context =
         {
             FromType = visitor.Visit context.fromType
             Arrow = context.arrow |> Node.toTerminal tokens
             ToType = visitor.Visit context.toType
-            Characteristics =  Option.ofObj context.character |> Option.map (Type.toCharacteristicSection tokens)
+            Characteristics = Option.ofObj context.character |> Option.map (Type.toCharacteristicSection tokens)
         }
         |> Type.Callable

--- a/src/QsFmt/Parser/QSharpParser.g4
+++ b/src/QsFmt/Parser/QSharpParser.g4
@@ -122,7 +122,7 @@ type
     | '(' (type (',' type)* ','?)? ')' # TupleType
     | TypeParameter # TypeParameter
     | type '[' ']' # ArrayType
-    | type ('->' | '=>') type characteristics? # CallableType
+    | fromType=type arrow=('->' | '=>') toType=type character=characteristics? # CallableType
     | 'BigInt' # BigIntType
     | 'Bool' # BoolType
     | 'Double' # DoubleType

--- a/src/QsFmt/Parser/QSharpParser.g4
+++ b/src/QsFmt/Parser/QSharpParser.g4
@@ -120,8 +120,8 @@ specializationParameter
 type
     : '_' # MissingType
     | openParen='(' (items+=type (commas+=',' items+=type)* commas+=','?)? closeParen=')' # TupleType
-    | TypeParameter # TypeParameter
-    | item=type openBracket='[' closeBracket=']' # ArrayType
+    | typeParameter=TypeParameter # TypeParameter
+    | itemType=type openBracket='[' closeBracket=']' # ArrayType
     | fromType=type arrow=('->' | '=>') toType=type character=characteristics? # CallableType
     | 'BigInt' # BigIntType
     | 'Bool' # BoolType

--- a/src/QsFmt/Parser/QSharpParser.g4
+++ b/src/QsFmt/Parser/QSharpParser.g4
@@ -121,7 +121,7 @@ type
     : '_' # MissingType
     | openParen='(' (items+=type (commas+=',' items+=type)* commas+=','?)? closeParen=')' # TupleType
     | TypeParameter # TypeParameter
-    | type '[' ']' # ArrayType
+    | item=type openBracket='[' closeBracket=']' # ArrayType
     | fromType=type arrow=('->' | '=>') toType=type character=characteristics? # CallableType
     | 'BigInt' # BigIntType
     | 'Bool' # BoolType

--- a/src/QsFmt/Parser/QSharpParser.g4
+++ b/src/QsFmt/Parser/QSharpParser.g4
@@ -119,7 +119,7 @@ specializationParameter
 
 type
     : '_' # MissingType
-    | '(' (type (',' type)* ','?)? ')' # TupleType
+    | openParen='(' (items+=type (commas+=',' items+=type)* commas+=','?)? closeParen=')' # TupleType
     | TypeParameter # TypeParameter
     | type '[' ']' # ArrayType
     | fromType=type arrow=('->' | '=>') toType=type character=characteristics? # CallableType


### PR DESCRIPTION
## Issue
Before this PR, only the `IntType` and `UserDefinedType` defined in [QSharpParser.g4](https://github.com/microsoft/qsharp-compiler/blob/main/src/QsFmt/Parser/QSharpParser.g4) can be transferred into a syntax tree. The other types are [parsed](https://github.com/microsoft/qsharp-compiler/blob/main/src/QsFmt/Formatter/ParseTree/Type.fs#L49-L50) into `Unknown` types. This uncompleted implementation prevents formatting rules to be applied within the subtree nodes of a `Type`. For example, the extra spaces inside the brackets are not removed.
```
namespace Foo {
    function Bar () : Int [    ] {}
}
```

## This pull request
In this PR, I have implemented all the other `Type`s defined in [Type.fs](https://github.com/microsoft/qsharp-compiler/blob/main/src/QsFmt/Formatter/SyntaxTree/Type.fs#L36-L44), i.e., `Missing`, `Parameter`, `Tuple`, `Array`, `Callable`, and `BuiltIn` other than `IntType`. The visitors of their context are created. I also named some ANTLA fields to assist the implementation.

## Testing
After the implementation, the previous example is formatted as
```
namespace Foo {
    function Bar () : Int [ ] {}
}
```
Notice that the extra spaces inside the brackets are removed.

I have added several test cases in [FixedPoints.fs](https://github.com/microsoft/qsharp-compiler/blob/main/src/QsFmt/Formatter.Tests/FixedPoints.fs) to demonstrate that the types can be parsed without errors. Note that these test cases can **pass** even before the implementation.

### Question
Should I add the code example shown above as a test case? I notice that there is only one example in [Examples.fs](https://github.com/microsoft/qsharp-compiler/blob/main/src/QsFmt/Formatter.Tests/Examples.fs#L60-L78) to demonstrate that extra spaces are removed. That example serves the same purpose as the one above.