### PR TITLE
Base Lifter Cleanup

### DIFF
--- a/src/QsCompiler/Tests.Compiler/ClassicalControlTests.fs
+++ b/src/QsCompiler/Tests.Compiler/ClassicalControlTests.fs
@@ -173,7 +173,7 @@ type ClassicalControlTests() =
             callables
             |> Seq.tryFindIndex (fun callSig -> hasCall callSig call)
             |> (fun x ->
-                Assert.True(x <> None, sprintf "Did not find expected generated content")
+                Assert.True(x <> None, "Did not find expected generated content")
                 rtrn <- Seq.append rtrn [ Seq.item x.Value callables ]
                 callables <- removeAt x.Value callables)
 
@@ -529,7 +529,7 @@ type ClassicalControlTests() =
         )
 
         let (success, typeArgs, _) = IsApplyIfArgMatch args "r" generated.FullName
-        Assert.True(success, sprintf "ApplyIfZero did not have the correct arguments")
+        Assert.True(success, "ApplyIfZero did not have the correct arguments")
 
         AssertTypeArgsMatch originalTypeParams <| typeArgs.Replace("'", "").Replace(" ", "").Split(",")
 
@@ -1459,7 +1459,7 @@ type ClassicalControlTests() =
         )
 
         let (success, _, _) = IsApplyIfArgMatch args "r" outer.FullName
-        Assert.True(success, sprintf "ApplyIfZero did not have the correct arguments")
+        Assert.True(success, "ApplyIfZero did not have the correct arguments")
 
         // Make sure outer calls inner generated
         let lines = outer |> GetBodyFromCallable |> GetLinesFromSpecialization
@@ -1473,7 +1473,7 @@ type ClassicalControlTests() =
         )
 
         let (success, _, _) = IsApplyIfArgMatch args "r" inner.FullName
-        Assert.True(success, sprintf "ApplyIfZero did not have the correct arguments")
+        Assert.True(success, "ApplyIfZero did not have the correct arguments")
 
     [<Fact>]
     [<Trait("Category", "Content Lifting")>]
@@ -1499,7 +1499,7 @@ type ClassicalControlTests() =
         )
 
         let (success, _, _) = IsApplyIfArgMatch args "r" generated.Parent
-        Assert.True(success, sprintf "ApplyIfZero did not have the correct arguments")
+        Assert.True(success, "ApplyIfZero did not have the correct arguments")
 
     [<Fact(Skip = "Known Issue https://github.com/microsoft/qsharp-compiler/issues/1115")>]
     [<Trait("Category", "Content Lifting")>]
@@ -1530,10 +1530,10 @@ type ClassicalControlTests() =
         )
 
         let (success, _, _) = IsApplyIfArgMatch args "Microsoft.Quantum.Testing.General.M(q)" generated.Parent
-        Assert.True(success, sprintf "ApplyIfZero did not have the correct arguments")
+        Assert.True(success, "ApplyIfZero did not have the correct arguments")
 
         // Make sure the classical condition is present
-        Assert.True(lines.[3] = "    if x < 1 {", "The classical condition is missing after transformation.")
+        Assert.True(lines.[3] = "    if x < 1 {", "The classical condition is missing after transformation")
 
     [<Fact>]
     [<Trait("Category", "Content Lifting")>]
@@ -1559,11 +1559,11 @@ type ClassicalControlTests() =
         )
 
         let (success, _, _) = IsApplyIfArgMatch args "Microsoft.Quantum.Testing.General.M(q)" generated.Parent
-        Assert.True(success, sprintf "ApplyIfZero did not have the correct arguments")
+        Assert.True(success, "ApplyIfZero did not have the correct arguments")
 
         // Make sure the classical condition is present
         let lines = generated |> GetLinesFromSpecialization
-        Assert.True(lines.[1] = "if x < 1 {", "The classical condition is missing after transformation.")
+        Assert.True(lines.[1] = "if x < 1 {", "The classical condition is missing after transformation")
 
     [<Fact>]
     [<Trait("Category", "Content Lifting")>]
@@ -1589,12 +1589,12 @@ type ClassicalControlTests() =
         )
 
         let (success, _, _) = IsApplyIfArgMatch args "Microsoft.Quantum.Testing.General.M(q)" generated.Parent
-        Assert.True(success, sprintf "ApplyIfZero did not have the correct arguments")
+        Assert.True(success, "ApplyIfZero did not have the correct arguments")
 
         // Make sure the classical condition is present
         let lines = generated |> GetLinesFromSpecialization
-        Assert.True(lines.[1] = "if x < 1 {", "The classical condition is missing after transformation.")
-        Assert.True(lines.[2] = "    if x < 2 {", "The classical condition is missing after transformation.")
+        Assert.True(lines.[1] = "if x < 1 {", "The classical condition is missing after transformation")
+        Assert.True(lines.[2] = "    if x < 2 {", "The classical condition is missing after transformation")
 
     [<Fact>]
     [<Trait("Category", "Content Lifting")>]
@@ -1620,13 +1620,13 @@ type ClassicalControlTests() =
         )
 
         let (success, _, _) = IsApplyIfArgMatch args "Microsoft.Quantum.Testing.General.M(q)" generated.Parent
-        Assert.True(success, sprintf "ApplyIfZero did not have the correct arguments")
+        Assert.True(success, "ApplyIfZero did not have the correct arguments")
 
         // Make sure the classical condition is present
-        Assert.True(lines.[3] = "    if x < 1 {", "The classical condition is missing after transformation.")
+        Assert.True(lines.[3] = "    if x < 1 {", "The classical condition is missing after transformation")
         let lines = generated |> GetLinesFromSpecialization
-        Assert.True(lines.[1] = "if x < 2 {", "The classical condition is missing after transformation.")
-        Assert.True(lines.[2] = "    if x < 3 {", "The classical condition is missing after transformation.")
+        Assert.True(lines.[1] = "if x < 2 {", "The classical condition is missing after transformation")
+        Assert.True(lines.[2] = "    if x < 3 {", "The classical condition is missing after transformation")
 
     [<Fact(Skip = "Known Issue https://github.com/microsoft/qsharp-compiler/issues/1115")>]
     [<Trait("Category", "Content Lifting")>]
@@ -1661,7 +1661,7 @@ type ClassicalControlTests() =
         // Make sure original calls generated
         let lines = original |> GetLinesFromSpecialization
 
-        Assert.True(lines.[3] = "    if x < 1 {", "The classical condition is missing after transformation.")
+        Assert.True(lines.[3] = "    if x < 1 {", "The classical condition is missing after transformation")
 
         let (success, _, args) =
             CheckIfLineIsCall BuiltIn.ApplyIfZero.FullName.Namespace BuiltIn.ApplyIfZero.FullName.Name lines.[4]
