### PR TITLE
Fixing an issue with repeat in generated QIR

### DIFF
--- a/src/QsCompiler/QirGeneration/Context.cs
+++ b/src/QsCompiler/QirGeneration/Context.cs
@@ -1345,7 +1345,7 @@ namespace Microsoft.Quantum.QsCompiler.QIR
             }
 
             Value? output = null;
-            this.ExecuteLoop(exitBlock, () =>
+            this.ExecuteLoop(() =>
             {
                 var (loopVariable, outputValue) = PopulateLoopHeader(startValue, evaluateCondition);
                 var newOutputValue = executeBody(loopVariable, outputValue);
@@ -1353,6 +1353,8 @@ namespace Microsoft.Quantum.QsCompiler.QIR
                 ContinueOrExitLoop((loopVariable, increment), outputUpdate);
                 output = outputUpdate?.Item1;
             });
+
+            this.SetCurrentBlock(exitBlock);
             return output;
         }
 
@@ -1382,14 +1384,12 @@ namespace Microsoft.Quantum.QsCompiler.QIR
         /// Executes the loop defined by the given action.
         /// Ensures that all pointers will be properly loaded during and after the loop.
         /// </summary>
-        /// <param name="continuation">The block to set as the current block after executing the loop</param>
         /// <param name="loop">The loop to execute</param>
-        internal void ExecuteLoop(BasicBlock continuation, Action loop)
+        internal void ExecuteLoop(Action loop)
         {
             this.StartLoop();
             loop();
             this.EndLoop();
-            this.SetCurrentBlock(continuation);
         }
 
         /// <summary>

--- a/src/QsCompiler/QirGeneration/Subtransformations/StatementKindTransformation.cs
+++ b/src/QsCompiler/QirGeneration/Subtransformations/StatementKindTransformation.cs
@@ -380,7 +380,7 @@ namespace Microsoft.Quantum.QsCompiler.QIR
             var fixupBlock = this.SharedState.CurrentFunction.AppendBasicBlock(this.SharedState.BlockName("fixup"));
             var contBlock = this.SharedState.CurrentFunction.AppendBasicBlock(this.SharedState.BlockName("rend"));
 
-            this.SharedState.ExecuteLoop(contBlock, () =>
+            this.SharedState.ExecuteLoop(() =>
             {
                 this.SharedState.ScopeMgr.OpenScope();
                 this.SharedState.CurrentBuilder.Branch(repeatBlock);
@@ -401,6 +401,7 @@ namespace Microsoft.Quantum.QsCompiler.QIR
                 // for variables and values in the repeat-block after the statement ends.
                 this.SharedState.SetCurrentBlock(contBlock);
                 this.SharedState.ScopeMgr.ExitScope();
+                contBlock = this.SharedState.CurrentBlock;
 
                 this.SharedState.SetCurrentBlock(fixupBlock);
                 this.Transformation.Statements.OnScope(stm.FixupBlock.Body);
@@ -412,6 +413,7 @@ namespace Microsoft.Quantum.QsCompiler.QIR
                 }
             });
 
+            this.SharedState.SetCurrentBlock(contBlock);
             return QsStatementKind.EmptyStatement;
         }
 
@@ -504,7 +506,7 @@ namespace Microsoft.Quantum.QsCompiler.QIR
             var bodyBlock = this.SharedState.CurrentFunction.AppendBasicBlock(this.SharedState.BlockName("do"));
             var contBlock = this.SharedState.CurrentFunction.AppendBasicBlock(this.SharedState.BlockName("wend"));
 
-            this.SharedState.ExecuteLoop(contBlock, () =>
+            this.SharedState.ExecuteLoop(() =>
             {
                 this.SharedState.ScopeMgr.OpenScope();
                 this.SharedState.CurrentBuilder.Branch(testBlock);
@@ -516,6 +518,7 @@ namespace Microsoft.Quantum.QsCompiler.QIR
                 this.ProcessBlock(bodyBlock, stm.Body, testBlock);
             });
 
+            this.SharedState.SetCurrentBlock(contBlock);
             return QsStatementKind.EmptyStatement;
         }
     }

--- a/src/QsCompiler/Tests.Compiler/QirTests.fs
+++ b/src/QsCompiler/Tests.Compiler/QirTests.fs
@@ -146,7 +146,8 @@ let ``QIR operation call`` () =
 let ``QIR while loop`` () = qirTest false "TestWhile"
 
 [<Fact>]
