### PR TITLE
`NOT` Condition Fix

### DIFF
--- a/src/QsCompiler/Tests.Compiler/ClassicalControlTests.fs
+++ b/src/QsCompiler/Tests.Compiler/ClassicalControlTests.fs
@@ -1421,3 +1421,8 @@ type ClassicalControlTests() =
 
         IsApplyIfElseArgsMatch args "r" SubOp1 NoOp
         |> (fun (x, _, _, _, _) -> Assert.True(x, "ApplyIfElse did not have the correct arguments"))
+
+    [<Fact>]
+    [<Trait("Category", "If Structure Reshape")>]
+    member this.``NOT Condition Remembers Known Symbols``() =
+        CompileClassicalControlTest 41 |> ignore

--- a/src/QsCompiler/Tests.Compiler/TestCases/ClassicalControl.qs
+++ b/src/QsCompiler/Tests.Compiler/TestCases/ClassicalControl.qs
@@ -1084,3 +1084,19 @@ namespace Microsoft.Quantum.Testing.ClassicalControl {
         }
     }
 }
+
+// =================================
+
+// NOT Condition Remembers Known Symbols
+namespace Microsoft.Quantum.Testing.ClassicalControl {
+    open SubOps;
+
+    operation Foo() : Unit {
+        let r1 = Zero;
+        let r2 = Zero;
+        if (not (r1 == Zero and r2 == Zero)) {
+            SubOp1();
+            SubOp2();
+        }
+    }
+}

--- a/src/QsCompiler/Tests.Compiler/TestUtils/Signatures.fs
+++ b/src/QsCompiler/Tests.Compiler/TestUtils/Signatures.fs
@@ -535,6 +535,14 @@ let public ClassicalControlSignatures =
          |])
         // One-sided NOT condition
         (_DefaultTypes, [| ClassicalControlNS, "Foo", [||], "Unit" |])
+        // NOT Condition Remembers Known Symbols
+        (_DefaultTypes,
+         [|
+             ClassicalControlNS, "Foo", [||], "Unit"
+             ClassicalControlNS, "_Foo", [| "Result"; "Result" |], "Unit"
+             ClassicalControlNS, "_Foo", [| "Result"; "Result" |], "Unit"
+             ClassicalControlNS, "_Foo", [| "Result"; "Result" |], "Unit"
+         |])
     |]
     |> _MakeSignatures
 

--- a/src/QsCompiler/Transformations/ClassicallyControlled.cs
+++ b/src/QsCompiler/Transformations/ClassicallyControlled.cs
@@ -31,8 +31,8 @@ namespace Microsoft.Quantum.QsCompiler.Transformations.ClassicallyControlled
         public static QsCompilation Apply(QsCompilation compilation)
         {
             compilation = RestructureConditions.Apply(compilation);
-            compilation = LiftConditionBlocks.Apply(compilation);
-            return ConvertConditions.Apply(compilation);
+            return LiftConditionBlocks.Apply(compilation);
+            //return ConvertConditions.Apply(compilation);
         }
 
         private class RestructureConditions : SyntaxTreeTransformation
@@ -185,10 +185,10 @@ namespace Microsoft.Quantum.QsCompiler.Transformations.ClassicallyControlled
                         {
                             var emptyScope = new QsScope(
                                 ImmutableArray<QsStatement>.Empty,
-                                LocalDeclarations.Empty);
+                                block.Body.KnownSymbols);
                             var newConditionalBlock = new QsPositionedBlock(
                                     emptyScope,
-                                    QsNullable<QsLocation>.Null,
+                                    block.Location,
                                     QsComments.Empty);
                             return (true, new QsConditionalStatement(
                                 ImmutableArray.Create(Tuple.Create(notCondition.Item, newConditionalBlock)),

--- a/src/QsCompiler/Transformations/ClassicallyControlled.cs
+++ b/src/QsCompiler/Transformations/ClassicallyControlled.cs
@@ -163,6 +163,11 @@ namespace Microsoft.Quantum.QsCompiler.Transformations.ClassicallyControlled
                     }
                 }
 
+                /// <summary>
+                /// Converts conditional statements whose top-most condition is a NOT.
+                /// Creates a blank `else` clause if there is no `else` clause already, then
+                /// swaps the `else` and `if` clauses while removing the NOT from the condition.
+                /// </summary>
                 private (bool, QsConditionalStatement) ProcessNOT(QsConditionalStatement conditionStatement)
                 {
                     // This method expects elif blocks to have been abstracted out

--- a/src/QsCompiler/Transformations/ClassicallyControlled.cs
+++ b/src/QsCompiler/Transformations/ClassicallyControlled.cs
@@ -31,8 +31,8 @@ namespace Microsoft.Quantum.QsCompiler.Transformations.ClassicallyControlled
         public static QsCompilation Apply(QsCompilation compilation)
         {
             compilation = RestructureConditions.Apply(compilation);
-            return LiftConditionBlocks.Apply(compilation);
-            //return ConvertConditions.Apply(compilation);
+            compilation = LiftConditionBlocks.Apply(compilation);
+            return ConvertConditions.Apply(compilation);
         }
 
         private class RestructureConditions : SyntaxTreeTransformation


### PR DESCRIPTION
Fixes an issue to make sure that the `NOT` condition reshaping that happens as part of the classical control rewrite step preserves the known symbols, which get turned into the arguments to the generated lifted bodies of the condition blocks.

Addresses #1112