### PR TITLE
Prevent Classical Conditions from being Lifted

### DIFF
--- a/src/QsCompiler/Tests.Compiler/ClassicalControlTests.fs
+++ b/src/QsCompiler/Tests.Compiler/ClassicalControlTests.fs
@@ -1627,3 +1627,8 @@ type ClassicalControlTests() =
         let lines = generated |> GetLinesFromSpecialization
         Assert.True(lines.[1] = "if x < 2 {", "The classical condition is missing after transformation.")
         Assert.True(lines.[2] = "    if x < 3 {", "The classical condition is missing after transformation.")
+
+    [<Fact(Skip = "Known Issue #???")>] // ToDo give proper issue number from GitHub
+    [<Trait("Category", "Content Lifting")>]
+    member this.``Nested Invalid Lifting``() =
+        CompileClassicalControlTest 49 |> ignore

--- a/src/QsCompiler/Tests.Compiler/ClassicalControlTests.fs
+++ b/src/QsCompiler/Tests.Compiler/ClassicalControlTests.fs
@@ -1449,6 +1449,7 @@ type ClassicalControlTests() =
 
         // Make sure original calls outer generated
         let lines = original |> GetLinesFromSpecialization
+
         let (success, _, args) =
             CheckIfLineIsCall BuiltIn.ApplyIfZero.FullName.Namespace BuiltIn.ApplyIfZero.FullName.Name lines.[1]
 
@@ -1462,6 +1463,7 @@ type ClassicalControlTests() =
 
         // Make sure outer calls inner generated
         let lines = outer |> GetBodyFromCallable |> GetLinesFromSpecialization
+
         let (success, _, args) =
             CheckIfLineIsCall BuiltIn.ApplyIfOne.FullName.Namespace BuiltIn.ApplyIfOne.FullName.Name lines.[0]
 
@@ -1487,6 +1489,7 @@ type ClassicalControlTests() =
 
         // Make sure original calls generated
         let lines = original |> GetLinesFromSpecialization
+
         let (success, _, args) =
             CheckIfLineIsCall BuiltIn.ApplyIfZero.FullName.Namespace BuiltIn.ApplyIfZero.FullName.Name lines.[1]
 
@@ -1498,8 +1501,7 @@ type ClassicalControlTests() =
         let (success, _, _) = IsApplyIfArgMatch args "r" generated.Parent
         Assert.True(success, sprintf "ApplyIfZero did not have the correct arguments")
 
-    [<Fact(Skip="Known Issue #???")>] // ToDo give proper issue number from GitHub
+    [<Fact(Skip = "Known Issue #???")>] // ToDo give proper issue number from GitHub
     [<Trait("Category", "Content Lifting")>]
     member this.``Mutables with Nesting Lift Neither``() =
         CompileClassicalControlTest 44 |> ignore
-

--- a/src/QsCompiler/Tests.Compiler/ClassicalControlTests.fs
+++ b/src/QsCompiler/Tests.Compiler/ClassicalControlTests.fs
@@ -1662,6 +1662,7 @@ type ClassicalControlTests() =
         let lines = original |> GetLinesFromSpecialization
 
         Assert.True(lines.[3] = "    if x < 1 {", "The classical condition is missing after transformation.")
+
         let (success, _, args) =
             CheckIfLineIsCall BuiltIn.ApplyIfZero.FullName.Namespace BuiltIn.ApplyIfZero.FullName.Name lines.[4]
 
@@ -1673,6 +1674,7 @@ type ClassicalControlTests() =
         let (success, _, _) = IsApplyIfArgMatch args "Microsoft.Quantum.Testing.General.M(q)" ifBlock.FullName
         Assert.True(success, sprintf "ApplyIfZero did not have the correct arguments")
         Assert.True(lines.[6] = "    else {", "The else condition is missing after transformation.")
+
         let (success, _, args) =
             CheckIfLineIsCall BuiltIn.ApplyIfElseR.FullName.Namespace BuiltIn.ApplyIfElseR.FullName.Name lines.[7]
 
@@ -1681,7 +1683,9 @@ type ClassicalControlTests() =
             sprintf "Callable %O(%A) did not have expected content" original.Parent QsSpecializationKind.QsBody
         )
 
-        let (success, _, _, _, _) = IsApplyIfElseArgsMatch args "Microsoft.Quantum.Testing.General.M(q)" elifBlock.FullName elseBlock.FullName
+        let (success, _, _, _, _) =
+            IsApplyIfElseArgsMatch args "Microsoft.Quantum.Testing.General.M(q)" elifBlock.FullName elseBlock.FullName
+
         Assert.True(success, sprintf "ApplyIfElseR did not have the correct arguments")
 
     [<Fact>]
@@ -1696,13 +1700,13 @@ type ClassicalControlTests() =
                 Assert.True(1 = Seq.length x)
                 Seq.item 0 x |> GetBodyFromCallable)
 
-        let TrimWhitespaceFromLines (lines : string []) =
-            lines |> Array.map (fun s -> s.Trim())
+        let TrimWhitespaceFromLines (lines: string []) = lines |> Array.map (fun s -> s.Trim())
 
         // Make sure original calls generated
         let lines = original |> GetLinesFromSpecialization |> TrimWhitespaceFromLines
 
         Assert.True(lines.[3] = "if x < 1 {", "The classical condition is missing after transformation.")
+
         let (success, _, args) =
             CheckIfLineIsCall BuiltIn.ApplyIfZero.FullName.Namespace BuiltIn.ApplyIfZero.FullName.Name lines.[4]
 
