### PR TITLE
swernli/version-update

### DIFF
--- a/src/Passes/README.md
+++ b/src/Passes/README.md
@@ -90,21 +90,21 @@ source_filename = "./analysis-example.ll"
 
 define internal fastcc void @TeleportChain__DemonstrateTeleportationUsingPresharedEntanglement__body() unnamed_addr {
 entry:
-  call void @__quantum__qis__h(%Qubit* null)
-  call void @__quantum__qis__cnot(%Qubit* null, %Qubit* nonnull inttoptr (i64 1 to %Qubit*))
-  call void @__quantum__qis__h(%Qubit* null)
-  call void @__quantum__qis__cnot(%Qubit* null, %Qubit* nonnull inttoptr (i64 2 to %Qubit*))
-  call void @__quantum__qis__h(%Qubit* nonnull inttoptr (i64 1 to %Qubit*))
-  call void @__quantum__qis__cnot(%Qubit* nonnull inttoptr (i64 1 to %Qubit*), %Qubit* nonnull inttoptr (i64 3 to %Qubit*))
-  call void @__quantum__qis__cnot(%Qubit* nonnull inttoptr (i64 1 to %Qubit*), %Qubit* null)
-  call void @__quantum__qis__h(%Qubit* nonnull inttoptr (i64 1 to %Qubit*))
+  call void @__quantum__qis__h__body(%Qubit* null)
+  call void @__quantum__qis__cnot__body(%Qubit* null, %Qubit* nonnull inttoptr (i64 1 to %Qubit*))
+  call void @__quantum__qis__h__body(%Qubit* null)
+  call void @__quantum__qis__cnot__body(%Qubit* null, %Qubit* nonnull inttoptr (i64 2 to %Qubit*))
+  call void @__quantum__qis__h__body(%Qubit* nonnull inttoptr (i64 1 to %Qubit*))
+  call void @__quantum__qis__cnot__body(%Qubit* nonnull inttoptr (i64 1 to %Qubit*), %Qubit* nonnull inttoptr (i64 3 to %Qubit*))
+  call void @__quantum__qis__cnot__body(%Qubit* nonnull inttoptr (i64 1 to %Qubit*), %Qubit* null)
+  call void @__quantum__qis__h__body(%Qubit* nonnull inttoptr (i64 1 to %Qubit*))
   %0 = call i1 @__quantum__qir__read_result(%Result* nonnull inttoptr (i64 4 to %Result*))
   call void @__quantum__qis__mz__body(%Qubit* nonnull inttoptr (i64 1 to %Qubit*), %Result* nonnull inttoptr (i64 4 to %Result*))
   call void @__quantum__qis__reset__body(%Qubit* nonnull inttoptr (i64 1 to %Qubit*))
   br i1 %0, label %then0__1.i.i, label %continue__1.i.i
 
 then0__1.i.i:                                     ; preds = %entry
-  call void @__quantum__qis__z(%Qubit* nonnull inttoptr (i64 2 to %Qubit*))
+  call void @__quantum__qis__z__body(%Qubit* nonnull inttoptr (i64 2 to %Qubit*))
   br label %continue__1.i.i
 
 continue__1.i.i:                                  ; preds = %then0__1.i.i, %entry
@@ -114,19 +114,19 @@ continue__1.i.i:                                  ; preds = %then0__1.i.i, %entr
   br i1 %1, label %then0__2.i.i, label %TeleportChain__TeleportQubitUsingPresharedEntanglement__body.1.exit
 
 then0__2.i.i:                                     ; preds = %continue__1.i.i
-  call void @__quantum__qis__x(%Qubit* nonnull inttoptr (i64 2 to %Qubit*))
+  call void @__quantum__qis__x__body(%Qubit* nonnull inttoptr (i64 2 to %Qubit*))
   br label %TeleportChain__TeleportQubitUsingPresharedEntanglement__body.1.exit
 
 TeleportChain__TeleportQubitUsingPresharedEntanglement__body.1.exit: ; preds = %continue__1.i.i, %then0__2.i.i
-  call void @__quantum__qis__cnot(%Qubit* nonnull inttoptr (i64 2 to %Qubit*), %Qubit* nonnull inttoptr (i64 1 to %Qubit*))
-  call void @__quantum__qis__h(%Qubit* nonnull inttoptr (i64 2 to %Qubit*))
+  call void @__quantum__qis__cnot__body(%Qubit* nonnull inttoptr (i64 2 to %Qubit*), %Qubit* nonnull inttoptr (i64 1 to %Qubit*))
+  call void @__quantum__qis__h__body(%Qubit* nonnull inttoptr (i64 2 to %Qubit*))
   %2 = call i1 @__quantum__qir__read_result(%Result* nonnull inttoptr (i64 6 to %Result*))
   call void @__quantum__qis__mz__body(%Qubit* nonnull inttoptr (i64 2 to %Qubit*), %Result* nonnull inttoptr (i64 6 to %Result*))
   call void @__quantum__qis__reset__body(%Qubit* nonnull inttoptr (i64 2 to %Qubit*))
   br i1 %2, label %then0__1.i.i2, label %continue__1.i.i3
 
 then0__1.i.i2:                                    ; preds = %TeleportChain__TeleportQubitUsingPresharedEntanglement__body.1.exit
-  call void @__quantum__qis__z(%Qubit* nonnull inttoptr (i64 3 to %Qubit*))
+  call void @__quantum__qis__z__body(%Qubit* nonnull inttoptr (i64 3 to %Qubit*))
   br label %continue__1.i.i3
 
 continue__1.i.i3:                                 ; preds = %then0__1.i.i2, %TeleportChain__TeleportQubitUsingPresharedEntanglement__body.1.exit
@@ -136,7 +136,7 @@ continue__1.i.i3:                                 ; preds = %then0__1.i.i2, %Tel
   br i1 %3, label %then0__2.i.i4, label %TeleportChain__TeleportQubitUsingPresharedEntanglement__body.2.exit
 
 then0__2.i.i4:                                    ; preds = %continue__1.i.i3
-  call void @__quantum__qis__x(%Qubit* nonnull inttoptr (i64 3 to %Qubit*))
+  call void @__quantum__qis__x__body(%Qubit* nonnull inttoptr (i64 3 to %Qubit*))
   br label %TeleportChain__TeleportQubitUsingPresharedEntanglement__body.2.exit
 
 TeleportChain__TeleportQubitUsingPresharedEntanglement__body.2.exit: ; preds = %continue__1.i.i3, %then0__2.i.i4

--- a/src/Passes/examples/OptimisationUsingOpt/SimpleExample/SimpleExample.csproj
+++ b/src/Passes/examples/OptimisationUsingOpt/SimpleExample/SimpleExample.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.Quantum.Sdk/0.18.2106148911">
+﻿<Project Sdk="Microsoft.Quantum.Sdk/0.18.2108157818-beta">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>

--- a/src/Passes/examples/QubitAllocationAnalysis/TeleportChain/TeleportChain.csproj
+++ b/src/Passes/examples/QubitAllocationAnalysis/TeleportChain/TeleportChain.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.Quantum.Sdk/0.18.2108155805-beta">
+<Project Sdk="Microsoft.Quantum.Sdk/0.18.2108157818-beta">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Type1.Core" Version="0.18.2108155805-beta" IsTargetPackage="true" />
+    <PackageReference Include="Microsoft.Quantum.Type1.Core" Version="0.18.2108157818-beta" IsTargetPackage="true" />
   </ItemGroup>
 
 </Project>

--- a/src/Passes/examples/QubitAllocationAnalysis/analysis-example.ll
+++ b/src/Passes/examples/QubitAllocationAnalysis/analysis-example.ll
@@ -48,13 +48,13 @@ declare void @__quantum__rt__result_update_reference_count(%Result*, i32) local_
 
 define internal fastcc void @Microsoft__Quantum__Intrinsic__Z__body(%Qubit* %qubit) unnamed_addr {
 entry:
-  call void @__quantum__qis__z(%Qubit* %qubit)
+  call void @__quantum__qis__z__body(%Qubit* %qubit)
   ret void
 }
 
 define internal fastcc void @Microsoft__Quantum__Intrinsic__X__body(%Qubit* %qubit) unnamed_addr {
 entry:
-  call void @__quantum__qis__x(%Qubit* %qubit)
+  call void @__quantum__qis__x__body(%Qubit* %qubit)
   ret void
 }
 
@@ -141,13 +141,13 @@ entry:
 
 define internal fastcc void @Microsoft__Quantum__Intrinsic__H__body(%Qubit* %qubit) unnamed_addr {
 entry:
-  call void @__quantum__qis__h(%Qubit* %qubit)
+  call void @__quantum__qis__h__body(%Qubit* %qubit)
   ret void
 }
 
 define internal fastcc void @Microsoft__Quantum__Intrinsic__CNOT__body(%Qubit* %control, %Qubit* %target) unnamed_addr {
 entry:
-  call void @__quantum__qis__cnot(%Qubit* %control, %Qubit* %target)
+  call void @__quantum__qis__cnot__body(%Qubit* %control, %Qubit* %target)
   ret void
 }
 
@@ -170,13 +170,13 @@ entry:
   ret void
 }
 
-declare void @__quantum__qis__cnot(%Qubit*, %Qubit*) local_unnamed_addr
+declare void @__quantum__qis__cnot__body(%Qubit*, %Qubit*) local_unnamed_addr
 
-declare void @__quantum__qis__h(%Qubit*) local_unnamed_addr
+declare void @__quantum__qis__h__body(%Qubit*) local_unnamed_addr
 
-declare void @__quantum__qis__x(%Qubit*) local_unnamed_addr
+declare void @__quantum__qis__x__body(%Qubit*) local_unnamed_addr
 
-declare void @__quantum__qis__z(%Qubit*) local_unnamed_addr
+declare void @__quantum__qis__z__body(%Qubit*) local_unnamed_addr
 
 declare %Result* @__quantum__qis__m__body(%Qubit*) local_unnamed_addr
 


### PR DESCRIPTION
This switches to a newer QDK beta package that has name fixes in the QIR generation for target packages (see https://github.com/microsoft/qsharp-runtime/pull/789). It includes the corresponding updates to the README.md and .ll files.