@@ -1672,8 +1672,8 @@ type ClassicalControlTests() =
         )
 
         let (success, _, _) = IsApplyIfArgMatch args "Microsoft.Quantum.Testing.General.M(q)" ifBlock.FullName
-        Assert.True(success, sprintf "ApplyIfZero did not have the correct arguments")
-        Assert.True(lines.[6] = "    else {", "The else condition is missing after transformation.")
+        Assert.True(success, "ApplyIfZero did not have the correct arguments")
+        Assert.True(lines.[6] = "    else {", "The else condition is missing after transformation")
 
         let (success, _, args) =
             CheckIfLineIsCall BuiltIn.ApplyIfElseR.FullName.Namespace BuiltIn.ApplyIfElseR.FullName.Name lines.[7]
@@ -1686,7 +1686,7 @@ type ClassicalControlTests() =
         let (success, _, _, _, _) =
             IsApplyIfElseArgsMatch args "Microsoft.Quantum.Testing.General.M(q)" elifBlock.FullName elseBlock.FullName
 
-        Assert.True(success, sprintf "ApplyIfElseR did not have the correct arguments")
+        Assert.True(success, "ApplyIfElseR did not have the correct arguments")
 
     [<Fact>]
     [<Trait("Category", "Content Lifting")>]
@@ -1705,7 +1705,7 @@ type ClassicalControlTests() =
         // Make sure original calls generated
         let lines = original |> GetLinesFromSpecialization |> TrimWhitespaceFromLines
 
-        Assert.True(lines.[3] = "if x < 1 {", "The classical condition is missing after transformation.")
+        Assert.True(lines.[3] = "if x < 1 {", "The classical condition is missing after transformation")
 
         let (success, _, args) =
             CheckIfLineIsCall BuiltIn.ApplyIfZero.FullName.Namespace BuiltIn.ApplyIfZero.FullName.Name lines.[4]
@@ -1716,30 +1716,64 @@ type ClassicalControlTests() =
         )
 
         let (success, _, _) = IsApplyIfArgMatch args "Microsoft.Quantum.Testing.General.M(q)" generated.Parent
-        Assert.True(success, sprintf "ApplyIfZero did not have the correct arguments")
-        Assert.True(lines.[6] = "else {", "The else condition is missing after transformation.")
+        Assert.True(success, "ApplyIfZero did not have the correct arguments")
+        Assert.True(lines.[6] = "else {", "The else condition is missing after transformation")
 
         Assert.True(
             lines.[7] = "if Microsoft.Quantum.Testing.General.M(q) == Zero {",
-            "The quantum condition is missing after transformation."
+            "The quantum condition is missing after transformation"
         )
 
-        Assert.True(lines.[8] = "if x < 4 {", "The classical condition is missing after transformation.")
-        Assert.True(lines.[9] = "if x < 5 {", "The classical condition is missing after transformation.")
-        Assert.True(lines.[14] = "else {", "The else condition is missing after transformation.")
+        Assert.True(lines.[8] = "if x < 4 {", "The classical condition is missing after transformation")
+        Assert.True(lines.[9] = "if x < 5 {", "The classical condition is missing after transformation")
+        Assert.True(lines.[14] = "else {", "The else condition is missing after transformation")
 
         Assert.True(
             lines.[16] = "if Microsoft.Quantum.Testing.General.M(q) == Zero {",
-            "The quantum condition is missing after transformation."
+            "The quantum condition is missing after transformation"
         )
 
-        Assert.True(lines.[17] = "if x < 6 {", "The classical condition is missing after transformation.")
+        Assert.True(lines.[17] = "if x < 6 {", "The classical condition is missing after transformation")
 
         let lines = generated |> GetLinesFromSpecialization |> TrimWhitespaceFromLines
-        Assert.True(lines.[1] = "if x < 2 {", "The classical condition is missing after transformation.")
-        Assert.True(lines.[2] = "if x < 3 {", "The classical condition is missing after transformation.")
+        Assert.True(lines.[1] = "if x < 2 {", "The classical condition is missing after transformation")
+        Assert.True(lines.[2] = "if x < 3 {", "The classical condition is missing after transformation")
 
     [<Fact>]
     [<Trait("Category", "If Structure Reshape")>]
     member this.``NOT Condition Retains Used Variables``() =
         CompileClassicalControlTest 52 |> ignore
+
+    [<Fact>]
+    [<Trait("Category", "Content Lifting")>]
+    member this.``Minimal Parameter Capture``() =
+        let result = CompileClassicalControlTest 53
+        let original = GetCallableWithName result Signatures.ClassicalControlNS "Foo" |> GetBodyFromCallable
+        let generated =
+            GetCallablesWithSuffix result Signatures.ClassicalControlNS "_Foo"
+            |> (fun x ->
+                Assert.True(1 = Seq.length x)
+                Seq.item 0 x)
+
+        let lines = original |> GetLinesFromSpecialization
+
+        let (success, _, args) =
+            CheckIfLineIsCall BuiltIn.ApplyIfZero.FullName.Namespace BuiltIn.ApplyIfZero.FullName.Name lines.[6]
+
+        Assert.True(
+            success,
+            sprintf "Callable %O(%A) did not have expected content" original.Parent QsSpecializationKind.QsBody
+        )
+
+        let (success, _, args) = IsApplyIfArgMatch args "r" generated.FullName
+        Assert.True(success, "ApplyIfZero did not have the correct arguments")
+
+        Assert.True((args = "myInt, myDouble, myString, myMutable"), "Generated operation did not have the correct arguments")
+
+        let parameters =
+            generated.ArgumentTuple.Items
+            |> Seq.choose (fun x -> match x.VariableName with | ValidName str -> Some str | InvalidName -> None)
+            |> (fun s -> String.Join(", ", s))
+
+        Assert.True((parameters = "myInt, myDouble, myString, myMutable"), "Generated operation did not have the correct parameters")
+

--- a/src/QsCompiler/Tests.Compiler/ClassicalControlTests.fs
+++ b/src/QsCompiler/Tests.Compiler/ClassicalControlTests.fs
@@ -1741,5 +1741,5 @@ type ClassicalControlTests() =
 
     [<Fact>]
     [<Trait("Category", "If Structure Reshape")>]
-    member this.``NOT Condition Remembers Known Symbols``() =
+    member this.``NOT Condition Retains Used Variables``() =
         CompileClassicalControlTest 52 |> ignore

--- a/src/QsCompiler/Tests.Compiler/ClassicalControlTests.fs
+++ b/src/QsCompiler/Tests.Compiler/ClassicalControlTests.fs
@@ -1501,7 +1501,7 @@ type ClassicalControlTests() =
         let (success, _, _) = IsApplyIfArgMatch args "r" generated.Parent
         Assert.True(success, "ApplyIfZero did not have the correct arguments")
 