@@ -1714,14 +1718,23 @@ type ClassicalControlTests() =
         let (success, _, _) = IsApplyIfArgMatch args "Microsoft.Quantum.Testing.General.M(q)" generated.Parent
         Assert.True(success, sprintf "ApplyIfZero did not have the correct arguments")
         Assert.True(lines.[6] = "else {", "The else condition is missing after transformation.")
-        Assert.True(lines.[7] = "if Microsoft.Quantum.Testing.General.M(q) == Zero {", "The quantum condition is missing after transformation.")
+
+        Assert.True(
+            lines.[7] = "if Microsoft.Quantum.Testing.General.M(q) == Zero {",
+            "The quantum condition is missing after transformation."
+        )
+
         Assert.True(lines.[8] = "if x < 4 {", "The classical condition is missing after transformation.")
         Assert.True(lines.[9] = "if x < 5 {", "The classical condition is missing after transformation.")
         Assert.True(lines.[14] = "else {", "The else condition is missing after transformation.")
-        Assert.True(lines.[16] = "if Microsoft.Quantum.Testing.General.M(q) == Zero {", "The quantum condition is missing after transformation.")
+
+        Assert.True(
+            lines.[16] = "if Microsoft.Quantum.Testing.General.M(q) == Zero {",
+            "The quantum condition is missing after transformation."
+        )
+
         Assert.True(lines.[17] = "if x < 6 {", "The classical condition is missing after transformation.")
 
         let lines = generated |> GetLinesFromSpecialization |> TrimWhitespaceFromLines
         Assert.True(lines.[1] = "if x < 2 {", "The classical condition is missing after transformation.")
         Assert.True(lines.[2] = "if x < 3 {", "The classical condition is missing after transformation.")
-

--- a/src/QsCompiler/Tests.Compiler/ClassicalControlTests.fs
+++ b/src/QsCompiler/Tests.Compiler/ClassicalControlTests.fs
@@ -1632,3 +1632,96 @@ type ClassicalControlTests() =
     [<Trait("Category", "Content Lifting")>]
     member this.``Nested Invalid Lifting``() =
         CompileClassicalControlTest 49 |> ignore
+
+    [<Fact>]
+    [<Trait("Category", "Content Lifting")>]
+    member this.``Mutables with Classic Nesting Elif``() =
+        let result = CompileClassicalControlTest 50
+        let original = GetCallableWithName result Signatures.ClassicalControlNS "Foo" |> GetBodyFromCallable
+        let generated = GetCallablesWithSuffix result Signatures.ClassicalControlNS "_Foo"
+
+        Assert.True(3 = Seq.length generated) // Should already be asserted by the signature check
+
+        let ifBlockContentCheck call =
+            let lines = call |> GetBodyFromCallable |> GetLinesFromSpecialization
+            lines.[1] = "if x < 2 {" && lines.[2] = "    if x < 3 {"
+
+        let elifBlockContentCheck call =
+            let lines = call |> GetBodyFromCallable |> GetLinesFromSpecialization
+            lines.[1] = "if x < 4 {" && lines.[2] = "    if x < 5 {"
+
+        let elseBlockContentCheck call =
+            let lines = call |> GetBodyFromCallable |> GetLinesFromSpecialization
+            lines.[1] = "if Microsoft.Quantum.Testing.General.M(q) == Zero {" && lines.[2] = "    if x < 6 {"
+
+        let ifBlock = Seq.find ifBlockContentCheck generated
+        let elifBlock = Seq.find elifBlockContentCheck generated
+        let elseBlock = Seq.find elseBlockContentCheck generated
+
+        // Make sure original calls generated
+        let lines = original |> GetLinesFromSpecialization
+
+        Assert.True(lines.[3] = "    if x < 1 {", "The classical condition is missing after transformation.")
+        let (success, _, args) =
+            CheckIfLineIsCall BuiltIn.ApplyIfZero.FullName.Namespace BuiltIn.ApplyIfZero.FullName.Name lines.[4]
+
+        Assert.True(
+            success,
+            sprintf "Callable %O(%A) did not have expected content" original.Parent QsSpecializationKind.QsBody
+        )
+
+        let (success, _, _) = IsApplyIfArgMatch args "Microsoft.Quantum.Testing.General.M(q)" ifBlock.FullName
+        Assert.True(success, sprintf "ApplyIfZero did not have the correct arguments")
+        Assert.True(lines.[6] = "    else {", "The else condition is missing after transformation.")
+        let (success, _, args) =
+            CheckIfLineIsCall BuiltIn.ApplyIfElseR.FullName.Namespace BuiltIn.ApplyIfElseR.FullName.Name lines.[7]
+
+        Assert.True(
+            success,
+            sprintf "Callable %O(%A) did not have expected content" original.Parent QsSpecializationKind.QsBody
+        )
+
+        let (success, _, _, _, _) = IsApplyIfElseArgsMatch args "Microsoft.Quantum.Testing.General.M(q)" elifBlock.FullName elseBlock.FullName
+        Assert.True(success, sprintf "ApplyIfElseR did not have the correct arguments")
+
+    [<Fact>]
+    [<Trait("Category", "Content Lifting")>]
+    member this.``Mutables with Classic Nesting Elif Lift First``() =
+        let result = CompileClassicalControlTest 51
+        let original = GetCallableWithName result Signatures.ClassicalControlNS "Foo" |> GetBodyFromCallable
+
+        let generated =
+            GetCallablesWithSuffix result Signatures.ClassicalControlNS "_Foo"
+            |> (fun x ->
+                Assert.True(1 = Seq.length x)
+                Seq.item 0 x |> GetBodyFromCallable)
+
+        let TrimWhitespaceFromLines (lines : string []) =
+            lines |> Array.map (fun s -> s.Trim())
+
+        // Make sure original calls generated
+        let lines = original |> GetLinesFromSpecialization |> TrimWhitespaceFromLines
+
+        Assert.True(lines.[3] = "if x < 1 {", "The classical condition is missing after transformation.")
+        let (success, _, args) =
+            CheckIfLineIsCall BuiltIn.ApplyIfZero.FullName.Namespace BuiltIn.ApplyIfZero.FullName.Name lines.[4]
+
+        Assert.True(
+            success,
+            sprintf "Callable %O(%A) did not have expected content" original.Parent QsSpecializationKind.QsBody
+        )
+
+        let (success, _, _) = IsApplyIfArgMatch args "Microsoft.Quantum.Testing.General.M(q)" generated.Parent
+        Assert.True(success, sprintf "ApplyIfZero did not have the correct arguments")
+        Assert.True(lines.[6] = "else {", "The else condition is missing after transformation.")
+        Assert.True(lines.[7] = "if Microsoft.Quantum.Testing.General.M(q) == Zero {", "The quantum condition is missing after transformation.")
+        Assert.True(lines.[8] = "if x < 4 {", "The classical condition is missing after transformation.")
+        Assert.True(lines.[9] = "if x < 5 {", "The classical condition is missing after transformation.")
+        Assert.True(lines.[14] = "else {", "The else condition is missing after transformation.")
+        Assert.True(lines.[16] = "if Microsoft.Quantum.Testing.General.M(q) == Zero {", "The quantum condition is missing after transformation.")
+        Assert.True(lines.[17] = "if x < 6 {", "The classical condition is missing after transformation.")
+
+        let lines = generated |> GetLinesFromSpecialization |> TrimWhitespaceFromLines
+        Assert.True(lines.[1] = "if x < 2 {", "The classical condition is missing after transformation.")
+        Assert.True(lines.[2] = "if x < 3 {", "The classical condition is missing after transformation.")
+

