### PR TITLE
Remove For-Loop Parenthesis

### DIFF
--- a/src/QsFmt/Formatter.Tests/Examples.fs
+++ b/src/QsFmt/Formatter.Tests/Examples.fs
@@ -228,6 +228,24 @@ let ``Updates Unit Types`` =
 }"""
 
 [<Example(ExampleKind.Update)>]
+let ``Removes For-Loop Parens`` =
+    """namespace Foo {
+    operation Bar() : Unit {
+        for (i in 0..3) {
+            Message("HelloQ");
+        }
+    }
+}""",
+
+    """namespace Foo {
+    operation Bar() : Unit {
+        for i in 0..3 {
+            Message("HelloQ");
+        }
+    }
+}"""
+
+[<Example(ExampleKind.Update)>]
 let ``Allows size as an Identifier`` =
     """namespace Foo {
     operation Bar() : Unit {

--- a/src/QsFmt/Formatter/Formatter.fs
+++ b/src/QsFmt/Formatter/Formatter.fs
@@ -65,6 +65,7 @@ let update source =
             document
             |> curry qubitBindingUpdate.Document ()
             |> curry unitUpdate.Document ()
+            |> curry forParensUpdate.Document ()
             |> curry arraySyntaxUpdate.Document ()
 
         let warningList = updatedDocument |> updateChecker

--- a/src/QsFmt/Formatter/Rules.fs
+++ b/src/QsFmt/Formatter/Rules.fs
@@ -148,10 +148,15 @@ let unitUpdate =
 
 let forParensUpdate =
     { new Rewriter<_>() with
-        override _.For((), loop) =
+        override rewriter.For((), loop) =
+            let openTrivia = loop.OpenParen |> getTrivia
+            let closeTrivia = loop.CloseParen |> getTrivia
+
             { loop with
                 OpenParen = None
+                Binding = loop.Binding |> ForBinding.mapPrefix ((@) openTrivia)
                 CloseParen = None
+                Block = rewriter.Block((), rewriter.Statement, loop.Block) |> Block.mapPrefix ((@) closeTrivia)
             }
     }
 

--- a/src/QsFmt/Formatter/Rules.fs
+++ b/src/QsFmt/Formatter/Rules.fs
@@ -158,8 +158,8 @@ let arraySyntaxUpdate =
         | "String" -> { Prefix = []; Text = "\"\"" } |> Literal |> Some
         | "Result" -> { Prefix = []; Text = "Zero" } |> Literal |> Some
         | "Pauli" -> { Prefix = []; Text = "PauliI" } |> Literal |> Some
-        | "Range" -> { Prefix = []; Text = "1..0" } |> Literal |> Some // ToDo: Double-check that this literal is correct
-        | _ -> None // TODO: Throw Warning
+        | "Range" -> { Prefix = []; Text = "1..0" } |> Literal |> Some
+        | _ -> None
 
     let rec getDefaultValue (``type``: Type) =
         let space = " " |> Trivia.ofString

--- a/src/QsFmt/Formatter/Rules.fs
+++ b/src/QsFmt/Formatter/Rules.fs
@@ -146,6 +146,15 @@ let unitUpdate =
             base.Type((), updated)
     }
 
+let forParensUpdate =
+    { new Rewriter<_>() with
+        override _.For((), loop) =
+            { loop with
+                OpenParen = None
+                CloseParen = None
+            }
+    }
+
 let arraySyntaxUpdate =
 
     let getBuiltInDefault builtIn =

--- a/src/QsFmt/Formatter/Rules.fsi
+++ b/src/QsFmt/Formatter/Rules.fsi
@@ -26,6 +26,9 @@ val qubitBindingUpdate: unit Rewriter
 /// Will not replace `()` when referencing the Unit value literal.
 val unitUpdate : unit Rewriter
 
+/// Updates for-loops to remove deprecated parentheses.
+val forParensUpdate: unit Rewriter
+
 /// Updates the `new <Type>[n]` array syntax to the new `[val, size = n]` array syntax.
 val arraySyntaxUpdate: unit Rewriter
 

--- a/src/QsFmt/Formatter/SyntaxTree/Reducer.fsi
+++ b/src/QsFmt/Formatter/SyntaxTree/Reducer.fsi
@@ -150,6 +150,12 @@ type internal 'result Reducer =
     default Else: elses:Else -> 'result
 
     /// <summary>
+    /// Reduces an <see cref="For"/> statement node.
+    /// </summary>
+    abstract For : loop: For -> 'result
+    default For : loop: For -> 'result
+
+    /// <summary>
     /// Reduces a <see cref="ParameterBinding"/> node.
     /// </summary>
     abstract ParameterBinding: binding:ParameterBinding -> 'result
@@ -172,6 +178,12 @@ type internal 'result Reducer =
     /// </summary>
     abstract QubitBinding: binding:QubitBinding -> 'result
     default QubitBinding: binding:QubitBinding -> 'result
+
+    /// <summary>
+    /// Reduces a <see cref="ForBinding"/> node.
+    /// </summary>
+    abstract ForBinding : binding: ForBinding -> 'result
+    default ForBinding : binding: ForBinding -> 'result
 
     /// <summary>
     /// Reduces a <see cref="QubitInitializer"/> node.

--- a/src/QsFmt/Formatter/SyntaxTree/Rewriter.fs
+++ b/src/QsFmt/Formatter/SyntaxTree/Rewriter.fs
@@ -164,6 +164,7 @@ type 'context Rewriter() =
         | QubitDeclaration decl -> rewriter.QubitDeclaration(context, decl) |> QubitDeclaration
         | If ifs -> rewriter.If(context, ifs) |> If
         | Else elses -> rewriter.Else(context, elses) |> Else
+        | For loop -> rewriter.For(context, loop) |> For
         | Statement.Unknown terminal -> rewriter.Terminal(context, terminal) |> Statement.Unknown
 
     abstract Let : context: 'context * lets: Let -> Let
@@ -218,6 +219,17 @@ type 'context Rewriter() =
             Block = rewriter.Block(context, rewriter.Statement, elses.Block)
         }
 
