### PR TITLE
Don't pass null pointer for empty strings

### DIFF
--- a/src/QsCompiler/LlvmBindings/Context.cs
+++ b/src/QsCompiler/LlvmBindings/Context.cs
@@ -397,7 +397,10 @@ namespace Ubiquity.NET.Llvm
         public ConstantDataArray CreateConstantString(string value, bool nullTerminate)
         {
             var handle = LLVM.ConstStringInContext(this.ContextHandle, value.AsMarshaledString(), (uint)value.Length, !nullTerminate ? 1 : 0);
-            return Value.FromHandle<ConstantDataArray>(handle)!;
+            var created = Value.FromHandle(handle);
+            return created is ConstantDataArray dataArr
+                ? dataArr
+                : new ConstantDataArray(created.ValueHandle);
         }
 
         /// <summary>Creates a new <see cref="ConstantInt"/> with a bit length of 1.</summary>

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestConditional1.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestConditional1.ll
@@ -22,7 +22,7 @@ else__1:                                          ; preds = %entry
   ret i64 0
 
 continue__1:                                      ; No predecessors!
-  %4 = call %String* @__quantum__rt__string_create(i8* getelementptr inbounds ([28 x i8], [28 x i8]* @6, i32 0, i32 0))
+  %4 = call %String* @__quantum__rt__string_create(i8* getelementptr inbounds ([28 x i8], [28 x i8]* @7, i32 0, i32 0))
   call void @__quantum__rt__array_update_alias_count(%Array* %arg__1, i32 -1)
   call void @__quantum__rt__tuple_update_alias_count(%Tuple* %1, i32 -1)
   call void @__quantum__rt__fail(%String* %4)

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestConditional2.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestConditional2.ll
@@ -9,7 +9,7 @@ entry:
   %5 = bitcast i8* %4 to %String**
   %6 = call %String* @__quantum__rt__string_create(i8* getelementptr inbounds ([6 x i8], [6 x i8]* @0, i32 0, i32 0))
   %7 = call %String* @__quantum__rt__string_create(i8* getelementptr inbounds ([6 x i8], [6 x i8]* @1, i32 0, i32 0))
-  %8 = call %String* @__quantum__rt__string_create(i8* null)
+  %8 = call %String* @__quantum__rt__string_create(i8* getelementptr inbounds ([1 x i8], [1 x i8]* @2, i32 0, i32 0))
   store %String* %6, %String** %1, align 8
   store %String* %7, %String** %3, align 8
   store %String* %8, %String** %5, align 8
@@ -22,7 +22,7 @@ condTrue__1:                                      ; preds = %entry
 condFalse__1:                                     ; preds = %entry
   %9 = call %Array* @__quantum__rt__array_copy(%Array* %arr, i1 false)
   %10 = icmp ne %Array* %arr, %9
-  %11 = call %String* @__quantum__rt__string_create(i8* getelementptr inbounds ([2 x i8], [2 x i8]* @2, i32 0, i32 0))
+  %11 = call %String* @__quantum__rt__string_create(i8* getelementptr inbounds ([2 x i8], [2 x i8]* @3, i32 0, i32 0))
   %12 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %9, i64 2)
   %13 = bitcast i8* %12 to %String**
   br i1 %10, label %condContinue__2, label %condFalse__2

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestConditional3.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestConditional3.ll
@@ -12,7 +12,7 @@ else__2:                                          ; preds = %then0__1
   ret i64 2
 
 continue__2:                                      ; No predecessors!
-  %0 = call %String* @__quantum__rt__string_create(i8* getelementptr inbounds ([28 x i8], [28 x i8]* @3, i32 0, i32 0))
+  %0 = call %String* @__quantum__rt__string_create(i8* getelementptr inbounds ([28 x i8], [28 x i8]* @4, i32 0, i32 0))
   call void @__quantum__rt__fail(%String* %0)
   unreachable
 
@@ -26,12 +26,12 @@ else__3:                                          ; preds = %else__1
   ret i64 4
 
 continue__3:                                      ; No predecessors!
-  %1 = call %String* @__quantum__rt__string_create(i8* getelementptr inbounds ([28 x i8], [28 x i8]* @4, i32 0, i32 0))
+  %1 = call %String* @__quantum__rt__string_create(i8* getelementptr inbounds ([28 x i8], [28 x i8]* @5, i32 0, i32 0))
   call void @__quantum__rt__fail(%String* %1)
   unreachable
 
 continue__1:                                      ; No predecessors!
