### PR TITLE
Setting LSP document version in Language Server

### DIFF
--- a/src/QsCompiler/CompilationManager/CompilationUnitManager.cs
+++ b/src/QsCompiler/CompilationManager/CompilationUnitManager.cs
@@ -362,6 +362,10 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
 
                 this.changedFiles.Add(docKey);
                 var publish = false;
+
+                // We should keep the file version in sync with the reported by the LSP.
+                file.Version = param.TextDocument.Version;
+
                 foreach (var change in param.ContentChanges)
                 {
                     file.PushChange(change, out publish); // only the last one here is relevant

--- a/src/QsCompiler/CompilationManager/EditorSupport/CodeActions.cs
+++ b/src/QsCompiler/CompilationManager/EditorSupport/CodeActions.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// </summary>
         private static WorkspaceEdit GetWorkspaceEdit(this FileContentManager file, params TextEdit[] edits)
         {
-            var versionedFileId = new VersionedTextDocumentIdentifier { Uri = file.Uri, Version = 1 }; // setting version to null here won't work in VS Code ...
+            var versionedFileId = new VersionedTextDocumentIdentifier { Uri = file.Uri, Version = file.Version };
             return new WorkspaceEdit
             {
                 DocumentChanges = new[] { new TextDocumentEdit { TextDocument = versionedFileId, Edits = edits } },

--- a/src/QsCompiler/CompilationManager/EditorSupport/CodeActions.cs
+++ b/src/QsCompiler/CompilationManager/EditorSupport/CodeActions.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// </summary>
         private static WorkspaceEdit GetWorkspaceEdit(this FileContentManager file, params TextEdit[] edits)
         {
-            var versionedFileId = new VersionedTextDocumentIdentifier { Uri = file.Uri, Version = file.Version };
+            var versionedFileId = new VersionedTextDocumentIdentifier { Uri = file.Uri, Version = file.Version ?? 1 };
             return new WorkspaceEdit
             {
                 DocumentChanges = new[] { new TextDocumentEdit { TextDocument = versionedFileId, Edits = edits } },

--- a/src/QsCompiler/CompilationManager/FileContentManager.cs
+++ b/src/QsCompiler/CompilationManager/FileContentManager.cs
@@ -32,6 +32,11 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
 
         public string FileName { get; }
 
+        /// <summary>
+        /// Indicates the current version of the document according to the Language Server Protocol.
+        /// </summary>
+        public int? Version { get; set; }
+
         private readonly ManagedList<CodeLine> content;
         private readonly ManagedList<ImmutableArray<CodeFragment>> tokens;
         private readonly FileHeader header;
@@ -113,6 +118,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
             this.SyncRoot = new ReaderWriterLockSlim(LockRecursionPolicy.SupportsRecursion);
             this.Uri = uri;
             this.FileName = fileName;
+            this.Version = 1;
 
             this.content = new ManagedList<CodeLine>(this.SyncRoot);
             this.content.Add(CodeLine.Empty()); // each new file per default has one line without text

--- a/src/QsCompiler/CompilationManager/FileContentManager.cs
+++ b/src/QsCompiler/CompilationManager/FileContentManager.cs
@@ -33,7 +33,8 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         public string FileName { get; }
 
         /// <summary>
-        /// Indicates the current version of the document according to the Language Server Protocol.
+        /// An arbitrary integer representing the current version number of the file, or null if no version number is available.
+        /// The version number may change at any time to any other integer, including a lower number than its current value.
         /// </summary>
         public int? Version { get; set; }
 

--- a/src/QsCompiler/CompilationManager/FileContentManager.cs
+++ b/src/QsCompiler/CompilationManager/FileContentManager.cs
@@ -118,7 +118,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
             this.SyncRoot = new ReaderWriterLockSlim(LockRecursionPolicy.SupportsRecursion);
             this.Uri = uri;
             this.FileName = fileName;
-            this.Version = 1;
+            this.Version = null;
 
             this.content = new ManagedList<CodeLine>(this.SyncRoot);
             this.content.Add(CodeLine.Empty()); // each new file per default has one line without text

--- a/src/QsCompiler/LanguageServer/EditorState.cs
+++ b/src/QsCompiler/LanguageServer/EditorState.cs
@@ -281,6 +281,9 @@ namespace Microsoft.Quantum.QsLanguageServer
                         MessageType.Info);
                 }
 
+                // When opening a file, the initial LSP version might have already changed.
+                file.Version = textDocument.Version;
+
                 _ = manager.AddOrUpdateSourceFileAsync(file);
             });
 


### PR DESCRIPTION
Each time that a document is change in an editor, the Language Server Protocol includes a document version number as part of its `textNotification/didChange` updates. This document version can be specified as part of WorkspaceEdit objects when setting up code actions.

Up to Visual Studio 16.9, it was optional by the LSP protocol to include a matching version, and the extension defaulted to a version of 1 in all cases. However, starting from 16.10, the protocol expects the version of the document to match the latest one provided by the LSP, otherwise code actions will be ignored.

This change keeps track of the last received version from the LSP and uses it when setting up code actions.