### PR TITLE
Fixing nullability and other errors as part of .NET6 migration.

### DIFF
--- a/src/QsCompiler/CommandLineTool/Options.cs
+++ b/src/QsCompiler/CommandLineTool/Options.cs
@@ -157,9 +157,10 @@ namespace Microsoft.Quantum.QsCompiler.CommandLineCompiler
         internal void SetupLoadingContext()
         {
             var current = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location)!;
-            var fallbackFolders = this.PackageLoadFallbackFolders.Prepend(current);
+            var fallbackFolders = this.PackageLoadFallbackFolders?.Prepend(current);
+
             CompilationLoader.LoadAssembly = path =>
-                LoadContext.LoadAssembly(path, fallbackFolders.ToArray());
+                LoadContext.LoadAssembly(path, fallbackFolders?.ToArray());
 
             var llvmLibs = this.LlvmLibs != null
                 ? LoadContext.ResolveFromPaths("libLLVM", new[] { this.LlvmLibs })

--- a/src/QsCompiler/Compiler/Logging.cs
+++ b/src/QsCompiler/Compiler/Logging.cs
@@ -206,8 +206,8 @@ namespace Microsoft.Quantum.QsCompiler.Diagnostics
 
     public static class Formatting
     {
-        public static IEnumerable<string>? Indent(params string[] items) =>
-            items?.Select(msg => $"    {msg}");
+        public static IEnumerable<string> Indent(params string[] items) =>
+            items?.Select(msg => $"    {msg}") ?? Enumerable.Empty<string>();
 
         /// <summary>
         /// Returns a string that contains all information about the given diagnostic in human readable format.

--- a/src/QsCompiler/Tests.LanguageServer/TestSetup.cs
+++ b/src/QsCompiler/Tests.LanguageServer/TestSetup.cs
@@ -62,8 +62,9 @@ namespace Microsoft.Quantum.QsLanguageServer.Testing
             var id = this.inputGenerator.GetRandom();
             string serverReaderPipe = $"QsLanguageServerReaderPipe{id}";
             string serverWriterPipe = $"QsLanguageServerWriterPipe{id}";
-            var readerPipe = new NamedPipeServerStream(serverWriterPipe, PipeDirection.InOut, 4, PipeTransmissionMode.Message, PipeOptions.Asynchronous, 256, 256);
-            var writerPipe = new NamedPipeServerStream(serverReaderPipe, PipeDirection.InOut, 4, PipeTransmissionMode.Message, PipeOptions.Asynchronous, 256, 256);
+            var pipeTransmissionMode = OperatingSystem.IsWindows() ? PipeTransmissionMode.Message : PipeTransmissionMode.Byte;
+            var readerPipe = new NamedPipeServerStream(serverWriterPipe, PipeDirection.InOut, 4, pipeTransmissionMode, PipeOptions.Asynchronous, 256, 256);
+            var writerPipe = new NamedPipeServerStream(serverReaderPipe, PipeDirection.InOut, 4, pipeTransmissionMode, PipeOptions.Asynchronous, 256, 256);
 
             var server = Server.ConnectViaNamedPipe(serverWriterPipe, serverReaderPipe);
             await readerPipe.WaitForConnectionAsync().ConfigureAwait(true);

--- a/src/QsCompiler/Tests.LanguageServer/Tests.cs
+++ b/src/QsCompiler/Tests.LanguageServer/Tests.cs
@@ -121,9 +121,9 @@ namespace Microsoft.Quantum.QsLanguageServer.Testing
             Assert.IsNotNull(initReply.Capabilities.CompletionProvider);
             Assert.IsTrue(initReply.Capabilities.CompletionProvider!.ResolveProvider);
             Assert.IsNotNull(initReply.Capabilities.CompletionProvider.TriggerCharacters);
-            Assert.IsTrue(initReply.Capabilities.CompletionProvider.TriggerCharacters.SequenceEqual(new[] { ".", "(" }));
+            Assert.IsTrue(initReply.Capabilities.CompletionProvider.TriggerCharacters!.SequenceEqual(new[] { ".", "(" }));
             Assert.IsNotNull(initReply.Capabilities.SignatureHelpProvider?.TriggerCharacters);
-            Assert.IsTrue(initReply.Capabilities.SignatureHelpProvider!.TriggerCharacters.Any());
+            Assert.IsTrue(initReply.Capabilities.SignatureHelpProvider!.TriggerCharacters!.Any());
             Assert.IsNotNull(initReply.Capabilities.ExecuteCommandProvider?.Commands);
             Assert.IsTrue(initReply.Capabilities.ExecuteCommandProvider!.Commands.Contains(CommandIds.ApplyEdit));
             Assert.IsTrue(initReply.Capabilities.TextDocumentSync.OpenClose);


### PR DESCRIPTION
This change covers the following changes:
- Added validations for nullable checks in Language Server and tests.
- Modified `Microsoft.Quantum.QsCompiler.Diagnostics.Formatting.Indent` to not return a null IEnumerable.
- Fixed CA1416 platforms specific error since `PipeTransmissionMode.Message` is only available in Windows.
