### PR TITLE
Making it possible to manually invoke the QIR generation logic...

### DIFF
--- a/src/QsCompiler/Compiler/CompilationLoader.cs
+++ b/src/QsCompiler/Compiler/CompilationLoader.cs
@@ -189,9 +189,9 @@ namespace Microsoft.Quantum.QsCompiler
             public IEnumerable<string>? TargetPackageAssemblies { get; set; }
 
             /// <summary>
-            /// Whether or not QIR Generation was requested for this compilation unit.
+            /// Indicates whether the necessary compiler passes are executed for the compilation to be compatible with QIR generation.
             /// </summary>
-            public bool IsQirGenerationEnabled { get; set; }
+            public bool PrepareQirGeneration { get; set; }
 
             /// <summary>
             /// Indicates whether a serialization of the syntax tree needs to be generated.
@@ -199,6 +199,13 @@ namespace Microsoft.Quantum.QsCompiler
             /// </summary>
             internal bool SerializeSyntaxTree =>
                 this.BuildOutputFolder != null || this.DllOutputPath != null;
+
+            /// <summary>
+            /// Indicates whether the compilation needs to be monomorphized.
+            /// This value is never true if SkipMonomorphization is specified.
+            /// </summary>
+            internal bool Monomorphize =>
+                (this.IsExecutable || this.PrepareQirGeneration) && !this.SkipMonomorphization;
 
             /// <summary>
             /// Indicates whether the compiler will remove if-statements and replace them with calls to appropriate intrinsic operations.
@@ -287,13 +294,13 @@ namespace Microsoft.Quantum.QsCompiler
                 this.ReferenceLoading <= 0 &&
                 this.WasSuccessful(true, this.Validation) &&
                 this.WasSuccessful(true, this.PluginLoading) &&
-                this.WasSuccessful((options.IsExecutable || options.IsQirGenerationEnabled) && !options.SkipSyntaxTreeTrimming, this.TreeTrimming) &&
+                this.WasSuccessful(options.IsExecutable && !options.SkipSyntaxTreeTrimming, this.TreeTrimming) &&
                 this.WasSuccessful(options.GenerateFunctorSupport, this.FunctorSupport) &&
                 this.WasSuccessful(!options.SkipConjugationInlining, this.ConjugationInlining) &&
                 this.WasSuccessful(options.AttemptFullPreEvaluation, this.PreEvaluation) &&
                 this.WasSuccessful(options.LoadTargetSpecificDecompositions, this.TargetSpecificReplacements) &&
                 this.WasSuccessful(options.ConvertClassicalControl, this.ConvertClassicalControl) &&
-                this.WasSuccessful((options.IsExecutable || options.IsQirGenerationEnabled) && !options.SkipMonomorphization, this.Monomorphization) &&
+                this.WasSuccessful(options.Monomorphize, this.Monomorphization) &&
                 this.WasSuccessful(!options.IsExecutable, this.CapabilityInference) &&
                 this.WasSuccessful(options.SerializeSyntaxTree, this.Serialization) &&
                 this.WasSuccessful(options.BuildOutputFolder != null, this.BinaryFormat) &&
@@ -573,16 +580,17 @@ namespace Microsoft.Quantum.QsCompiler
             // executing the specified rewrite steps
             PerformanceTracking.TaskStart(PerformanceTracking.Task.RewriteSteps);
             var steps = new List<(int, string, Func<QsCompilation?>)>();
-            this.config.IsQirGenerationEnabled = this.externalRewriteSteps.Any(step => step.Name == "QIR Generation");
+            this.config.PrepareQirGeneration = this.config.PrepareQirGeneration || this.externalRewriteSteps.Any(step => step.Name == "QIR Generation");
 
