### PR TITLE
Fix Phase Estimation code in QIR example

### DIFF
--- a/examples/QIR/Emission/Program.qs
+++ b/examples/QIR/Emission/Program.qs
@@ -30,8 +30,8 @@
     
         for _ in 1 .. nrIter {
     
-            let time = mu - PI() * sigma / 2.0;
-            let theta = 1.0 / sigma;
+            let theta = mu - PI() * sigma / 2.0;
+            let time = 1.0 / sigma;
 
             let datum = Iterate(time, theta, target);
     


### PR DESCRIPTION
The example for QIR Emission uses a Random Walk Phase Estimation algorithm that has a bug: the variables `time` and `theta` were inadvertantly swapped.