### PR TITLE
Fix type range used when resolving type parameters

### DIFF
--- a/src/QsCompiler/SyntaxProcessor/TypeInference/InferenceContext.fs
+++ b/src/QsCompiler/SyntaxProcessor/TypeInference/InferenceContext.fs
@@ -367,9 +367,12 @@ type InferenceContext(symbolTracker: SymbolTracker) =
         |> rememberErrors (resolvedType :: Constraint.types typeConstraint)
 
     member internal context.Resolve resolvedType =
-        let resolveWithRange type' =
-            let type' = context.Resolve type'
-            type' |> ResolvedType.withRange (type'.Range |> TypeRange.orElse resolvedType.Range)
+        let resolveWithRange type_ =
+            let resolvedType' = context.Resolve type_
+
+            // Prefer the original type range since it may be closer to the source of the error, but otherwise fall back
+            // to the newly resolved type range.
+            resolvedType' |> ResolvedType.withRange (resolvedType.Range |> TypeRange.orElse resolvedType'.Range)
 
         match resolvedType.Resolution with
         | TypeParameter param ->

--- a/src/QsCompiler/SyntaxProcessor/TypeInference/InferenceContext.fs
+++ b/src/QsCompiler/SyntaxProcessor/TypeInference/InferenceContext.fs
@@ -370,7 +370,7 @@ type InferenceContext(symbolTracker: SymbolTracker) =
         let resolveWithRange type_ =
             let resolvedType' = context.Resolve type_
 
-            // Prefer the original type range since it may be closer to the source of the error, but otherwise fall back
+            // Prefer the original type range since it may be closer to the source of an error, but otherwise fall back
             // to the newly resolved type range.
             resolvedType' |> ResolvedType.withRange (resolvedType.Range |> TypeRange.orElse resolvedType'.Range)
 


### PR DESCRIPTION
Resolves #1087.

This is a bit subtle... Basically, when resolving a type parameter, the original code preferred the range of the type that the type parameter pointed to. This is not correct for the example in #1087, because that type range comes from the previous line that declared the variable `carry`.

In this PR, it now prefers the range of the original type before resolution, whose range corresponds to the reference to `carry` on the line with the call to `Message`.

Since there are no tests for diagnostic ranges, it's hard to say if this won't break any other diagnostics, but I can't think of any examples where this is incorrect...