+    abstract For : context: 'context * loop: For -> For
+
+    default rewriter.For(context, loop) =
+        {
+            ForKeyword = rewriter.Terminal(context, loop.ForKeyword)
+            OpenParen = loop.OpenParen |> Option.map (curry rewriter.Terminal context)
+            Binding = rewriter.ForBinding(context, loop.Binding)
+            CloseParen = loop.CloseParen |> Option.map (curry rewriter.Terminal context)
+            Block = rewriter.Block(context, rewriter.Statement, loop.Block)
+        }
+
     abstract ParameterBinding : context: 'context * binding: ParameterBinding -> ParameterBinding
 
     default rewriter.ParameterBinding(context, binding) =
@@ -248,6 +260,15 @@ type 'context Rewriter() =
             Name = rewriter.SymbolBinding(context, binding.Name)
             Equals = rewriter.Terminal(context, binding.Equals)
             Initializer = rewriter.QubitInitializer(context, binding.Initializer)
+        }
+
+    abstract ForBinding : context: 'context * binding: ForBinding -> ForBinding
+
+    default rewriter.ForBinding(context, binding) =
+        {
+            Name = rewriter.SymbolBinding(context, binding.Name)
+            In = rewriter.Terminal(context, binding.In)
+            Value = rewriter.Expression(context, binding.Value)
         }
 
     abstract QubitInitializer : context: 'context * initializer: QubitInitializer -> QubitInitializer

--- a/src/QsFmt/Formatter/SyntaxTree/Rewriter.fsi
+++ b/src/QsFmt/Formatter/SyntaxTree/Rewriter.fsi
@@ -146,6 +146,12 @@ type internal 'context Rewriter =
     default Else: context:'context * elses:Else -> Else
 
     /// <summary>
+    /// Rewrites a <see cref="For"/> statement node.
+    /// </summary>
+    abstract For : context: 'context * loop: For -> For
+    default For : context: 'context * loop: For -> For
+
+    /// <summary>
     /// Rewrites a <see cref="ParameterBinding"/> node.
     /// </summary>
     abstract ParameterBinding: context:'context * binding:ParameterBinding -> ParameterBinding
@@ -168,6 +174,12 @@ type internal 'context Rewriter =
     /// </summary>
     abstract QubitBinding: context:'context * binding:QubitBinding -> QubitBinding
     default QubitBinding: context:'context * binding:QubitBinding -> QubitBinding
+
+    /// <summary>
+    /// Rewrites a <see cref="ForBinding"/> node.
+    /// </summary>
+    abstract ForBinding : context: 'context * binding: ForBinding -> ForBinding
+    default ForBinding : context: 'context * binding: ForBinding -> ForBinding
 
     /// <summary>
     /// Rewrites a <see cref="QubitInitializer"/> node.

--- a/src/QsFmt/Formatter/SyntaxTree/Statement.fs
+++ b/src/QsFmt/Formatter/SyntaxTree/Statement.fs
@@ -50,6 +50,17 @@ module QubitBinding =
     let mapPrefix mapper (binding: QubitBinding) =
         { binding with Name = SymbolBinding.mapPrefix mapper binding.Name }
 
