### PR TITLE
Update .NET version as target framework for qsharp-compiler binaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ dotnet build MyProject.csproj
 If your project builds successfully, edit the project file in the text editor to add the following project property, adjusting the path as needed:
 ```
   <PropertyGroup>
-    <QscExe>dotnet $(MSBuildThisFileDirectory)src/QsCompiler/CommandLineTool/bin/$(Configuration)/netcoreapp3.1/qsc.dll</QscExe>
+    <QscExe>dotnet $(MSBuildThisFileDirectory)src/QsCompiler/CommandLineTool/bin/$(Configuration)/net6.0/qsc.dll</QscExe>
   </PropertyGroup>
 ```
 To confirm that indeed the locally built compiler version is used, you can edit `Run<T>` in your local [Project.cs](./src/QsCompiler/CommandLineTool/Program.cs) file to include the following line:

--- a/build/manifest.ps1
+++ b/build/manifest.ps1
@@ -21,7 +21,7 @@ if ($Env:ENABLE_VSIX -ne "false") {
     # The language server is only built if either the VS2019 or VS Code extension
     # is enabled.
     $VsixAssemblies = @(
-        ".\src\QsCompiler\LanguageServer\bin\$Env:BUILD_CONFIGURATION\netcoreapp3.1\Microsoft.Quantum.QsLanguageServer.dll",
+        ".\src\QsCompiler\LanguageServer\bin\$Env:BUILD_CONFIGURATION\net6.0\Microsoft.Quantum.QsLanguageServer.dll",
         ".\src\VisualStudioExtension\QSharpVsix\bin\$Env:BUILD_CONFIGURATION\Microsoft.Quantum.VisualStudio.Extension.dll"
     );
 }
@@ -55,9 +55,9 @@ $artifacts = @{
         ".\src\QsCompiler\RoslynWrapper\bin\$Env:BUILD_CONFIGURATION\netstandard2.1\Microsoft.Quantum.RoslynWrapper.dll",
         ".\src\QsCompiler\LlvmBindings\bin\$Env:BUILD_CONFIGURATION\netstandard2.1\Microsoft.Quantum.LlvmBindings.dll",
         ".\src\QsCompiler\Transformations\bin\$Env:BUILD_CONFIGURATION\netstandard2.1\Microsoft.Quantum.QsTransformations.dll",
-        ".\src\QsCompiler\CommandLineTool\bin\$Env:BUILD_CONFIGURATION\netcoreapp3.1\qsc.dll",
-        ".\src\QuantumSdk\Tools\BuildConfiguration\bin\$Env:BUILD_CONFIGURATION\netcoreapp3.1\Microsoft.Quantum.Sdk.BuildConfiguration.dll",
-        ".\src\QuantumSdk\Tools\DefaultEntryPoint\bin\$Env:BUILD_CONFIGURATION\netcoreapp3.1\Microsoft.Quantum.Sdk.DefaultEntryPoint.Generation.dll"
+        ".\src\QsCompiler\CommandLineTool\bin\$Env:BUILD_CONFIGURATION\net6.0\qsc.dll",
+        ".\src\QuantumSdk\Tools\BuildConfiguration\bin\$Env:BUILD_CONFIGURATION\net6.0\Microsoft.Quantum.Sdk.BuildConfiguration.dll",
+        ".\src\QuantumSdk\Tools\DefaultEntryPoint\bin\$Env:BUILD_CONFIGURATION\net6.0\Microsoft.Quantum.Sdk.DefaultEntryPoint.Generation.dll"
     ) | ForEach-Object { Join-Path $PSScriptRoot (Join-Path ".." $_) };
 }
 

--- a/src/Documentation/Tests.DocGenerator/Tests.DocGenerator.csproj
+++ b/src/Documentation/Tests.DocGenerator/Tests.DocGenerator.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <RootNamespace>Microsoft.Quantum.QsCompiler.Documentation.Testing</RootNamespace>
     <AssemblyName>Tests.Microsoft.Quantum.QsDocumentationParser</AssemblyName>