--- a/src/QsCompiler/Tests.Compiler/ClassicalControlTests.fs
+++ b/src/QsCompiler/Tests.Compiler/ClassicalControlTests.fs
@@ -1501,7 +1501,7 @@ type ClassicalControlTests() =
         let (success, _, _) = IsApplyIfArgMatch args "r" generated.Parent
         Assert.True(success, sprintf "ApplyIfZero did not have the correct arguments")
 
-    [<Fact(Skip = "Known Issue #???")>] // ToDo give proper issue number from GitHub
+    [<Fact(Skip = "https://github.com/microsoft/qsharp-compiler/issues/1115")>]
     [<Trait("Category", "Content Lifting")>]
     member this.``Mutables with Nesting Lift Neither``() =
         CompileClassicalControlTest 44 |> ignore
@@ -1628,7 +1628,7 @@ type ClassicalControlTests() =
         Assert.True(lines.[1] = "if x < 2 {", "The classical condition is missing after transformation.")
         Assert.True(lines.[2] = "    if x < 3 {", "The classical condition is missing after transformation.")
 
-    [<Fact(Skip = "Known Issue #???")>] // ToDo give proper issue number from GitHub
+    [<Fact(Skip = "Known Issue https://github.com/microsoft/qsharp-compiler/issues/1115")>]
     [<Trait("Category", "Content Lifting")>]
     member this.``Nested Invalid Lifting``() =
         CompileClassicalControlTest 49 |> ignore

--- a/src/QsCompiler/Tests.Compiler/ClassicalControlTests.fs
+++ b/src/QsCompiler/Tests.Compiler/ClassicalControlTests.fs
@@ -1505,3 +1505,125 @@ type ClassicalControlTests() =
     [<Trait("Category", "Content Lifting")>]
     member this.``Mutables with Nesting Lift Neither``() =
         CompileClassicalControlTest 44 |> ignore
