### PR TITLE
added MSBuild_Logs to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -366,3 +366,6 @@ src/ProjectTemplates/Quantum.Test1/.template.config/template.json
 src/QsCompiler/QirGeneration/QirGeneration.nuspec
 /examples/QIR/Development/qir/*
 /examples/QIR/Development/build
+
+# MSBuild logs
+MSBuild_Logs/


### PR DESCRIPTION
There is a possible new `MSBuild_Logs` generated under the working directory (see https://github.com/dotnet/msbuild/commit/cdb5077c451180ab38161e0b5e70f5448e70355b) when MSBuild crashes.

This should not happen often but it showed up for me in three places when working with this repo, so I thought it would make sense to extend the default gitignore

<img width="755" alt="Bildschirmfoto 2021-09-27 um 21 22 57" src="https://user-images.githubusercontent.com/1710369/134971657-02fe6049-e4cd-438a-90b3-e12da170b36a.png"> 