+type ForBinding =
+    {
+        Name: SymbolBinding
+        In: Terminal
+        Value: Expression
+    }
+
+module ForBinding =
+    let mapPrefix mapper (binding: ForBinding) =
+        { binding with Name = SymbolBinding.mapPrefix mapper binding.Name }
+
 type Let =
     {
         LetKeyword: Terminal
@@ -93,12 +104,22 @@ and If =
 
 and Else = { ElseKeyword: Terminal; Block: Statement Block }
 
+and For =
+    {
+        ForKeyword: Terminal
+        OpenParen: Terminal option
+        Binding: ForBinding
+        CloseParen: Terminal option
+        Block: Statement Block
+    }
+
 and Statement =
     | Let of Let
     | Return of Return
     | QubitDeclaration of QubitDeclaration
     | If of If
     | Else of Else
+    | For of For
     | Unknown of Terminal
 
 module Statement =
@@ -110,4 +131,5 @@ module Statement =
         | QubitDeclaration decl -> { decl with Keyword = decl.Keyword |> Terminal.mapPrefix mapper } |> QubitDeclaration
         | If ifs -> { ifs with IfKeyword = ifs.IfKeyword |> Terminal.mapPrefix mapper } |> If
         | Else elses -> { elses with ElseKeyword = elses.ElseKeyword |> Terminal.mapPrefix mapper } |> Else
+        | For loop -> { loop with ForKeyword = loop.ForKeyword |> Terminal.mapPrefix mapper } |> For
         | Unknown terminal -> Terminal.mapPrefix mapper terminal |> Unknown

--- a/src/QsFmt/Formatter/SyntaxTree/Statement.fsi
+++ b/src/QsFmt/Formatter/SyntaxTree/Statement.fsi
@@ -98,6 +98,25 @@ module internal QubitBinding =
     /// </summary>
     val mapPrefix: mapper:(Trivia list -> Trivia list) -> binding: QubitBinding -> QubitBinding
 
+/// The binding for a for-loop variable.
+type internal ForBinding =
+    {
+        /// The symbol binding.
+        Name: SymbolBinding
+
+        /// The <c>in</c> keyword.
+        In: Terminal
+
+        /// The value of the symbol binding.
+        Value: Expression
+    }
+    
+module internal ForBinding =
+    /// <summary>
+    /// Maps <paramref name="binding"/> by applying <paramref name="mapper"/> to its leftmost terminal's trivia prefix.
+    /// </summary>
+    val mapPrefix: mapper:(Trivia list -> Trivia list) -> binding: ForBinding -> ForBinding
+
 /// <summary>
 /// A <c>let</c> statement.
 /// </summary>
@@ -212,6 +231,29 @@ and internal Else =
         /// The conditional block.
         Block: Statement Block
     }
+    
+/// <summary>
+/// A <c>for</c> statement.
+/// </summary>
+and internal For =
+    {
+        /// <summary>
+        /// The <c>for</c> keyword.
+        /// </summary>
+        ForKeyword: Terminal
+
+        /// The optional open parenthesis.
+        OpenParen: Terminal option
+
+        /// The binding for loop variable.
+        Binding: ForBinding
+
+        /// The optional close parenthesis.
+        CloseParen: Terminal option
+
+        /// The loop body.
+        Block: Statement Block
+    }
 
 /// A statement.
 and internal Statement =
@@ -237,6 +279,11 @@ and internal Statement =
     /// An <c>else</c> statement.
     /// </summary>
     | Else of Else
+
+    /// <summary>
+    /// A <c>for</c> statement.
+    /// </summary>
+    | For of For
 
     /// An unknown statement.
     | Unknown of Terminal

--- a/src/QsFmt/Parser/QSharpParser.g4
+++ b/src/QsFmt/Parser/QSharpParser.g4
@@ -151,7 +151,7 @@ statement
     | if='if' condition=expression body=scope # IfStatement
     | 'elif' expression scope # ElifStatement
     | else='else' body=scope # ElseStatement
-    | 'for' (forBinding | '(' forBinding ')') scope # ForStatement
+    | for='for' (binding=forBinding | openParen='(' binding=forBinding closeParen=')') body=scope # ForStatement
     | 'while' expression scope # WhileStatement
     | 'repeat' scope # RepeatStatement
     | 'until' expression (';' | 'fixup' scope) # UntilStatement
@@ -184,7 +184,7 @@ updateOperator
     | 'or='
     ;
 
-forBinding : symbolBinding 'in' expression;
+forBinding : binding=symbolBinding in='in' value=expression;
 
 qubitBinding : binding=symbolBinding equals='=' value=qubitInitializer;
 


### PR DESCRIPTION
Adds data structures for for-loops and for-loop bindings.
Adds a rule that removes the deprecated parenthesis around the bindings of for-loop statements.

Addresses Issue #1144 