-    [<Fact(Skip = "Known Issue https://github.com/microsoft/qsharp-compiler/issues/1115")>]
+    [<Fact>]
     [<Trait("Category", "Content Lifting")>]
     member this.``Mutables with Nesting Lift Neither``() =
         CompileClassicalControlTest 44 |> ignore
@@ -1628,7 +1628,7 @@ type ClassicalControlTests() =
         Assert.True(lines.[1] = "if x < 2 {", "The classical condition is missing after transformation")
         Assert.True(lines.[2] = "    if x < 3 {", "The classical condition is missing after transformation")
 
-    [<Fact(Skip = "Known Issue https://github.com/microsoft/qsharp-compiler/issues/1115")>]
+    [<Fact>]
     [<Trait("Category", "Content Lifting")>]
     member this.``Nested Invalid Lifting``() =
         CompileClassicalControlTest 49 |> ignore

--- a/src/QsCompiler/Tests.Compiler/ClassicalControlTests.fs
+++ b/src/QsCompiler/Tests.Compiler/ClassicalControlTests.fs
@@ -1749,6 +1749,7 @@ type ClassicalControlTests() =
     member this.``Minimal Parameter Capture``() =
         let result = CompileClassicalControlTest 53
         let original = GetCallableWithName result Signatures.ClassicalControlNS "Foo" |> GetBodyFromCallable