-let ``QIR repeat loop`` () = qirTest true "TestRepeat"
+let ``QIR repeat loop`` () =
+    qirMultiTest true "TestRepeat" [ "TestRepeat1"; "TestRepeat2" ]
 
 [<Fact>]
 let ``QIR integers`` () = qirTest false "TestIntegers"

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestRepeat.qs
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestRepeat.qs
@@ -7,7 +7,22 @@ namespace Microsoft.Quantum.Testing.QIR
 
     newtype Energy = (Abs : Double, Name : String);
 
-    operation TestRepeat (q : Qubit) : Int
+    operation TestRepeat2 (q : Qubit) : Result[] {
+
+        mutable (iter, res) = (1, []);
+        repeat {
+            H(q);
+            set res += [M(q)];
+        }
+        until (iter > 3)
+        fixup {
+            set iter *= 2;
+        }
+
+        return res;
+    }
+
+    operation TestRepeat1 (q : Qubit) : Int
     {
         mutable n = 0;
         repeat
@@ -44,6 +59,7 @@ namespace Microsoft.Quantum.Testing.QIR
     @EntryPoint()
     operation Main() : Unit {
         use q = Qubit();
-        let _ = TestRepeat(q);
+        let _ = TestRepeat1(q);
+        let _ = TestRepeat2(q);
     }
 }

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestRepeat1.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestRepeat1.ll
@@ -1,4 +1,4 @@
-define internal i64 @Microsoft__Quantum__Testing__QIR__TestRepeat__body(%Qubit* %q) {
+define internal i64 @Microsoft__Quantum__Testing__QIR__TestRepeat1__body(%Qubit* %q) {
 entry:
   %n = alloca i64, align 8
   store i64 0, i64* %n, align 4

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestRepeat2.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestRepeat2.ll
@@ -1,0 +1,125 @@
+define internal %Array* @Microsoft__Quantum__Testing__QIR__TestRepeat2__body(%Qubit* %q) {
+entry:
+  %iter = alloca i64, align 8
+  store i64 1, i64* %iter, align 4
+  %0 = call %Array* @__quantum__rt__array_create_1d(i32 8, i64 0)
+  %res = alloca %Array*, align 8
+  store %Array* %0, %Array** %res, align 8
+  call void @__quantum__rt__array_update_alias_count(%Array* %0, i32 1)
+  br label %repeat__1
+
+repeat__1:                                        ; preds = %exit__4, %entry
+  call void @__quantum__qis__h__body(%Qubit* %q)
+  %1 = load %Array*, %Array** %res, align 8
+  %2 = call %Array* @__quantum__rt__array_create_1d(i32 8, i64 1)
+  %3 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %2, i64 0)
+  %4 = bitcast i8* %3 to %Result**
+  %5 = call %Result* @__quantum__qis__mz(%Qubit* %q)
+  store %Result* %5, %Result** %4, align 8
+  %6 = call %Array* @__quantum__rt__array_concatenate(%Array* %1, %Array* %2)
+  call void @__quantum__rt__array_update_alias_count(%Array* %6, i32 1)
+  call void @__quantum__rt__array_update_alias_count(%Array* %1, i32 -1)
+  %7 = call i64 @__quantum__rt__array_get_size_1d(%Array* %1)
+  %8 = sub i64 %7, 1
+  br label %header__1
+
+until__1:                                         ; preds = %exit__1
+  %9 = load i64, i64* %iter, align 4
+  %10 = icmp sgt i64 %9, 3
+  %11 = call i64 @__quantum__rt__array_get_size_1d(%Array* %6)
+  %12 = sub i64 %11, 1
+  br label %header__2
+
+fixup__1:                                         ; preds = %exit__2
+  %13 = mul i64 %9, 2
+  store i64 %13, i64* %iter, align 4
+  br label %header__4
+
+rend__1:                                          ; preds = %exit__2
+  br label %header__3
+
+header__1:                                        ; preds = %exiting__1, %repeat__1
+  %14 = phi i64 [ 0, %repeat__1 ], [ %19, %exiting__1 ]
+  %15 = icmp sle i64 %14, %8
+  br i1 %15, label %body__1, label %exit__1
+
+body__1:                                          ; preds = %header__1
+  %16 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %1, i64 %14)
+  %17 = bitcast i8* %16 to %Result**
+  %18 = load %Result*, %Result** %17, align 8
+  call void @__quantum__rt__result_update_reference_count(%Result* %18, i32 -1)
+  br label %exiting__1
+
+exiting__1:                                       ; preds = %body__1
+  %19 = add i64 %14, 1
+  br label %header__1
+
+exit__1:                                          ; preds = %header__1
+  call void @__quantum__rt__array_update_reference_count(%Array* %1, i32 -1)
+  store %Array* %6, %Array** %res, align 8
+  br label %until__1
+
+header__2:                                        ; preds = %exiting__2, %until__1
+  %20 = phi i64 [ 0, %until__1 ], [ %25, %exiting__2 ]
+  %21 = icmp sle i64 %20, %12
+  br i1 %21, label %body__2, label %exit__2
+
+body__2:                                          ; preds = %header__2
+  %22 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %6, i64 %20)
+  %23 = bitcast i8* %22 to %Result**
+  %24 = load %Result*, %Result** %23, align 8
+  call void @__quantum__rt__result_update_reference_count(%Result* %24, i32 1)
+  br label %exiting__2
+
+exiting__2:                                       ; preds = %body__2
+  %25 = add i64 %20, 1
+  br label %header__2
+
+exit__2:                                          ; preds = %header__2
+  call void @__quantum__rt__array_update_reference_count(%Array* %6, i32 1)
+  br i1 %10, label %rend__1, label %fixup__1
+
+header__3:                                        ; preds = %exiting__3, %rend__1
+  %26 = phi i64 [ 0, %rend__1 ], [ %31, %exiting__3 ]
+  %27 = icmp sle i64 %26, 0
+  br i1 %27, label %body__3, label %exit__3
+
+body__3:                                          ; preds = %header__3
+  %28 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %2, i64 %26)
+  %29 = bitcast i8* %28 to %Result**
+  %30 = load %Result*, %Result** %29, align 8
+  call void @__quantum__rt__result_update_reference_count(%Result* %30, i32 -1)
+  br label %exiting__3
+
+exiting__3:                                       ; preds = %body__3
+  %31 = add i64 %26, 1
+  br label %header__3
+
+exit__3:                                          ; preds = %header__3
+  call void @__quantum__rt__array_update_reference_count(%Array* %2, i32 -1)
+  call void @__quantum__rt__array_update_reference_count(%Array* %6, i32 -1)
+  %32 = load %Array*, %Array** %res, align 8
+  call void @__quantum__rt__array_update_alias_count(%Array* %32, i32 -1)
+  ret %Array* %32
+
+header__4:                                        ; preds = %exiting__4, %fixup__1
+  %33 = phi i64 [ 0, %fixup__1 ], [ %38, %exiting__4 ]
+  %34 = icmp sle i64 %33, 0
+  br i1 %34, label %body__4, label %exit__4
+
+body__4:                                          ; preds = %header__4
+  %35 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %2, i64 %33)
+  %36 = bitcast i8* %35 to %Result**
+  %37 = load %Result*, %Result** %36, align 8
+  call void @__quantum__rt__result_update_reference_count(%Result* %37, i32 -1)
+  br label %exiting__4
+
+exiting__4:                                       ; preds = %body__4
+  %38 = add i64 %33, 1
+  br label %header__4
+
+exit__4:                                          ; preds = %header__4
+  call void @__quantum__rt__array_update_reference_count(%Array* %2, i32 -1)
+  call void @__quantum__rt__array_update_reference_count(%Array* %6, i32 -1)
+  br label %repeat__1
+}

--- a/src/QsCompiler/Tests.Compiler/Tests.Compiler.fsproj
+++ b/src/QsCompiler/Tests.Compiler/Tests.Compiler.fsproj
@@ -293,7 +293,10 @@
     <Content Include="TestCases\QirTests\TestReferenceCounts.qs">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
-    <Content Include="TestCases\QirTests\TestRepeat.ll">
+    <Content Include="TestCases\QirTests\TestRepeat1.ll">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="TestCases\QirTests\TestRepeat2.ll">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
     <Content Include="TestCases\QirTests\TestRepeat.qs">


### PR DESCRIPTION
The block after completion of a repeat until success loop was set incorrectly. 
Fixes https://github.com/MicrosoftDocs/AzureQuantumEarlyAccess/issues/14.