+
+    [<Fact>]
+    [<Trait("Category", "Content Lifting")>]
+    member this.``Mutables with Classic Nesting Lift Inner``() =
+        let result = CompileClassicalControlTest 45
+        let original = GetCallableWithName result Signatures.ClassicalControlNS "Foo" |> GetBodyFromCallable
+
+        let generated =
+            GetCallablesWithSuffix result Signatures.ClassicalControlNS "_Foo"
+            |> (fun x ->
+                Assert.True(1 = Seq.length x)
+                Seq.item 0 x |> GetBodyFromCallable)
+
+        // Make sure original calls generated
+        let lines = original |> GetLinesFromSpecialization
+
+        let (success, _, args) =
+            CheckIfLineIsCall BuiltIn.ApplyIfZero.FullName.Namespace BuiltIn.ApplyIfZero.FullName.Name lines.[4]
+
+        Assert.True(
+            success,
+            sprintf "Callable %O(%A) did not have expected content" original.Parent QsSpecializationKind.QsBody
+        )
+
+        let (success, _, _) = IsApplyIfArgMatch args "Microsoft.Quantum.Testing.General.M(q)" generated.Parent
+        Assert.True(success, sprintf "ApplyIfZero did not have the correct arguments")
+
+        // Make sure the classical condition is present
+        Assert.True(lines.[3] = "    if x < 1 {", "The classical condition is missing after transformation.")
+
+    [<Fact>]
+    [<Trait("Category", "Content Lifting")>]
+    member this.``Mutables with Classic Nesting Lift Outer``() =
+        let result = CompileClassicalControlTest 46
+        let original = GetCallableWithName result Signatures.ClassicalControlNS "Foo" |> GetBodyFromCallable
+
+        let generated =
+            GetCallablesWithSuffix result Signatures.ClassicalControlNS "_Foo"
+            |> (fun x ->
+                Assert.True(1 = Seq.length x)
+                Seq.item 0 x |> GetBodyFromCallable)
+
+        // Make sure original calls generated
+        let lines = original |> GetLinesFromSpecialization
+
+        let (success, _, args) =
+            CheckIfLineIsCall BuiltIn.ApplyIfZero.FullName.Namespace BuiltIn.ApplyIfZero.FullName.Name lines.[3]
+
+        Assert.True(
+            success,
+            sprintf "Callable %O(%A) did not have expected content" original.Parent QsSpecializationKind.QsBody
+        )
+
+        let (success, _, _) = IsApplyIfArgMatch args "Microsoft.Quantum.Testing.General.M(q)" generated.Parent
+        Assert.True(success, sprintf "ApplyIfZero did not have the correct arguments")
+
+        // Make sure the classical condition is present
+        let lines = generated |> GetLinesFromSpecialization
+        Assert.True(lines.[1] = "if x < 1 {", "The classical condition is missing after transformation.")
+
+    [<Fact>]
+    [<Trait("Category", "Content Lifting")>]
+    member this.``Mutables with Classic Nesting Lift Outer With More Classic``() =
+        let result = CompileClassicalControlTest 47
+        let original = GetCallableWithName result Signatures.ClassicalControlNS "Foo" |> GetBodyFromCallable
+
+        let generated =
+            GetCallablesWithSuffix result Signatures.ClassicalControlNS "_Foo"
+            |> (fun x ->
+                Assert.True(1 = Seq.length x)
+                Seq.item 0 x |> GetBodyFromCallable)
+
+        // Make sure original calls generated
+        let lines = original |> GetLinesFromSpecialization
+
+        let (success, _, args) =
+            CheckIfLineIsCall BuiltIn.ApplyIfZero.FullName.Namespace BuiltIn.ApplyIfZero.FullName.Name lines.[3]
+
+        Assert.True(
+            success,
+            sprintf "Callable %O(%A) did not have expected content" original.Parent QsSpecializationKind.QsBody
+        )
+
+        let (success, _, _) = IsApplyIfArgMatch args "Microsoft.Quantum.Testing.General.M(q)" generated.Parent
+        Assert.True(success, sprintf "ApplyIfZero did not have the correct arguments")
+
+        // Make sure the classical condition is present
+        let lines = generated |> GetLinesFromSpecialization
+        Assert.True(lines.[1] = "if x < 1 {", "The classical condition is missing after transformation.")
+        Assert.True(lines.[2] = "    if x < 2 {", "The classical condition is missing after transformation.")
+
+    [<Fact>]
+    [<Trait("Category", "Content Lifting")>]
+    member this.``Mutables with Classic Nesting Lift Middle``() =
+        let result = CompileClassicalControlTest 48
+        let original = GetCallableWithName result Signatures.ClassicalControlNS "Foo" |> GetBodyFromCallable
+
+        let generated =
+            GetCallablesWithSuffix result Signatures.ClassicalControlNS "_Foo"
+            |> (fun x ->
+                Assert.True(1 = Seq.length x)
+                Seq.item 0 x |> GetBodyFromCallable)
+
+        // Make sure original calls generated
+        let lines = original |> GetLinesFromSpecialization
+
+        let (success, _, args) =
+            CheckIfLineIsCall BuiltIn.ApplyIfZero.FullName.Namespace BuiltIn.ApplyIfZero.FullName.Name lines.[4]
+
+        Assert.True(
+            success,
+            sprintf "Callable %O(%A) did not have expected content" original.Parent QsSpecializationKind.QsBody
+        )
+
+        let (success, _, _) = IsApplyIfArgMatch args "Microsoft.Quantum.Testing.General.M(q)" generated.Parent
+        Assert.True(success, sprintf "ApplyIfZero did not have the correct arguments")
+
+        // Make sure the classical condition is present
+        Assert.True(lines.[3] = "    if x < 1 {", "The classical condition is missing after transformation.")
+        let lines = generated |> GetLinesFromSpecialization
+        Assert.True(lines.[1] = "if x < 2 {", "The classical condition is missing after transformation.")
+        Assert.True(lines.[2] = "    if x < 3 {", "The classical condition is missing after transformation.")

--- a/src/QsCompiler/Tests.Compiler/ClassicalControlTests.fs
+++ b/src/QsCompiler/Tests.Compiler/ClassicalControlTests.fs
@@ -1501,7 +1501,7 @@ type ClassicalControlTests() =
         let (success, _, _) = IsApplyIfArgMatch args "r" generated.Parent
         Assert.True(success, sprintf "ApplyIfZero did not have the correct arguments")
 
-    [<Fact(Skip = "https://github.com/microsoft/qsharp-compiler/issues/1115")>]
+    [<Fact(Skip = "Known Issue https://github.com/microsoft/qsharp-compiler/issues/1115")>]
     [<Trait("Category", "Content Lifting")>]
     member this.``Mutables with Nesting Lift Neither``() =
         CompileClassicalControlTest 44 |> ignore

--- a/src/QsCompiler/Tests.Compiler/TestCases/ClassicalControl.qs
+++ b/src/QsCompiler/Tests.Compiler/TestCases/ClassicalControl.qs
@@ -1274,3 +1274,82 @@ namespace Microsoft.Quantum.Testing.ClassicalControl {
     }
 }
 
