### PR TITLE
Add tests for lambda hover info and symbol references

### DIFF
--- a/src/QsCompiler/TestProjects/test16/Lambda.qs
+++ b/src/QsCompiler/TestProjects/test16/Lambda.qs
@@ -1,0 +1,22 @@
+namespace Test16 {
+    operation Lambda() : Unit {
+        let x1 = (x1 -> $"{x1}")(1.0);
+
+        use q1 = Qubit[(x -> x + 1)(1)];
+
+        use q2 = (Qubit[(x -> x + 1)(1)], Qubit(), Qubit[(x -> x == 1.0 ? 0 | 1)(1.0)]);
+
+        let f1 = (foo) -> foo + 1 + foo;
+
+        let f2 = (foo, bar) -> foo + bar + 1;
+
+        let f3 = foo -> foo + 1;
+
+        for i in (i -> [i])(1.0) {}
+
+        if (x -> x or true)(true) {
+        } elif (y -> y or y or true)(true) {
+        } elif (y -> y == 1)(1) {
+        }
+    }
+}

--- a/src/QsCompiler/TestProjects/test16/Lambda.qs
+++ b/src/QsCompiler/TestProjects/test16/Lambda.qs
@@ -12,7 +12,7 @@ namespace Test16 {
 
         let f3 = foo -> foo + 1;
 
-        for i in (i -> [i])(1.0) {}
+        for i in (i -> [$"{i}"])(1.0) {}
 
         if (x -> x or true)(true) {
         } elif (y -> y or y or true)(true) {

--- a/src/QsCompiler/TestProjects/test16/test16.csproj
+++ b/src/QsCompiler/TestProjects/test16/test16.csproj
@@ -1,0 +1,6 @@
+<Project Sdk="Microsoft.Quantum.Sdk/0.20.2110171573">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+  </PropertyGroup>  
+</Project>

--- a/src/QsCompiler/Tests.LanguageServer/TestUtils.cs
+++ b/src/QsCompiler/Tests.LanguageServer/TestUtils.cs
@@ -157,5 +157,34 @@ namespace Microsoft.Quantum.QsLanguageServer.Testing
                    IsValidPosition(range.End) &&
                    IsBeforeOrEqual(range.Start, range.End);
         }
+
+        internal static void AssertCapability<TOptions>(
+            this SumType<bool, TOptions>? capability, bool shouldHave = true, Func<TOptions, bool>? condition = null)
+        {
+            if (shouldHave)
+            {
+                Assert.IsTrue(capability.HasValue, "Expected capability to have value, but was null.");
+            }
+
+            capability?.Match(
+                flag =>
+                {
+                    Assert.AreEqual(flag, shouldHave);
+                    return true;
+                },
+                options =>
+                {
+                    if (condition is null)
+                    {
+                        Assert.IsNotNull(options);
+                    }
+                    else
+                    {
+                        Assert.IsTrue(condition(options));
+                    }
+
+                    return true;
+                });
+        }
     }
 }

--- a/src/QsCompiler/Tests.LanguageServer/TestUtils.cs
+++ b/src/QsCompiler/Tests.LanguageServer/TestUtils.cs
@@ -5,6 +5,8 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Quantum.QsCompiler.CompilationBuilder;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Builder = Microsoft.Quantum.QsCompiler.CompilationBuilder.Utils;
@@ -186,5 +188,17 @@ namespace Microsoft.Quantum.QsLanguageServer.Testing
                     return true;
                 });
         }
+
+        internal static Task TestAfterTypeCheckingAsync(ProjectManager projectManager, Uri file, Action action) =>
+            projectManager.ManagerTaskAsync(file, (unitManager, foundProject) =>
+            {
+                Assert.IsTrue(foundProject);
+
+                unitManager.FlushAndExecute(() =>
+                {
+                    action();
+                    return new object();
+                });
+            });
     }
 }

--- a/src/QsCompiler/Tests.LanguageServer/Tests.cs
+++ b/src/QsCompiler/Tests.LanguageServer/Tests.cs
@@ -403,6 +403,7 @@ namespace Microsoft.Quantum.QsLanguageServer.Testing
             }
         }
 
