### PR TITLE
Remove call to initialize LLVM target

### DIFF
--- a/src/QsCompiler/QirGeneration/Context.cs
+++ b/src/QsCompiler/QirGeneration/Context.cs
@@ -36,7 +36,6 @@ namespace Microsoft.Quantum.QsCompiler.QIR
         static GenerationContext()
         {
             LibContext = Library.InitializeLLVM();
-            LibContext.RegisterTarget(CodeGenTarget.Native);
         }
 
         #region Member variables


### PR DESCRIPTION
The `GenerationContext` constructor included a call to Register the current plaform as the target for LLVM, which it turns out is unnecessary for generating target agnostic IR like we do. Further, this reduces the surface are of APIs that we utilize from LLVM, making it easy to identify the required libraries for QIR generation.