+// =================================
+
+// Mutables with Classic Nesting Elif
+namespace Microsoft.Quantum.Testing.ClassicalControl {
+    open Microsoft.Quantum.Testing.General;
+
+    operation Foo() : Unit {
+        use q = Qubit();
+        Unitary(q);
+        let x = 0;
+        
+        if x < 1 {
+            if M(q) == Zero {
+                mutable y = 0;
+                if x < 2 {
+                    if x < 3 {
+                        set y = 1;
+                    }
+                }
+            }
+        }
+        elif M(q) == Zero {
+            mutable y = 0;
+            if x < 4 {
+                if x < 5 {
+                    set y = 2;
+                }
+            }
+        }
+        else {
+            mutable y = 0;
+            if M(q) == Zero {
+                if x < 6 {
+                    set y = 3;
+                }
+            }
+        }
+    }
+}
+
+// =================================
+
+// Mutables with Classic Nesting Elif Lift First
+namespace Microsoft.Quantum.Testing.ClassicalControl {
+    open Microsoft.Quantum.Testing.General;
+
+    operation Foo() : Unit {
+        use q = Qubit();
+        Unitary(q);
+        mutable x = 0;
+
+        if x < 1 {
+            if M(q) == Zero {
+                mutable y = 0;
+                if x < 2 {
+                    if x < 3 {
+                        set y = 1;
+                    }
+                }
+            }
+        }
+        elif M(q) == Zero {
+            if x < 4 {
+                if x < 5 {
+                    set x = 2;
+                }
+            }
+        }
+        else {
+            mutable y = 0;
+            if M(q) == Zero {
+                if x < 6 {
+                    set y = 3;
+                }
+            }
+        }
+    }
+}
+

--- a/src/QsCompiler/Tests.Compiler/TestCases/ClassicalControl.qs
+++ b/src/QsCompiler/Tests.Compiler/TestCases/ClassicalControl.qs
@@ -1259,3 +1259,18 @@ namespace Microsoft.Quantum.Testing.ClassicalControl {
     }
 }
 
+// =================================
+
+// Nested Invalid Lifting
+namespace Microsoft.Quantum.Testing.ClassicalControl {
+    operation Foo() : Unit {
+        let r = Zero;
+        
+        if r == Zero {
+            if r == One {
+                return ();
+            }
+        }
+    }
+}
+

--- a/src/QsCompiler/Tests.Compiler/TestCases/ClassicalControl.qs
+++ b/src/QsCompiler/Tests.Compiler/TestCases/ClassicalControl.qs
@@ -1084,3 +1084,78 @@ namespace Microsoft.Quantum.Testing.ClassicalControl {
         }
     }
 }
+
+// =================================
+
+// Don't Lift Classical Conditions
+namespace Microsoft.Quantum.Testing.ClassicalControl {
+    open SubOps;
+
+    operation Foo() : Unit {
+        let x = 0;
+
+        if x == 1 {
+            let y = 0;
+            SubOp1();
+        }
+
+        if x == 2 {
+            if x == 3 {
+                let y = 0;
+                SubOp1();
+            }
+        }
+        else {
+            let y = 0;
+            SubOp1();
+        }
+    }
+}
+
+// =================================
+
+// Mutables with Nesting Lift Both
+namespace Microsoft.Quantum.Testing.ClassicalControl {
+    operation Foo() : Unit {
+        let r = Zero;
+        
+        if r == Zero {
+            if r == One {
+                mutable x = 0;
+                set x = 1;
+            }
+        }
+    }
+}
+
+// =================================
+
+// Mutables with Nesting Lift Outer
+namespace Microsoft.Quantum.Testing.ClassicalControl {
+    operation Foo() : Unit {
+        let r = Zero;
+
+        if r == Zero {
+            mutable x = 0;
+            if r == One {
+                set x = 1;
+            }
+        }
+    }
+}
+
+// =================================
+
+// Mutables with Nesting Lift Neither
+namespace Microsoft.Quantum.Testing.ClassicalControl {
+    operation Foo() : Unit {
+        let r = Zero;
+        
+        mutable x = 0;
+        if r == Zero {
+            if r == One {
+                set x = 1;
+            }
+        }
+    }
+}

--- a/src/QsCompiler/Tests.Compiler/TestCases/ClassicalControl.qs
+++ b/src/QsCompiler/Tests.Compiler/TestCases/ClassicalControl.qs
@@ -11,6 +11,19 @@ namespace SubOps {
     operation SubOpCA3() : Unit is Ctl + Adj { }
 }
 
+namespace Microsoft.Quantum.Testing.General {
+    operation Unitary (q : Qubit) : Unit {
+        body intrinsic;
+        adjoint auto;
+        controlled auto;
+        controlled adjoint auto;
+    }
+
+    operation M (q : Qubit) : Result {
+        body intrinsic;
+    }
+}
+
 // =================================
 
 // Basic Lift
@@ -1159,3 +1172,90 @@ namespace Microsoft.Quantum.Testing.ClassicalControl {
         }
     }
 }