--- a/src/QsCompiler/CommandLineTool/CommandLineTool.csproj
+++ b/src/QsCompiler/CommandLineTool/CommandLineTool.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <AssemblyName>qsc</AssemblyName>
     <AssemblyTitle>Microsoft Q# compiler command line tool.</AssemblyTitle>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
 

--- a/src/QsCompiler/LanguageServer/LanguageServer.csproj
+++ b/src/QsCompiler/LanguageServer/LanguageServer.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <AssemblyName>Microsoft.Quantum.QsLanguageServer</AssemblyName>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
 

--- a/src/QsCompiler/QirGeneration/README.md
+++ b/src/QsCompiler/QirGeneration/README.md
@@ -16,7 +16,7 @@ If the project builds successfully, the .ll file containing QIR can be found in 
 <Project Sdk="Microsoft.Quantum.Sdk/0.18.2107151063-beta">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <QirOutputPath>$(MSBuildThisFileDirectory)/qir</QirOutputPath>
     <QscVerbosity>Detailed</QscVerbosity>
   </PropertyGroup>

--- a/src/QsCompiler/TestProjects/test13/test13.csproj
+++ b/src/QsCompiler/TestProjects/test13/test13.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
 

--- a/src/QsCompiler/TestTargets/Libraries/Library1/Library1.csproj
+++ b/src/QsCompiler/TestTargets/Libraries/Library1/Library1.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk" InitialTargets="RecompileOnChange">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <NoWarn>QS7010</NoWarn> <!-- Reference cannot be included in the generated DLL. -->
   </PropertyGroup>
 

--- a/src/QsCompiler/TestTargets/Libraries/Library2/Library2.csproj
+++ b/src/QsCompiler/TestTargets/Libraries/Library2/Library2.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk" InitialTargets="RecompileOnChange">
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <NoWarn>QS7010</NoWarn> <!-- Reference cannot be included in the generated DLL. -->
   </PropertyGroup>
 

--- a/src/QsCompiler/TestTargets/Libraries/build/Library.targets
+++ b/src/QsCompiler/TestTargets/Libraries/build/Library.targets
@@ -7,7 +7,7 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <QscExe>dotnet "../../../CommandLineTool/bin/$(Configuration)/netcoreapp3.1/qsc.dll"</QscExe>
+    <QscExe>dotnet "../../../CommandLineTool/bin/$(Configuration)/net6.0/qsc.dll"</QscExe>
   </PropertyGroup>
 
   <Target Name="RecompileOnChange">

--- a/src/QsCompiler/TestTargets/Simulation/Example/Example.csproj
+++ b/src/QsCompiler/TestTargets/Simulation/Example/Example.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <QscVerbosity>Detailed</QscVerbosity>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <ExposeReferencesViaTestNames>true</ExposeReferencesViaTestNames>
     <IncludeQSharpCorePackages>false</IncludeQSharpCorePackages>
     <IncludeProviderPackages>false</IncludeProviderPackages>
@@ -17,9 +17,9 @@
   <PropertyGroup>
     <GeneratedFilesOutputPath>generated/</GeneratedFilesOutputPath>
     <ExecutionTestsDir>ExecutionTests/</ExecutionTestsDir>
-    <SimulationTarget>../Target/bin/$(Configuration)/netcoreapp3.1/Simulation.dll</SimulationTarget>
+    <SimulationTarget>../Target/bin/$(Configuration)/net6.0/Simulation.dll</SimulationTarget>
     <AdditionalQscArguments>--load $(SimulationTarget)</AdditionalQscArguments>
-    <QscExe>dotnet "../../../CommandLineTool/bin/$(Configuration)/netcoreapp3.1/qsc.dll"</QscExe>
+    <QscExe>dotnet "../../../CommandLineTool/bin/$(Configuration)/net6.0/qsc.dll"</QscExe>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/QsCompiler/TestTargets/Simulation/Target/Simulation.csproj
+++ b/src/QsCompiler/TestTargets/Simulation/Target/Simulation.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <AssemblyName>Simulation</AssemblyName>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
 