+        [Ignore("Finding references for lambda parameters is not yet implemented.")]
         [TestMethod]
         public async Task TestLambdaReferencesAsync()
         {

--- a/src/QsCompiler/Tests.LanguageServer/Tests.cs
+++ b/src/QsCompiler/Tests.LanguageServer/Tests.cs
@@ -15,40 +15,6 @@ using Builder = Microsoft.Quantum.QsCompiler.CompilationBuilder.Utils;
 
 namespace Microsoft.Quantum.QsLanguageServer.Testing
 {
-    internal static class Extensions
-    {
-        internal static void AssertCapability<TOptions>(this SumType<bool, TOptions>? capability, bool shouldHave = true, Func<TOptions, bool>? condition = null)
-        {
-            if (shouldHave)
-            {
-                Assert.IsTrue(capability.HasValue, "Expected capability to have value, but was null.");
-            }
-
-            if (capability.HasValue)
-            {
-                capability!.Value.Match(
-                    flag =>
-                    {
-                        Assert.AreEqual(flag, shouldHave);
-                        return true;
-                    },
-                    options =>
-                    {
-                        if (condition != null)
-                        {
-                            Assert.IsTrue(condition(options));
-                        }
-                        else
-                        {
-                            Assert.IsNotNull(options);
-                        }
-
-                        return true;
-                    });
-            }
-        }
-    }
-
     [TestClass]
     public partial class BasicFunctionality
     {

--- a/src/QsCompiler/Tests.LanguageServer/Tests.cs
+++ b/src/QsCompiler/Tests.LanguageServer/Tests.cs
@@ -337,11 +337,8 @@ namespace Microsoft.Quantum.QsLanguageServer.Testing
         public async Task TestLambdaHoverInfoAsync()
         {
             var projectFile = ProjectLoaderTests.ProjectUri("test16");
+            var projectManager = await LoadProjectFileAsync(projectFile);
             var lambdaFile = new Uri(projectFile, "Lambda.qs");
-            var projectManager = new ProjectManager(e => throw e);
-
-            await projectManager.LoadProjectsAsync(
-                new[] { projectFile }, CompilationContext.Editor.QsProjectLoader, enableLazyLoading: false);
 
             await TestUtils.TestAfterTypeCheckingAsync(projectManager, lambdaFile, () =>
             {
@@ -410,11 +407,8 @@ namespace Microsoft.Quantum.QsLanguageServer.Testing
         public async Task TestLambdaReferencesAsync()
         {
             var projectFile = ProjectLoaderTests.ProjectUri("test16");
+            var projectManager = await LoadProjectFileAsync(projectFile);
             var lambdaFile = new Uri(projectFile, "Lambda.qs");
-            var projectManager = new ProjectManager(e => throw e);
-
-            await projectManager.LoadProjectsAsync(
-                new[] { projectFile }, CompilationContext.Editor.QsProjectLoader, enableLazyLoading: false);
 
             await TestUtils.TestAfterTypeCheckingAsync(projectManager, lambdaFile, () =>
             {
@@ -485,6 +479,14 @@ namespace Microsoft.Quantum.QsLanguageServer.Testing
             }
 
             static string PositionToString(Position p) => $"Ln {p.Line}, Col {p.Character}";
+        }
+
+        private static async Task<ProjectManager> LoadProjectFileAsync(Uri uri)
+        {
+            var projectManager = new ProjectManager(e => throw e);
+            await projectManager.LoadProjectsAsync(
+                new[] { uri }, CompilationContext.Editor.QsProjectLoader, enableLazyLoading: false);
+            return projectManager;
         }
     }
 }

--- a/src/QsCompiler/Tests.LanguageServer/Tests.cs
+++ b/src/QsCompiler/Tests.LanguageServer/Tests.cs
@@ -337,6 +337,7 @@ namespace Microsoft.Quantum.QsLanguageServer.Testing
             var projectFile = ProjectLoaderTests.ProjectUri("test16");
             var lambdaFile = new Uri(projectFile, "Lambda.qs");
             var projectManager = new ProjectManager(e => throw e);
+
             await projectManager.LoadProjectsAsync(
                 new[] { projectFile }, CompilationContext.Editor.QsProjectLoader, enableLazyLoading: false);
 
@@ -345,6 +346,43 @@ namespace Microsoft.Quantum.QsLanguageServer.Testing
                 AssertHover(new Position(2, 12), "x1", "String", true);
                 AssertHover(new Position(2, 18), "x1", "Double", true);
                 AssertHover(new Position(2, 27), "x1", "Double", false);
+
+                AssertHover(new Position(4, 12), "q1", "Qubit[]", true);
+                AssertHover(new Position(4, 24), "x", "Int", true);
+                AssertHover(new Position(4, 29), "x", "Int", false);
+
+                AssertHover(new Position(6, 12), "q2", "(Qubit[], Qubit, Qubit[])", true);
+                AssertHover(new Position(6, 25), "x", "Int", true);
+                AssertHover(new Position(6, 30), "x", "Int", false);
+                AssertHover(new Position(6, 58), "x", "Double", true);
+                AssertHover(new Position(6, 63), "x", "Double", false);
+
+                AssertHover(new Position(8, 12), "f1", "(Int -> Int)", true);
+                AssertHover(new Position(8, 18), "foo", "Int", true);
+                AssertHover(new Position(8, 26), "foo", "Int", false);
+                AssertHover(new Position(8, 36), "foo", "Int", false);
+
+                AssertHover(new Position(10, 12), "f2", "((Int, Int) -> Int)", true);
+                AssertHover(new Position(10, 18), "foo", "Int", true);
+                AssertHover(new Position(10, 23), "bar", "Int", true);
+                AssertHover(new Position(10, 31), "foo", "Int", false);
+                AssertHover(new Position(10, 37), "bar", "Int", false);
+
+                AssertHover(new Position(12, 12), "f3", "(Int -> Int)", true);
+                AssertHover(new Position(12, 17), "foo", "Int", true);
+                AssertHover(new Position(12, 24), "foo", "Int", false);
+
+                AssertHover(new Position(14, 12), "i", "String", true);
+                AssertHover(new Position(14, 18), "i", "Double", true);
+                AssertHover(new Position(14, 27), "i", "Double", false);
+
+                AssertHover(new Position(16, 12), "x", "Bool", true);
+                AssertHover(new Position(16, 17), "x", "Bool", false);
+                AssertHover(new Position(17, 16), "y", "Bool", true);
+                AssertHover(new Position(17, 21), "y", "Bool", false);
+                AssertHover(new Position(17, 26), "y", "Bool", false);
+                AssertHover(new Position(18, 16), "y", "Int", true);
+                AssertHover(new Position(18, 21), "y", "Int", false);
             });
 
             void AssertHover(Position position, string expectedName, string expectedType, bool expectedDeclaration)

--- a/src/QsCompiler/Tests.LanguageServer/Tests.cs
+++ b/src/QsCompiler/Tests.LanguageServer/Tests.cs
@@ -389,7 +389,7 @@ namespace Microsoft.Quantum.QsLanguageServer.Testing
                 var documentPosition = new TextDocumentPositionParams
                 {
                     Position = position,
-                    TextDocument = new TextDocumentIdentifier { Uri = lambdaFile },
+                    TextDocument = new TextDocumentIdentifier { Uri = lambdaFile! },
                 };
 
                 var expected =
@@ -398,7 +398,7 @@ namespace Microsoft.Quantum.QsLanguageServer.Testing
                         : $"Immutable variable {expectedName}")
                     + $"    \nType: {expectedType}";
 
-                var actual = projectManager.HoverInformation(documentPosition);
+                var actual = projectManager!.HoverInformation(documentPosition);
                 Assert.AreEqual(expected, actual!.Contents.Third.Value);
             }
         }
