### PR TITLE
QAT support for bitcode output

### DIFF
--- a/src/Passes/Source/Apps/Qat/Qat.cpp
+++ b/src/Passes/Source/Apps/Qat/Qat.cpp
@@ -255,6 +255,10 @@ int main(int argc, char** argv)
         {
             llvm::outs() << *module << "\n";
         }
+        else
+        {
+            llvm::WriteBitcodeToFile(*module, llvm::outs());
+        }
 
         if (config.verifyModule())
         {

--- a/src/Passes/Source/Llvm/Llvm.hpp
+++ b/src/Passes/Source/Llvm/Llvm.hpp
@@ -62,6 +62,9 @@
 // Linking
 #include "llvm/Linker/Linker.h"
 
+// Bitcode output
+#include "llvm/Bitcode/BitcodeWriter.h"
+
 #if defined(__clang__)
 #pragma clang diagnostic pop
 #endif


### PR DESCRIPTION
This PR makes bitcode the standard output format. Human readible code can be generated by adding `-S`