### PR TITLE
Force use of LLVM 11 in build pipeline

### DIFF
--- a/build/build.ps1
+++ b/build/build.ps1
@@ -7,7 +7,7 @@ $ErrorActionPreference = 'Stop'
 $all_ok = $True
 Write-Host "Assembly version: $Env:ASSEMBLY_VERSION"
 
-choco install llvm --version=11.1.0
+choco install llvm --version=11.1.0 --allow-downgrade
 if (!(Get-Command clang -ErrorAction SilentlyContinue) -and (choco find --idonly -l llvm) -contains "llvm") {
     # For some reason, adding to the path does not work on our build servers, even after calling refreshenv.
     # LLVM was installed by Chocolatey, so add the install location to the path.


### PR DESCRIPTION
The latest Windows-2019 DevOps image has LLVM 12.0.1 installed by default and our LLVM code is not yet compatible with vesion 12. This forces the downgrade to 11.1.0 to allow our builds to still succeed.