--- a/src/QsCompiler/Tests.CSharpGeneration/Tests.CSharpGeneration.fsproj
+++ b/src/QsCompiler/Tests.CSharpGeneration/Tests.CSharpGeneration.fsproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <AssemblyName>Tests.Microsoft.Quantum.CSharpGeneration</AssemblyName>
     <IsPackable>false</IsPackable>
     <PlatformTarget>x64</PlatformTarget>

--- a/src/QsCompiler/Tests.Compiler/Tests.Compiler.fsproj
+++ b/src/QsCompiler/Tests.Compiler/Tests.Compiler.fsproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <AssemblyName>Tests.Microsoft.Quantum.QsCompiler</AssemblyName>
     <OutputType>Library</OutputType>
@@ -590,9 +590,9 @@
 
   <Target Name="PrepareReferenceTests" Condition="'$(DesignTimeBuild)' != 'true'" BeforeTargets="CoreCompile">
     <PropertyGroup>
-      <ExecutionTarget>$(MSBuildThisFileDirectory)..\TestTargets\Simulation\Example\bin\$(Configuration)\netcoreapp3.1\Example.dll</ExecutionTarget>
-      <QirExecutionTarget>$(MSBuildThisFileDirectory)..\TestTargets\Simulation\Target\bin\$(Configuration)\netcoreapp3.1\Simulation.dll</QirExecutionTarget>
-      <LibraryTarget>$(MSBuildThisFileDirectory)..\TestTargets\Libraries\Library1\bin\$(Configuration)\netcoreapp3.1\Library1.dll</LibraryTarget>
+      <ExecutionTarget>$(MSBuildThisFileDirectory)..\TestTargets\Simulation\Example\bin\$(Configuration)\net6.0\Example.dll</ExecutionTarget>
+      <QirExecutionTarget>$(MSBuildThisFileDirectory)..\TestTargets\Simulation\Target\bin\$(Configuration)\net6.0\Simulation.dll</QirExecutionTarget>
+      <LibraryTarget>$(MSBuildThisFileDirectory)..\TestTargets\Libraries\Library1\bin\$(Configuration)\net6.0\Library1.dll</LibraryTarget>
     </PropertyGroup>
     <WriteLinesToFile File="$(OutputPath)ReferenceTargets.txt" Lines="$(ExecutionTarget); $(QirExecutionTarget); $(LibraryTarget)" Overwrite="true" />
     <PropertyGroup>

--- a/src/QsCompiler/Tests.LanguageServer/ProjectLoaderTests.cs
+++ b/src/QsCompiler/Tests.LanguageServer/ProjectLoaderTests.cs
@@ -68,7 +68,7 @@ namespace Microsoft.Quantum.QsLanguageServer.Testing
             Assert.IsTrue(loader.IsSupportedQsFramework("netcoreapp2.1"));
             Assert.IsTrue(loader.IsSupportedQsFramework("netcoreapp2.2"));
             Assert.IsTrue(loader.IsSupportedQsFramework("netcoreapp3.0"));
-            Assert.IsTrue(loader.IsSupportedQsFramework("netcoreapp3.1"));
+            Assert.IsTrue(loader.IsSupportedQsFramework("net6.0"));
         }
 
         [TestMethod]
@@ -101,7 +101,7 @@ namespace Microsoft.Quantum.QsLanguageServer.Testing
                 ("test10", "netcoreapp2.1"),
                 ("test11", "netcoreapp3.0"),
                 ("test12", "netstandard2.1"),
-                ("test13", "netcoreapp3.1"),
+                ("test13", "net6.0"),
             };
 
             foreach (var (project, framework) in testProjects)

