### PR TITLE
Microsoft Simulator Library Fix

### DIFF
--- a/src/QsCompiler/CSharpGeneration/Context.fs
+++ b/src/QsCompiler/CSharpGeneration/Context.fs
@@ -152,6 +152,7 @@ type CodegenContext =
                 target = AssemblyConstants.HoneywellProcessor
                 || target = AssemblyConstants.IonQProcessor
                 || target = AssemblyConstants.QCIProcessor
+                || target = "AzureSimulator" // ToDo: We need to have an assembly constant for this.
             | _ -> false
 
         not (fileName.EndsWith ".dll") || targetsQuantumProcessor

--- a/src/QsCompiler/CSharpGeneration/Context.fs
+++ b/src/QsCompiler/CSharpGeneration/Context.fs
@@ -152,7 +152,7 @@ type CodegenContext =
                 target = AssemblyConstants.HoneywellProcessor
                 || target = AssemblyConstants.IonQProcessor
                 || target = AssemblyConstants.QCIProcessor
-                || target = "AzureSimulator" // ToDo: We need to have an assembly constant for this.
+                || target = "MicrosoftSimulator" // ToDo: We need to have an assembly constant for this.
             | _ -> false
 
         not (fileName.EndsWith ".dll") || targetsQuantumProcessor


### PR DESCRIPTION
Ensures the Q# libraries get regenerated with monomorphized content when compiling with the AzureSimulator process architecture.

Addressed #1069 