### PR TITLE
Removing extra guidance for Linux lib rename

### DIFF
--- a/examples/QIR/Optimization/Hello/Hello.csproj
+++ b/examples/QIR/Optimization/Hello/Hello.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.Quantum.Sdk/0.18.2106148911">
+<Project Sdk="Microsoft.Quantum.Sdk/0.18.2107153439">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -8,8 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Qir.Runtime" Version="0.18.2106148911-alpha" GeneratePathProperty="true" />
-    <PackageReference Include="Microsoft.Quantum.Simulators" Version="0.18.2106148911" GeneratePathProperty="true" />
+    <PackageReference Include="Microsoft.Quantum.Qir.Runtime" Version="0.18.2107153439-alpha" GeneratePathProperty="true" />
+    <PackageReference Include="Microsoft.Quantum.Simulators" Version="0.18.2107153439" GeneratePathProperty="true" />
   </ItemGroup>
 
   <Target Name="GetDependencies" AfterTargets="Build">

--- a/examples/QIR/Optimization/README.md
+++ b/examples/QIR/Optimization/README.md
@@ -426,15 +426,6 @@ build
 └── SimFactory.hpp
 ```
 
-(**Linux**) The `Microsoft.Quantum.Qir.*` dynamic libraries will already have the right naming scheme for Clang to use, but the `Microsoft.Quantum.Simulator.Runtime` library needs to be renamed.
-The proper name format is `lib<library-name>.so`.
-
-Execute the following command from the project root directory:
-
-```bash
-mv build/Microsoft.Quantum.Simulator.Runtime.dll build/libMicrosoft.Quantum.Simulator.Runtime.so
-```
-
 ### Adding a driver
 
 Trying to compile the QIR code in `Hello.ll` as is would present some problems, as it's missing a program entry point and the proper setup of the simulator.

--- a/examples/QIR/Optimization/README.md
+++ b/examples/QIR/Optimization/README.md
@@ -120,7 +120,7 @@ Q# uses .NET project files to control the compilation process, located in the pr
 The standard one provided for a standalone Q# application looks as follows:
 
 ```xml
-<Project Sdk="Microsoft.Quantum.Sdk/0.18.2106148911">
+<Project Sdk="Microsoft.Quantum.Sdk/0.18.2107153439">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -133,7 +133,7 @@ The standard one provided for a standalone Q# application looks as follows:
 Enabling QIR generation is a simple matter of adding the `<QirGeneration>` property to the project file:
 
 ```xml
-<Project Sdk="Microsoft.Quantum.Sdk/0.18.2106148911">
+<Project Sdk="Microsoft.Quantum.Sdk/0.18.2107153439">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -329,8 +329,8 @@ One for the runtime and one for the simulator, using the `PackageReference` comm
 
 ```xml
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Qir.Runtime" Version="0.18.2106148911-alpha" GeneratePathProperty="true" />
-    <PackageReference Include="Microsoft.Quantum.Simulators" Version="0.18.2106148911" GeneratePathProperty="true" />
+    <PackageReference Include="Microsoft.Quantum.Qir.Runtime" Version="0.18.2107153439-alpha" GeneratePathProperty="true" />
+    <PackageReference Include="Microsoft.Quantum.Simulators" Version="0.18.2107153439" GeneratePathProperty="true" />
   </ItemGroup>
 ```
 
@@ -376,7 +376,7 @@ Only `.hpp` files from the QIR header directory will be copied, and no `.exe` fi
 Put together, the new `Hello.csproj` project file should look as follows:
 
 ```xml
-<Project Sdk="Microsoft.Quantum.Sdk/0.18.2106148911">
+<Project Sdk="Microsoft.Quantum.Sdk/0.18.2107153439">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -386,8 +386,8 @@ Put together, the new `Hello.csproj` project file should look as follows:
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Qir.Runtime" Version="0.18.2106148911-alpha" GeneratePathProperty="true" />
-    <PackageReference Include="Microsoft.Quantum.Simulators" Version="0.18.2106148911" GeneratePathProperty="true" />
+    <PackageReference Include="Microsoft.Quantum.Qir.Runtime" Version="0.18.2107153439-alpha" GeneratePathProperty="true" />
+    <PackageReference Include="Microsoft.Quantum.Simulators" Version="0.18.2107153439" GeneratePathProperty="true" />
   </ItemGroup>
 
   <Target Name="GetDependencies" AfterTargets="Build">


### PR DESCRIPTION
Since the fix for the simulator dll name was merged with the cloud simulator feature branch, the guidance on renaming the simulator dll for Linux is no longer needed. See https://github.com/microsoft/qsharp-compiler/pull/1093#discussion_r677814103 for context.