-  %2 = call %String* @__quantum__rt__string_create(i8* getelementptr inbounds ([28 x i8], [28 x i8]* @5, i32 0, i32 0))
+  %2 = call %String* @__quantum__rt__string_create(i8* getelementptr inbounds ([28 x i8], [28 x i8]* @6, i32 0, i32 0))
   call void @__quantum__rt__fail(%String* %2)
   unreachable
 }

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestConditional4.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestConditional4.ll
@@ -1,7 +1,7 @@
 define internal i64 @Microsoft__Quantum__Testing__QIR__TestConditions__body(%String* %input, %Array* %arr) {
 entry:
   call void @__quantum__rt__array_update_alias_count(%Array* %arr, i32 1)
-  %0 = call %String* @__quantum__rt__string_create(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @7, i32 0, i32 0))
+  %0 = call %String* @__quantum__rt__string_create(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @9, i32 0, i32 0))
   %1 = call i1 @__quantum__rt__string_equal(%String* %input, %String* %0)
   call void @__quantum__rt__string_update_reference_count(%String* %0, i32 -1)
   br i1 %1, label %then0__1, label %test1__1
@@ -10,7 +10,7 @@ then0__1:                                         ; preds = %entry
   br label %continue__1
 
 test1__1:                                         ; preds = %entry
