### PR TITLE
Fix hover info for declarations of `for` and `use` statements

### DIFF
--- a/src/QsCompiler/CompilationManager/EditorSupport/SymbolInfo.cs
+++ b/src/QsCompiler/CompilationManager/EditorSupport/SymbolInfo.cs
@@ -158,17 +158,22 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
 
             return new LocalDeclarations((expressionVars ?? statementVars).ToImmutableArray());
 
-            IEnumerable<LocalVariableDeclaration<string>>? ExpressionVars(TypedExpression e) =>
-                e.Range.Any(r => r.Contains(position - currentStatement.Location.Item.Offset))
-                    ? DeclarationsInExpression(e, position - currentStatement.Location.Item.Offset)
-                    : null;
+            IEnumerable<LocalVariableDeclaration<string>>? ExpressionVars(TypedExpression e)
+            {
+                var p = position - currentStatement.Location.Item.Offset;
+                return e.Range.Any(r => r.Contains(p)) ? DeclarationsInExpression(e, p) : null;
+            }
 
             IEnumerable<LocalVariableDeclaration<string>>? CondExpressionVars(QsStatementKind.QsConditionalStatement c)
-                =>
-                LastConditionBlockBefore(c, position) is ({ } lastCond, var lastBlock)
-                && lastCond.Range.Any(r => r.Contains(position - lastBlock.Location.Item.Offset))
-                    ? DeclarationsInExpression(lastCond, position - lastBlock.Location.Item.Offset)
-                    : null;
+            {
+                if (LastConditionBlockBefore(c, position) is ({ } lastCond, var lastBlock))
+                {
+                    var p = position - lastBlock.Location.Item.Offset;
+                    return lastCond.Range.Any(r => r.Contains(p)) ? DeclarationsInExpression(lastCond, p) : null;
+                }
+
+                return null;
+            }
 
             IEnumerable<LocalVariableDeclaration<string>>? QubitInitVars(ResolvedInitializer i) => i.Resolution switch
             {

--- a/src/QsCompiler/CompilationManager/EditorSupport/SymbolInfo.cs
+++ b/src/QsCompiler/CompilationManager/EditorSupport/SymbolInfo.cs
@@ -134,6 +134,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
                 return new LocalDeclarations(varsBefore);
             }
 
+            // This is null if the position does not occur in an expression of the current statement.
             var expressionVars = (currentStatement.Statement switch
             {
                 QsStatementKind.QsExpressionStatement e => ExpressionVars(e.Item),

--- a/src/QsCompiler/DataStructures/DataTypes.fs
+++ b/src/QsCompiler/DataStructures/DataTypes.fs
@@ -7,8 +7,11 @@ open System
 open System.Collections
 open System.Collections.Generic
 open Microsoft.Quantum.QsCompiler.Diagnostics
+open Newtonsoft.Json
+open Newtonsoft.Json.Converters
 
-// to avoid having to include the F# core in the C# part of the compiler...
+/// A nullable type.
+[<JsonConverter(typeof<DiscriminatedUnionConverter>)>]
 [<Struct>]
 type QsNullable<'T> =
     | Null

--- a/src/QsCompiler/DataStructures/DataTypes.fs
+++ b/src/QsCompiler/DataStructures/DataTypes.fs
@@ -1,18 +1,29 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
 namespace Microsoft.Quantum.QsCompiler.DataTypes
 
 open System
+open System.Collections
 open System.Collections.Generic
 open Microsoft.Quantum.QsCompiler.Diagnostics
-
 
 // to avoid having to include the F# core in the C# part of the compiler...
 [<Struct>]
 type QsNullable<'T> =
     | Null
     | Value of 'T
+
+    interface 'T seq with
+        member nullable.GetEnumerator() =
+            match nullable with
+            | Null -> Seq.empty.GetEnumerator()
+            | Value x -> Seq.singleton(x).GetEnumerator()
+
+        member nullable.GetEnumerator() =
+            match nullable with
+            | Null -> (Seq.empty :> IEnumerable).GetEnumerator()
+            | Value x -> (Seq.singleton x :> IEnumerable).GetEnumerator()
 
     /// If the given nullable has a value, applies the given function to it and returns the result, which must be
     /// another nullable. Returns Null otherwise.
@@ -57,14 +68,6 @@ type QsNullable<'T> =
                 | Null -> None
                 | Value v -> Some v
         )
-
-    /// Converts the given F# option to a QsNullable.
-    // TODO: RELEASE 2021-08: Remove QsNullable<T>.FromOption.
-    [<Obsolete "Use QsNullable.ofOption or QsNullable.FromOption instead.">]
-    static member FromOption opt =
-        match opt with
-        | Some v -> Value v
-        | None -> Null
 
 /// Operations for QsNullable<'T>.
 module QsNullable =

--- a/src/QsCompiler/Tests.Compiler/CapabilityInferenceTests.fs
+++ b/src/QsCompiler/Tests.Compiler/CapabilityInferenceTests.fs
@@ -23,7 +23,7 @@ let private callables =
 let private expect capability name =
     let fullName = CapabilityVerificationTests.testName name
     let actual = SymbolResolution.TryGetRequiredCapability callables.[fullName].Attributes
-    Assert.Equal(Value capability, actual)
+    Assert.Contains(capability, actual)
 
 [<Fact>]
 let ``Infers BasicQuantumFunctionality by source code`` () =


### PR DESCRIPTION
* Fix a regression introduced on the feature/lambda branch that didn't include the `for` loop variable, or the declared qubits from `use`, in `LocalsInScope` when `inclusive: true`.
* Add `seq` interface to `QsNullable` for convenience.
* Remove deprecated `QsNullable<'T>.FromOption`.