### PR TITLE
Create VSIX for VS Code extension using a version allowed by Marketplace

### DIFF
--- a/bootstrap.ps1
+++ b/bootstrap.ps1
@@ -10,7 +10,10 @@ param(
     $NuGetVersion = $Env:NUGET_VERSION,
 
     [string]
-    $VsVsixVersion = $Env:VSVSIX_VERSION
+    $VsVsixVersion = $Env:VSVSIX_VERSION,
+
+    [string]
+    $VsCodeVsixVersion = $Env:VSCODEVSIX_VERSION
 );
 
 if ("$AssemblyVersion".Trim().Length -eq 0) {
@@ -41,6 +44,11 @@ if ("$VsVsixVersion".Trim().Length -eq 0) {
     $VsVsixVersion = "$MajorVersion.$MinorVersion.$patch.$rev";
 }
 
+if ("$VsCodeVsixVersion".Trim().Length -eq 0) {
+    $VsCodeVsixVersion = "$SemverVersion".split('-')[0];
+}
+
+
 $Telemetry = "$($Env:ASSEMBLY_CONSTANTS)".Contains("TELEMETRY").ToString().ToLower();
 Write-Host "Enable telemetry: $Telemetry";
 
@@ -57,6 +65,7 @@ Get-ChildItem -Recurse *.v.template `
                     Replace("#ASSEMBLY_VERSION#", $AssemblyVersion).
                     Replace("#NUGET_VERSION#", $NuGetVersion).
                     Replace("#VSVSIX_VERSION#", $VsVsixVersion).
+                    Replace("#VSCODEVSIX_VERSION#", $VsCodeVsixVersion).
                     Replace("#SEMVER_VERSION#", $SemverVersion).
                     Replace("#ENABLE_TELEMETRY#", $Telemetry)
             } `
@@ -67,7 +76,9 @@ If ($Env:ASSEMBLY_VERSION -eq $null) { $Env:ASSEMBLY_VERSION ="$AssemblyVersion"
 If ($Env:NUGET_VERSION -eq $null) { $Env:NUGET_VERSION ="$NuGetVersion" }
 If ($Env:SEMVER_VERSION -eq $null) { $Env:SEMVER_VERSION ="$SemverVersion" }
 If ($Env:VSVSIX_VERSION -eq $null) { $Env:VSVSIX_VERSION ="$VsVsixVersion" }
+If ($Env:VSCODEVSIX_VERSION -eq $null) { $Env:VSCODEVSIX_VERSION ="$VsCodeVsixVersion" }
 Write-Host "##vso[task.setvariable variable=VsVsix.Version]$VsVsixVersion"
+Write-Host "##vso[task.setvariable variable=VsCodeVsixVersion]$VsCodeVsixVersion"
 
 Write-Host "##[info]Finding NuSpec references..."
 Push-Location (Join-Path $PSScriptRoot 'src/QsCompiler/Compiler')

--- a/src/VSCodeExtension/package-lock.json.v.template
+++ b/src/VSCodeExtension/package-lock.json.v.template
@@ -1,12 +1,12 @@
 {
     "name": "quantum-devkit-vscode-net6",
-    "version": "#SEMVER_VERSION#",
+    "version": "#VSCODEVSIX_VERSION#",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "quantum-devkit-vscode-net6",
-            "version": "#SEMVER_VERSION#",
+            "version": "#VSCODEVSIX_VERSION#",
             "license": "MIT",
             "dependencies": {
                 "@types/fs-extra": "^8.0.0",

--- a/src/VSCodeExtension/package.json.v.template
+++ b/src/VSCodeExtension/package.json.v.template
@@ -1,6 +1,6 @@
 {
     "name": "quantum-devkit-vscode-net6",
-    "version": "#SEMVER_VERSION#",
+    "version": "#VSCODEVSIX_VERSION#",
     "displayName": "Microsoft Quantum Development Kit for Visual Studio Code .NET 6 Preview",
     "description": "Microsoft Quantum Development Kit for Visual Studio Code provides support for developing quantum algorithms in the Q# programming language.",
     "publisher": "quantum",

--- a/src/VSCodeExtension/src/languageServer.ts
+++ b/src/VSCodeExtension/src/languageServer.ts
@@ -165,8 +165,9 @@ export class LanguageServer {
         if (info === undefined || info === null) {
             throw new Error("Package info was undefined.");
         }
+        console.log(`[qsharp-lsp] Package is ${info.name} with ${info.nugetVersion} and ${info.version}`);
         if (versionCheck && info.version !== version) {
-            console.log(`[qsharp-lsp] Found version ${version}, expected version ${info.version}. Clearing cached version.`);
+            console.log(`[qsharp-lsp] Found version ${version}, expected version ${info.nugetVersion}. Clearing cached version.`);
             await this.clearCache();
             return false;
         }

--- a/src/VSCodeExtension/src/languageServer.ts
+++ b/src/VSCodeExtension/src/languageServer.ts
@@ -166,7 +166,7 @@ export class LanguageServer {
             throw new Error("Package info was undefined.");
         }
         console.log(`[qsharp-lsp] Package is ${info.name} with ${info.nugetVersion} and ${info.version}`);
-        if (versionCheck && info.version !== version) {
+        if (versionCheck && info.nugetVersion !== version) {
             console.log(`[qsharp-lsp] Found version ${version}, expected version ${info.nugetVersion}. Clearing cached version.`);
             await this.clearCache();
             return false;


### PR DESCRIPTION
Visual Studio Marketplace will not allow an extension with a version number that contains a release type suffix like '-beta'.

This blocks us from releasing directly a beta build as built. With this change, we allow the VSIX extension to be packaged using a version that only contains the numeric part of the version, while keeping the NuGet version of all components in full (including the release type suffix).