-            if ((this.config.IsExecutable || this.config.IsQirGenerationEnabled) && !this.config.SkipSyntaxTreeTrimming)
+            if (this.config.IsExecutable && !this.config.SkipSyntaxTreeTrimming)
             {
                 // TODO: It would be nicer to trim unused intrinsics. Currently, this is not possible due to how the old setup of the C# runtime works.
                 // With the new setup (interface-based approach for target packages), it is possible to trim ununsed intrinsics.
 #pragma warning disable CS0618 // Type or member is obsolete
                 // TODO: The dependencies for rewrite steps should be declared as part of IRewriteStep interface, and we should query those here.
-                var rewriteStep = new LoadedStep(new SyntaxTreeTrimming(keepAllIntrinsics: !this.config.IsQirGenerationEnabled, BuiltIn.AllBuiltIns.Select(e => e.FullName), !this.config.IsExecutable), typeof(IRewriteStep), thisDllUri);
+                var trimming = new SyntaxTreeTrimming(keepAllIntrinsics: true, BuiltIn.AllBuiltIns.Select(e => e.FullName));
 #pragma warning restore CS0618 // Type or member is obsolete
+                var rewriteStep = new LoadedStep(trimming, typeof(IRewriteStep), thisDllUri);
                 steps.Add((rewriteStep.Priority, rewriteStep.Name, () => this.ExecuteAsAtomicTransformation(rewriteStep, ref this.compilationStatus.TreeTrimming)));
             }
 
@@ -610,7 +618,7 @@ namespace Microsoft.Quantum.QsCompiler
                 steps.Add((rewriteStep.Priority, rewriteStep.Name, () => this.ExecuteAsAtomicTransformation(rewriteStep, ref this.compilationStatus.PreEvaluation)));
             }
 