--- a/src/QsCompiler/Tests.LanguageServer/ProjectLoaderTests.cs
+++ b/src/QsCompiler/Tests.LanguageServer/ProjectLoaderTests.cs
@@ -68,6 +68,7 @@ namespace Microsoft.Quantum.QsLanguageServer.Testing
             Assert.IsTrue(loader.IsSupportedQsFramework("netcoreapp2.1"));
             Assert.IsTrue(loader.IsSupportedQsFramework("netcoreapp2.2"));
             Assert.IsTrue(loader.IsSupportedQsFramework("netcoreapp3.0"));
+            Assert.IsTrue(loader.IsSupportedQsFramework("netcoreapp3.1"));
             Assert.IsTrue(loader.IsSupportedQsFramework("net6.0"));
         }
 

--- a/src/QsCompiler/Tests.LanguageServer/Tests.LanguageServer.csproj
+++ b/src/QsCompiler/Tests.LanguageServer/Tests.LanguageServer.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <AssemblyName>Tests.Microsoft.Quantum.QsLanguageServer</AssemblyName>
     <OutputType>Library</OutputType>

--- a/src/QsCompiler/Tests.RoslynWrapper/Tests.RoslynWrapper.fsproj
+++ b/src/QsCompiler/Tests.RoslynWrapper/Tests.RoslynWrapper.fsproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <AssemblyName>Tests.Microsoft.Quantum.RoslynWrapper</AssemblyName>
     <IsPackable>false</IsPackable>
     <PlatformTarget>x64</PlatformTarget>

--- a/src/QsFmt/App.Tests/App.Tests.fsproj
+++ b/src/QsFmt/App.Tests/App.Tests.fsproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <AssemblyName>Microsoft.Quantum.QsFmt.App.Tests</AssemblyName>
     <RootNamespace>$(AssemblyName)</RootNamespace>
   </PropertyGroup>

--- a/src/QsFmt/App.Tests/Examples/TestProjects/OldApplication/OldApplication.csproj
+++ b/src/QsFmt/App.Tests/Examples/TestProjects/OldApplication/OldApplication.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
 

--- a/src/QsFmt/App.Tests/Examples/TestProjects/OldVersion/OldVersion.csproj
+++ b/src/QsFmt/App.Tests/Examples/TestProjects/OldVersion/OldVersion.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
 </Project>

--- a/src/QsFmt/App.Tests/Examples/TestProjects/SimpleApplication/QSharpApplication1.csproj
+++ b/src/QsFmt/App.Tests/Examples/TestProjects/SimpleApplication/QSharpApplication1.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/QsFmt/App.Tests/Examples/TestProjects/SimpleTestProject/QSharpTestProject1.csproj
+++ b/src/QsFmt/App.Tests/Examples/TestProjects/SimpleTestProject/QSharpTestProject1.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.Quantum.Sdk/0.18.2109162713">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/src/QsFmt/App.Tests/Examples/TestTarget/TestTarget.csproj
+++ b/src/QsFmt/App.Tests/Examples/TestTarget/TestTarget.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/QsFmt/App/App.fsproj
+++ b/src/QsFmt/App/App.fsproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <AssemblyName>qsfmt</AssemblyName>
     <RootNamespace>Microsoft.Quantum.QsFmt.App</RootNamespace>
   </PropertyGroup>

--- a/src/QsFmt/Formatter.Tests/Formatter.Tests.fsproj
+++ b/src/QsFmt/Formatter.Tests/Formatter.Tests.fsproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <AssemblyName>Microsoft.Quantum.QsFmt.Formatter.Tests</AssemblyName>
     <RootNamespace>$(AssemblyName)</RootNamespace>
   </PropertyGroup>

--- a/src/QuantumSdk/QuantumSdk.nuspec
+++ b/src/QuantumSdk/QuantumSdk.nuspec
@@ -22,9 +22,9 @@
     <file src="Sdk\**\*" target="Sdk" exclude="**\*.v.template"/>
     <file src="DefaultItems\**\*" target="DefaultItems" exclude="**\*.v.template"/>
     <file src="ProjectSystem\**\*" target="ProjectSystem" exclude="**\*.v.template"/>