+
+// =================================
+
+// Mutables with Classic Nesting Lift Inner
+namespace Microsoft.Quantum.Testing.ClassicalControl {
+    open Microsoft.Quantum.Testing.General;
+
+    operation Foo() : Unit {
+        use q = Qubit();
+        Unitary(q);
+        let x = 0;
+        
+        if x < 1 {
+            if M(q) == Zero {
+                mutable y = 0;
+                set y = 1;
+            }
+        }
+    }
+}
+
+// =================================
+
+// Mutables with Classic Nesting Lift Outer
+namespace Microsoft.Quantum.Testing.ClassicalControl {
+    open Microsoft.Quantum.Testing.General;
+
+    operation Foo() : Unit {
+        use q = Qubit();
+        Unitary(q);
+        let x = 0;
+
+        if M(q) == Zero {
+            mutable y = 0;
+            if x < 1 {
+                set y = 1;
+            }
+        }
+    }
+}
+
+// =================================
+
+// Mutables with Classic Nesting Lift Outer With More Classic
+namespace Microsoft.Quantum.Testing.ClassicalControl {
+    open Microsoft.Quantum.Testing.General;
+
+    operation Foo() : Unit {
+        use q = Qubit();
+        Unitary(q);
+        let x = 0;
+        
+        if M(q) == Zero {
+            mutable y = 0;
+            if x < 1 {
+                if x < 2 {
+                    set y = 1;
+                }
+            }
+        }
+    }
+}
+
+// =================================
+
+// Mutables with Classic Nesting Lift Middle
+namespace Microsoft.Quantum.Testing.ClassicalControl {
+    open Microsoft.Quantum.Testing.General;
+
+    operation Foo() : Unit {
+        use q = Qubit();
+        Unitary(q);
+        let x = 0;
+        
+        if x < 1 {
+            if M(q) == Zero {
+                mutable y = 0;
+                if x < 2 {
+                    if x < 3 {
+                        set y = 1;
+                    }
+                }
+            }
+        }
+    }
+}
+

--- a/src/QsCompiler/Tests.Compiler/TestUtils/Signatures.fs
+++ b/src/QsCompiler/Tests.Compiler/TestUtils/Signatures.fs
@@ -586,7 +586,7 @@ let public ClassicalControlSignatures =
              ClassicalControlNS, "_Foo", [| "Int"; "Qubit" |], "Unit"
              ClassicalControlNS, "_Foo", [| "Int"; "Qubit" |], "Unit"
          |])
-         // Mutables with Classic Nesting Elif Lift First
+        // Mutables with Classic Nesting Elif Lift First
         (_DefaultTypes,
          [|
              ClassicalControlNS, "Foo", [||], "Unit"

--- a/src/QsCompiler/Tests.Compiler/TestUtils/Signatures.fs
+++ b/src/QsCompiler/Tests.Compiler/TestUtils/Signatures.fs
@@ -578,6 +578,20 @@ let public ClassicalControlSignatures =
          |])
         // Nested Invalid Lifting
         (_DefaultTypes, [| ClassicalControlNS, "Foo", [||], "Unit" |])
+        // Mutables with Classic Nesting Elif
+        (_DefaultTypes,
+         [|
+             ClassicalControlNS, "Foo", [||], "Unit"
+             ClassicalControlNS, "_Foo", [| "Int"; "Qubit" |], "Unit"
+             ClassicalControlNS, "_Foo", [| "Int"; "Qubit" |], "Unit"
+             ClassicalControlNS, "_Foo", [| "Int"; "Qubit" |], "Unit"
+         |])
+         // Mutables with Classic Nesting Elif Lift First
+        (_DefaultTypes,
+         [|
+             ClassicalControlNS, "Foo", [||], "Unit"
+             ClassicalControlNS, "_Foo", [| "Int"; "Qubit" |], "Unit"
+         |])
     |]
     |> _MakeSignatures
 

--- a/src/QsCompiler/Tests.Compiler/TestUtils/Signatures.fs
+++ b/src/QsCompiler/Tests.Compiler/TestUtils/Signatures.fs
@@ -539,17 +539,17 @@ let public ClassicalControlSignatures =
         (_DefaultTypes, [| ClassicalControlNS, "Foo", [||], "Unit" |])
         // Mutables with Nesting Lift Both
         (_DefaultTypes,
-            [|
-                ClassicalControlNS, "Foo", [||], "Unit"
-                ClassicalControlNS, "_Foo", [| "Result" |], "Unit"
-                ClassicalControlNS, "_Foo", [| "Result" |], "Unit"
-            |])
+         [|
+             ClassicalControlNS, "Foo", [||], "Unit"
+             ClassicalControlNS, "_Foo", [| "Result" |], "Unit"
+             ClassicalControlNS, "_Foo", [| "Result" |], "Unit"
+         |])
         // Mutables with Nesting Lift Outer
         (_DefaultTypes,
-            [|
-                ClassicalControlNS, "Foo", [||], "Unit"
-                ClassicalControlNS, "_Foo", [| "Result" |], "Unit"
-            |])
+         [|
+             ClassicalControlNS, "Foo", [||], "Unit"
+             ClassicalControlNS, "_Foo", [| "Result" |], "Unit"
+         |])
         // Mutables with Nesting Lift Neither
         (_DefaultTypes, [| ClassicalControlNS, "Foo", [||], "Unit" |])
     |]

--- a/src/QsCompiler/Tests.Compiler/TestUtils/Signatures.fs
+++ b/src/QsCompiler/Tests.Compiler/TestUtils/Signatures.fs
@@ -552,6 +552,30 @@ let public ClassicalControlSignatures =
          |])
         // Mutables with Nesting Lift Neither
         (_DefaultTypes, [| ClassicalControlNS, "Foo", [||], "Unit" |])
+        // Mutables with Classic Nesting Lift Inner
+        (_DefaultTypes,
+         [|
+             ClassicalControlNS, "Foo", [||], "Unit"
+             ClassicalControlNS, "_Foo", [| "Int"; "Qubit" |], "Unit"
+         |])
+        // Mutables with Classic Nesting Lift Outer
+        (_DefaultTypes,
+         [|
+             ClassicalControlNS, "Foo", [||], "Unit"
+             ClassicalControlNS, "_Foo", [| "Int"; "Qubit" |], "Unit"
+         |])
+        // Mutables with Classic Nesting Lift Outer With More Classic
+        (_DefaultTypes,
+         [|
+             ClassicalControlNS, "Foo", [||], "Unit"
+             ClassicalControlNS, "_Foo", [| "Int"; "Qubit" |], "Unit"
+         |])
+        // Mutables with Classic Nesting Lift Middle
+        (_DefaultTypes,
+         [|
+             ClassicalControlNS, "Foo", [||], "Unit"
+             ClassicalControlNS, "_Foo", [| "Int"; "Qubit" |], "Unit"
+         |])
     |]
     |> _MakeSignatures
 

