### PR TITLE
Update all project template files to .NET6

### DIFF
--- a/src/ProjectTemplates/Quantum.App1/Quantum.App1.csproj.v.template
+++ b/src/ProjectTemplates/Quantum.App1/Quantum.App1.csproj.v.template
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
 </Project>

--- a/src/ProjectTemplates/Quantum.Honeywell.App1/Quantum.Honeywell.App1.csproj.v.template
+++ b/src/ProjectTemplates/Quantum.Honeywell.App1/Quantum.Honeywell.App1.csproj.v.template
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <ExecutionTarget>honeywell.hqs-lt-1.0</ExecutionTarget>
   </PropertyGroup>
 

--- a/src/ProjectTemplates/Quantum.IonQ.App1/Quantum.IonQ.App1.csproj.v.template
+++ b/src/ProjectTemplates/Quantum.IonQ.App1/Quantum.IonQ.App1.csproj.v.template
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <ExecutionTarget>ionq.qpu</ExecutionTarget>
   </PropertyGroup>
 

--- a/src/ProjectTemplates/Quantum.Test1/Quantum.Test1.csproj.v.template
+++ b/src/ProjectTemplates/Quantum.Test1/Quantum.Test1.csproj.v.template
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.Quantum.Sdk/#NUGET_VERSION#">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/src/VSCodeExtension/templates/application/Application.csproj.v.template
+++ b/src/VSCodeExtension/templates/application/Application.csproj.v.template
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
 </Project>

--- a/src/VSCodeExtension/templates/honeywell/HoneywellApplication.csproj.v.template
+++ b/src/VSCodeExtension/templates/honeywell/HoneywellApplication.csproj.v.template
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <ExecutionTarget>honeywell.hqs-lt-1.0</ExecutionTarget>
   </PropertyGroup>
 

--- a/src/VSCodeExtension/templates/ionq/IonQApplication.csproj.v.template
+++ b/src/VSCodeExtension/templates/ionq/IonQApplication.csproj.v.template
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <ExecutionTarget>ionq.qpu</ExecutionTarget>
   </PropertyGroup>
 

--- a/src/VSCodeExtension/templates/unittest/Test.csproj.v.template
+++ b/src/VSCodeExtension/templates/unittest/Test.csproj.v.template
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.Quantum.Sdk/#NUGET_VERSION#">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/src/VisualStudioExtension/QSharpAppTemplate/AppProjectTemplate.xml.v.template
+++ b/src/VisualStudioExtension/QSharpAppTemplate/AppProjectTemplate.xml.v.template
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
 </Project>

--- a/src/VisualStudioExtension/QSharpTestTemplate/TestProjectTemplate.xml.v.template
+++ b/src/VisualStudioExtension/QSharpTestTemplate/TestProjectTemplate.xml.v.template
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.Quantum.Sdk/#NUGET_VERSION#">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/src/VisualStudioExtension/QsharpHoneywellAppTemplate/HoneywellAppProjectTemplate.xml.v.template
+++ b/src/VisualStudioExtension/QsharpHoneywellAppTemplate/HoneywellAppProjectTemplate.xml.v.template
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <ExecutionTarget>honeywell.hqs-lt-1.0</ExecutionTarget>
   </PropertyGroup>
 

--- a/src/VisualStudioExtension/QsharpIonQAppTemplate/IonQAppProjectTemplate.xml.v.template
+++ b/src/VisualStudioExtension/QsharpIonQAppTemplate/IonQAppProjectTemplate.xml.v.template
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <ExecutionTarget>ionq.qpu</ExecutionTarget>
   </PropertyGroup>
 


### PR DESCRIPTION
As a consequence of the work required to support .NET 6 and make it a the new minimum supported .NET version as tracked in issue #1224, we are updating the template files accordingly.