-            if ((this.config.IsExecutable || this.config.IsQirGenerationEnabled) && !this.config.SkipMonomorphization)
+            if (this.config.Monomorphize)
             {
                 var rewriteStep = new LoadedStep(new Monomorphization(monomorphizeIntrinsics: false, !this.config.IsExecutable), typeof(IRewriteStep), thisDllUri);
                 steps.Add((rewriteStep.Priority, rewriteStep.Name, () => this.ExecuteAsAtomicTransformation(rewriteStep, ref this.compilationStatus.Monomorphization)));

--- a/src/QsCompiler/Compiler/CompilationLoader.cs
+++ b/src/QsCompiler/Compiler/CompilationLoader.cs
@@ -620,7 +620,7 @@ namespace Microsoft.Quantum.QsCompiler
 
             if (this.config.Monomorphize)
             {
-                var rewriteStep = new LoadedStep(new Monomorphization(monomorphizeIntrinsics: false, !this.config.IsExecutable), typeof(IRewriteStep), thisDllUri);
+                var rewriteStep = new LoadedStep(new Monomorphization(monomorphizeIntrinsics: false), typeof(IRewriteStep), thisDllUri);
                 steps.Add((rewriteStep.Priority, rewriteStep.Name, () => this.ExecuteAsAtomicTransformation(rewriteStep, ref this.compilationStatus.Monomorphization)));
             }
 

--- a/src/QsCompiler/Compiler/RewriteSteps/Monomorphization.cs
+++ b/src/QsCompiler/Compiler/RewriteSteps/Monomorphization.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Quantum.QsCompiler.BuiltInRewriteSteps
     internal class Monomorphization : IRewriteStep
     {
         private readonly bool monomorphizeIntrinsics;
-        private readonly bool isLibrary;
+        private readonly bool enabledForLibraries;
 
         public string Name => "Monomorphization";
 
@@ -36,15 +36,15 @@ namespace Microsoft.Quantum.QsCompiler.BuiltInRewriteSteps
         /// Constructor for the Monomorphization Rewrite Step.
         /// </summary>
         /// <param name="monomorphizeIntrinsics">When true, intrinsics will be monomorphized as part of the rewrite step.</param>
-        /// <param name="isLibrary">When true, each public, non-generic callable will be treated as an entry point in the call graph.</param>
-        public Monomorphization(bool monomorphizeIntrinsics = false, bool isLibrary = false)
+        /// <param name="enabledForLibraries">When true, each public, non-generic callable will be treated as an entry point in the call graph.</param>
+        public Monomorphization(bool monomorphizeIntrinsics = false, bool enabledForLibraries = false)
         {
             this.monomorphizeIntrinsics = monomorphizeIntrinsics;
             this.AssemblyConstants = new Dictionary<string, string?>();
-            this.isLibrary = isLibrary;
+            this.enabledForLibraries = enabledForLibraries;
         }
 
-        public bool PreconditionVerification(QsCompilation compilation) => compilation.EntryPoints.Any() || this.isLibrary;
+        public bool PreconditionVerification(QsCompilation compilation) => compilation.EntryPoints.Any() || this.enabledForLibraries;
 
         public bool Transformation(QsCompilation compilation, out QsCompilation transformed)
         {
@@ -71,7 +71,7 @@ namespace Microsoft.Quantum.QsCompiler.BuiltInRewriteSteps
         {
             // If this compilation is for a library project, there are no defined entry points. Instead,
             // treat every public, non-generic callable as a possible entry point into the library.
-            return this.isLibrary ?
+            return compilation.EntryPoints.Length == 0 ?
                 compilation.Namespaces.GlobalCallableResolutions()
                     .Where(g => g.Value.Source.AssemblyFile.IsNull && g.Value.Signature.TypeParameters.IsEmpty && g.Value.Access.IsPublic)
                     .Select(e => e.Key)

--- a/src/QsCompiler/Compiler/RewriteSteps/Monomorphization.cs
+++ b/src/QsCompiler/Compiler/RewriteSteps/Monomorphization.cs
@@ -71,7 +71,7 @@ namespace Microsoft.Quantum.QsCompiler.BuiltInRewriteSteps
         {
             // If this compilation is for a library project, there are no defined entry points. Instead,
             // treat every public, non-generic callable as a possible entry point into the library.
-            return compilation.EntryPoints.Length == 0 ?
+            return this.enabledForLibraries && compilation.EntryPoints.Length == 0 ?
                 compilation.Namespaces.GlobalCallableResolutions()
                     .Where(g => g.Value.Source.AssemblyFile.IsNull && g.Value.Signature.TypeParameters.IsEmpty && g.Value.Access.IsPublic)
                     .Select(e => e.Key)

--- a/src/QsCompiler/Compiler/RewriteSteps/Monomorphization.cs
+++ b/src/QsCompiler/Compiler/RewriteSteps/Monomorphization.cs
@@ -71,12 +71,12 @@ namespace Microsoft.Quantum.QsCompiler.BuiltInRewriteSteps
         {
             // If this compilation is for a library project, there are no defined entry points. Instead,
             // treat every public, non-generic callable as a possible entry point into the library.
-            return this.enabledForLibraries && compilation.EntryPoints.Length == 0 ?
-                compilation.Namespaces.GlobalCallableResolutions()
+            return this.enabledForLibraries && compilation.EntryPoints.Length == 0
+                ? compilation.Namespaces.GlobalCallableResolutions()
                     .Where(g => g.Value.Source.AssemblyFile.IsNull && g.Value.Signature.TypeParameters.IsEmpty && g.Value.Access.IsPublic)
                     .Select(e => e.Key)
-                    .ToImmutableArray() :
-                compilation.EntryPoints;
+                    .ToImmutableArray()
+                : compilation.EntryPoints;
         }
     }
 }

--- a/src/QsCompiler/Compiler/RewriteSteps/Monomorphization.cs
+++ b/src/QsCompiler/Compiler/RewriteSteps/Monomorphization.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
@@ -16,7 +17,6 @@ namespace Microsoft.Quantum.QsCompiler.BuiltInRewriteSteps
     internal class Monomorphization : IRewriteStep
     {
         private readonly bool monomorphizeIntrinsics;
-        private readonly bool enabledForLibraries;
 
         public string Name => "Monomorphization";
 
@@ -26,7 +26,7 @@ namespace Microsoft.Quantum.QsCompiler.BuiltInRewriteSteps
 
         public IEnumerable<IRewriteStep.Diagnostic> GeneratedDiagnostics => Enumerable.Empty<IRewriteStep.Diagnostic>();
 
-        public bool ImplementsPreconditionVerification => true;
+        public bool ImplementsPreconditionVerification => false;
 
         public bool ImplementsTransformation => true;
 
@@ -36,15 +36,14 @@ namespace Microsoft.Quantum.QsCompiler.BuiltInRewriteSteps
         /// Constructor for the Monomorphization Rewrite Step.
         /// </summary>
         /// <param name="monomorphizeIntrinsics">When true, intrinsics will be monomorphized as part of the rewrite step.</param>
-        /// <param name="enabledForLibraries">When true, each public, non-generic callable will be treated as an entry point in the call graph.</param>
-        public Monomorphization(bool monomorphizeIntrinsics = false, bool enabledForLibraries = false)
+        public Monomorphization(bool monomorphizeIntrinsics = false)
         {
             this.monomorphizeIntrinsics = monomorphizeIntrinsics;
             this.AssemblyConstants = new Dictionary<string, string?>();
-            this.enabledForLibraries = enabledForLibraries;
         }
 
-        public bool PreconditionVerification(QsCompilation compilation) => compilation.EntryPoints.Any() || this.enabledForLibraries;
+        public bool PreconditionVerification(QsCompilation compilation) =>
+            throw new NotImplementedException();
 
         public bool Transformation(QsCompilation compilation, out QsCompilation transformed)
         {
@@ -71,7 +70,7 @@ namespace Microsoft.Quantum.QsCompiler.BuiltInRewriteSteps
         {
             // If this compilation is for a library project, there are no defined entry points. Instead,
             // treat every public, non-generic callable as a possible entry point into the library.
-            return this.enabledForLibraries && compilation.EntryPoints.Length == 0
+            return compilation.EntryPoints.Length == 0
                 ? compilation.Namespaces.GlobalCallableResolutions()
                     .Where(g => g.Value.Source.AssemblyFile.IsNull && g.Value.Signature.TypeParameters.IsEmpty && g.Value.Access.IsPublic)
                     .Select(e => e.Key)

--- a/src/QsCompiler/Compiler/RewriteSteps/SyntaxTreeTrimming.cs
+++ b/src/QsCompiler/Compiler/RewriteSteps/SyntaxTreeTrimming.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Quantum.QsCompiler.BuiltInRewriteSteps
     internal class SyntaxTreeTrimming : IRewriteStep
     {
         private readonly bool keepAllIntrinsics;
-        private readonly bool isLibrary;
+        private readonly bool enabledForLibraries;
         private readonly IEnumerable<QsQualifiedName>? dependencies;
 
         public string Name => "Syntax Tree Trimming";
@@ -35,19 +35,19 @@ namespace Microsoft.Quantum.QsCompiler.BuiltInRewriteSteps
         /// Initializes a new instance of the <see cref="SyntaxTreeTrimming"/> class.
         /// </summary>
         /// <param name="keepAllIntrinsics">When true, intrinsics will not be removed as part of the rewrite step.</param>
-        /// <param name="isLibrary">When true, trimming will consider every public, non-generic callabe as an entry point.</param>
-        public SyntaxTreeTrimming(bool keepAllIntrinsics = true, IEnumerable<QsQualifiedName>? dependencies = null, bool isLibrary = false)
+        /// <param name="enabledForLibraries">When true, trimming will consider every public, non-generic callabe as an entry point.</param>
+        public SyntaxTreeTrimming(bool keepAllIntrinsics = true, IEnumerable<QsQualifiedName>? dependencies = null, bool enabledForLibraries = false)
         {
             this.keepAllIntrinsics = keepAllIntrinsics;
             this.dependencies = dependencies;
-            this.isLibrary = isLibrary;
+            this.enabledForLibraries = enabledForLibraries;
         }
 
-        public bool PreconditionVerification(QsCompilation compilation) => compilation.EntryPoints.Any() || this.isLibrary;
+        public bool PreconditionVerification(QsCompilation compilation) => compilation.EntryPoints.Any() || this.enabledForLibraries;
 
         public bool Transformation(QsCompilation compilation, out QsCompilation transformed)
         {
-            transformed = TrimSyntaxTree.Apply(compilation, this.keepAllIntrinsics, this.dependencies, this.isLibrary);
+            transformed = TrimSyntaxTree.Apply(compilation, this.keepAllIntrinsics, this.dependencies);
             return true;
         }
 

--- a/src/QsCompiler/Compiler/RewriteSteps/SyntaxTreeTrimming.cs
+++ b/src/QsCompiler/Compiler/RewriteSteps/SyntaxTreeTrimming.cs
@@ -14,7 +14,6 @@ namespace Microsoft.Quantum.QsCompiler.BuiltInRewriteSteps
     internal class SyntaxTreeTrimming : IRewriteStep
     {
         private readonly bool keepAllIntrinsics;
-        private readonly bool enabledForLibraries;
         private readonly IEnumerable<QsQualifiedName>? dependencies;
 
         public string Name => "Syntax Tree Trimming";
@@ -25,7 +24,7 @@ namespace Microsoft.Quantum.QsCompiler.BuiltInRewriteSteps
 
         public IEnumerable<IRewriteStep.Diagnostic> GeneratedDiagnostics => Enumerable.Empty<IRewriteStep.Diagnostic>();
 
-        public bool ImplementsPreconditionVerification => true;
+        public bool ImplementsPreconditionVerification => false;
 
         public bool ImplementsTransformation => true;
 
@@ -35,15 +34,14 @@ namespace Microsoft.Quantum.QsCompiler.BuiltInRewriteSteps
         /// Initializes a new instance of the <see cref="SyntaxTreeTrimming"/> class.
         /// </summary>
         /// <param name="keepAllIntrinsics">When true, intrinsics will not be removed as part of the rewrite step.</param>
-        /// <param name="enabledForLibraries">When true, trimming will consider every public, non-generic callabe as an entry point.</param>
-        public SyntaxTreeTrimming(bool keepAllIntrinsics = true, IEnumerable<QsQualifiedName>? dependencies = null, bool enabledForLibraries = false)
+        public SyntaxTreeTrimming(bool keepAllIntrinsics = true, IEnumerable<QsQualifiedName>? dependencies = null)
         {
             this.keepAllIntrinsics = keepAllIntrinsics;
             this.dependencies = dependencies;
-            this.enabledForLibraries = enabledForLibraries;
         }
 
-        public bool PreconditionVerification(QsCompilation compilation) => compilation.EntryPoints.Any() || this.enabledForLibraries;
+        public bool PreconditionVerification(QsCompilation compilation) =>
+            throw new System.NotImplementedException();
 
         public bool Transformation(QsCompilation compilation, out QsCompilation transformed)
         {
@@ -51,9 +49,7 @@ namespace Microsoft.Quantum.QsCompiler.BuiltInRewriteSteps
             return true;
         }
 
-        public bool PostconditionVerification(QsCompilation compilation)
-        {
+        public bool PostconditionVerification(QsCompilation compilation) =>
             throw new System.NotImplementedException();
-        }
     }
 }

--- a/src/QsCompiler/QirGeneration/Context.cs
+++ b/src/QsCompiler/QirGeneration/Context.cs
@@ -10,7 +10,6 @@ using Microsoft.Quantum.QIR;
 using Microsoft.Quantum.QIR.Emission;
 using Microsoft.Quantum.QsCompiler.SyntaxTokens;
 using Microsoft.Quantum.QsCompiler.SyntaxTree;
-using Microsoft.Quantum.QsCompiler.Transformations.Targeting;
 using Ubiquity.NET.Llvm;
 using Ubiquity.NET.Llvm.Instructions;
 using Ubiquity.NET.Llvm.Interop;
@@ -178,7 +177,7 @@ namespace Microsoft.Quantum.QsCompiler.QIR
         /// </summary>
         /// <param name="syntaxTree">The syntax tree for which QIR is generated.</param>
         /// <param name="isLibrary">Whether the current compilation is being performed for a library.</param>
-        internal GenerationContext(IEnumerable<QsNamespace> syntaxTree, bool isLibrary)
+        public GenerationContext(IEnumerable<QsNamespace> syntaxTree, bool isLibrary)
         {
             this.IsLibrary = isLibrary;
             this.globalCallables = syntaxTree.GlobalCallableResolutions();

--- a/src/QsCompiler/QirGeneration/Context.cs
+++ b/src/QsCompiler/QirGeneration/Context.cs
@@ -177,7 +177,7 @@ namespace Microsoft.Quantum.QsCompiler.QIR
         /// </summary>
         /// <param name="syntaxTree">The syntax tree for which QIR is generated.</param>
         /// <param name="isLibrary">Whether the current compilation is being performed for a library.</param>
-        public GenerationContext(IEnumerable<QsNamespace> syntaxTree, bool isLibrary)
+        internal GenerationContext(IEnumerable<QsNamespace> syntaxTree, bool isLibrary)
         {
             this.IsLibrary = isLibrary;
             this.globalCallables = syntaxTree.GlobalCallableResolutions();

--- a/src/QsCompiler/QirGeneration/Generator.cs
+++ b/src/QsCompiler/QirGeneration/Generator.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Quantum.QsCompiler.QIR
     /// <summary>
     /// Transformation class used to generate QIR.
     /// </summary>
-    public class Generator : SyntaxTreeTransformation<GenerationContext>
+    public class Generator : SyntaxTreeTransformation<GenerationContext>, IDisposable
     {
         /// <summary>
         /// The compilation unit for which QIR is generated.
@@ -102,5 +102,8 @@ namespace Microsoft.Quantum.QsCompiler.QIR
                 throw new IOException(errorMessage);
             }
         }
+
+        public void Dispose() =>
+            this.SharedState.Dispose();
     }
 }

--- a/src/QsCompiler/QirGeneration/Generator.cs
+++ b/src/QsCompiler/QirGeneration/Generator.cs
@@ -36,8 +36,9 @@ namespace Microsoft.Quantum.QsCompiler.QIR
         /// Instantiates a transformation capable of emitting QIR for the given compilation.
         /// </summary>
         /// <param name="compilation">The compilation for which to generate QIR</param>
-        public Generator(QsCompilation compilation, GenerationContext context)
-        : base(context, TransformationOptions.NoRebuild)
+        /// <param name="isLibrary">Whether the current compilation is being performed for a library.</param>
+        public Generator(QsCompilation compilation, bool isLibrary)
+        : base(new GenerationContext(compilation.Namespaces, isLibrary), TransformationOptions.NoRebuild)
         {
             this.Compilation = compilation;
 

--- a/src/QsCompiler/QirGeneration/Generator.cs
+++ b/src/QsCompiler/QirGeneration/Generator.cs
@@ -36,9 +36,8 @@ namespace Microsoft.Quantum.QsCompiler.QIR
         /// Instantiates a transformation capable of emitting QIR for the given compilation.
         /// </summary>
         /// <param name="compilation">The compilation for which to generate QIR</param>
-        /// <param name="isLibrary">Whether the current compilation is being performed for a library.</param>
-        public Generator(QsCompilation compilation, bool isLibrary)
-        : base(new GenerationContext(compilation.Namespaces, isLibrary), TransformationOptions.NoRebuild)
+        public Generator(QsCompilation compilation)
+        : base(new GenerationContext(compilation.Namespaces, compilation.EntryPoints.Length == 0), TransformationOptions.NoRebuild)
         {
             this.Compilation = compilation;
 

--- a/src/QsCompiler/QirGeneration/RewriteSteps.cs
+++ b/src/QsCompiler/QirGeneration/RewriteSteps.cs
@@ -75,7 +75,7 @@ namespace Microsoft.Quantum.QsCompiler
         public bool Transformation(QsCompilation compilation, out QsCompilation transformed)
         {
             transformed = compilation;
-            var generator = new Generator(transformed);
+            using var generator = new Generator(transformed);
             generator.Apply();
 
             // write generated QIR to disk

--- a/src/QsCompiler/QirGeneration/RewriteSteps.cs
+++ b/src/QsCompiler/QirGeneration/RewriteSteps.cs
@@ -17,7 +17,7 @@ using Microsoft.Quantum.QsCompiler.Transformations.Targeting;
 
 namespace Microsoft.Quantum.QsCompiler
 {
-    internal class QirGeneration : IRewriteStep
+    public class QirGeneration : IRewriteStep
     {
         internal const int EmissionPriority = -10;
 
@@ -119,7 +119,7 @@ namespace Microsoft.Quantum.QsCompiler
     /// or a non-intrinsic callable contains intrinsic specializations,
     /// or the a callable doesn't have a body specialization.
     /// </exception>
-    internal class TargetInstructionInference : IRewriteStep
+    public class TargetInstructionInference : IRewriteStep
     {
         private readonly List<IRewriteStep.Diagnostic> diagnostics = new List<IRewriteStep.Diagnostic>();
 

--- a/src/QsCompiler/QirGeneration/RewriteSteps.cs
+++ b/src/QsCompiler/QirGeneration/RewriteSteps.cs
@@ -76,8 +76,7 @@ namespace Microsoft.Quantum.QsCompiler
         {
             transformed = compilation;
             var isLibrary = this.AssemblyConstants.TryGetValue(ReservedKeywords.AssemblyConstants.QsharpOutputType, out var outputType) && string.Equals(outputType, ReservedKeywords.AssemblyConstants.QsharpLibrary);
-            using var generationContext = new GenerationContext(compilation.Namespaces, isLibrary);
-            var generator = new Generator(transformed, generationContext);
+            var generator = new Generator(transformed, isLibrary);
             generator.Apply();
 
             // write generated QIR to disk

--- a/src/QsCompiler/QirGeneration/RewriteSteps.cs
+++ b/src/QsCompiler/QirGeneration/RewriteSteps.cs
@@ -75,8 +75,7 @@ namespace Microsoft.Quantum.QsCompiler
         public bool Transformation(QsCompilation compilation, out QsCompilation transformed)
         {
             transformed = compilation;
-            var isLibrary = this.AssemblyConstants.TryGetValue(ReservedKeywords.AssemblyConstants.QsharpOutputType, out var outputType) && string.Equals(outputType, ReservedKeywords.AssemblyConstants.QsharpLibrary);
-            var generator = new Generator(transformed, isLibrary);
+            var generator = new Generator(transformed);
             generator.Apply();
 
             // write generated QIR to disk
@@ -160,10 +159,7 @@ namespace Microsoft.Quantum.QsCompiler
         /// <inheritdoc/>
         public bool Transformation(QsCompilation compilation, out QsCompilation transformed)
         {
-            transformed = TrimSyntaxTree.Apply(
-                compilation,
-                keepAllIntrinsics: false,
-                isLibrary: this.AssemblyConstants.TryGetValue(ReservedKeywords.AssemblyConstants.QsharpOutputType, out var outputType) && string.Equals(outputType, ReservedKeywords.AssemblyConstants.QsharpLibrary));
+            transformed = TrimSyntaxTree.Apply(compilation, keepAllIntrinsics: false);
             transformed = InferTargetInstructions.ReplaceSelfAdjointSpecializations(transformed);
             transformed = InferTargetInstructions.LiftIntrinsicSpecializations(transformed);
             var allAttributesAdded = InferTargetInstructions.TryAddMissingTargetInstructionAttributes(transformed, out transformed);

--- a/src/QsCompiler/Transformations/SyntaxTreeTrimming.cs
+++ b/src/QsCompiler/Transformations/SyntaxTreeTrimming.cs
@@ -25,14 +25,14 @@ namespace Microsoft.Quantum.QsCompiler.Transformations.SyntaxTreeTrimming
         /// regardless of usage. Note that unused type constructors will be subject to
         /// trimming as any other callable.
         /// </summary>
-        public static QsCompilation Apply(QsCompilation compilation, bool keepAllIntrinsics, IEnumerable<QsQualifiedName>? dependencies = null, bool isLibrary = false)
+        public static QsCompilation Apply(QsCompilation compilation, bool keepAllIntrinsics, IEnumerable<QsQualifiedName>? dependencies = null)
         {
-            return TrimTree.Apply(compilation, keepAllIntrinsics, dependencies, isLibrary);
+            return TrimTree.Apply(compilation, keepAllIntrinsics, dependencies);
         }
 
         private class TrimTree : SyntaxTreeTransformation<TrimTree.TransformationState>
         {
-            public static QsCompilation Apply(QsCompilation compilation, bool keepAllIntrinsics, IEnumerable<QsQualifiedName>? dependencies, bool isLibrary)
+            public static QsCompilation Apply(QsCompilation compilation, bool keepAllIntrinsics, IEnumerable<QsQualifiedName>? dependencies)
             {
                 var globals = compilation.Namespaces.GlobalCallableResolutions();
                 var dependenciesToKeep = dependencies?.Where(globals.ContainsKey) ?? ImmutableArray<QsQualifiedName>.Empty;
@@ -42,7 +42,7 @@ namespace Microsoft.Quantum.QsCompiler.Transformations.SyntaxTreeTrimming
 
                 // If this compilation is for a Library project, treat each public, non-generic callable as an entry point
                 // for the purpose of constructing the call graph and pruning the syntax tree.
-                if (isLibrary)
+                if (compilation.EntryPoints.Length == 0)
                 {
                     var externals = globals.Where(g => g.Value.Source.AssemblyFile.IsNull && g.Value.Signature.TypeParameters.IsEmpty && g.Value.Access.IsPublic);
                     augmentedEntryPoints = augmentedEntryPoints.Concat(externals.Select(e => e.Key)).Distinct();


### PR DESCRIPTION
...without loading it as a rewrite step. Ensures that QIR and C# generation can run at the same time.