### PR TITLE
Ensure Spacing After Removed Parentheses

### DIFF
--- a/src/QsFmt/Formatter.Tests/Examples.fs
+++ b/src/QsFmt/Formatter.Tests/Examples.fs
@@ -251,6 +251,28 @@ let ``Removes For-Loop Parens`` =
 }"""
 
 [<Example(ExampleKind.Update)>]
+let ``Ensure Spaces with Removed Parens`` =
+    """namespace Foo {
+    operation Bar() : Unit {
+        using(q = Qubit()) {
+            for(i in 0..3) {
+                Message("HelloQ");
+            }
+        }
+    }
+}""",
+
+    """namespace Foo {
+    operation Bar() : Unit {
+        use q = Qubit() {
+            for i in 0..3 {
+                Message("HelloQ");
+            }
+        }
+    }
+}"""
+
+[<Example(ExampleKind.Update)>]
 let ``Update Specialization Declaration`` =
     """namespace Foo {
     operation Bar() : Unit is Ctl + Adj {

--- a/src/QsFmt/Formatter/Rules.fs
+++ b/src/QsFmt/Formatter/Rules.fs
@@ -110,6 +110,12 @@ let getTrivia paren =
     | None -> []
     | Some p -> p.Prefix
 
+/// <summary>
+/// Insert a whitespace to <paramref name="prefix"/> if it is empty.
+/// </summary>
+let ensureSpace prefix =
+    if List.isEmpty prefix then [ spaces 1 ] else prefix
+
 let qubitBindingUpdate =
     { new Rewriter<_>() with
         override rewriter.QubitDeclarationStatement(_, decl) =
@@ -124,7 +130,7 @@ let qubitBindingUpdate =
             { decl with
                 Keyword = rewriter.Terminal((), { decl.Keyword with Text = keyword })
                 OpenParen = None
-                Binding = decl.Binding |> QubitBinding.mapPrefix ((@) openTrivia)
+                Binding = decl.Binding |> QubitBinding.mapPrefix (((@) openTrivia) >> ensureSpace)
                 CloseParen = None
                 Coda =
                     match decl.Coda with
@@ -154,7 +160,7 @@ let forParensUpdate =
 
             { loop with
                 OpenParen = None
-                Binding = loop.Binding |> ForBinding.mapPrefix ((@) openTrivia)
+                Binding = loop.Binding |> ForBinding.mapPrefix (((@) openTrivia) >> ensureSpace)
                 CloseParen = None
                 Block = rewriter.Block((), rewriter.Statement, loop.Block) |> Block.mapPrefix ((@) closeTrivia)
             }
@@ -378,12 +384,6 @@ let checkArraySyntax fileName document =
         }
 
     reducer.Document document
-
-/// <summary>
-/// Insert a whitespace to <paramref name="prefix"/> if it is empty.
-/// </summary>
-let ensureSpace prefix =
-    if List.isEmpty prefix then [ spaces 1 ] else prefix
 
 let booleanOperatorUpdate =
     { new Rewriter<_>() with


### PR DESCRIPTION
Fixed a bug, #1346 where a space needed to be inserted after removing parentheses around for loops conditions and qubit declaration bindings.