-  %2 = call %String* @__quantum__rt__string_create(i8* getelementptr inbounds ([6 x i8], [6 x i8]* @8, i32 0, i32 0))
+  %2 = call %String* @__quantum__rt__string_create(i8* getelementptr inbounds ([6 x i8], [6 x i8]* @10, i32 0, i32 0))
   %3 = call i1 @__quantum__rt__string_equal(%String* %input, %String* %2)
   call void @__quantum__rt__string_update_reference_count(%String* %2, i32 -1)
   br i1 %3, label %then1__1, label %test2__1

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestForLoop.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestForLoop.ll
@@ -1,7 +1,7 @@
 define internal { double, %String* }* @Microsoft__Quantum__Testing__QIR__TestNestedLoops__body() {
 entry:
   %name = call %String* @__quantum__rt__string_create(i8* getelementptr inbounds ([7 x i8], [7 x i8]* @0, i32 0, i32 0))
-  %0 = call %String* @__quantum__rt__string_create(i8* null)
+  %0 = call %String* @__quantum__rt__string_create(i8* getelementptr inbounds ([1 x i8], [1 x i8]* @1, i32 0, i32 0))
   %1 = call { double, %String* }* @Microsoft__Quantum__Testing__QIR__Energy__body(double 0.000000e+00, %String* %0)
   %res = alloca { double, %String* }*, align 8
   store { double, %String* }* %1, { double, %String* }** %res, align 8

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestLocalCallables1.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestLocalCallables1.ll
@@ -54,7 +54,7 @@ exit__1:                                          ; preds = %header__1
   %fct = call %Callable* @__quantum__rt__callable_create([4 x void (%Tuple*, %Tuple*, %Tuple*)*]* @Microsoft__Quantum__Testing__QIR__ReturnTuple, [2 x void (%Tuple*, i32)*]* null, %Tuple* null)
   call void @__quantum__rt__capture_update_alias_count(%Callable* %fct, i32 1)
   call void @__quantum__rt__callable_update_alias_count(%Callable* %fct, i32 1)
-  %25 = call %String* @__quantum__rt__string_create(i8* null)
+  %25 = call %String* @__quantum__rt__string_create(i8* getelementptr inbounds ([1 x i8], [1 x i8]* @0, i32 0, i32 0))
   %26 = call %Tuple* @__quantum__rt__tuple_create(i64 ptrtoint (i1** getelementptr (i1*, i1** null, i32 1) to i64))
   %27 = bitcast %Tuple* %26 to { %String* }*
   %28 = getelementptr inbounds { %String* }, { %String* }* %27, i32 0, i32 0

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestPartials1.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestPartials1.ll
@@ -53,7 +53,7 @@ then0__1:                                         ; preds = %body__1
   %tuple2 = bitcast %Tuple* %19 to { %String*, %Qubit* }*
   %20 = getelementptr inbounds { %String*, %Qubit* }, { %String*, %Qubit* }* %tuple2, i32 0, i32 0
   %21 = getelementptr inbounds { %String*, %Qubit* }, { %String*, %Qubit* }* %tuple2, i32 0, i32 1
-  %22 = call %String* @__quantum__rt__string_create(i8* null)
+  %22 = call %String* @__quantum__rt__string_create(i8* getelementptr inbounds ([1 x i8], [1 x i8]* @0, i32 0, i32 0))
   store %String* %22, %String** %20, align 8
   store %Qubit* %qb, %Qubit** %21, align 8
   call void @__quantum__rt__tuple_update_alias_count(%Tuple* %19, i32 1)
@@ -99,7 +99,7 @@ then0__1:                                         ; preds = %body__1
   %41 = getelementptr inbounds { %Callable*, %String*, %Qubit* }, { %Callable*, %String*, %Qubit* }* %39, i32 0, i32 1
   %42 = getelementptr inbounds { %Callable*, %String*, %Qubit* }, { %Callable*, %String*, %Qubit* }* %39, i32 0, i32 2
   %43 = call %Callable* @__quantum__rt__callable_create([4 x void (%Tuple*, %Tuple*, %Tuple*)*]* @Microsoft__Quantum__Testing__QIR__TakesNestedTuple, [2 x void (%Tuple*, i32)*]* null, %Tuple* null)
-  %44 = call %String* @__quantum__rt__string_create(i8* null)
+  %44 = call %String* @__quantum__rt__string_create(i8* getelementptr inbounds ([1 x i8], [1 x i8]* @1, i32 0, i32 0))
   store %Callable* %43, %Callable** %40, align 8
   store %String* %44, %String** %41, align 8
   store %Qubit* %qb, %Qubit** %42, align 8

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestRepeat.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestRepeat.ll
@@ -10,7 +10,7 @@ repeat__1:                                        ; preds = %condContinue__2, %e
   call void @__quantum__qis__t__adj(%Qubit* %q)
   call void @__quantum__qis__h__body(%Qubit* %q)
   %name = call %String* @__quantum__rt__string_create(i8* getelementptr inbounds ([7 x i8], [7 x i8]* @0, i32 0, i32 0))
-  %0 = call %String* @__quantum__rt__string_create(i8* null)
+  %0 = call %String* @__quantum__rt__string_create(i8* getelementptr inbounds ([1 x i8], [1 x i8]* @1, i32 0, i32 0))
   %1 = call { double, %String* }* @Microsoft__Quantum__Testing__QIR__Energy__body(double 0.000000e+00, %String* %0)
   %res = alloca { double, %String* }*, align 8
   store { double, %String* }* %1, { double, %String* }** %res, align 8
@@ -57,7 +57,7 @@ fixup__1:                                         ; preds = %until__1
   br i1 %15, label %then0__1, label %continue__1
 
 then0__1:                                         ; preds = %fixup__1
-  %16 = call %String* @__quantum__rt__string_create(i8* getelementptr inbounds ([20 x i8], [20 x i8]* @1, i32 0, i32 0))
+  %16 = call %String* @__quantum__rt__string_create(i8* getelementptr inbounds ([20 x i8], [20 x i8]* @2, i32 0, i32 0))
   call void @__quantum__rt__tuple_update_alias_count(%Tuple* %5, i32 -1)
   call void @__quantum__rt__string_update_reference_count(%String* %name, i32 -1)
   call void @__quantum__rt__string_update_reference_count(%String* %0, i32 -1)
@@ -80,7 +80,7 @@ continue__1:                                      ; preds = %fixup__1
   %18 = icmp ne %Tuple* %5, %17
   %19 = bitcast %Tuple* %17 to { double, %String* }*
   %20 = getelementptr inbounds { double, %String* }, { double, %String* }* %19, i32 0, i32 1
-  %21 = call %String* @__quantum__rt__string_create(i8* null)
+  %21 = call %String* @__quantum__rt__string_create(i8* getelementptr inbounds ([1 x i8], [1 x i8]* @3, i32 0, i32 0))
   call void @__quantum__rt__string_update_reference_count(%String* %21, i32 1)
   %22 = load %String*, %String** %20, align 8
   br i1 %18, label %condContinue__2, label %condFalse__2


### PR DESCRIPTION
This PR fixes https://github.com/microsoft/qsharp-compiler/issues/1043. See the issue for further information. 