@@ -448,18 +448,18 @@ namespace Microsoft.Quantum.QsLanguageServer.Testing
                     var reference = new ReferenceParams
                     {
                         Position = position,
-                        TextDocument = new TextDocumentIdentifier { Uri = lambdaFile },
+                        TextDocument = new TextDocumentIdentifier { Uri = lambdaFile! },
                     };
 
                     var expected = positions
                         .Select(p => new Location
                         {
-                            Uri = lambdaFile,
+                            Uri = lambdaFile!,
                             Range = new Range { Start = p, End = new Position(p.Line, p.Character + symbolLength) },
                         })
                         .ToImmutableHashSet();
 
-                    if (projectManager.SymbolReferences(reference)?.ToImmutableHashSet() is { } actual)
+                    if (projectManager!.SymbolReferences(reference)?.ToImmutableHashSet() is { } actual)
                     {
                         var expectedStr = string.Join(", ", expected.Select(LocationToString));
                         var actualStr = string.Join(", ", actual.Select(LocationToString));

--- a/src/QsCompiler/Tests.LanguageServer/Tests.cs
+++ b/src/QsCompiler/Tests.LanguageServer/Tests.cs
@@ -378,15 +378,7 @@ namespace Microsoft.Quantum.QsLanguageServer.Testing
 
             void Test()
             {
-                AssertHover(
-                    "x1",
-                    "String",
-                    true,
-                    projectManager.HoverInformation(new TextDocumentPositionParams
-                    {
-                        Position = new Position(2, 12),
-                        TextDocument = new TextDocumentIdentifier { Uri = lambdaQs },
-                    }));
+                AssertHover("x1", "String", true, 2, 12);
             }
 
             void TestAfterTypeChecking(CompilationUnitManager compilationUnitManager, bool projectFound)
@@ -399,13 +391,20 @@ namespace Microsoft.Quantum.QsLanguageServer.Testing
                 });
             }
 
-            static void AssertHover(string expectedName, string expectedType, bool expectedDeclaration, Hover? actual)
+            void AssertHover(
+                string expectedName, string expectedType, bool expectedDeclaration, int line, int character)
             {
                 var expected =
                     (expectedDeclaration
                         ? $"Declaration of an immutable variable {expectedName}"
                         : $"Immutable variable {expectedName}")
                     + $"    \nType: {expectedType}";
+
+                var actual = projectManager!.HoverInformation(new TextDocumentPositionParams
+                {
+                    Position = new Position(line, character),
+                    TextDocument = new TextDocumentIdentifier { Uri = lambdaQs! },
+                });
 
                 Assert.AreEqual(expected, actual!.Contents.Third.Value);
             }


### PR DESCRIPTION
TestLambdaReferencesAsync will fail until #1231 is merged.