--- a/src/QsCompiler/Tests.Compiler/TestUtils/Signatures.fs
+++ b/src/QsCompiler/Tests.Compiler/TestUtils/Signatures.fs
@@ -576,6 +576,8 @@ let public ClassicalControlSignatures =
              ClassicalControlNS, "Foo", [||], "Unit"
              ClassicalControlNS, "_Foo", [| "Int"; "Qubit" |], "Unit"
          |])
+        // Nested Invalid Lifting
+        (_DefaultTypes, [| ClassicalControlNS, "Foo", [||], "Unit" |])
     |]
     |> _MakeSignatures
 

--- a/src/QsCompiler/Tests.Compiler/TestUtils/Signatures.fs
+++ b/src/QsCompiler/Tests.Compiler/TestUtils/Signatures.fs
@@ -535,6 +535,23 @@ let public ClassicalControlSignatures =
          |])
         // One-sided NOT condition
         (_DefaultTypes, [| ClassicalControlNS, "Foo", [||], "Unit" |])
+        // Don't Lift Classical Conditions
+        (_DefaultTypes, [| ClassicalControlNS, "Foo", [||], "Unit" |])
+        // Mutables with Nesting Lift Both
+        (_DefaultTypes,
+            [|
+                ClassicalControlNS, "Foo", [||], "Unit"
+                ClassicalControlNS, "_Foo", [| "Result" |], "Unit"
+                ClassicalControlNS, "_Foo", [| "Result" |], "Unit"
+            |])
+        // Mutables with Nesting Lift Outer
+        (_DefaultTypes,
+            [|
+                ClassicalControlNS, "Foo", [||], "Unit"
+                ClassicalControlNS, "_Foo", [| "Result" |], "Unit"
+            |])
+        // Mutables with Nesting Lift Neither
+        (_DefaultTypes, [| ClassicalControlNS, "Foo", [||], "Unit" |])
     |]
     |> _MakeSignatures
 

--- a/src/QsCompiler/Transformations/ClassicallyControlled.cs
+++ b/src/QsCompiler/Transformations/ClassicallyControlled.cs
@@ -847,21 +847,14 @@ namespace Microsoft.Quantum.QsCompiler.Transformations.ClassicallyControlled
 
             private static bool IsConditionValidForLifting(QsConditionalStatement conditionStatement)
             {
-                if (conditionStatement.ConditionalBlocks.Length == 1)
-                {
-                    var condition = conditionStatement.ConditionalBlocks[0].Item1;
-                    return
-                        (condition.Expression is ExpressionKind.EQ eq
-                        && eq.Item1.ResolvedType.Resolution == ResolvedTypeKind.Result
-                        && eq.Item2.ResolvedType.Resolution == ResolvedTypeKind.Result)
-                        || (condition.Expression is ExpressionKind.NEQ neq
-                        && neq.Item1.ResolvedType.Resolution == ResolvedTypeKind.Result
-                        && neq.Item2.ResolvedType.Resolution == ResolvedTypeKind.Result);
-                }
-                else
-                {
-                    return false;
-                }
+                var condition = conditionStatement.ConditionalBlocks.Single().Item1;
+                return
+                    (condition.Expression is ExpressionKind.EQ eq
+                    && eq.Item1.ResolvedType.Resolution == ResolvedTypeKind.Result
+                    && eq.Item2.ResolvedType.Resolution == ResolvedTypeKind.Result)
+                    || (condition.Expression is ExpressionKind.NEQ neq
+                    && neq.Item1.ResolvedType.Resolution == ResolvedTypeKind.Result
+                    && neq.Item2.ResolvedType.Resolution == ResolvedTypeKind.Result);
             }
 
             private new class StatementKindTransformation : ContentLifting.LiftContent<TransformationState>.StatementKindTransformation