-    <file src="Tools\BuildConfiguration\bin\$Configuration$\netcoreapp3.1\publish\**" target="tools\utils" exclude="**\*.pdb" />
-    <file src="Tools\DefaultEntryPoint\bin\$Configuration$\netcoreapp3.1\publish\**" target="tools\utils" exclude="**\*.pdb" />
-    <file src="..\QsCompiler\CommandLineTool\bin\$Configuration$\netcoreapp3.1\publish\**" target="tools\qsc" />
+    <file src="Tools\BuildConfiguration\bin\$Configuration$\net6.0\publish\**" target="tools\utils" exclude="**\*.pdb" />
+    <file src="Tools\DefaultEntryPoint\bin\$Configuration$\net6.0\publish\**" target="tools\utils" exclude="**\*.pdb" />
+    <file src="..\QsCompiler\CommandLineTool\bin\$Configuration$\net6.0\publish\**" target="tools\qsc" />
     <file src="..\..\build\assets\qdk-nuget-icon.png" target="images" />
   </files>
 </package>

--- a/src/QuantumSdk/Tools/BuildConfiguration/BuildConfiguration.csproj
+++ b/src/QuantumSdk/Tools/BuildConfiguration/BuildConfiguration.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <AssemblyName>Microsoft.Quantum.Sdk.BuildConfiguration</AssemblyName>
     <AssemblyTitle>Build configuration tools included in the Microsoft Quantum Sdk.</AssemblyTitle>
   </PropertyGroup>

--- a/src/QuantumSdk/Tools/DefaultEntryPoint/DefaultEntryPoint.csproj
+++ b/src/QuantumSdk/Tools/DefaultEntryPoint/DefaultEntryPoint.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
         <AssemblyName>Microsoft.Quantum.Sdk.DefaultEntryPoint.Generation</AssemblyName>
         <AssemblyTitle>Build tool to generate a minimal C# entry point when no C# files are included in the compilation.</AssemblyTitle>
     </PropertyGroup>

--- a/src/VSCodeExtension/BUILDING.md
+++ b/src/VSCodeExtension/BUILDING.md
@@ -69,7 +69,7 @@ PS> dotnet publish --self-contained --runtime win10-x64
 To get the value that you need for the `quantumDevKit.languageServerPath` preference:
 
 ```
-PS> Resolve-Path bin/Debug/netcoreapp3.1/win10-x64/publish/Microsoft.Quantum.QsLanguageServer.exe
+PS> Resolve-Path bin/Debug/net6.0/win10-x64/publish/Microsoft.Quantum.QsLanguageServer.exe
 ```
 
 ## Debugging ##

--- a/src/VisualStudioExtension/QSharpVsix/QSharpVsix.csproj
+++ b/src/VisualStudioExtension/QSharpVsix/QSharpVsix.csproj
@@ -16,7 +16,7 @@
     <RootNamespace>Microsoft.Quantum.VisualStudio</RootNamespace>
     <AssemblyName>Microsoft.Quantum.VisualStudio.Extension</AssemblyName>
     <TargetVsixContainerName>Microsoft.Quantum.Development.Kit-$(VSVSIX_VERSION).vsix</TargetVsixContainerName>
-    <LanguageServerPath>..\..\QsCompiler\LanguageServer\bin\$(Configuration)\netcoreapp3.1\publish\</LanguageServerPath>
+    <LanguageServerPath>..\..\QsCompiler\LanguageServer\bin\$(Configuration)\net6.0\publish\</LanguageServerPath>
     <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <GeneratePkgDefFile>false</GeneratePkgDefFile>
     <UseCodebase>true</UseCodebase>


### PR DESCRIPTION
This pull request is updating binaries of the Q# Compiler to target .NET6 as part of a larger effort tracked by issue #1224 .

This pull request is partial work into a feature branch, so not all checks are expected to pass.