+
         let generated =
             GetCallablesWithSuffix result Signatures.ClassicalControlNS "_Foo"
             |> (fun x ->
@@ -1768,12 +1769,21 @@ type ClassicalControlTests() =
         let (success, _, args) = IsApplyIfArgMatch args "r" generated.FullName
         Assert.True(success, "ApplyIfZero did not have the correct arguments")
 
-        Assert.True((args = "myInt, myDouble, myString, myMutable"), "Generated operation did not have the correct arguments")
+        Assert.True(
+            (args = "myInt, myDouble, myString, myMutable"),
+            "Generated operation did not have the correct arguments"
+        )
 
         let parameters =
             generated.ArgumentTuple.Items
-            |> Seq.choose (fun x -> match x.VariableName with | ValidName str -> Some str | InvalidName -> None)
+            |> Seq.choose
+                (fun x ->
+                    match x.VariableName with
+                    | ValidName str -> Some str
+                    | InvalidName -> None)
             |> (fun s -> String.Join(", ", s))
 
-        Assert.True((parameters = "myInt, myDouble, myString, myMutable"), "Generated operation did not have the correct parameters")
-
+        Assert.True(
+            (parameters = "myInt, myDouble, myString, myMutable"),
+            "Generated operation did not have the correct parameters"
+        )

--- a/src/QsCompiler/Tests.Compiler/QirTests.fs
+++ b/src/QsCompiler/Tests.Compiler/QirTests.fs
@@ -8,9 +8,16 @@ open Microsoft.Quantum.QsCompiler.CommandLineCompiler
 open Xunit
 open System.Reflection
 open System.Text.RegularExpressions
+open System
 
 let private GUID =
     new Regex(@"[({]?[a-fA-F0-9]{8}[-]?([a-fA-F0-9]{4}[-]?){3}[a-fA-F0-9]{12}[})]?", RegexOptions.IgnoreCase)
+
+/// <summary>
+/// Ensures that the new line characters will conform to the standard of the environment's new line character.
+/// </summary>
+let private standardizeNewLines (s: string) =
+    s.Replace("\r", "").Replace("\n", Environment.NewLine)
 
 let private testOne expected args =
     let result = Program.Main args
@@ -21,7 +28,8 @@ let private clearOutput name =
 
 let private checkAltOutput name actualText =
     let expectedText = ("TestCases", "QirTests", name) |> Path.Combine |> File.ReadAllText
-    Assert.Contains(expectedText, GUID.Replace(actualText, "__GUID__"))
+    let replacedGUID = GUID.Replace(actualText, "__GUID__")
+    Assert.Contains(standardizeNewLines expectedText, standardizeNewLines replacedGUID)
 
 let private compilerArgs target (name: string) =
     seq {

--- a/src/QsCompiler/Tests.Compiler/TestCases/ClassicalControl.qs
+++ b/src/QsCompiler/Tests.Compiler/TestCases/ClassicalControl.qs
@@ -38,7 +38,7 @@ namespace Microsoft.Quantum.Testing.ClassicalControl {
             SubOp2();
             SubOp3();
             let temp = 4;
-            using (q = Qubit()) {
+            use q = Qubit() {
                 let temp2 = q;
             }
         }
@@ -54,7 +54,7 @@ namespace Microsoft.Quantum.Testing.ClassicalControl {
         let r = Zero;
 
         if (r == Zero) {
-            for (index in 0 .. 3) {
+            for index in 0 .. 3 {
                 let temp = index;
             }
 
@@ -1355,7 +1355,7 @@ namespace Microsoft.Quantum.Testing.ClassicalControl {
 
 // =================================
 
-// NOT Condition Remembers Known Symbols
+// NOT Condition Retains Used Variables
 namespace Microsoft.Quantum.Testing.ClassicalControl {
     open SubOps;
 
@@ -1363,6 +1363,8 @@ namespace Microsoft.Quantum.Testing.ClassicalControl {
         let r1 = Zero;
         let r2 = Zero;
         if (not (r1 == Zero and r2 == Zero)) {
+            let t1 = r1;
+            let t2 = r2;
             SubOp1();
             SubOp2();
         }

--- a/src/QsCompiler/Tests.Compiler/TestCases/ClassicalControl.qs
+++ b/src/QsCompiler/Tests.Compiler/TestCases/ClassicalControl.qs
@@ -1362,11 +1362,35 @@ namespace Microsoft.Quantum.Testing.ClassicalControl {
     operation Foo() : Unit {
         let r1 = Zero;
         let r2 = Zero;
-        if (not (r1 == Zero and r2 == Zero)) {
+        if not (r1 == Zero and r2 == Zero) {
             let t1 = r1;
             let t2 = r2;
             SubOp1();
             SubOp2();
+        }
+    }
+}
+
+// =================================
+
+// Minimal Parameter Capture
+namespace Microsoft.Quantum.Testing.ClassicalControl {
+    open SubOps;
+
+    operation Foo() : Unit {
+        let myInt = 1;
+        let myDouble = 2.0;
+        let unused = 3;
+        let myString = "four";
+        mutable myMutable = 5.0;
+
+        let r = Zero;
+        if r == Zero {
+            let innerDouble = myDouble;
+            let innerInt = myInt;
+            let innerString = myString;
+            let innerMutable = myMutable;
+            SubOp1();
         }
     }
 }

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestTargeting.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestTargeting.ll
@@ -3,13 +3,13 @@ entry:
   %q = call %Qubit* @__quantum__rt__qubit_allocate()
   %0 = call %Result* @__quantum__qis__mz(%Qubit* %q)
   %1 = call %Tuple* @__quantum__rt__tuple_create(i64 mul nuw (i64 ptrtoint (i1** getelementptr (i1*, i1** null, i32 1) to i64), i64 2))
-  %2 = bitcast %Tuple* %1 to { %Callable*, %Qubit* }*
-  %3 = getelementptr inbounds { %Callable*, %Qubit* }, { %Callable*, %Qubit* }* %2, i32 0, i32 0
-  %4 = getelementptr inbounds { %Callable*, %Qubit* }, { %Callable*, %Qubit* }* %2, i32 0, i32 1
+  %2 = bitcast %Tuple* %1 to { %Callable*, %Tuple* }*
+  %3 = getelementptr inbounds { %Callable*, %Tuple* }, { %Callable*, %Tuple* }* %2, i32 0, i32 0
+  %4 = getelementptr inbounds { %Callable*, %Tuple* }, { %Callable*, %Tuple* }* %2, i32 0, i32 1
   %5 = call %Callable* @__quantum__rt__callable_create([4 x void (%Tuple*, %Tuple*, %Tuple*)*]* @Microsoft__Quantum__Testing__QIR_____GUID___NoArgs__FunctionTable, [2 x void (%Tuple*, i32)*]* null, %Tuple* null)
   store %Callable* %5, %Callable** %3, align 8
-  store %Qubit* %q, %Qubit** %4, align 8
-  call void @Microsoft__Quantum__ClassicalControl_____GUID___ApplyIfOne__body(%Result* %0, { %Callable*, %Qubit* }* %2)
+  store %Tuple* null, %Tuple** %4, align 8
+  call void @Microsoft__Quantum__ClassicalControl_____GUID___ApplyIfOne__body(%Result* %0, { %Callable*, %Tuple* }* %2)
   call void @__quantum__rt__result_update_reference_count(%Result* %0, i32 -1)
   call void @__quantum__rt__capture_update_reference_count(%Callable* %5, i32 -1)
   call void @__quantum__rt__callable_update_reference_count(%Callable* %5, i32 -1)

--- a/src/QsCompiler/Tests.Compiler/TestUtils/Signatures.fs
+++ b/src/QsCompiler/Tests.Compiler/TestUtils/Signatures.fs
@@ -271,13 +271,13 @@ let public ClassicalControlSignatures =
         (_DefaultTypes,
          [|
              ClassicalControlNS, "Foo", [||], "Unit" // The original operation
-             ClassicalControlNS, "_Foo", [| "Result" |], "Unit" // The generated operation
+             ClassicalControlNS, "_Foo", [||], "Unit" // The generated operation
          |])
         // Lift Loops
         (_DefaultTypes,
          [|
              ClassicalControlNS, "Foo", [||], "Unit"
-             ClassicalControlNS, "_Foo", [| "Result" |], "Unit"
+             ClassicalControlNS, "_Foo", [||], "Unit"
          |])
         // Don't Lift Single Call
         (_DefaultTypes, [| ClassicalControlNS, "Foo", [||], "Unit" |])
@@ -285,7 +285,7 @@ let public ClassicalControlSignatures =
         (_DefaultTypes,
          [|
              ClassicalControlNS, "Foo", [||], "Unit"
-             ClassicalControlNS, "_Foo", [| "Result" |], "Unit"
+             ClassicalControlNS, "_Foo", [||], "Unit"
          |])
         // Don't Lift Return Statements
         (_DefaultTypes, [| ClassicalControlNS, "Foo", [||], "Unit" |])
@@ -340,7 +340,7 @@ let public ClassicalControlSignatures =
         (_DefaultTypes,
          [|
              ClassicalControlNS, "Foo", [||], "Unit"
-             ClassicalControlNS, "_Foo", [| "Result" |], "Unit"
+             ClassicalControlNS, "_Foo", [||], "Unit"
          |])
         // Don't Lift General Mutable
         (_DefaultTypes, [| ClassicalControlNS, "Foo", [||], "Unit" |])
@@ -348,7 +348,7 @@ let public ClassicalControlSignatures =
         (_DefaultTypes,
          [|
              ClassicalControlNS, "Foo", [||], "Unit"
-             ClassicalControlNS, "_Foo", [| "Result" |], "Unit"
+             ClassicalControlNS, "_Foo", [||], "Unit"
          |])
         // Adjoint Support
         (_DefaultTypes,
@@ -356,19 +356,19 @@ let public ClassicalControlSignatures =
              ClassicalControlNS, "Provided", [||], "Unit"
              ClassicalControlNS, "Self", [||], "Unit"
              ClassicalControlNS, "Invert", [||], "Unit"
-             ClassicalControlNS, "_Provided", [| "Result" |], "Unit"
-             ClassicalControlNS, "_Provided", [| "Result" |], "Unit"
-             ClassicalControlNS, "_Self", [| "Result" |], "Unit"
-             ClassicalControlNS, "_Invert", [| "Result" |], "Unit"
+             ClassicalControlNS, "_Provided", [||], "Unit"
+             ClassicalControlNS, "_Provided", [||], "Unit"
+             ClassicalControlNS, "_Self", [||], "Unit"
+             ClassicalControlNS, "_Invert", [||], "Unit"
          |])
         // Controlled Support
         (_DefaultTypes,
          [|
              ClassicalControlNS, "Provided", [||], "Unit"
              ClassicalControlNS, "Distribute", [||], "Unit"
-             ClassicalControlNS, "_Provided", [| "Result" |], "Unit"
-             ClassicalControlNS, "_Provided", [| "Result"; "Qubit[]"; "Unit" |], "Unit"
-             ClassicalControlNS, "_Distribute", [| "Result" |], "Unit"
+             ClassicalControlNS, "_Provided", [||], "Unit"
+             ClassicalControlNS, "_Provided", [||], "Unit"
+             ClassicalControlNS, "_Distribute", [||], "Unit"
          |])
         // Controlled Adjoint Support - Provided
         (_DefaultTypes,
@@ -378,21 +378,21 @@ let public ClassicalControlSignatures =
              ClassicalControlNS, "ProvidedControlled", [||], "Unit"
              ClassicalControlNS, "ProvidedAll", [||], "Unit"
 
-             ClassicalControlNS, "_ProvidedBody", [| "Result" |], "Unit"
-             ClassicalControlNS, "_ProvidedBody", [| "Result"; "Qubit[]"; "Unit" |], "Unit"
+             ClassicalControlNS, "_ProvidedBody", [||], "Unit"
+             ClassicalControlNS, "_ProvidedBody", [||], "Unit"
 
-             ClassicalControlNS, "_ProvidedAdjoint", [| "Result" |], "Unit"
-             ClassicalControlNS, "_ProvidedAdjoint", [| "Result" |], "Unit"
-             ClassicalControlNS, "_ProvidedAdjoint", [| "Result"; "Qubit[]"; "Unit" |], "Unit"
+             ClassicalControlNS, "_ProvidedAdjoint", [||], "Unit"
+             ClassicalControlNS, "_ProvidedAdjoint", [||], "Unit"
+             ClassicalControlNS, "_ProvidedAdjoint", [||], "Unit"
 
-             ClassicalControlNS, "_ProvidedControlled", [| "Result" |], "Unit"
-             ClassicalControlNS, "_ProvidedControlled", [| "Result"; "Qubit[]"; "Unit" |], "Unit"
-             ClassicalControlNS, "_ProvidedControlled", [| "Result"; "Qubit[]"; "Unit" |], "Unit"
+             ClassicalControlNS, "_ProvidedControlled", [||], "Unit"
+             ClassicalControlNS, "_ProvidedControlled", [||], "Unit"
+             ClassicalControlNS, "_ProvidedControlled", [||], "Unit"
 
-             ClassicalControlNS, "_ProvidedAll", [| "Result" |], "Unit"
-             ClassicalControlNS, "_ProvidedAll", [| "Result" |], "Unit"
-             ClassicalControlNS, "_ProvidedAll", [| "Result"; "Qubit[]"; "Unit" |], "Unit"
-             ClassicalControlNS, "_ProvidedAll", [| "Result"; "Qubit[]"; "Unit" |], "Unit"
+             ClassicalControlNS, "_ProvidedAll", [||], "Unit"
+             ClassicalControlNS, "_ProvidedAll", [||], "Unit"
+             ClassicalControlNS, "_ProvidedAll", [||], "Unit"
+             ClassicalControlNS, "_ProvidedAll", [||], "Unit"
          |])
         // Controlled Adjoint Support - Distribute
         (_DefaultTypes,
@@ -402,17 +402,17 @@ let public ClassicalControlSignatures =
              ClassicalControlNS, "DistributeControlled", [||], "Unit"
              ClassicalControlNS, "DistributeAll", [||], "Unit"
 
-             ClassicalControlNS, "_DistributeBody", [| "Result" |], "Unit"
+             ClassicalControlNS, "_DistributeBody", [||], "Unit"
 
-             ClassicalControlNS, "_DistributeAdjoint", [| "Result" |], "Unit"
-             ClassicalControlNS, "_DistributeAdjoint", [| "Result" |], "Unit"
+             ClassicalControlNS, "_DistributeAdjoint", [||], "Unit"
+             ClassicalControlNS, "_DistributeAdjoint", [||], "Unit"
 
-             ClassicalControlNS, "_DistributeControlled", [| "Result" |], "Unit"
-             ClassicalControlNS, "_DistributeControlled", [| "Result"; "Qubit[]"; "Unit" |], "Unit"
+             ClassicalControlNS, "_DistributeControlled", [||], "Unit"
+             ClassicalControlNS, "_DistributeControlled", [||], "Unit"
 
-             ClassicalControlNS, "_DistributeAll", [| "Result" |], "Unit"
-             ClassicalControlNS, "_DistributeAll", [| "Result" |], "Unit"
-             ClassicalControlNS, "_DistributeAll", [| "Result"; "Qubit[]"; "Unit" |], "Unit"
+             ClassicalControlNS, "_DistributeAll", [||], "Unit"
+             ClassicalControlNS, "_DistributeAll", [||], "Unit"
+             ClassicalControlNS, "_DistributeAll", [||], "Unit"
          |])
         // Controlled Adjoint Support - Invert
         (_DefaultTypes,
@@ -422,17 +422,17 @@ let public ClassicalControlSignatures =
              ClassicalControlNS, "InvertControlled", [||], "Unit"
              ClassicalControlNS, "InvertAll", [||], "Unit"
 
-             ClassicalControlNS, "_InvertBody", [| "Result" |], "Unit"
+             ClassicalControlNS, "_InvertBody", [||], "Unit"
 
-             ClassicalControlNS, "_InvertAdjoint", [| "Result" |], "Unit"
-             ClassicalControlNS, "_InvertAdjoint", [| "Result" |], "Unit"
+             ClassicalControlNS, "_InvertAdjoint", [||], "Unit"
+             ClassicalControlNS, "_InvertAdjoint", [||], "Unit"
 
-             ClassicalControlNS, "_InvertControlled", [| "Result" |], "Unit"
-             ClassicalControlNS, "_InvertControlled", [| "Result"; "Qubit[]"; "Unit" |], "Unit"
+             ClassicalControlNS, "_InvertControlled", [||], "Unit"
+             ClassicalControlNS, "_InvertControlled", [||], "Unit"
 
-             ClassicalControlNS, "_InvertAll", [| "Result" |], "Unit"
-             ClassicalControlNS, "_InvertAll", [| "Result" |], "Unit"
-             ClassicalControlNS, "_InvertAll", [| "Result"; "Qubit[]"; "Unit" |], "Unit"
+             ClassicalControlNS, "_InvertAll", [||], "Unit"
+             ClassicalControlNS, "_InvertAll", [||], "Unit"
+             ClassicalControlNS, "_InvertAll", [||], "Unit"
          |])
         // Controlled Adjoint Support - Self
         (_DefaultTypes,
@@ -440,17 +440,17 @@ let public ClassicalControlSignatures =
              ClassicalControlNS, "SelfBody", [||], "Unit"
              ClassicalControlNS, "SelfControlled", [||], "Unit"
 
-             ClassicalControlNS, "_SelfBody", [| "Result" |], "Unit"
+             ClassicalControlNS, "_SelfBody", [||], "Unit"
 
-             ClassicalControlNS, "_SelfControlled", [| "Result" |], "Unit"
-             ClassicalControlNS, "_SelfControlled", [| "Result"; "Qubit[]"; "Unit" |], "Unit"
+             ClassicalControlNS, "_SelfControlled", [||], "Unit"
+             ClassicalControlNS, "_SelfControlled", [||], "Unit"
          |])
         // Within Block Support
         (_DefaultTypes,
          [|
              ClassicalControlNS, "Foo", [||], "Unit"
-             ClassicalControlNS, "_Foo", [| "Result" |], "Unit"
-             ClassicalControlNS, "_Foo", [| "Result" |], "Unit"
+             ClassicalControlNS, "_Foo", [||], "Unit"
+             ClassicalControlNS, "_Foo", [||], "Unit"
          |])
         // Arguments Partially Resolve Type Parameters
         (_TypeParameterTypes,
@@ -462,26 +462,26 @@ let public ClassicalControlSignatures =
         (_DefaultTypes,
          [|
              ClassicalControlNS, "Foo", [||], "Unit"
-             ClassicalControlNS, "_Foo", [| "Result" |], "Unit"
+             ClassicalControlNS, "_Foo", [||], "Unit"
          |])
         // Lift Partial Application
         (_DefaultTypes,
          [|
              ClassicalControlNS, "Bar", [| "Int"; "Double" |], "Unit"
              ClassicalControlNS, "Foo", [||], "Unit"
-             ClassicalControlNS, "_Foo", [| "Result" |], "Unit"
+             ClassicalControlNS, "_Foo", [||], "Unit"
          |])
         // Lift Array Item Call
         (_DefaultWithOperation,
          [|
              ClassicalControlNS, "Foo", [||], "Unit"
-             ClassicalControlNS, "_Foo", [| "SubOp1Type[]"; "Result" |], "Unit"
+             ClassicalControlNS, "_Foo", [| "SubOp1Type[]" |], "Unit"
          |])
         // Lift One Not Both
         (_DefaultTypes,
          [|
              ClassicalControlNS, "Foo", [||], "Unit"
-             ClassicalControlNS, "_Foo", [| "Result" |], "Unit"
+             ClassicalControlNS, "_Foo", [||], "Unit"
          |])
         // Apply Conditionally
         (_DefaultTypes,
@@ -541,7 +541,7 @@ let public ClassicalControlSignatures =
         (_DefaultTypes,
          [|
              ClassicalControlNS, "Foo", [||], "Unit"
-             ClassicalControlNS, "_Foo", [| "Result" |], "Unit"
+             ClassicalControlNS, "_Foo", [||], "Unit"
              ClassicalControlNS, "_Foo", [| "Result" |], "Unit"
          |])
         // Mutables with Nesting Lift Outer
@@ -556,25 +556,25 @@ let public ClassicalControlSignatures =
         (_DefaultTypes,
          [|
              ClassicalControlNS, "Foo", [||], "Unit"
-             ClassicalControlNS, "_Foo", [| "Int"; "Qubit" |], "Unit"
+             ClassicalControlNS, "_Foo", [||], "Unit"
          |])
         // Mutables with Classic Nesting Lift Outer
         (_DefaultTypes,
          [|
              ClassicalControlNS, "Foo", [||], "Unit"
-             ClassicalControlNS, "_Foo", [| "Int"; "Qubit" |], "Unit"
+             ClassicalControlNS, "_Foo", [| "Int" |], "Unit"
          |])
         // Mutables with Classic Nesting Lift Outer With More Classic
         (_DefaultTypes,
          [|
              ClassicalControlNS, "Foo", [||], "Unit"
-             ClassicalControlNS, "_Foo", [| "Int"; "Qubit" |], "Unit"
+             ClassicalControlNS, "_Foo", [| "Int" |], "Unit"
          |])
         // Mutables with Classic Nesting Lift Middle
         (_DefaultTypes,
          [|
              ClassicalControlNS, "Foo", [||], "Unit"
-             ClassicalControlNS, "_Foo", [| "Int"; "Qubit" |], "Unit"
+             ClassicalControlNS, "_Foo", [| "Int" |], "Unit"
          |])
         // Nested Invalid Lifting
         (_DefaultTypes, [| ClassicalControlNS, "Foo", [||], "Unit" |])
@@ -583,16 +583,16 @@ let public ClassicalControlSignatures =
          [|
              ClassicalControlNS, "Foo", [||], "Unit"
              ClassicalControlNS, "_Foo", [| "Int"; "Qubit" |], "Unit"
-             ClassicalControlNS, "_Foo", [| "Int"; "Qubit" |], "Unit"
-             ClassicalControlNS, "_Foo", [| "Int"; "Qubit" |], "Unit"
+             ClassicalControlNS, "_Foo", [| "Int" |], "Unit"
+             ClassicalControlNS, "_Foo", [| "Int" |], "Unit"
          |])
         // Mutables with Classic Nesting Elif Lift First
         (_DefaultTypes,
          [|
              ClassicalControlNS, "Foo", [||], "Unit"
-             ClassicalControlNS, "_Foo", [| "Int"; "Qubit" |], "Unit"
+             ClassicalControlNS, "_Foo", [| "Int" |], "Unit"
          |])
-        // NOT Condition Remembers Known Symbols
+        // NOT Condition Retains Used Variables
         (_DefaultTypes,
          [|
              ClassicalControlNS, "Foo", [||], "Unit"

--- a/src/QsCompiler/Tests.Compiler/TestUtils/Signatures.fs
+++ b/src/QsCompiler/Tests.Compiler/TestUtils/Signatures.fs
@@ -600,6 +600,12 @@ let public ClassicalControlSignatures =
              ClassicalControlNS, "_Foo", [| "Result"; "Result" |], "Unit"
              ClassicalControlNS, "_Foo", [| "Result"; "Result" |], "Unit"
          |])
+         // Minimal Parameter Capture
+        (_DefaultTypes,
+         [|
+             ClassicalControlNS, "Foo", [||], "Unit"
+             ClassicalControlNS, "_Foo", [| "Int"; "Double"; "String"; "Double" |], "Unit"
+         |])
     |]
     |> _MakeSignatures
 

--- a/src/QsCompiler/Tests.Compiler/TestUtils/Signatures.fs
+++ b/src/QsCompiler/Tests.Compiler/TestUtils/Signatures.fs
@@ -600,7 +600,7 @@ let public ClassicalControlSignatures =
              ClassicalControlNS, "_Foo", [| "Result"; "Result" |], "Unit"
              ClassicalControlNS, "_Foo", [| "Result"; "Result" |], "Unit"
          |])
-         // Minimal Parameter Capture
+        // Minimal Parameter Capture
         (_DefaultTypes,
          [|
              ClassicalControlNS, "Foo", [||], "Unit"

--- a/src/QsCompiler/Transformations/ClassicallyControlled.cs
+++ b/src/QsCompiler/Transformations/ClassicallyControlled.cs
@@ -847,6 +847,7 @@ namespace Microsoft.Quantum.QsCompiler.Transformations.ClassicallyControlled
             public LiftContent()
                 : base(new TransformationState())
             {
+                this.Namespaces = new NamespaceTransformation(this);
                 this.StatementKinds = new StatementKindTransformation(this);
             }
 
@@ -860,6 +861,17 @@ namespace Microsoft.Quantum.QsCompiler.Transformations.ClassicallyControlled
                     || (condition.Expression is ExpressionKind.NEQ neq
                     && neq.Item1.ResolvedType.Resolution == ResolvedTypeKind.Result
                     && neq.Item2.ResolvedType.Resolution == ResolvedTypeKind.Result);
+            }
+
+            private new class NamespaceTransformation : ContentLifting.LiftContent<TransformationState>.NamespaceTransformation
+            {
+                public NamespaceTransformation(SyntaxTreeTransformation<TransformationState> parent)
+                    : base(parent)
+                {
+                }
+
+                /// <inheritdoc/>
+                public override QsCallable OnFunction(QsCallable c) => c; // Prevent anything in functions from being lifted
             }
 
             private new class StatementKindTransformation : ContentLifting.LiftContent<TransformationState>.StatementKindTransformation
@@ -986,7 +998,7 @@ namespace Microsoft.Quantum.QsCompiler.Transformations.ClassicallyControlled
 
                     if (this.SharedState.IsConditionLiftable)
                     {
-                        this.SharedState.GeneratedOperations?.AddRange(generatedOperations);
+                        this.SharedState.GeneratedCallables?.AddRange(generatedOperations);
                     }
 
                     var rtrn = this.SharedState.IsConditionLiftable

--- a/src/QsCompiler/Transformations/ClassicallyControlled.cs
+++ b/src/QsCompiler/Transformations/ClassicallyControlled.cs
@@ -955,7 +955,7 @@ namespace Microsoft.Quantum.QsCompiler.Transformations.ClassicallyControlled
                         else
                         {
                             // Lift the scope to its own operation
-                            if (this.SharedState.LiftBody(block.Body, out var call, out var callable))
+                            if (this.SharedState.LiftBody(block.Body, false, out var call, out var callable))
                             {
                                 var callStatement = new QsStatement(
                                     QsStatementKind.NewQsExpressionStatement(call),
@@ -996,7 +996,7 @@ namespace Microsoft.Quantum.QsCompiler.Transformations.ClassicallyControlled
                         else
                         {
                             // Lift the scope to its own operation
-                            if (this.SharedState.LiftBody(block.Body, out var call, out var callable))
+                            if (this.SharedState.LiftBody(block.Body, false, out var call, out var callable))
                             {
                                 var callStatement = new QsStatement(
                                     QsStatementKind.NewQsExpressionStatement(call),

--- a/src/QsCompiler/Transformations/ClassicallyControlled.cs
+++ b/src/QsCompiler/Transformations/ClassicallyControlled.cs
@@ -1019,7 +1019,7 @@ namespace Microsoft.Quantum.QsCompiler.Transformations.ClassicallyControlled
 
                     if (this.SharedState.IsConditionLiftable)
                     {
-                        this.SharedState.GeneratedCallables?.AddRange(generatedOperations);
+                        this.SharedState.GeneratedCallables!.AddRange(generatedOperations);
                     }
 
                     var rtrn = this.SharedState.IsConditionLiftable

--- a/src/QsCompiler/Transformations/ClassicallyControlled.cs
+++ b/src/QsCompiler/Transformations/ClassicallyControlled.cs
@@ -946,8 +946,13 @@ namespace Microsoft.Quantum.QsCompiler.Transformations.ClassicallyControlled
                             // Lift the scope to its own operation
                             if (this.SharedState.LiftBody(block.Body, out var callable, out var call))
                             {
+                                var callStatement = new QsStatement(
+                                    QsStatementKind.NewQsExpressionStatement(call),
+                                    LocalDeclarations.Empty,
+                                    QsNullable<QsLocation>.Null,
+                                    QsComments.Empty);
                                 block = new QsPositionedBlock(
-                                    new QsScope(ImmutableArray.Create(call), block.Body.KnownSymbols),
+                                    new QsScope(ImmutableArray.Create(callStatement), block.Body.KnownSymbols),
                                     block.Location,
                                     block.Comments);
                                 newConditionBlocks.Add(Tuple.Create(expr.Item, block));
@@ -982,8 +987,13 @@ namespace Microsoft.Quantum.QsCompiler.Transformations.ClassicallyControlled
                             // Lift the scope to its own operation
                             if (this.SharedState.LiftBody(block.Body, out var callable, out var call))
                             {
+                                var callStatement = new QsStatement(
+                                    QsStatementKind.NewQsExpressionStatement(call),
+                                    LocalDeclarations.Empty,
+                                    QsNullable<QsLocation>.Null,
+                                    QsComments.Empty);
                                 block = new QsPositionedBlock(
-                                    new QsScope(ImmutableArray.Create(call), block.Body.KnownSymbols),
+                                    new QsScope(ImmutableArray.Create(callStatement), block.Body.KnownSymbols),
                                     block.Location,
                                     block.Comments);
                                 newDefault = QsNullable<QsPositionedBlock>.NewValue(block);

--- a/src/QsCompiler/Transformations/ClassicallyControlled.cs
+++ b/src/QsCompiler/Transformations/ClassicallyControlled.cs
@@ -899,12 +899,6 @@ namespace Microsoft.Quantum.QsCompiler.Transformations.ClassicallyControlled
                     var generatedOperations = new List<QsCallable>();
                     foreach (var conditionBlock in stm.ConditionalBlocks)
                     {
-                        var contextValidScope = this.SharedState.IsValidScope;
-                        var contextParams = this.SharedState.GeneratedOpParams;
-
-                        this.SharedState.IsValidScope = true;
-                        this.SharedState.GeneratedOpParams = conditionBlock.Item2.Body.KnownSymbols.Variables;
-
                         var (expr, block) = this.OnPositionedBlock(QsNullable<TypedExpression>.NewValue(conditionBlock.Item1), conditionBlock.Item2);
 
                         if (block.Body.Statements.Length == 0)
@@ -953,9 +947,6 @@ namespace Microsoft.Quantum.QsCompiler.Transformations.ClassicallyControlled
                             }
                         }
 
-                        this.SharedState.GeneratedOpParams = contextParams;
-                        this.SharedState.IsValidScope = contextValidScope;
-
                         if (!this.SharedState.IsConditionLiftable)
                         {
                             break;
@@ -965,12 +956,6 @@ namespace Microsoft.Quantum.QsCompiler.Transformations.ClassicallyControlled
                     var newDefault = QsNullable<QsPositionedBlock>.Null;
                     if (this.SharedState.IsConditionLiftable && stm.Default.IsValue)
                     {
-                        var contextValidScope = this.SharedState.IsValidScope;
-                        var contextParams = this.SharedState.GeneratedOpParams;
-
-                        this.SharedState.IsValidScope = true;
-                        this.SharedState.GeneratedOpParams = stm.Default.Item.Body.KnownSymbols.Variables;
-
                         var (_, block) = this.OnPositionedBlock(QsNullable<TypedExpression>.Null, stm.Default.Item);
 
                         if (this.IsScopeSingleCall(block.Body))
@@ -997,9 +982,6 @@ namespace Microsoft.Quantum.QsCompiler.Transformations.ClassicallyControlled
                                 this.SharedState.IsConditionLiftable = false;
                             }
                         }
-
-                        this.SharedState.GeneratedOpParams = contextParams;
-                        this.SharedState.IsValidScope = contextValidScope;
                     }
 
                     if (this.SharedState.IsConditionLiftable)

--- a/src/QsCompiler/Transformations/ContentLifting.cs
+++ b/src/QsCompiler/Transformations/ContentLifting.cs
@@ -61,15 +61,6 @@ namespace Microsoft.Quantum.QsCompiler.Transformations.ContentLifting
 
         public class TransformationState
         {
-            // ToDo: It should be possible to make these three properties private,
-            // if we absorb the corresponding logic into LiftBody.
-            public bool IsValidScope { get; set; } = true;
-
-            internal bool ContainsParamRef { get; set; } = false;
-
-            internal ImmutableArray<LocalVariableDeclaration<string>> GeneratedOpParams { get; set; } =
-                ImmutableArray<LocalVariableDeclaration<string>>.Empty;
-
             internal CallableDetails? CurrentCallable { get; set; } = null;
 
             protected internal bool InBody { get; set; } = false;
@@ -244,14 +235,15 @@ namespace Microsoft.Quantum.QsCompiler.Transformations.ContentLifting
             }
 
             /// <summary>
-            /// Generates a new operation with the body's contents. All the known variables at the
-            /// start of the block will become parameters to the new operation, and the operation
-            /// will have all the valid type parameters of the calling context as type parameters.
-            /// The generated operation is returned, along with a call to the new operation is
-            /// also returned with all the type parameters and known variables being forwarded to
-            /// the new operation as arguments.
-            ///
-            /// The given body should be validated with the SharedState.IsValidScope before using this function.
+            /// Generates a new callable with the body's contents. All the known variables at the
+            /// start of the block that get used in the body will become parameters to the new
+            /// callable, and the callable will have all the valid type parameters of the calling
+            /// context as type parameters.
+            /// If the body is valid to be lifted, 'true' is returned, and the generated callable
+            /// is returned as an out-parameter. A call to the new callable is also returned as
+            /// an out-parameter with all the type parameters and used variables being forwarded
+            /// to the new callable as arguments.
+            /// If the body is not valid to be lifted, 'false' is returned and the out-parameters are null.
             /// </summary>
             public bool LiftBody(
                 QsScope body,

--- a/src/QsCompiler/Transformations/ContentLifting.cs
+++ b/src/QsCompiler/Transformations/ContentLifting.cs
@@ -73,7 +73,7 @@ namespace Microsoft.Quantum.QsCompiler.Transformations.ContentLifting
 
             protected internal bool InWithinBlock { get; set; } = false;
 
-            protected internal List<QsCallable>? GeneratedOperations { get; set; } = null;
+            protected internal List<QsCallable>? GeneratedCallables { get; set; } = null;
 
             private (ResolvedSignature, IEnumerable<QsSpecialization>) MakeSpecializations(
                 CallableDetails callable,
@@ -654,16 +654,12 @@ namespace Microsoft.Quantum.QsCompiler.Transformations.ContentLifting
             }
 
             /// <inheritdoc/>
-            // ToDo: We will want to support lifting of functions in the future
-            public override QsCallable OnFunction(QsCallable c) => c; // Prevent anything in functions from being lifted
-
-            /// <inheritdoc/>
             public override QsNamespace OnNamespace(QsNamespace ns)
             {
-                // Generated operations list will be populated in the transform
-                this.SharedState.GeneratedOperations = new List<QsCallable>();
+                // Generated callables list will be populated in the transform
+                this.SharedState.GeneratedCallables = new List<QsCallable>();
                 return base.OnNamespace(ns)
-                    .WithElements(elems => elems.AddRange(this.SharedState.GeneratedOperations.Select(op => QsNamespaceElement.NewQsCallable(op))));
+                    .WithElements(elems => elems.AddRange(this.SharedState.GeneratedCallables.Select(callable => QsNamespaceElement.NewQsCallable(callable))));
             }
         }
 

--- a/src/QsCompiler/Transformations/ContentLifting.cs
+++ b/src/QsCompiler/Transformations/ContentLifting.cs
@@ -272,12 +272,12 @@ namespace Microsoft.Quantum.QsCompiler.Transformations.ContentLifting
             public bool LiftBody(
                 QsScope body,
                 [NotNullWhen(true)] out QsCallable? callable,
-                [NotNullWhen(true)] out QsStatement? callStatement)
+                [NotNullWhen(true)] out TypedExpression? callExpression)
             {
                 if (this.CurrentCallable is null)
                 {
                     callable = null;
-                    callStatement = null;
+                    callExpression = null;
                     return false;
                 }
 
@@ -286,7 +286,7 @@ namespace Microsoft.Quantum.QsCompiler.Transformations.ContentLifting
                 if (!isValid)
                 {
                     callable = null;
-                    callStatement = null;
+                    callExpression = null;
                     return false;
                 }
 
@@ -338,7 +338,9 @@ namespace Microsoft.Quantum.QsCompiler.Transformations.ContentLifting
                         QsNullable<Range>.Null);
                 }
 
-                var call = new TypedExpression(
+                // set output parameters
+                callable = generatedCallable;
+                callExpression = new TypedExpression(
                     ExpressionKind.NewCallLikeExpression(generatedCallableId, arguments),
                     typeArguments.IsNull
                         ? TypeArgsResolution.Empty
@@ -348,14 +350,6 @@ namespace Microsoft.Quantum.QsCompiler.Transformations.ContentLifting
                     ResolvedType.New(ResolvedTypeKind.UnitType),
                     new InferredExpressionInformation(false, true),
                     QsNullable<Range>.Null);
-
-                // set output parameters
-                callable = generatedCallable;
-                callStatement = new QsStatement(
-                    QsStatementKind.NewQsExpressionStatement(call),
-                    LocalDeclarations.Empty,
-                    QsNullable<QsLocation>.Null,
-                    QsComments.Empty);
 
                 return true;
             }

--- a/src/QsCompiler/Transformations/ContentLifting.cs
+++ b/src/QsCompiler/Transformations/ContentLifting.cs
@@ -700,8 +700,6 @@ namespace Microsoft.Quantum.QsCompiler.Transformations.ContentLifting
     /// the operation will have all the valid type parameters of the calling context as type parameters.
     /// A call to the new operation is also returned with all the valid type parameters and known variables
     /// being forwarded to the new operation as arguments.
-    ///
-    /// ToDo: This transformation currently does not support lifting inside of functions.
     /// </summary>
     public class LiftContent<T> : SyntaxTreeTransformation<T>
         where T : LiftContent.TransformationState

--- a/src/QsCompiler/Transformations/ContentLifting.cs
+++ b/src/QsCompiler/Transformations/ContentLifting.cs
@@ -631,6 +631,8 @@ namespace Microsoft.Quantum.QsCompiler.Transformations.ContentLifting
                     }
                     else
                     {
+                        // ToDo: Currently this is unused functionality as IsReturnAllowed is in-practice always false.
+                        // This functionality will be used in the implementation of lambda elimination.
                         if (this.SharedState.ReturnType == null)
                         {
                             this.SharedState.ReturnType = ex.ResolvedType;


### PR DESCRIPTION
This PR makes some structural changes to the Base Lifter to allow it to be more flexible and easier to work with. A functional change is that the generated callable will now only have the minimal parameter set, rather than taking all the known symbols as parameters. This PR also addresses #1115.