--- a/src/QsCompiler/Transformations/ClassicallyControlled.cs
+++ b/src/QsCompiler/Transformations/ClassicallyControlled.cs
@@ -620,19 +620,19 @@ namespace Microsoft.Quantum.QsCompiler.Transformations.ClassicallyControlled
                 /// </summary>
                 private QsStatement ConvertConditionalToControlCall(QsStatement statement)
                 {
-                    var condition = this.IsConditionWithSingleBlock(statement);
+                    var condition = IsConditionWithSingleBlock(statement);
 
                     if (condition.HasValue)
                     {
-                        if (this.IsConditionedOnResultLiteralExpression(condition.Value.Condition, out var literal, out var conditionExpression))
+                        if (IsConditionedOnResultLiteralExpression(condition.Value.Condition, out var literal, out var conditionExpression))
                         {
                             return this.CreateControlStatement(statement, this.CreateApplyIfExpression(literal, conditionExpression, condition.Value.Body, condition.Value.Default));
                         }
-                        else if (this.IsConditionedOnResultEqualityExpression(condition.Value.Condition, out var lhsConditionExpression, out var rhsConditionExpression))
+                        else if (IsConditionedOnResultEqualityExpression(condition.Value.Condition, out var lhsConditionExpression, out var rhsConditionExpression))
                         {
                             return this.CreateControlStatement(statement, this.CreateApplyConditionallyExpression(lhsConditionExpression, rhsConditionExpression, condition.Value.Body, condition.Value.Default));
                         }
-                        else if (this.IsConditionedOnResultInequalityExpression(condition.Value.Condition, out lhsConditionExpression, out rhsConditionExpression))
+                        else if (IsConditionedOnResultInequalityExpression(condition.Value.Condition, out lhsConditionExpression, out rhsConditionExpression))
                         {
                             // The scope arguments are reversed to account for the negation of the NEQ
                             return this.CreateControlStatement(statement, this.CreateApplyConditionallyExpression(lhsConditionExpression, rhsConditionExpression, condition.Value.Default, condition.Value.Body));
@@ -655,7 +655,7 @@ namespace Microsoft.Quantum.QsCompiler.Transformations.ClassicallyControlled
                 /// If it is, returns the condition, the body of the conditional block, and, optionally, the body of the
                 /// default block, otherwise returns null. If there is no default block, the last value of the return tuple will be null.
                 /// </summary>
-                private (TypedExpression Condition, QsScope Body, QsScope? Default)? IsConditionWithSingleBlock(QsStatement statement)
+                private static (TypedExpression Condition, QsScope Body, QsScope? Default)? IsConditionWithSingleBlock(QsStatement statement)
                 {
                     if (statement.Statement is QsStatementKind.QsConditionalStatement condition && condition.Item.ConditionalBlocks.Length == 1)
                     {
@@ -671,7 +671,7 @@ namespace Microsoft.Quantum.QsCompiler.Transformations.ClassicallyControlled
                 /// expression in the (in)equality, otherwise returns false with nulls. If it is an
                 /// inequality, the returned result value will be the opposite of the result literal found.
                 /// </summary>
-                private bool IsConditionedOnResultLiteralExpression(
+                private static bool IsConditionedOnResultLiteralExpression(
                     TypedExpression expression,
                     [NotNullWhen(true)] out QsResult? literal,
                     [NotNullWhen(true)] out TypedExpression? conditionExpression)
@@ -719,7 +719,7 @@ namespace Microsoft.Quantum.QsCompiler.Transformations.ClassicallyControlled
                 /// Checks if the expression is an equality comparison between two Result-typed expressions.
                 /// If it is, returns true along with the two expressions, otherwise returns false with nulls.
                 /// </summary>
-                private bool IsConditionedOnResultEqualityExpression(
+                private static bool IsConditionedOnResultEqualityExpression(
                     TypedExpression expression,
                     [NotNullWhen(true)] out TypedExpression? lhs,
                     [NotNullWhen(true)] out TypedExpression? rhs)
@@ -743,7 +743,7 @@ namespace Microsoft.Quantum.QsCompiler.Transformations.ClassicallyControlled
                 /// Checks if the expression is an inequality comparison between two Result-typed expressions.
                 /// If it is, returns true along with the two expressions, otherwise returns false with nulls.
                 /// </summary>
-                private bool IsConditionedOnResultInequalityExpression(
+                private static bool IsConditionedOnResultInequalityExpression(
                     TypedExpression expression,
                     [NotNullWhen(true)] out TypedExpression? lhs,
                     [NotNullWhen(true)] out TypedExpression? rhs)
@@ -845,6 +845,25 @@ namespace Microsoft.Quantum.QsCompiler.Transformations.ClassicallyControlled
                 this.StatementKinds = new StatementKindTransformation(this);
             }
 
+            private static bool IsConditionValidForLifting(QsConditionalStatement conditionStatement)
+            {
+                if (conditionStatement.ConditionalBlocks.Length == 1)
+                {
+                    var condition = conditionStatement.ConditionalBlocks[0].Item1;
+                    return
+                        (condition.Expression is ExpressionKind.EQ eq
+                        && eq.Item1.ResolvedType.Resolution == ResolvedTypeKind.Result
+                        && eq.Item2.ResolvedType.Resolution == ResolvedTypeKind.Result)
+                        || (condition.Expression is ExpressionKind.NEQ neq
+                        && neq.Item1.ResolvedType.Resolution == ResolvedTypeKind.Result
+                        && neq.Item2.ResolvedType.Resolution == ResolvedTypeKind.Result);
+                }
+                else
+                {
+                    return false;
+                }
+            }
+
             private new class StatementKindTransformation : ContentLifting.LiftContent<TransformationState>.StatementKindTransformation
             {
                 public StatementKindTransformation(SyntaxTreeTransformation<TransformationState> parent)
@@ -868,6 +887,13 @@ namespace Microsoft.Quantum.QsCompiler.Transformations.ClassicallyControlled
 
                 public override QsStatementKind OnConditionalStatement(QsConditionalStatement stm)
                 {
+                    // If the conditional is classical, don't lift it.
+                    if (!IsConditionValidForLifting(stm))
+                    {
+                        // But still check nested conditionals.
+                        return base.OnConditionalStatement(stm);
+                    }
+
                     var contextIsConditionLiftable = this.SharedState.IsConditionLiftable;
                     this.SharedState.IsConditionLiftable = true;
 
@@ -883,9 +909,6 @@ namespace Microsoft.Quantum.QsCompiler.Transformations.ClassicallyControlled
 
                         var (expr, block) = this.OnPositionedBlock(QsNullable<TypedExpression>.NewValue(conditionBlock.Item1), conditionBlock.Item2);
 
-                        // ToDo: Reduce the number of unnecessary generated operations by generalizing
-                        // the condition logic for the conversion and using that condition here
-                        // var (isExprCondition, _, _) = IsConditionedOnResultLiteralExpression(expr.Item);
                         if (block.Body.Statements.Length == 0)
                         {
                             // This is an empty scope, so it can just be treated as a call to NoOp.


### PR DESCRIPTION
Prevents classical conditions (those that don't compare Result type expressions) from being lifted. Adds unit tests.

Addresses #768.