### PR TITLE
Pulling in Ryan's contribution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -307,7 +307,7 @@ __pycache__/
 *.pyc
 
 # Python Virtual environments
-*__venv/ 
+*__venv/
 
 # Cake - Uncomment if you are using it
 # tools/**
@@ -368,6 +368,7 @@ src/ProjectTemplates/Quantum.Test1/.template.config/template.json
 src/QsCompiler/QirGeneration/QirGeneration.nuspec
 /examples/QIR/Development/qir/*
 /examples/QIR/Development/build
+/examples/QIR/Development/DebugInfo/Development.exe
 src/Telemetry/Tests/coverage.json
 src/Telemetry/.vscode/settings.json
 

--- a/.gitignore
+++ b/.gitignore
@@ -307,7 +307,7 @@ __pycache__/
 *.pyc
 
 # Python Virtual environments
-*__venv/
+*__venv/ 
 
 # Cake - Uncomment if you are using it
 # tools/**
@@ -368,7 +368,6 @@ src/ProjectTemplates/Quantum.Test1/.template.config/template.json
 src/QsCompiler/QirGeneration/QirGeneration.nuspec
 /examples/QIR/Development/qir/*
 /examples/QIR/Development/build
-/examples/QIR/Development/DebugInfo/Development.exe
 src/Telemetry/Tests/coverage.json
 src/Telemetry/.vscode/settings.json
 

--- a/examples/QIR/Development/Development.csproj
+++ b/examples/QIR/Development/Development.csproj
@@ -28,6 +28,8 @@
     <CSharpGeneration>false</CSharpGeneration>
     <QscExe>dotnet $(MSBuildThisFileDirectory)../../../src/QsCompiler/CommandLineTool/bin/$(Configuration)/netcoreapp3.1/qsc.dll</QscExe>
     <_QscCommandPredefinedAssemblyProperties>$(_QscCommandPredefinedAssemblyProperties) QirOutputPath:"qir"</_QscCommandPredefinedAssemblyProperties>
+    <!-- The line below enables debug information within the generated QIR. Uncomment the line to emit debug information. -->
+    <!-- <_QscCommandPredefinedAssemblyProperties>$(_QscCommandPredefinedAssemblyProperties) EnableDebugSymbols:"true"</_QscCommandPredefinedAssemblyProperties> -->
   </PropertyGroup>
 
   <ItemGroup>

--- a/examples/QIR/Development/Program.qs
+++ b/examples/QIR/Development/Program.qs
@@ -15,3 +15,5 @@
         return "Executed successfully!";
     }
 }
+
+

--- a/examples/QIR/Development/Program.qs
+++ b/examples/QIR/Development/Program.qs
@@ -15,5 +15,3 @@
         return "Executed successfully!";
     }
 }
-
-

--- a/examples/QIR/Development/README.md
+++ b/examples/QIR/Development/README.md
@@ -8,3 +8,43 @@ Note: If you are using the Development project on Linux, you may run into the fo
 ```
 export LD_LIBRARY_PATH=/usr/lib/llvm-11/lib
 ```
+
+# Development of the QIR Debug Info Generation
+
+## NOTE: Incompatible with Windows
+
+This debug feature is currently incompatible with Windows due to some LLVM tool limitations. The QIR emission itself still works on Windows, meaning you can request debug symbols within Development.csproj and they will appear in the emitted QIR when you build without errors. However, when you go to actually test the Q# debugging experience on Windows, you won't be able to set breakpoints. If you use the VS Code UI for debugging, the program simply won't stop at the lines you attempt to put breakpoints on. If you use LLDB from the command line, you will get this specific message when you attempt to set breakpoints:
+```
+WARNING:  Unable to resolve breakpoint to any actual locations.
+```
+
+This seems to be due to a bug in LLVM within either LLDB or Clang that prevents us from having debug information point back to a ".qs" file on Windows. This is not a problem on Linux or Mac.
+
+As a workaround, you can duplicate the Q# file into into a ".c" file and change the emitted QIR such that the source file references have extension ".c" instead of ".qs." Then, you would attach the debugger to the ".c" file.
+
+## Emitting debug information within the QIR
+
+To emit debug information within the QIR, uncomment the following line in `Development.csproj`.
+```
+<_QscCommandPredefinedAssemblyProperties>$(_QscCommandPredefinedAssemblyProperties) EnableDebugSymbols:"true"</_QscCommandPredefinedAssemblyProperties>
+```
+
+## Testing the Q# debugging experience
+To test the Q# debugging experience, you can use `lldb` from the command line, but we recommend using the built in VS Code debugging GUI for a better experience. Use the following steps to set this up:
+* Install the (CodeLLDB extension)[https://marketplace.visualstudio.com/items?itemName=vadimcn.vscode-lldb].
+* Open or create a launch.json file within the subdirectory `.vscode` from the base of this repository. Add the following configuration.
+```
+        {
+            "name": "Debug Program.qs",
+            "type": "lldb",
+            "request": "launch",
+            "program": "${workspaceFolder}/examples/QIR/Development/build/Development",
+            "args": [],
+        }
+```
+* Make sure that you have the following set in VSCode to allow breakpoints in Q# files: VSCode > Settings > Breakpoints > Allow Breakpoints in Any File
+
+Each time you want to test the Q# debugging experience based on the local version of the compiler, take the following steps:
+* From the Development directory, run `dotnet build`. This will emit the QIR.
+* Set breakpoints in `Program.qs`.
+* Launch the "Debug Program.qs" configuration from the VS Code debugger

--- a/src/QsCompiler/BondSchemas/Generated/CompilerDataStructures.cs
+++ b/src/QsCompiler/BondSchemas/Generated/CompilerDataStructures.cs
@@ -45,7 +45,7 @@ namespace Microsoft.Quantum.QsCompiler.BondSchemas
 
         protected Position(string fullName, string name)
         {
-
+            
         }
     }
 
@@ -661,7 +661,7 @@ namespace Microsoft.Quantum.QsCompiler.BondSchemas
 
         protected InferredCallableInformation(string fullName, string name)
         {
-
+            
         }
     }
 
@@ -823,7 +823,7 @@ namespace Microsoft.Quantum.QsCompiler.BondSchemas
 
         protected InferredExpressionInformation(string fullName, string name)
         {
-
+            
         }
     }
 

--- a/src/QsCompiler/BondSchemas/Generated/CompilerDataStructures.cs
+++ b/src/QsCompiler/BondSchemas/Generated/CompilerDataStructures.cs
@@ -45,7 +45,7 @@ namespace Microsoft.Quantum.QsCompiler.BondSchemas
 
         protected Position(string fullName, string name)
         {
-            
+
         }
     }
 
@@ -661,7 +661,7 @@ namespace Microsoft.Quantum.QsCompiler.BondSchemas
 
         protected InferredCallableInformation(string fullName, string name)
         {
-            
+
         }
     }
 
@@ -823,7 +823,7 @@ namespace Microsoft.Quantum.QsCompiler.BondSchemas
 
         protected InferredExpressionInformation(string fullName, string name)
         {
-            
+
         }
     }
 

--- a/src/QsCompiler/CommandLineTool/Options.cs
+++ b/src/QsCompiler/CommandLineTool/Options.cs
@@ -125,6 +125,11 @@ namespace Microsoft.Quantum.QsCompiler.CommandLineCompiler
 
             foreach (var keyValue in this.AdditionalAssemblyProperties ?? Array.Empty<string>())
             {
+                if (string.IsNullOrWhiteSpace(keyValue))
+                {
+                    continue;
+                }
+
                 // NB: We use `count: 2` here to ensure that assembly constants can contain colons.
                 var pieces = keyValue?.Split(":", count: 2);
                 if (pieces is null || pieces.Length != 2)

--- a/src/QsCompiler/Compiler/CompilationLoader.cs
+++ b/src/QsCompiler/Compiler/CompilationLoader.cs
@@ -1256,10 +1256,5 @@ namespace Microsoft.Quantum.QsCompiler
             File.WriteAllText(targetFile, content);
             return targetFile;
         }
-
-        /// <summary>
-        /// Gets the executing assembly (the Qsharp Compiler) AssemblyName
-        /// </summary>
-        public static AssemblyName QSharpCompilerAssemblyName => typeof(CompilationLoader).Assembly.GetName();
     }
 }

--- a/src/QsCompiler/Compiler/CompilationLoader.cs
+++ b/src/QsCompiler/Compiler/CompilationLoader.cs
@@ -1256,5 +1256,10 @@ namespace Microsoft.Quantum.QsCompiler
             File.WriteAllText(targetFile, content);
             return targetFile;
         }
+
+        /// <summary>
+        /// Gets the executing assembly (the Qsharp Compiler) AssemblyName
+        /// </summary>
+        public static AssemblyName QSharpCompilerAssemblyName => typeof(CompilationLoader).Assembly.GetName();
     }
 }

--- a/src/QsCompiler/Core/Transformations/TypeTransformation.fs
+++ b/src/QsCompiler/Core/Transformations/TypeTransformation.fs
@@ -26,7 +26,7 @@ type TypeTransformationBase(options: TransformationOptions) =
     // supplementary type information
 
     // TODO: RELEASE 2021-10: Remove obsolete method.
-    [<Obsolete "Use OnRangeInformation(TypeRange) instead.">]
+    [<Obsolete "Use OnTypeRange(TypeRange) instead.">]
     abstract OnRangeInformation : QsNullable<Range> -> QsNullable<Range>
 
     default this.OnRangeInformation range = range

--- a/src/QsCompiler/Core/Transformations/TypeTransformation.fs
+++ b/src/QsCompiler/Core/Transformations/TypeTransformation.fs
@@ -26,7 +26,7 @@ type TypeTransformationBase(options: TransformationOptions) =
     // supplementary type information
 
     // TODO: RELEASE 2021-10: Remove obsolete method.
-    [<Obsolete "Use OnTypeRange(TypeRange) instead.">]
+    [<Obsolete "Use OnRangeInformation(TypeRange) instead.">]
     abstract OnRangeInformation : QsNullable<Range> -> QsNullable<Range>
 
     default this.OnRangeInformation range = range

--- a/src/QsCompiler/DataStructures/ReservedKeywords.fs
+++ b/src/QsCompiler/DataStructures/ReservedKeywords.fs
@@ -269,6 +269,7 @@ module AssemblyConstants =
     let ResourcesEstimator = "ResourcesEstimator"
     let ExposeReferencesViaTestNames = "ExposeReferencesViaTestNames"
     let QirOutputPath = "QirOutputPath"
+    let EnableDebugSymbols = "EnableDebugSymbols"
     let PerfDataOutputPath = "PerfDataOutputPath"
     let DocsOutputPath = "DocsOutputPath"
     let DocsPackageId = "DocsPackageId"

--- a/src/QsCompiler/LlvmBindings/DebugInfo/DILocation.cs
+++ b/src/QsCompiler/LlvmBindings/DebugInfo/DILocation.cs
@@ -15,8 +15,8 @@ namespace Ubiquity.NET.Llvm.DebugInfo
     {
         /// <summary>Initializes a new instance of the <see cref="DILocation"/> class.</summary>
         /// <param name="context">Context that owns this location</param>
-        /// <param name="line">line number for the location</param>
-        /// <param name="column">Column number for the location</param>
+        /// <param name="line">line number for the location (1-based)</param>
+        /// <param name="column">Column number for the location (1-based)</param>
         /// <param name="scope">Containing scope for the location</param>
         public DILocation(Context context, uint line, uint column, DILocalScope scope)
             : this(context, line, column, scope, null)
@@ -25,8 +25,8 @@ namespace Ubiquity.NET.Llvm.DebugInfo
 
         /// <summary>Initializes a new instance of the <see cref="DILocation"/> class.</summary>
         /// <param name="context">Context that owns this location</param>
-        /// <param name="line">line number for the location</param>
-        /// <param name="column">Column number for the location</param>
+        /// <param name="line">line number for the location (1-based)</param>
+        /// <param name="column">Column number for the location (1-based)</param>
         /// <param name="scope">Containing scope for the location</param>
         /// <param name="inlinedAt">Scope where this scope is inlined at/into</param>
         public DILocation(Context context, uint line, uint column, DILocalScope scope, DILocation? inlinedAt)
@@ -41,10 +41,10 @@ namespace Ubiquity.NET.Llvm.DebugInfo
         /// <summary>Gets the scope for this location</summary>
         public DILocalScope Scope => FromHandle<DILocalScope>(this.Context, this.MetadataHandle.DILocationGetScope())!;
 
-        /// <summary>Gets the line for this location</summary>
+        /// <summary>Gets the line for this location (1-based)</summary>
         public uint Line => this.MetadataHandle.DILocationGetLine();
 
-        /// <summary>Gets the column for this location</summary>
+        /// <summary>Gets the column for this location (1-based)</summary>
         public uint Column => this.MetadataHandle.DILocationGetColumn();
 
         /// <summary>Gets the location this location is inlined at</summary>

--- a/src/QsCompiler/LlvmBindings/DebugInfo/DebugArrayType.cs
+++ b/src/QsCompiler/LlvmBindings/DebugInfo/DebugArrayType.cs
@@ -22,32 +22,32 @@ namespace Ubiquity.NET.Llvm.DebugInfo
         /// <summary>Initializes a new instance of the <see cref="DebugArrayType"/> class</summary>
         /// <param name="llvmType">Underlying LLVM array type to bind debug info to</param>
         /// <param name="elementType">Array element type with debug information</param>
-        /// <param name="module">module to use for creating debug information</param>
+        /// <param name="dIBuilder"><see cref="DebugInfoBuilder"/> to use when constructing debug info</param>
         /// <param name="count">Number of elements in the array</param>
         /// <param name="lowerBound">Lower bound of the array [default = 0]</param>
         /// <param name="alignment">Alignment for the type</param>
         public DebugArrayType(
             IArrayType llvmType,
             IDebugType<ITypeRef, DIType> elementType,
-            BitcodeModule module,
+            DebugInfoBuilder dIBuilder,
             uint count,
             uint lowerBound = 0,
             uint alignment = 0)
-            : base(llvmType, BuildDebugType(llvmType, elementType, module, count, lowerBound, alignment))
+            : base(llvmType, BuildDebugType(llvmType, elementType, dIBuilder, count, lowerBound, alignment))
         {
             this.DebugElementType = elementType;
         }
 
         /// <summary>Initializes a new instance of the <see cref="DebugArrayType"/> class.</summary>
         /// <param name="elementType">Type of elements in the array</param>
-        /// <param name="module"><see cref="BitcodeModule"/> to use for the context of the debug information</param>
+        /// <param name="dIBuilder"><see cref="DebugInfoBuilder"/> to use when constructing debug info</param>
         /// <param name="count">Number of elements in the array</param>
         /// <param name="lowerBound"><see cref="LowerBound"/> value for the array indices [Default: 0]</param>
-        public DebugArrayType(IDebugType<ITypeRef, DIType> elementType, BitcodeModule module, uint count, uint lowerBound = 0)
+        public DebugArrayType(IDebugType<ITypeRef, DIType> elementType, DebugInfoBuilder dIBuilder, uint count, uint lowerBound = 0)
             : this(
                 elementType.CreateArrayType(count),
                 elementType,
-                module,
+                dIBuilder,
                 count,
                 lowerBound)
         {
@@ -55,12 +55,12 @@ namespace Ubiquity.NET.Llvm.DebugInfo
 
         /// <summary>Initializes a new instance of the <see cref="DebugArrayType"/> class.</summary>
         /// <param name="llvmType">Native LLVM type for the elements</param>
-        /// <param name="module"><see cref="BitcodeModule"/> to use for the context of the debug information</param>
+        /// <param name="dIBuilder"><see cref="DebugInfoBuilder"/> to use when constructing debug info</param>
         /// <param name="elementType">Debug type of the array elements</param>
         /// <param name="count">Number of elements in the array</param>
         /// <param name="lowerBound"><see cref="LowerBound"/> value for the array indices [Default: 0]</param>
-        public DebugArrayType(IArrayType llvmType, BitcodeModule module, DIType elementType, uint count, uint lowerBound = 0)
-            : this(DebugType.Create(llvmType.ElementType, elementType), module, count, lowerBound)
+        public DebugArrayType(IArrayType llvmType, DebugInfoBuilder dIBuilder, DIType elementType, uint count, uint lowerBound = 0)
+            : this(DebugType.Create(llvmType.ElementType, elementType), dIBuilder, count, lowerBound)
         {
         }
 
@@ -104,7 +104,7 @@ namespace Ubiquity.NET.Llvm.DebugInfo
         private static DICompositeType BuildDebugType(
             IArrayType llvmType,
             IDebugType<ITypeRef, DIType> elementType,
-            BitcodeModule module,
+            DebugInfoBuilder dIBuilder,
             uint count,
             uint lowerBound,
             uint alignment)
@@ -116,17 +116,17 @@ namespace Ubiquity.NET.Llvm.DebugInfo
 
             if (llvmType.IsSized)
             {
-                return module.DIBuilder.CreateArrayType(
-                    module.Layout.BitSizeOf(llvmType),
+                return dIBuilder.CreateArrayType(
+                    dIBuilder.OwningModule.Layout.BitSizeOf(llvmType),
                     alignment,
                     elementType.DIType!, // validated not null in constructor
-                    module.DIBuilder.CreateSubRange(lowerBound, count));
+                    dIBuilder.CreateSubRange(lowerBound, count));
             }
 
-            return module.DIBuilder.CreateReplaceableCompositeType(
+            return dIBuilder.CreateReplaceableCompositeType(
                 Tag.ArrayType,
                 string.Empty,
-                module.DICompileUnit ?? default,
+                dIBuilder.CompileUnit ?? default,
                 default,
                 0);
         }

--- a/src/QsCompiler/LlvmBindings/DebugInfo/DebugBasicType.cs
+++ b/src/QsCompiler/LlvmBindings/DebugInfo/DebugBasicType.cs
@@ -28,20 +28,19 @@ namespace Ubiquity.NET.Llvm.DebugInfo
     {
         /// <summary>Initializes a new instance of the <see cref="DebugBasicType"/> class.</summary>
         /// <param name="llvmType">Type to wrap debug information for</param>
-        /// <param name="module">Module to use when constructing the debug information</param>
+        /// <param name="dIBuilder"><see cref="DebugInfoBuilder"/> to use when constructing debug info</param>
         /// <param name="name">Source language name of the type</param>
         /// <param name="encoding">Encoding for the type</param>
-        public DebugBasicType(ITypeRef llvmType, BitcodeModule module, string name, DiTypeKind encoding)
+        public DebugBasicType(ITypeRef llvmType, DebugInfoBuilder dIBuilder, string name, DiTypeKind encoding)
             : base(
                 llvmType,
-                module
-                          .DIBuilder
+                dIBuilder
                           .CreateBasicType(
                               name,
-                              module.Layout.BitSizeOf(llvmType),
+                              dIBuilder.OwningModule.Layout.BitSizeOf(llvmType),
                               encoding))
         {
-            if (module.Layout == null)
+            if (dIBuilder.OwningModule.Layout == null)
             {
                 throw new ArgumentException();
             }

--- a/src/QsCompiler/LlvmBindings/DebugInfo/DebugFunctionType.cs
+++ b/src/QsCompiler/LlvmBindings/DebugInfo/DebugFunctionType.cs
@@ -43,20 +43,19 @@ namespace Ubiquity.NET.Llvm.DebugInfo
     {
         /// <summary>Initializes a new instance of the <see cref="DebugFunctionType"/> class.</summary>
         /// <param name="llvmType">Native LLVM function signature</param>
-        /// <param name="module"><see cref="BitcodeModule"/> to use when construction debug information</param>
+        /// <param name="dIBuilder"><see cref="DebugInfoBuilder"/> to use when constructing debug info</param>
         /// <param name="debugFlags"><see cref="DebugInfoFlags"/> for this signature</param>
         /// <param name="retType">Return type for the function</param>
         /// <param name="argTypes">Potentially empty set of argument types for the signature</param>
         public DebugFunctionType(
             IFunctionType llvmType,
-            BitcodeModule module,
+            DebugInfoBuilder dIBuilder,
             DebugInfoFlags debugFlags,
             IDebugType<ITypeRef, DIType> retType,
             params IDebugType<ITypeRef, DIType>[] argTypes)
             : base(
                 llvmType,
-                module
-                          .DIBuilder.CreateSubroutineType(
+                dIBuilder.CreateSubroutineType(
                               debugFlags,
                               retType.DIType,
                               argTypes.Select(t => t.DIType)))

--- a/src/QsCompiler/LlvmBindings/DebugInfo/DebugPointerType.cs
+++ b/src/QsCompiler/LlvmBindings/DebugInfo/DebugPointerType.cs
@@ -17,14 +17,14 @@ namespace Ubiquity.NET.Llvm.DebugInfo
     {
         /// <summary>Initializes a new instance of the <see cref="DebugPointerType"/> class.</summary>
         /// <param name="debugElementType">Debug type of the pointee</param>
-        /// <param name="module"><see cref="BitcodeModule"/> used for creating the pointer type and debug information</param>
+        /// <param name="dIBuilder"><see cref="DebugInfoBuilder"/> to use when constructing pointer type and debug info</param>
         /// <param name="addressSpace">Target address space for the pointer [Default: 0]</param>
         /// <param name="name">Name of the type [Default: null]</param>
         /// <param name="alignment">Alignment on pointer</param>
-        public DebugPointerType(IDebugType<ITypeRef, DIType> debugElementType, BitcodeModule module, uint addressSpace = 0, string? name = null, uint alignment = 0)
+        public DebugPointerType(IDebugType<ITypeRef, DIType> debugElementType, DebugInfoBuilder dIBuilder, uint addressSpace = 0, string? name = null, uint alignment = 0)
             : this(
                 debugElementType.NativeType,
-                module,
+                dIBuilder,
                 debugElementType.DIType,
                 addressSpace,
                 name,
@@ -34,15 +34,15 @@ namespace Ubiquity.NET.Llvm.DebugInfo
 
         /// <summary>Initializes a new instance of the <see cref="DebugPointerType"/> class.</summary>
         /// <param name="llvmElementType">Native type of the pointee</param>
-        /// <param name="module"><see cref="BitcodeModule"/> used for creating the pointer type and debug information</param>
+        /// <param name="dIBuilder"><see cref="DebugInfoBuilder"/> to use when constructing the pointer type and debug info</param>
         /// <param name="elementType">Debug type of the pointee</param>
         /// <param name="addressSpace">Target address space for the pointer [Default: 0]</param>
         /// <param name="name">Name of the type [Default: null]</param>
         /// <param name="alignment">Alignment of pointer</param>
-        public DebugPointerType(ITypeRef llvmElementType, BitcodeModule module, DIType? elementType, uint addressSpace = 0, string? name = null, uint alignment = 0)
+        public DebugPointerType(ITypeRef llvmElementType, DebugInfoBuilder dIBuilder, DIType? elementType, uint addressSpace = 0, string? name = null, uint alignment = 0)
             : this(
                 llvmElementType.CreatePointerType(addressSpace),
-                module,
+                dIBuilder,
                 elementType,
                 name,
                 alignment)
@@ -51,18 +51,17 @@ namespace Ubiquity.NET.Llvm.DebugInfo
 
         /// <summary>Initializes a new instance of the <see cref="DebugPointerType"/> class.</summary>
         /// <param name="llvmPtrType">Native type of the pointer</param>
-        /// <param name="module"><see cref="BitcodeModule"/> used for creating the pointer type and debug information</param>
+        /// <param name="dIBuilder"><see cref="DebugInfoBuilder"/> to use when constructing debug info</param>
         /// <param name="elementType">Debug type of the pointee</param>
         /// <param name="name">Name of the type [Default: null]</param>
         /// <param name="alignment">Alignment for pointer type</param>
-        public DebugPointerType(IPointerType llvmPtrType, BitcodeModule module, DIType? elementType, string? name = null, uint alignment = 0)
+        public DebugPointerType(IPointerType llvmPtrType, DebugInfoBuilder dIBuilder, DIType? elementType, string? name = null, uint alignment = 0)
             : base(
                 llvmPtrType,
-                module.DIBuilder
-                          .CreatePointerType(
+                dIBuilder.CreatePointerType(
                               elementType,
                               name,
-                              module.Layout.BitSizeOf(llvmPtrType),
+                              dIBuilder.OwningModule.Layout.BitSizeOf(llvmPtrType),
                               alignment))
         {
         }

--- a/src/QsCompiler/LlvmBindings/DebugInfo/DebugStructType.cs
+++ b/src/QsCompiler/LlvmBindings/DebugInfo/DebugStructType.cs
@@ -21,7 +21,7 @@ namespace Ubiquity.NET.Llvm.DebugInfo
         IStructType
     {
         /// <summary>Initializes a new instance of the <see cref="DebugStructType"/> class.</summary>
-        /// <param name="module">Module to contain the debug meta data</param>
+        /// <param name="dIBuilder"><see cref="DebugInfoBuilder"/> to use when constructing debug meta data</param>
         /// <param name="nativeName">Name of the type in LLVM IR (use <see cref="string.Empty"/> for anonymous types)</param>
         /// <param name="scope">Debug scope for the structure</param>
         /// <param name="sourceName">Source/debug name of the struct (use <see cref="string.Empty"/> for anonymous types)</param>
@@ -34,7 +34,7 @@ namespace Ubiquity.NET.Llvm.DebugInfo
         /// <param name="bitSize">Total bit size for this type or <see langword="null"/> to use default for target</param>
         /// <param name="bitAlignment">Alignment of the type in bits, 0 indicates default for target</param>
         public DebugStructType(
-            BitcodeModule module,
+            DebugInfoBuilder dIBuilder,
             string nativeName,
             DIScope? scope,
             string sourceName,
@@ -47,8 +47,8 @@ namespace Ubiquity.NET.Llvm.DebugInfo
             uint? bitSize = null,
             uint bitAlignment = 0)
             : base(
-                module.Context.CreateStructType(nativeName, packed, members.Select(e => e.DebugType).ToArray()),
-                module.DIBuilder.CreateReplaceableCompositeType(
+                dIBuilder.OwningModule.Context.CreateStructType(nativeName, packed, members.Select(e => e.DebugType).ToArray()),
+                dIBuilder.CreateReplaceableCompositeType(
                       Tag.StructureType,
                       sourceName,
                       scope,
@@ -58,14 +58,14 @@ namespace Ubiquity.NET.Llvm.DebugInfo
             this.DebugMembers = new ReadOnlyCollection<DebugMemberInfo>(members as IList<DebugMemberInfo> ?? members.ToList());
 
             var memberTypes = from memberInfo in this.DebugMembers
-                              select this.CreateMemberType(module, memberInfo);
+                              select this.CreateMemberType(dIBuilder, memberInfo);
 
-            var concreteType = module.DIBuilder.CreateStructType(
+            var concreteType = dIBuilder.CreateStructType(
                 scope: scope,
                 name: sourceName,
                 file: file,
                 line: line,
-                bitSize: bitSize ?? module.Layout.BitSizeOf(this.NativeType),
+                bitSize: bitSize ?? dIBuilder.OwningModule.Layout.BitSizeOf(this.NativeType),
                 bitAlign: bitAlignment,
                 debugFlags: debugFlags,
                 derivedFrom: derivedFrom,
@@ -77,7 +77,7 @@ namespace Ubiquity.NET.Llvm.DebugInfo
 
         /// <summary>Initializes a new instance of the <see cref="DebugStructType"/> class.</summary>
         /// <param name="llvmType">LLVM native type to build debug information for</param>
-        /// <param name="module">Module to contain the debug meta data</param>
+        /// <param name="dIBuilder"><see cref="DebugInfoBuilder"/> to use when constructing debug info</param>
         /// <param name="scope">Debug scope for the structure</param>
         /// <param name="name">Source/debug name of the struct (use <see cref="string.Empty"/> for anonymous types)</param>
         /// <param name="file">File containing the definition of this type</param>
@@ -88,7 +88,7 @@ namespace Ubiquity.NET.Llvm.DebugInfo
         /// <param name="bitAlignment">Alignment of the type in bits, 0 indicates default for target</param>
         public DebugStructType(
             IStructType llvmType,
-            BitcodeModule module,
+            DebugInfoBuilder dIBuilder,
             DIScope? scope,
             string name,
             DIFile? file,
@@ -99,12 +99,12 @@ namespace Ubiquity.NET.Llvm.DebugInfo
             uint bitAlignment = 0)
             : base(
                 llvmType,
-                module.DIBuilder.CreateStructType(
+                dIBuilder.CreateStructType(
                       scope,
                       name,
                       file,
                       line,
-                      module.Layout.BitSizeOf(llvmType),
+                      dIBuilder.OwningModule.Layout.BitSizeOf(llvmType),
                       bitAlignment,
                       debugFlags,
                       derivedFrom,
@@ -114,7 +114,7 @@ namespace Ubiquity.NET.Llvm.DebugInfo
 
         /// <summary>Initializes a new instance of the <see cref="DebugStructType"/> class.</summary>
         /// <param name="llvmType">LLVM native type to build debug information for</param>
-        /// <param name="module">Module to contain the debug meta data</param>
+        /// <param name="dIBuilder"><see cref="DebugInfoBuilder"/> to use when constructing debug meta data</param>
         /// <param name="scope">Debug scope for the structure</param>
         /// <param name="name">Source/debug name of the struct (use <see cref="string.Empty"/> for anonymous types)</param>
         /// <param name="file">File containing the definition of this type</param>
@@ -125,14 +125,14 @@ namespace Ubiquity.NET.Llvm.DebugInfo
         /// </remarks>
         public DebugStructType(
             IStructType llvmType,
-            BitcodeModule module,
+            DebugInfoBuilder dIBuilder,
             DIScope? scope,
             string name,
             DIFile? file,
             uint line)
             : base(
                 llvmType,
-                module.DIBuilder
+                dIBuilder
                           .CreateReplaceableCompositeType(
                               Tag.StructureType,
                               name,
@@ -143,7 +143,7 @@ namespace Ubiquity.NET.Llvm.DebugInfo
         }
 
         /// <summary>Initializes a new instance of the <see cref="DebugStructType"/> class.</summary>
-        /// <param name="module">Module to contain the debug meta data</param>
+        /// <param name="dIBuilder"><see cref="DebugInfoBuilder"/> to contain the debug meta data</param>
         /// <param name="nativeName">Name of the type in LLVM IR</param>
         /// <param name="scope">Debug scope for the structure</param>
         /// <param name="name">Source/debug name of the struct (use <see cref="string.Empty"/> for anonymous types)</param>
@@ -154,15 +154,15 @@ namespace Ubiquity.NET.Llvm.DebugInfo
         /// definition of the type
         /// </remarks>
         public DebugStructType(
-            BitcodeModule module,
+            DebugInfoBuilder dIBuilder,
             string nativeName,
             DIScope? scope,
             string name,
             DIFile? file = null,
             uint line = 0)
             : this(
-                module.Context.CreateStructType(nativeName),
-                module,
+                dIBuilder.OwningModule.Context.CreateStructType(nativeName),
+                dIBuilder,
                 scope,
                 name,
                 file,
@@ -199,7 +199,7 @@ namespace Ubiquity.NET.Llvm.DebugInfo
 
         /// <summary>Set the body of a type</summary>
         /// <param name="packed">Flag to indicate if the body elements are packed (e.g. no padding)</param>
-        /// <param name="module">Module to contain the debug metadata for the type</param>
+        /// <param name="dIBuilder"><see cref="DebugInfoBuilder"/> to contain debug meta data for the type</param>
         /// <param name="scope">Scope containing this type</param>
         /// <param name="file">File containing the type</param>
         /// <param name="line">Line in <paramref name="file"/> for this type</param>
@@ -207,7 +207,7 @@ namespace Ubiquity.NET.Llvm.DebugInfo
         /// <param name="debugElements">Descriptors for all the elements in the type</param>
         public void SetBody(
             bool packed,
-            BitcodeModule module,
+            DebugInfoBuilder dIBuilder,
             DIScope? scope,
             DIFile? file,
             uint line,
@@ -216,12 +216,12 @@ namespace Ubiquity.NET.Llvm.DebugInfo
         {
             var debugMembersArray = debugElements as IList<DebugMemberInfo> ?? debugElements.ToList();
             var nativeElements = debugMembersArray.Select(e => e.DebugType.NativeType);
-            this.SetBody(packed, module, scope, file, line, debugFlags, nativeElements, debugMembersArray);
+            this.SetBody(packed, dIBuilder, scope, file, line, debugFlags, nativeElements, debugMembersArray);
         }
 
         /// <summary>Set the body of a type</summary>
         /// <param name="packed">Flag to indicate if the body elements are packed (e.g. no padding)</param>
-        /// <param name="module">Module to contain the debug metadata for the type</param>
+        /// <param name="dIBuilder"><see cref="DebugInfoBuilder"/> to use when constructing debug info for the type</param>
         /// <param name="scope">Scope containing this type</param>
         /// <param name="file">File containing the type</param>
         /// <param name="line">Line in <paramref name="file"/> for this type</param>
@@ -233,7 +233,7 @@ namespace Ubiquity.NET.Llvm.DebugInfo
         /// <param name="bitAlignment">Alignment of the type in bits, 0 indicates default for target</param>
         public void SetBody(
             bool packed,
-            BitcodeModule module,
+            DebugInfoBuilder dIBuilder,
             DIScope? scope,
             DIFile? file,
             uint line,
@@ -247,14 +247,14 @@ namespace Ubiquity.NET.Llvm.DebugInfo
             this.DebugMembers = new ReadOnlyCollection<DebugMemberInfo>(debugElements as IList<DebugMemberInfo> ?? debugElements.ToList());
             this.SetBody(packed, nativeElements.ToArray());
             var memberTypes = from memberInfo in this.DebugMembers
-                              select this.CreateMemberType(module, memberInfo);
+                              select this.CreateMemberType(dIBuilder, memberInfo);
 
-            var concreteType = module.DIBuilder.CreateStructType(
+            var concreteType = dIBuilder.CreateStructType(
                 scope: scope,
                 name: this.DIType?.Name ?? string.Empty,
                 file: file,
                 line: line,
-                bitSize: bitSize ?? module.Layout.BitSizeOf(this.NativeType),
+                bitSize: bitSize ?? dIBuilder.OwningModule.Layout.BitSizeOf(this.NativeType),
                 bitAlign: bitAlignment,
                 debugFlags: debugFlags,
                 derivedFrom: derivedFrom,
@@ -265,7 +265,7 @@ namespace Ubiquity.NET.Llvm.DebugInfo
         /// <summary>Gets a list of descriptors for each members</summary>
         public IReadOnlyList<DebugMemberInfo> DebugMembers { get; private set; } = new List<DebugMemberInfo>().AsReadOnly();
 
-        private DIDerivedType CreateMemberType(BitcodeModule module, DebugMemberInfo memberInfo)
+        private DIDerivedType CreateMemberType(DebugInfoBuilder dIBuilder, DebugMemberInfo memberInfo)
         {
             if (this.DIType == null)
             {
@@ -277,7 +277,7 @@ namespace Ubiquity.NET.Llvm.DebugInfo
             ulong bitOffset;
 
             // if explicit layout info provided, use it;
-            // otherwise use module.Layout as the default
+            // otherwise use dIBuilder.OwningModule.Layout as the default
             if (memberInfo.ExplicitLayout != null)
             {
                 bitSize = memberInfo.ExplicitLayout.BitSize;
@@ -286,12 +286,12 @@ namespace Ubiquity.NET.Llvm.DebugInfo
             }
             else
             {
-                bitSize = module.Layout.BitSizeOf(memberInfo.DebugType.NativeType);
+                bitSize = dIBuilder.OwningModule.Layout.BitSizeOf(memberInfo.DebugType.NativeType);
                 bitAlign = 0;
-                bitOffset = module.Layout.BitOffsetOfElement(this.NativeType, memberInfo.Index);
+                bitOffset = dIBuilder.OwningModule.Layout.BitOffsetOfElement(this.NativeType, memberInfo.Index);
             }
 
-            return module.DIBuilder.CreateMemberType(
+            return dIBuilder.CreateMemberType(
                 scope: this.DIType,
                 name: memberInfo.Name,
                 file: memberInfo.File,

--- a/src/QsCompiler/LlvmBindings/DebugInfo/DebugType.cs
+++ b/src/QsCompiler/LlvmBindings/DebugInfo/DebugType.cs
@@ -26,7 +26,7 @@ namespace Ubiquity.NET.Llvm.DebugInfo
     /// type. (e.g. unsigned char, char, byte and signed byte might all be 8 bit integer values as far
     /// as LLVM is concerned.) Also, when using the pointer+alloca+memcpy pattern to pass by value the
     /// actual source debug info type is different than the LLVM function signature. This interface and
-    /// it's implementations are used to construct native type and debug info pairing to allow applications
+    /// its implementations are used to construct native type and debug info pairing to allow applications
     /// to maintain a link from their AST or IR types into the LLVM native type and debug information.
     /// </para>
     /// <note type="note">
@@ -48,17 +48,17 @@ namespace Ubiquity.NET.Llvm.DebugInfo
         TDebug? DIType { get; }
 
         /// <summary>Creates a pointer to this type for a given module and address space</summary>
-        /// <param name="bitcodeModule">Module the debug type information belongs to</param>
+        /// <param name="dIBuilder"><see cref="DebugInfoBuilder"/> the debug type info belongs to</param>
         /// <param name="addressSpace">Address space for the pointer</param>
         /// <returns><see cref="DebugPointerType"/></returns>
-        DebugPointerType CreatePointerType(BitcodeModule bitcodeModule, uint addressSpace);
+        DebugPointerType CreatePointerType(DebugInfoBuilder dIBuilder, uint addressSpace);
 
         /// <summary>Creates a type defining an array of elements of this type</summary>
-        /// <param name="bitcodeModule">Module the debug information belongs to</param>
+        /// <param name="dIBuilder"><see cref="DebugInfoBuilder"/> the debug type info belongs to</param>
         /// <param name="lowerBound">Lower bound of the array</param>
         /// <param name="count">Count of elements in the array</param>
         /// <returns><see cref="DebugArrayType"/></returns>
-        DebugArrayType CreateArrayType(BitcodeModule bitcodeModule, uint lowerBound, uint count);
+        DebugArrayType CreateArrayType(DebugInfoBuilder dIBuilder, uint lowerBound, uint count);
     }
 
     /// <summary>Base class for Debug types bound with an LLVM type</summary>
@@ -168,7 +168,7 @@ namespace Ubiquity.NET.Llvm.DebugInfo
         public IPointerType CreatePointerType(uint addressSpace) => this.NativeType.CreatePointerType(addressSpace);
 
         /// <inheritdoc/>
-        public DebugPointerType CreatePointerType(BitcodeModule bitcodeModule, uint addressSpace)
+        public DebugPointerType CreatePointerType(DebugInfoBuilder dIBuilder, uint addressSpace)
         {
             if (this.DIType == null)
             {
@@ -176,11 +176,11 @@ namespace Ubiquity.NET.Llvm.DebugInfo
             }
 
             var nativePointer = this.NativeType.CreatePointerType(addressSpace);
-            return new DebugPointerType(nativePointer, bitcodeModule, this.DIType, string.Empty);
+            return new DebugPointerType(nativePointer, dIBuilder, this.DIType, string.Empty);
         }
 
         /// <inheritdoc/>
-        public DebugArrayType CreateArrayType(BitcodeModule bitcodeModule, uint lowerBound, uint count)
+        public DebugArrayType CreateArrayType(DebugInfoBuilder dIBuilder, uint lowerBound, uint count)
         {
             if (this.DIType == null)
             {
@@ -188,7 +188,7 @@ namespace Ubiquity.NET.Llvm.DebugInfo
             }
 
             var llvmArray = this.NativeType.CreateArrayType(count);
-            return new DebugArrayType(llvmArray, bitcodeModule, this.DIType, count, lowerBound);
+            return new DebugArrayType(llvmArray, dIBuilder, this.DIType, count, lowerBound);
         }
 
         /// <inheritdoc/>

--- a/src/QsCompiler/LlvmBindings/Instructions/InstructionBuilder.cs
+++ b/src/QsCompiler/LlvmBindings/Instructions/InstructionBuilder.cs
@@ -7,9 +7,9 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using LLVMSharp.Interop;
+using Ubiquity.NET.Llvm.DebugInfo;
 using Ubiquity.NET.Llvm.Types;
 using Ubiquity.NET.Llvm.Values;
 
@@ -36,6 +36,27 @@ namespace Ubiquity.NET.Llvm.Instructions
 
         /// <summary>Gets the context this builder is creating instructions for.</summary>
         public Context Context { get; }
+
+        /// <summary>Set the current debug location for this <see cref="InstructionBuilder"/></summary>
+        /// <param name="line">1-based line number</param>
+        /// <param name="column">1-based column number</param>
+        /// <param name="scope"><see cref="DIScope"/> for the location</param>
+        /// <param name="inlinedAt"><see cref="DILocation"/>the location is inlined into</param>
+        /// <returns>This builder for fluent API usage</returns>
+        public InstructionBuilder SetDebugLocation(uint line, uint column, DILocalScope scope, DILocation? inlinedAt = null)
+        {
+            var loc = new DILocation(this.Context, line, column, scope, inlinedAt);
+            return this.SetDebugLocation(loc);
+        }
+
+        /// <summary>Set the current debug location for this <see cref="InstructionBuilder"/></summary>
+        /// <param name="location">Location to set</param>
+        /// <returns>This builder for fluent API usage</returns>
+        private InstructionBuilder SetDebugLocation(DILocation? location)
+        {
+            LLVM.SetCurrentDebugLocation2(this.BuilderHandle, location?.MetadataHandle ?? default);
+            return this;
+        }
 
         /// <summary>Gets the <see cref="BasicBlock"/> this builder is building instructions for.</summary>
         public BasicBlock? InsertBlock

--- a/src/QsCompiler/LlvmBindings/LLVMSharpExtensions/LLVMContextRefExtensions.cs
+++ b/src/QsCompiler/LlvmBindings/LLVMSharpExtensions/LLVMContextRefExtensions.cs
@@ -1,0 +1,17 @@
+// <copyright file="LLVMContextRefExtensions.cs" company="Ubiquity.NET Contributors">
+// Copyright (c) Ubiquity.NET Contributors. All rights reserved.
+// Portions Copyright (c) Microsoft Corporation
+// </copyright>
+
+namespace LLVMSharp.Interop
+{
+    /// <summary>Extensions for <see cref="LLVMContextRef"/>.</summary>
+    public static unsafe class LLVMContextRefExtensions
+    {
+        /// <summary>Convenience wrapper for <see cref="LLVMContextRef.GetMDString(string, uint)"/>.</summary>
+        public static LLVMValueRef GetMDString(this LLVMContextRef self, string str)
+        {
+            return self.GetMDString(str, (uint)str.Length);
+        }
+    }
+}

--- a/src/QsCompiler/LlvmBindings/LLVMSharpExtensions/LLVMModuleRefExtensions.cs
+++ b/src/QsCompiler/LlvmBindings/LLVMSharpExtensions/LLVMModuleRefExtensions.cs
@@ -68,9 +68,12 @@ namespace LLVMSharp.Interop
         }
 
         /// <summary>Convenience wrapper for <see cref="LLVM.AddModuleFlag"/>.</summary>
-        public static void AddModuleFlag(this LLVMModuleRef self, LLVMModuleFlagBehavior behavior, string key, LLVMMetadataRef val)
+        /// <remarks>When we update LLVMSharp to include the updates from this PR (https://github.com/microsoft/LLVMSharp/pull/181/files),
+        /// we can remove this wrapper</remarks>
+        public static void AddModuleFlag(this LLVMModuleRef self, string key, LLVMModuleFlagBehavior behavior, uint val)
         {
-            LLVM.AddModuleFlag(self, behavior, key.AsMarshaledString(), (UIntPtr)key.Length, val);
+            LLVMOpaqueMetadata* valAsMetadata = LLVM.ValueAsMetadata(LLVMValueRef.CreateConstInt(LLVMTypeRef.Int32, val));
+            LLVM.AddModuleFlag(self, behavior, key.AsMarshaledString(), (UIntPtr)key.Length, valAsMetadata);
         }
 
         /// <summary>Convenience wrapper for <see cref="LLVM.GetIntrinsicDeclaration"/>.</summary>

--- a/src/QsCompiler/QirGeneration/DebugInfoManager.cs
+++ b/src/QsCompiler/QirGeneration/DebugInfoManager.cs
@@ -1,0 +1,585 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using Microsoft.Quantum.QIR.Emission;
+using Microsoft.Quantum.QsCompiler.DataTypes;
+using Microsoft.Quantum.QsCompiler.SyntaxTokens;
+using Microsoft.Quantum.QsCompiler.SyntaxTree;
+using Ubiquity.NET.Llvm;
+using Ubiquity.NET.Llvm.DebugInfo;
+using Ubiquity.NET.Llvm.Instructions;
+using Ubiquity.NET.Llvm.Types;
+using Ubiquity.NET.Llvm.Values;
+
+namespace Microsoft.Quantum.QsCompiler.QIR
+{
+    using ResolvedTypeKind = QsTypeKind<ResolvedType, UserDefinedType, QsTypeParameter, CallableInformation>;
+
+    /// <summary>
+    /// This class holds shared utility routines for generating QIR debug information.
+    /// It contains a reference to the GenerationContext that owns it because it needs
+    /// access to the same shared state represented by the GenerationContext.
+    /// </summary>
+    internal sealed class DebugInfoManager
+    {
+        private static class Config
+        {
+            /// <summary>
+            /// Whether or not to emit debug information during QIR generation
+            /// </summary>
+            public static bool EnableDebugSymbols { get; set; } = false;
+
+            /// <summary>
+            /// Dwarf version we are using for the debug info in the QIR generation
+            /// </summary>
+            public static uint DwarfVersion => 4;
+
+            /// <summary>
+            /// Title of the CodeView module flag for debug info
+            /// </summary>
+            public static string CodeviewName => "CodeView";
+
+            /// <summary>
+            /// CodeView version we are using for the debug info in the QIR generation
+            /// </summary>
+            public static uint CodeviewVersion => 1;
+
+            /// <summary>
+            /// The source language information for Dwarf.
+            /// For now, we are using the C interface. Ideally this would be a user defined language for Q#.
+            /// </summary>
+            public static SourceLanguage QSharpLanguage => SourceLanguage.C99;
+
+            /// <summary>
+            /// Returns a string representing the producer information for the QIR
+            /// </summary>
+            public static string QirProducerIdentifier =>
+                $"{CompilationLoader.QSharpCompilerAssemblyName.Name} with {DebugInfoProducerAssemblyName.Name} V {DebugInfoProducerAssemblyName.Version}";
+        }
+
+        private static AssemblyName DebugInfoProducerAssemblyName => Assembly.GetExecutingAssembly().GetName();
+
+        /// <summary><see cref="DebugPosition"/> represents a line/col position in source code and is 1-based.</summary>
+        /// <summary>If a column number is not provided, 1 is used.</summary>
+        private class DebugPosition
+        {
+            public uint Line { get; set; }
+
+            public uint Column { get; set; }
+
+            private DebugPosition(uint line, uint col)
+            {
+                this.Line = line;
+                this.Column = col;
+            }
+
+            public static DebugPosition FromZeroBased(uint line, uint col)
+            {
+                return new DebugPosition(line + 1, col + 1);
+            }
+
+            public static DebugPosition FromZeroBased(int line, int col)
+            {
+                return FromZeroBased((uint)line, (uint)col);
+            }
+
+            public static DebugPosition FromZeroBasedLine(uint line)
+            {
+                return new DebugPosition(line + 1, 1);
+            }
+
+            public static DebugPosition FromZeroBasedLine(int line)
+            {
+                return FromZeroBasedLine((uint)line);
+            }
+        }
+
+        /// <summary>
+        /// Converts from a 0-based <see cref="Position"/> to a 1-based <see cref="DebugPosition"/>.
+        /// </summary>
+        /// <param name="position">The 0-based <see cref="Position"/></param>
+        /// <return>The 1-based <see cref="DebugPosition"/></return>
+        private static DebugPosition ConvertToDebugPosition(Position position)
+        {
+            return DebugPosition.FromZeroBased(position.Line, position.Column);
+        }
+
+        public static string DebugTypeNotSupportedMessage => "This debug type is not yet supported";
+
+        /// <summary>
+        /// Contains the location information for the statement nodes we are currently parsing
+        /// </summary>
+        internal Stack<QsLocation?> StatementLocationStack { get; }
+
+        /// <summary>
+        /// Contains the location information for the Expression we are inside
+        /// </summary>
+        internal Stack<DataTypes.Range?> ExpressionRangeStack { get; }
+
+        /// <summary>
+        /// Contains the location information for the namespace element we are inside
+        /// </summary>
+        internal QsLocation? CurrentNamespaceElementLocation { get; set; }
+
+        /// <summary>
+        /// The GenerationContext that owns this DebugInfoManager
+        /// </summary>
+        private readonly GenerationContext sharedState;
+
+        /// <summary>
+        /// Contains the DIBuilders included in the module related to this DebugInfoManager.
+        /// The key is the source file path of the DebugInfoBuilder's compile unit
+        /// </summary>
+        private readonly Dictionary<string, DebugInfoBuilder> dIBuilders;
+
+        /// <summary>
+        /// Constructs a DebugInfoManager with access to the <see cref="GenerationContext"/> as the shared state.
+        /// </summary>
+        internal DebugInfoManager(GenerationContext generationContext, bool enableDebugSymbols)
+        {
+            this.sharedState = generationContext;
+            Config.EnableDebugSymbols = enableDebugSymbols;
+            this.StatementLocationStack = new Stack<QsLocation?>();
+            this.ExpressionRangeStack = new Stack<DataTypes.Range?>();
+            this.dIBuilders = new Dictionary<string, DebugInfoBuilder>();
+        }
+
+        /// <summary>
+        /// If <see cref="Config.EnableDebugSymbols"/> is set to true, creates and adds top level debug info to the module.
+        /// Note: because this is called from within the constructor of the GenerationContext,
+        /// we cannot access this.Module or anything else that uses <see cref="sharedState"/>.
+        /// </summary>
+        /// <param name="owningModule">The <see cref="BitcodeModule"/> that this DebugInfoManager is related to</param>
+        internal void AddTopLevelDebugInfo(BitcodeModule owningModule)
+        {
+            if (!Config.EnableDebugSymbols)
+            {
+                return;
+            }
+
+            // Add Module identity and Module Flags
+            owningModule.AddProducerIdentMetadata(Config.QirProducerIdentifier);
+            owningModule.AddModuleFlag(ModuleFlagBehavior.Warning, BitcodeModule.DwarfVersionValue, Config.DwarfVersion);
+            owningModule.AddModuleFlag(ModuleFlagBehavior.Warning, BitcodeModule.DebugVersionValue, BitcodeModule.DebugMetadataVersion);
+            owningModule.AddModuleFlag(ModuleFlagBehavior.Warning, Config.CodeviewName, Config.CodeviewVersion);
+        }
+
+        /// <summary>
+        /// Makes the necessary calls to finalize the <see cref="DebugInfoBuilder"/>s.
+        /// </summary>
+        internal void FinalizeDebugInfo()
+        {
+            if (!Config.EnableDebugSymbols)
+            {
+                return;
+            }
+
+            foreach (KeyValuePair<string, DebugInfoBuilder> entry in this.dIBuilders)
+            {
+                entry.Value.Finish(); // must be called for every DIBuilder after all QIR generation
+            }
+        }
+
+        /// <summary>
+        /// If <see cref="Config.EnableDebugSymbols"/> is set to true, emits a location allowing for a breakpoint when debugging. Expects a 0-based <see cref="Position"/>
+        /// relative to the namespace and statement stack of parent <see cref="QsStatement"/>s,
+        /// which is converted to a 1-based <see cref="DebugPosition"/>.
+        /// </summary>
+        /// <param name="relativePosition">The 0-based <see cref="Position"/> at which to emit the location
+        /// relative to the namespace and stack of parent <see cref="QsStatement"/>s.</param>
+        internal void EmitLocationWithOffset(Position? relativePosition)
+        {
+            if (!Config.EnableDebugSymbols)
+            {
+                return;
+            }
+
+            DISubProgram? subProgram = this.sharedState.CurrentFunction?.DISubProgram;
+            QsLocation? namespaceLocation = this.sharedState.DIManager.CurrentNamespaceElementLocation;
+
+            if (namespaceLocation != null && relativePosition != null && subProgram != null)
+            {
+                Position absolutePosition = namespaceLocation.Offset + this.TotalOffsetFromStatements() + relativePosition;
+                this.EmitLocation(absolutePosition, subProgram);
+            }
+        }
+
+        /// <summary>
+        /// If <see cref="Config.EnableDebugSymbols"/> is set to true, emits the current location allowing for a breakpoint when debugging.
+        /// </summary>
+        internal void EmitLocation()
+        {
+            if (!Config.EnableDebugSymbols)
+            {
+                return;
+            }
+
+            this.EmitLocationWithOffset(Position.Zero);
+        }
+
+        /// <summary>
+        /// If the debug flag is set to true, this creates the debug information for a local variable.
+        /// </summary>
+        /// <param name="name">The name of the local variable.</param>
+        /// <param name="value">The value of the variable.</param>
+        internal void CreateLocalVariable(string name, IValue value, bool isMutableBinding)
+        {
+            if (!Config.EnableDebugSymbols)
+            {
+                return;
+            }
+
+            // Get the DebugInfoBuilder for this variable
+            DISubProgram? subProgram = this.sharedState.CurrentFunction?.DISubProgram;
+            string? sourcePath = subProgram?.File?.Path;
+            if (string.IsNullOrEmpty(sourcePath))
+            {
+                return;
+            }
+
+            DebugInfoBuilder dIBuilder = this.GetOrCreateDIBuilder(sourcePath);
+
+            // Get the type information for the variable
+            ResolvedType? resType = value.QSharpType;
+            DIType? dIType = resType == null ? null : this.DebugTypeFromQsharpType(resType, dIBuilder)?.DIType;
+
+            // Get the location information for the variable declaration
+            QsLocation? namespaceLocation = this.CurrentNamespaceElementLocation;
+            Position namespaceOffset = namespaceLocation?.Offset ?? Position.Zero;
+            Position absolutePosition = namespaceOffset + this.TotalOffsetFromStatements() + this.TotalOffsetFromExpressions();
+
+            // LLVM Native API has a bug and will crash if we pass in a null dIType
+            // for either CreateLocalVariable or InsertDeclare (https://bugs.llvm.org/show_bug.cgi?id=52459)
+            if (subProgram != null && dIType != null)
+            {
+                if (dIType.Name.Equals(DebugTypeNotSupportedMessage))
+                {
+                    name += " [value display for this type is not currently supported]";
+                }
+
+                DebugPosition debugLocation = ConvertToDebugPosition(absolutePosition);
+
+                // create the debug info for the local variable
+                DILocalVariable dIVar = dIBuilder.CreateLocalVariable(
+                    subProgram,
+                    name,
+                    dIBuilder.CompileUnit?.File,
+                    debugLocation.Line,
+                    dIType,
+                    alwaysPreserve: true,
+                    DebugInfoFlags.None);
+
+                DILocation dILocation = new DILocation(
+                    this.Context,
+                    debugLocation.Line,
+                    debugLocation.Column,
+                    subProgram);
+
+                if (this.sharedState.CurrentBlock != null)
+                {
+                    if (isMutableBinding)
+                    {
+                        // variable is represented as a pointer to the value
+                        Value variable = ((PointerValue)value).Pointer;
+
+                        // InsertDeclare because we have a pointer to the value
+                        dIBuilder.InsertDeclare(
+                            storage: variable,
+                            varInfo: dIVar,
+                            location: dILocation,
+                            insertAtEnd: this.sharedState.CurrentBlock);
+                    }
+                    else
+                    {
+                        // variable is represented as the value itself
+                        Value variable = value.Value;
+
+                        // InsertValue because we have the value itself
+                        dIBuilder.InsertValue(
+                            value: variable,
+                            varInfo: dIVar,
+                            location: dILocation,
+                            insertAtEnd: this.sharedState.CurrentBlock);
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Creates a global function. If debug symbols are enabled and we support the debug information
+        /// for the given specialization kind, we include debug information with the global function.
+        /// Currently, debug symbols are only enabled for body functions.
+        /// </summary>
+        /// <param name="spec">The <see cref="QsSpecialization"/> for the function.</param>
+        /// <param name="mangledName">The mangled name for the function.</param>
+        /// <param name="signature">The signature for the function.</param>
+        /// <returns>The <see cref="IrFunction"/> corresponding to the given Q# type.</returns>
+        internal IrFunction CreateGlobalFunction(QsSpecialization spec, string mangledName, IFunctionType signature)
+        {
+            if (spec.Kind == QsSpecializationKind.QsBody && Config.EnableDebugSymbols)
+            {
+                return this.CreateFunctionWithDebugInfo(spec, mangledName, signature);
+            }
+            else
+            {
+                return this.CreateFunctionNoDebug(mangledName, signature);
+            }
+        }
+
+        /// <summary>
+        /// Creates a global function. Includes debug information with the global function.
+        /// </summary>
+        /// <param name="spec">The <see cref="QsSpecialization"/> for the function.</param>
+        /// <param name="mangledName">The mangled name for the function.</param>
+        /// <param name="signature">The signature for the function.</param>
+        /// <returns>The <see cref="IrFunction"/> corresponding to the given Q# type.</returns>
+        private IrFunction CreateFunctionWithDebugInfo(QsSpecialization spec, string mangledName, IFunctionType signature)
+        {
+            // set up the DIBuilder
+            string sourcePath = spec.Source.CodeFile;
+            DebugInfoBuilder curDIBuilder = this.GetOrCreateDIBuilder(sourcePath);
+            DIFile debugFile = curDIBuilder.CreateFile(sourcePath);
+
+            // set up debug info for the function
+            IDebugType<ITypeRef, DIType>? retDebugType;
+            IDebugType<ITypeRef, DIType>?[] argDebugTypes;
+            retDebugType = this.DebugTypeFromQsharpType(spec.Signature.ReturnType, curDIBuilder);
+            argDebugTypes = spec.Signature.ArgumentType.Resolution is ResolvedTypeKind.TupleType ts ?
+                ts.Item.Select(t => this.DebugTypeFromQsharpType(t, curDIBuilder)).ToArray() :
+                new IDebugType<ITypeRef, DIType>?[] { this.DebugTypeFromQsharpType(spec.Signature.ArgumentType, curDIBuilder) };
+            string shortName = spec.Parent.Name;
+
+            // Get the location info
+            QsNullable<QsLocation> debugLocation = spec.Location;
+            if (debugLocation.IsNull)
+            {
+                return this.CreateFunctionNoDebug(mangledName, signature);
+            }
+
+            Position absolutePosition = debugLocation.Item.Offset; // the position stored in a QsSpecialization is absolute, not relative to the ancestor namespace and statements
+
+                // checking the debug types for null ensures we have valid debug info
+            if (retDebugType != null && !argDebugTypes.Contains(null))
+            {
+                DebugPosition debugPosition = ConvertToDebugPosition(absolutePosition);
+
+                // create the function with debug info
+                DebugFunctionType debugSignature = new DebugFunctionType(signature, curDIBuilder, DebugInfoFlags.None, retDebugType, argDebugTypes!);
+                IrFunction func = this.Module.CreateFunction(
+                    scope: curDIBuilder.CompileUnit,
+                    name: shortName,
+                    mangledName: mangledName,
+                    file: debugFile,
+                    line: debugPosition.Line,
+                    signature: debugSignature,
+                    isLocalToUnit: true, // we're using the compile unit from the source file this was declared in
+                    isDefinition: true, // if this isn't set to true, it results in temporary metadata nodes that don't get resolved.
+                    scopeLine: debugPosition.Line,
+                    debugFlags: DebugInfoFlags.None,
+                    isOptimized: false,
+                    curDIBuilder);
+
+                return func;
+            }
+            else
+            {
+                return this.CreateFunctionNoDebug(mangledName, signature);
+            }
+        }
+
+        /// <summary>
+        /// Creates the debug info for a function argument.
+        /// </summary>
+        /// <param name="spec">The function's <see cref="QsSpecialization"/></param>
+        /// <param name="name">The name of the function's argument.</param>
+        /// <param name="value">The value of the function's argument.</param>
+        /// <param name="argNo">The index of the argument (expected to be 1-indexed).</param>
+        internal void CreateFunctionArgument(QsSpecialization spec, string name, IValue value, int argNo)
+        {
+            if (!Config.EnableDebugSymbols)
+            {
+                return;
+            }
+
+            // get the DIBuilder
+            string sourcePath = spec.Source.CodeFile;
+            DebugInfoBuilder curDIBuilder = this.GetOrCreateDIBuilder(sourcePath);
+            DIFile debugFile = curDIBuilder.CreateFile(sourcePath);
+
+            // get the debug location of the function
+            QsNullable<QsLocation> debugLocation = spec.Location;
+            if (debugLocation.IsNull)
+            {
+                throw new ArgumentException("Expected a specialiazation with a non-null location");
+            }
+
+            // the position stored in a QsSpecialization is absolute, not relative to the ancestor namespace and statements
+            DebugPosition debugPosition = DebugPosition.FromZeroBasedLine(debugLocation.Item.Offset.Line);
+
+            // get necessary debug information
+            DIType? dIType = this.DebugTypeFromQsharpType(value.QSharpType, curDIBuilder)?.DIType;
+            DISubProgram? subProgram = this.sharedState.CurrentFunction?.DISubProgram;
+            DILocalVariable dIVariable = curDIBuilder.CreateArgument(
+                subProgram,
+                name,
+                debugFile,
+                debugPosition.Line,
+                dIType,
+                alwaysPreserve: true,
+                DebugInfoFlags.None,
+                (ushort)argNo); // arg numbers are 1-indexed
+
+            if (this.sharedState.CurrentBlock != null && dIType != null && subProgram != null)
+            {
+                DILocation dILocation = new DILocation(
+                    this.Context,
+                    debugPosition.Line,
+                    debugPosition.Column,
+                    subProgram);
+
+                // all arguments are passed by value
+                Value variable = value.Value;
+                curDIBuilder.InsertValue(
+                    value: variable,
+                    varInfo: dIVariable,
+                    location: dILocation,
+                    insertAtEnd: this.sharedState.CurrentBlock);
+            }
+        }
+
+        /// <summary>
+        /// Gets the DebugInfoBuilder with a CompileUnit associated with this source file if it has already been created,
+        /// Creates a DebugInfoBuilder with a CompileUnit associated with this source file otherwise.
+        /// </summary>
+        /// <param name="sourcePath">The source file's path for this compile unit</param>
+        /// <returns>The compile unit related to this source file</returns>
+        private DebugInfoBuilder GetOrCreateDIBuilder(string sourcePath)
+        {
+            DebugInfoBuilder di;
+            if (this.dIBuilders.TryGetValue(sourcePath, out di))
+            {
+                return di;
+            }
+            else
+            {
+                di = this.Module.CreateDIBuilder();
+                di.CreateCompileUnit(
+                    Config.QSharpLanguage,
+                    sourcePath,
+                    Config.QirProducerIdentifier,
+                    null);
+                this.dIBuilders.Add(sourcePath, di);
+                return di;
+            }
+        }
+
+        /// <summary>
+        /// If <see cref="Config.EnableDebugSymbols"/> is set to true, creates a debug type for a particular Q# type.
+        /// The debug type connects a debug info type with its corresponding LLVM Native type.
+        /// Note: If the debug type is not implemented, ideally we would return a <see cref="DebugType"/> with a valid LLVM Native type
+        /// and a null DIType. However, this causes an error in the QIR emission because of a bug in the native LLVM API, so we return null.
+        /// </summary>
+        /// <param name="resolvedType">The Q# type to create a DebugType from.</param>
+        /// <param name="dIBuilder">The <see cref="DebugInfoBuilder"/> to use to create the debug type.</param>
+        /// <returns>The <see cref="DebugType"/> corresponding to the given Q# type. Returns null if the debug type is not implemented.</returns>
+        private IDebugType<ITypeRef, DIType>? DebugTypeFromQsharpType(ResolvedType resolvedType, DebugInfoBuilder dIBuilder)
+        {
+            if (!Config.EnableDebugSymbols)
+            {
+                return null;
+            }
+
+            return this.sharedState.Types.Transform.DebugTypeFromQsharpType(resolvedType, dIBuilder);
+        }
+
+        /// <summary>
+        /// Creates a function without debug information. Whenver the debug information
+        /// being created is invalid, not requsted, or unsupported, this should be used.
+        /// </summary>
+        /// <param name="mangledName">The mangled name for the function.</param>
+        /// <param name="signature">The signature for the function.</param>
+        /// <returns>The created <see cref="IrFunction"/> with no debug info.</returns>
+        private IrFunction CreateFunctionNoDebug(string mangledName, IFunctionType signature) => this.Module.CreateFunction(mangledName, signature);
+
+        /// <summary>
+        /// If <see cref="Config.EnableDebugSymbols"/> is set to true, emits a location allowing for a breakpoint when debugging. Expects a 0-based <see cref="Position"/>
+        /// which is converted to a 1-based <see cref="DebugPosition"/>.
+        /// </summary>
+        /// <param name="absolutePosition">The 0-based <see cref="Position"/> at which to emit the location.</param>
+        /// <param name="localScope">The <see cref="DILocalScope"/>at this location. If the argument is null,
+        /// this will not emit a location.</param>
+        private void EmitLocation(Position absolutePosition, DILocalScope? localScope)
+        {
+            if (!Config.EnableDebugSymbols)
+            {
+                return;
+            }
+
+            DebugPosition debugPosition = ConvertToDebugPosition(absolutePosition);
+            if (localScope != null)
+            {
+                this.CurrentInstrBuilder.SetDebugLocation(debugPosition.Line, debugPosition.Column, localScope);
+            }
+        }
+
+        /// <summary>
+        /// Sums up the offsets from the stack of statement locations <see cref="StatementLocationStack"/>.
+        /// </summary>
+        /// <returns>The offset that the current stack of statements yields as a <see cref="Position"/>.</returns>
+        private Position TotalOffsetFromStatements()
+        {
+            Position offset = Position.Zero;
+
+            foreach (QsLocation? loc in this.StatementLocationStack)
+            {
+                if (loc != null)
+                {
+                    offset += loc.Offset;
+                    return offset;
+                }
+            }
+
+            return offset;
+        }
+
+        /// <summary>
+        /// Sums up the offsets from the stack of expression ranges <see cref="ExpressionRangeStack"/>.
+        /// </summary>
+        /// <returns>The offset that the current stack of expression yields as a <see cref="Position"/>.</returns>
+        private Position TotalOffsetFromExpressions()
+        {
+            Position offset = Position.Zero;
+
+            foreach (DataTypes.Range? range in this.ExpressionRangeStack)
+            {
+                if (range != null)
+                {
+                    offset += range.Start;
+                }
+            }
+
+            return offset;
+        }
+
+        /// <summary>
+        /// Access to the GenerationContext's Context
+        /// </summary>
+        private Context Context => this.sharedState.Context;
+
+        /// <summary>
+        /// Access to the GenerationContext's Module
+        /// </summary>
+        private BitcodeModule Module => this.sharedState.Module;
+
+        /// <summary>
+        /// Access to the GenerationContext's Context's InstructionBuilder
+        /// </summary>
+        private InstructionBuilder CurrentInstrBuilder => this.sharedState.CurrentBuilder;
+    }
+}

--- a/src/QsCompiler/QirGeneration/DebugInfoManager.cs
+++ b/src/QsCompiler/QirGeneration/DebugInfoManager.cs
@@ -60,8 +60,10 @@ namespace Microsoft.Quantum.QsCompiler.QIR
             /// Returns a string representing the producer information for the QIR
             /// </summary>
             public static string QirProducerIdentifier =>
-                $"{CompilationLoader.QSharpCompilerAssemblyName.Name} with {DebugInfoProducerAssemblyName.Name} V {DebugInfoProducerAssemblyName.Version}";
+                $"{QSharpCompilerAssemblyName.Name} with {DebugInfoProducerAssemblyName.Name} V {DebugInfoProducerAssemblyName.Version}";
         }
+
+        private static AssemblyName QSharpCompilerAssemblyName => typeof(CompilationLoader).Assembly.GetName();
 
         private static AssemblyName DebugInfoProducerAssemblyName => Assembly.GetExecutingAssembly().GetName();
 

--- a/src/QsCompiler/QirGeneration/Generator.cs
+++ b/src/QsCompiler/QirGeneration/Generator.cs
@@ -36,7 +36,8 @@ namespace Microsoft.Quantum.QsCompiler.QIR
         /// Instantiates a transformation capable of emitting QIR for the given compilation.
         /// </summary>
         /// <param name="compilation">The compilation for which to generate QIR</param>
-        public Generator(QsCompilation compilation, bool enableDebugSymbols)
+        /// <param name="enableDebugSymbols">Emit debug symbols</param>
+        public Generator(QsCompilation compilation, bool enableDebugSymbols = false)
         : base(new GenerationContext(compilation.Namespaces, compilation.EntryPoints.Length == 0, enableDebugSymbols), TransformationOptions.NoRebuild)
         {
             this.Compilation = compilation;

--- a/src/QsCompiler/QirGeneration/Generator.cs
+++ b/src/QsCompiler/QirGeneration/Generator.cs
@@ -36,12 +36,13 @@ namespace Microsoft.Quantum.QsCompiler.QIR
         /// Instantiates a transformation capable of emitting QIR for the given compilation.
         /// </summary>
         /// <param name="compilation">The compilation for which to generate QIR</param>
-        public Generator(QsCompilation compilation)
-        : base(new GenerationContext(compilation.Namespaces, compilation.EntryPoints.Length == 0), TransformationOptions.NoRebuild)
+        public Generator(QsCompilation compilation, bool enableDebugSymbols)
+        : base(new GenerationContext(compilation.Namespaces, compilation.EntryPoints.Length == 0, enableDebugSymbols), TransformationOptions.NoRebuild)
         {
             this.Compilation = compilation;
 
             this.Namespaces = new QirNamespaceTransformation(this, TransformationOptions.NoRebuild);
+            this.Statements = new QirStatementTransformation(this, TransformationOptions.NoRebuild);
             this.StatementKinds = new QirStatementKindTransformation(this, TransformationOptions.NoRebuild);
             this.Expressions = new QirExpressionTransformation(this, TransformationOptions.NoRebuild);
             this.ExpressionKinds = new QirExpressionKindTransformation(this, TransformationOptions.NoRebuild);
@@ -73,6 +74,7 @@ namespace Microsoft.Quantum.QsCompiler.QIR
             }
 
             this.SharedState.GenerateRequiredFunctions();
+            this.SharedState.DIManager.FinalizeDebugInfo();
         }
 
         /// <summary>

--- a/src/QsCompiler/QirGeneration/QIR/DataStructures.cs
+++ b/src/QsCompiler/QirGeneration/QIR/DataStructures.cs
@@ -140,7 +140,8 @@ namespace Microsoft.Quantum.QIR.Emission
     internal class PointerValue : IValue
     {
         private readonly IValue.Cached<IValue> cachedValue;
-        private readonly Value pointer;
+
+        public Value Pointer { get; }
 
         public Value Value => this.LoadValue().Value;
 
@@ -159,16 +160,16 @@ namespace Microsoft.Quantum.QIR.Emission
         internal PointerValue(Value? pointer, ResolvedType type, GenerationContext context)
         {
             void Store(IValue v) =>
-                context.CurrentBuilder.Store(v.Value, this.pointer);
+                context.CurrentBuilder.Store(v.Value, this.Pointer);
 
             IValue Reload() =>
                 context.Values.From(
-                    context.CurrentBuilder.Load(this.LlvmType, this.pointer),
+                    context.CurrentBuilder.Load(this.LlvmType, this.Pointer),
                     this.QSharpType);
 
             this.QSharpType = type;
             this.LlvmType = context.LlvmTypeFromQsharpType(this.QSharpType);
-            this.pointer = pointer ?? context.CurrentBuilder.Alloca(this.LlvmType);
+            this.Pointer = pointer ?? context.CurrentBuilder.Alloca(this.LlvmType);
             this.cachedValue = new IValue.Cached<IValue>(context, Reload, Store);
         }
 
@@ -197,9 +198,9 @@ namespace Microsoft.Quantum.QIR.Emission
 
         void IValue.RegisterName(string name)
         {
-            if (string.IsNullOrEmpty(this.pointer.Name))
+            if (string.IsNullOrEmpty(this.Pointer.Name))
             {
-                this.pointer.RegisterName(name);
+                this.Pointer.RegisterName(name);
             }
         }
     }

--- a/src/QsCompiler/QirGeneration/QIR/DataStructures.cs
+++ b/src/QsCompiler/QirGeneration/QIR/DataStructures.cs
@@ -141,7 +141,7 @@ namespace Microsoft.Quantum.QIR.Emission
     {
         private readonly IValue.Cached<IValue> cachedValue;
 
-        public Value Pointer { get; }
+        internal Value Pointer { get; } // internal access for the purpose of generating debug symbols only
 
         public Value Value => this.LoadValue().Value;
 

--- a/src/QsCompiler/QirGeneration/RewriteSteps.cs
+++ b/src/QsCompiler/QirGeneration/RewriteSteps.cs
@@ -74,8 +74,14 @@ namespace Microsoft.Quantum.QsCompiler
         /// <inheritdoc/>
         public bool Transformation(QsCompilation compilation, out QsCompilation transformed)
         {
+            bool enableDebugSymbols = false;
+            if (this.AssemblyConstants.TryGetValue(ReservedKeywords.AssemblyConstants.EnableDebugSymbols, out string? debugEnabledString))
+            {
+                enableDebugSymbols = string.Equals(debugEnabledString?.Trim(), "true", StringComparison.OrdinalIgnoreCase);
+            }
+
             transformed = compilation;
-            using var generator = new Generator(transformed);
+            using var generator = new Generator(transformed, enableDebugSymbols);
             generator.Apply();
 
             // write generated QIR to disk

--- a/src/QsCompiler/QirGeneration/Subtransformations/ExpressionKindTransformation.cs
+++ b/src/QsCompiler/QirGeneration/Subtransformations/ExpressionKindTransformation.cs
@@ -13,6 +13,7 @@ using Microsoft.Quantum.QsCompiler.DataTypes;
 using Microsoft.Quantum.QsCompiler.SyntaxTokens;
 using Microsoft.Quantum.QsCompiler.SyntaxTree;
 using Microsoft.Quantum.QsCompiler.Transformations.Core;
+using Ubiquity.NET.Llvm.DebugInfo;
 using Ubiquity.NET.Llvm.Instructions;
 using Ubiquity.NET.Llvm.Types;
 using Ubiquity.NET.Llvm.Values;
@@ -1496,6 +1497,15 @@ namespace Microsoft.Quantum.QsCompiler.QIR
             return ResolvedExpressionKind.InvalidExpr;
         }
 
+        public override ResolvedExpressionKind OnCallLikeExpression(TypedExpression method, TypedExpression arg)
+        {
+            // create a debug location for the call
+            DataTypes.Range? relativeRange = method.Range.IsNull ? null : method.Range.Item;
+            Position? relativePosition = relativeRange?.Start;
+            this.SharedState.DIManager.EmitLocationWithOffset(relativePosition);
+            return base.OnCallLikeExpression(method, arg);
+        }
+
         public override ResolvedExpressionKind OnGreaterThan(TypedExpression lhsEx, TypedExpression rhsEx)
         {
             var lhs = this.SharedState.EvaluateSubexpression(lhsEx);
@@ -1587,6 +1597,7 @@ namespace Microsoft.Quantum.QsCompiler.QIR
             }
 
             this.SharedState.ValueStack.Push(value);
+            this.SharedState.DIManager.EmitLocation();
             return ResolvedExpressionKind.InvalidExpr;
         }
 

--- a/src/QsCompiler/QirGeneration/Subtransformations/ExpressionTransformation.cs
+++ b/src/QsCompiler/QirGeneration/Subtransformations/ExpressionTransformation.cs
@@ -33,7 +33,9 @@ namespace Microsoft.Quantum.QsCompiler.QIR
         public override TypedExpression OnTypedExpression(TypedExpression ex)
         {
             this.SharedState.ExpressionTypeStack.Push(ex.ResolvedType);
+            this.SharedState.DIManager.ExpressionRangeStack.Push(ex.Range.Item);
             var result = base.OnTypedExpression(ex);
+            this.SharedState.DIManager.ExpressionRangeStack.Pop();
             this.SharedState.ExpressionTypeStack.Pop();
             return result;
         }

--- a/src/QsCompiler/QirGeneration/Subtransformations/StatementKindTransformation.cs
+++ b/src/QsCompiler/QirGeneration/Subtransformations/StatementKindTransformation.cs
@@ -485,6 +485,7 @@ namespace Microsoft.Quantum.QsCompiler.QIR
 
                     QirExpressionKindTransformation.AccessViaLocalId(ex, out var localId);
                     this.SharedState.ScopeMgr.RegisterVariable(varName, value, fromLocalId: localId);
+                    this.SharedState.DIManager.CreateLocalVariable(varName, value, stm.Kind.IsMutableBinding);
                 };
 
             this.BindSymbolTuple(stm.Lhs, stm.Rhs, (syms, boundEx) =>

--- a/src/QsCompiler/QirGeneration/Subtransformations/StatementTransformation.cs
+++ b/src/QsCompiler/QirGeneration/Subtransformations/StatementTransformation.cs
@@ -1,0 +1,45 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Microsoft.Quantum.QsCompiler.DataTypes;
+using Microsoft.Quantum.QsCompiler.SyntaxTree;
+using Microsoft.Quantum.QsCompiler.Transformations.Core;
+
+namespace Microsoft.Quantum.QsCompiler.QIR
+{
+    internal class QirStatementTransformation : StatementTransformation<GenerationContext>
+    {
+        public QirStatementTransformation(SyntaxTreeTransformation<GenerationContext> parentTransformation)
+            : base(parentTransformation)
+        {
+        }
+
+        public QirStatementTransformation(GenerationContext sharedState)
+            : base(sharedState)
+        {
+        }
+
+        public QirStatementTransformation(SyntaxTreeTransformation<GenerationContext> parentTransformation, TransformationOptions options)
+            : base(parentTransformation, options)
+        {
+        }
+
+        public QirStatementTransformation(GenerationContext sharedState, TransformationOptions options)
+            : base(sharedState, options)
+        {
+        }
+
+        /* public overrides */
+
+        public override QsStatement OnStatement(QsStatement stm)
+        {
+            this.SharedState.DIManager.StatementLocationStack.Push(stm.Location.Item);
+
+            // create a debug location for every statement
+            this.SharedState.DIManager.EmitLocation();
+            QsStatement result = base.OnStatement(stm);
+            this.SharedState.DIManager.StatementLocationStack.Pop();
+            return result;
+        }
+    }
+}

--- a/src/QsCompiler/Tests.Compiler/TestCases/DebugInfoTests/TestBooleanVariable.qs
+++ b/src/QsCompiler/Tests.Compiler/TestCases/DebugInfoTests/TestBooleanVariable.qs
@@ -1,0 +1,10 @@
+namespace Microsoft.Quantum.Testing.QirDebugInfo {
+
+    @EntryPoint()
+    operation Main() : Bool {
+        let varX = true;
+        mutable varY = false;
+        set varY = varX;
+        return varY;
+    }
+}

--- a/src/QsCompiler/Tests.Compiler/TestCases/DebugInfoTests/TestBooleanVariable1.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/DebugInfoTests/TestBooleanVariable1.ll
@@ -1,0 +1,9 @@
+define internal i1 @Microsoft__Quantum__Testing__QirDebugInfo__Main__body() !dbg !7 {
+entry:
+  tail call void @llvm.dbg.value(metadata i1 true, metadata !13, metadata !DIExpression()), !dbg !15
+  %varY = alloca i1, align 1, !dbg !16
+  store i1 false, i1* %varY, align 1, !dbg !16
+  call void @llvm.dbg.declare(metadata i1* %varY, metadata !14, metadata !DIExpression()), !dbg !16
+  store i1 true, i1* %varY, align 1, !dbg !17
+  ret i1 true, !dbg !18
+}

--- a/src/QsCompiler/Tests.Compiler/TestCases/DebugInfoTests/TestBooleanVariable2.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/DebugInfoTests/TestBooleanVariable2.ll
@@ -1,0 +1,5 @@
+!13 = !DILocalVariable(name: "varX", scope: !7, file: !5, line: 5, type: !10)
+!14 = !DILocalVariable(name: "varY", scope: !7, file: !5, line: 6, type: !10)
+!15 = !DILocation(line: 5, column: 9, scope: !7)
+!16 = !DILocation(line: 6, column: 9, scope: !7)
+!17 = !DILocation(line: 7, column: 9, scope: !7)

--- a/src/QsCompiler/Tests.Compiler/TestCases/DebugInfoTests/TestDoubleVariable.qs
+++ b/src/QsCompiler/Tests.Compiler/TestCases/DebugInfoTests/TestDoubleVariable.qs
@@ -1,0 +1,10 @@
+namespace Microsoft.Quantum.Testing.QirDebugInfo {
+
+    @EntryPoint()
+    operation Main() : Double {
+        let varX = 42.1;
+        mutable varY = 43.3;
+        set varY = varX;
+        return varY;
+    }
+}

--- a/src/QsCompiler/Tests.Compiler/TestCases/DebugInfoTests/TestDoubleVariable1.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/DebugInfoTests/TestDoubleVariable1.ll
@@ -1,0 +1,9 @@
+define internal double @Microsoft__Quantum__Testing__QirDebugInfo__Main__body() !dbg !7 {
+entry:
+  tail call void @llvm.dbg.value(metadata double 4.210000e+01, metadata !13, metadata !DIExpression()), !dbg !15
+  %varY = alloca double, align 8, !dbg !16
+  store double 4.330000e+01, double* %varY, align 8, !dbg !16
+  call void @llvm.dbg.declare(metadata double* %varY, metadata !14, metadata !DIExpression()), !dbg !16
+  store double 4.210000e+01, double* %varY, align 8, !dbg !17
+  ret double 4.210000e+01, !dbg !18
+}

--- a/src/QsCompiler/Tests.Compiler/TestCases/DebugInfoTests/TestDoubleVariable2.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/DebugInfoTests/TestDoubleVariable2.ll
@@ -1,0 +1,5 @@
+!13 = !DILocalVariable(name: "varX", scope: !7, file: !5, line: 5, type: !10)
+!14 = !DILocalVariable(name: "varY", scope: !7, file: !5, line: 6, type: !10)
+!15 = !DILocation(line: 5, column: 9, scope: !7)
+!16 = !DILocation(line: 6, column: 9, scope: !7)
+!17 = !DILocation(line: 7, column: 9, scope: !7)

--- a/src/QsCompiler/Tests.Compiler/TestCases/DebugInfoTests/TestFunctionReturnsType.qs
+++ b/src/QsCompiler/Tests.Compiler/TestCases/DebugInfoTests/TestFunctionReturnsType.qs
@@ -1,0 +1,18 @@
+namespace Microsoft.Quantum.Testing.QirDebugInfo {
+
+    @EntryPoint()
+    operation Main() : Int {
+        let varX = 42;
+        mutable varY = IntToInt(varX);
+        set varY = ToInt();
+        return varY;
+    }
+
+    operation IntToInt(varX: Int) : Int {
+        return varX + 1;
+    }
+
+    operation ToInt() : Int {
+        return 26;
+    }
+}

--- a/src/QsCompiler/Tests.Compiler/TestCases/DebugInfoTests/TestFunctionReturnsType1.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/DebugInfoTests/TestFunctionReturnsType1.ll
@@ -1,0 +1,10 @@
+!6 = !{}
+!7 = distinct !DISubprogram(name: "IntToInt", linkageName: "Microsoft__Quantum__Testing__QirDebugInfo__IntToInt__body", scope: null, file: !5, line: 11, type: !8, scopeLine: 11, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition, unit: !4, retainedNodes: !11)
+!8 = !DISubroutineType(types: !9)
+!9 = !{!10, !10}
+!10 = !DIBasicType(name: "Int", size: 64, encoding: DW_ATE_signed)
+!11 = !{!12}
+!12 = !DILocalVariable(name: "varX", arg: 1, scope: !7, file: !5, line: 11, type: !10)
+!13 = !DILocation(line: 11, column: 1, scope: !7)
+!14 = !DILocation(line: 12, column: 9, scope: !7)
+!15 = distinct !DISubprogram(name: "Main", linkageName: "Microsoft__Quantum__Testing__QirDebugInfo__Main__body", scope: null, file: !5, line: 4, type: !16, scopeLine: 4, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition, unit: !4, retainedNodes: !19)

--- a/src/QsCompiler/Tests.Compiler/TestCases/DebugInfoTests/TestFunctionReturnsType2.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/DebugInfoTests/TestFunctionReturnsType2.ll
@@ -1,0 +1,1 @@
+!26 = distinct !DISubprogram(name: "ToInt", linkageName: "Microsoft__Quantum__Testing__QirDebugInfo__ToInt__body", scope: null, file: !5, line: 15, type: !16, scopeLine: 15, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition, unit: !4, retainedNodes: !6)

--- a/src/QsCompiler/Tests.Compiler/TestCases/DebugInfoTests/TestFunctionReturnsType3.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/DebugInfoTests/TestFunctionReturnsType3.ll
@@ -1,0 +1,3 @@
+!16 = !DISubroutineType(types: !17)
+!17 = !{!10, !18}
+!18 = !DIBasicType(name: "This debug type is not yet supported")

--- a/src/QsCompiler/Tests.Compiler/TestCases/DebugInfoTests/TestFunctionReturnsType4.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/DebugInfoTests/TestFunctionReturnsType4.ll
@@ -1,0 +1,2 @@
+!23 = !DILocation(line: 6, column: 9, scope: !15)
+!24 = !DILocation(line: 7, column: 20, scope: !15)

--- a/src/QsCompiler/Tests.Compiler/TestCases/DebugInfoTests/TestFunctionReturnsType5.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/DebugInfoTests/TestFunctionReturnsType5.ll
@@ -1,0 +1,4 @@
+define internal i64 @Microsoft__Quantum__Testing__QirDebugInfo__ToInt__body() !dbg !26 {
+entry:
+  ret i64 26, !dbg !27
+}

--- a/src/QsCompiler/Tests.Compiler/TestCases/DebugInfoTests/TestFunctionReturnsType6.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/DebugInfoTests/TestFunctionReturnsType6.ll
@@ -1,0 +1,6 @@
+define internal i64 @Microsoft__Quantum__Testing__QirDebugInfo__IntToInt__body(i64 %varX) !dbg !7 {
+entry:
+  tail call void @llvm.dbg.value(metadata i64 %varX, metadata !12, metadata !DIExpression()), !dbg !13
+  %0 = add i64 %varX, 1, !dbg !14
+  ret i64 %0, !dbg !14
+}

--- a/src/QsCompiler/Tests.Compiler/TestCases/DebugInfoTests/TestFunctionReturnsType7.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/DebugInfoTests/TestFunctionReturnsType7.ll
@@ -1,0 +1,1 @@
+!27 = !DILocation(line: 16, column: 9, scope: !26)

--- a/src/QsCompiler/Tests.Compiler/TestCases/DebugInfoTests/TestFunctionReturnsUnit.qs
+++ b/src/QsCompiler/Tests.Compiler/TestCases/DebugInfoTests/TestFunctionReturnsUnit.qs
@@ -1,0 +1,17 @@
+namespace Microsoft.Quantum.Testing.QirDebugInfo {
+
+    @EntryPoint()
+    operation Main() : Unit {
+        let varX = 42;
+        IntToUnit(varX);
+        ToUnit();
+    }
+
+    operation IntToUnit(varX: Int) : Unit {
+
+    }
+
+    operation ToUnit() : Unit {
+
+    }
+}

--- a/src/QsCompiler/Tests.Compiler/TestCases/DebugInfoTests/TestFunctionReturnsUnit1.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/DebugInfoTests/TestFunctionReturnsUnit1.ll
@@ -1,0 +1,9 @@
+!6 = !{}
+!7 = distinct !DISubprogram(name: "IntToUnit", linkageName: "Microsoft__Quantum__Testing__QirDebugInfo__IntToUnit__body", scope: null, file: !5, line: 10, type: !8, scopeLine: 10, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition, unit: !4, retainedNodes: !12)
+!8 = !DISubroutineType(types: !9)
+!9 = !{!10, !11}
+!10 = !DIBasicType(name: "This debug type is not yet supported")
+!11 = !DIBasicType(name: "Int", size: 64, encoding: DW_ATE_signed)
+!12 = !{!13}
+!13 = !DILocalVariable(name: "varX", arg: 1, scope: !7, file: !5, line: 10, type: !11)
+!14 = !DILocation(line: 10, column: 1, scope: !7)

--- a/src/QsCompiler/Tests.Compiler/TestCases/DebugInfoTests/TestFunctionReturnsUnit2.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/DebugInfoTests/TestFunctionReturnsUnit2.ll
@@ -1,0 +1,1 @@
+!23 = distinct !DISubprogram(name: "ToUnit", linkageName: "Microsoft__Quantum__Testing__QirDebugInfo__ToUnit__body", scope: null, file: !5, line: 14, type: !16, scopeLine: 14, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition, unit: !4, retainedNodes: !6)

--- a/src/QsCompiler/Tests.Compiler/TestCases/DebugInfoTests/TestFunctionReturnsUnit3.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/DebugInfoTests/TestFunctionReturnsUnit3.ll
@@ -1,0 +1,2 @@
+!16 = !DISubroutineType(types: !17)
+!17 = !{!10, !10}

--- a/src/QsCompiler/Tests.Compiler/TestCases/DebugInfoTests/TestFunctionReturnsUnit4.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/DebugInfoTests/TestFunctionReturnsUnit4.ll
@@ -1,0 +1,2 @@
+!21 = !DILocation(line: 6, column: 9, scope: !15)
+!22 = !DILocation(line: 7, column: 9, scope: !15)

--- a/src/QsCompiler/Tests.Compiler/TestCases/DebugInfoTests/TestFunctionReturnsUnit5.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/DebugInfoTests/TestFunctionReturnsUnit5.ll
@@ -1,0 +1,7 @@
+define internal void @Microsoft__Quantum__Testing__QirDebugInfo__Main__body() !dbg !15 {
+entry:
+  tail call void @llvm.dbg.value(metadata i64 42, metadata !19, metadata !DIExpression()), !dbg !20
+  call void @Microsoft__Quantum__Testing__QirDebugInfo__IntToUnit__body(i64 42), !dbg !21
+  call void @Microsoft__Quantum__Testing__QirDebugInfo__ToUnit__body(), !dbg !22
+  ret void, !dbg !22
+}

--- a/src/QsCompiler/Tests.Compiler/TestCases/DebugInfoTests/TestFunctionReturnsUnit6.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/DebugInfoTests/TestFunctionReturnsUnit6.ll
@@ -1,0 +1,5 @@
+define internal void @Microsoft__Quantum__Testing__QirDebugInfo__IntToUnit__body(i64 %varX) !dbg !7 {
+entry:
+  tail call void @llvm.dbg.value(metadata i64 %varX, metadata !13, metadata !DIExpression()), !dbg !14
+  ret void
+}

--- a/src/QsCompiler/Tests.Compiler/TestCases/DebugInfoTests/TestFunctionReturnsUnit7.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/DebugInfoTests/TestFunctionReturnsUnit7.ll
@@ -1,0 +1,4 @@
+define internal void @Microsoft__Quantum__Testing__QirDebugInfo__ToUnit__body() !dbg !23 {
+entry:
+  ret void
+}

--- a/src/QsCompiler/Tests.Compiler/TestCases/DebugInfoTests/TestIntVariable.qs
+++ b/src/QsCompiler/Tests.Compiler/TestCases/DebugInfoTests/TestIntVariable.qs
@@ -1,0 +1,10 @@
+namespace Microsoft.Quantum.Testing.QirDebugInfo {
+
+    @EntryPoint()
+    operation Main() : Int {
+        let varX = 42;
+        mutable varY = 43;
+        set varY = varX;
+        return varY;
+    }
+}

--- a/src/QsCompiler/Tests.Compiler/TestCases/DebugInfoTests/TestIntVariable1.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/DebugInfoTests/TestIntVariable1.ll
@@ -1,0 +1,9 @@
+define internal i64 @Microsoft__Quantum__Testing__QirDebugInfo__Main__body() !dbg !7 {
+entry:
+  tail call void @llvm.dbg.value(metadata i64 42, metadata !13, metadata !DIExpression()), !dbg !15
+  %varY = alloca i64, align 8, !dbg !16
+  store i64 43, i64* %varY, align 4, !dbg !16
+  call void @llvm.dbg.declare(metadata i64* %varY, metadata !14, metadata !DIExpression()), !dbg !16
+  store i64 42, i64* %varY, align 4, !dbg !17
+  ret i64 42, !dbg !18
+}

--- a/src/QsCompiler/Tests.Compiler/TestCases/DebugInfoTests/TestIntVariable2.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/DebugInfoTests/TestIntVariable2.ll
@@ -1,0 +1,5 @@
+!13 = !DILocalVariable(name: "varX", scope: !7, file: !5, line: 5, type: !10)
+!14 = !DILocalVariable(name: "varY", scope: !7, file: !5, line: 6, type: !10)
+!15 = !DILocation(line: 5, column: 9, scope: !7)
+!16 = !DILocation(line: 6, column: 9, scope: !7)
+!17 = !DILocation(line: 7, column: 9, scope: !7)

--- a/src/QsCompiler/Tests.Compiler/TestCases/DebugInfoTests/TestModuleInfo.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/DebugInfoTests/TestModuleInfo.ll
@@ -1,0 +1,11 @@
+!llvm.ident = !{!0}
+!llvm.module.flags = !{!1, !2, !3}
+!llvm.dbg.cu = !{!4}
+
+!0 = !{!"Microsoft.Quantum.QsCompiler with Microsoft.Quantum.QirGeneration V __QIRPRODUCERVERSION__"}
+!1 = !{i32 2, !"Dwarf Version", i32 4}
+!2 = !{i32 2, !"Debug Info Version", i32 3}
+!3 = !{i32 2, !"CodeView", i32 1}
+!4 = distinct !DICompileUnit(language: DW_LANG_C99, file: !5, producer: "Microsoft.Quantum.QsCompiler with Microsoft.Quantum.QirGeneration V __QIRPRODUCERVERSION__", isOptimized: false, runtimeVersion: 0, emissionKind: FullDebug, enums: !6, splitDebugInlining: false)
+!5 = !DIFile(filename: "TestModuleInfo.qs", directory: "__DIRECTORY__")
+!6 = !{}

--- a/src/QsCompiler/Tests.Compiler/TestCases/DebugInfoTests/TestModuleInfo.qs
+++ b/src/QsCompiler/Tests.Compiler/TestCases/DebugInfoTests/TestModuleInfo.qs
@@ -1,0 +1,6 @@
+namespace Microsoft.Quantum.Testing.QirDebugInfo {
+
+    @EntryPoint()
+    operation Main() : Unit {
+    }
+}

--- a/src/QsCompiler/Tests.Compiler/TestCases/DebugInfoTests/TestStatementBreakpoints.qs
+++ b/src/QsCompiler/Tests.Compiler/TestCases/DebugInfoTests/TestStatementBreakpoints.qs
@@ -1,0 +1,19 @@
+namespace Microsoft.Quantum.Testing.QirDebugInfo {
+
+    @EntryPoint()
+    operation Main() : Int {
+        mutable boolean = true;
+
+        if (not boolean) {
+            return 1;
+        }
+
+        set boolean = false;
+
+        if (not boolean) {
+            return 0;
+        }
+
+        return 1;
+    }
+}

--- a/src/QsCompiler/Tests.Compiler/TestCases/DebugInfoTests/TestStatementBreakpoints1.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/DebugInfoTests/TestStatementBreakpoints1.ll
@@ -1,0 +1,20 @@
+define internal i64 @Microsoft__Quantum__Testing__QirDebugInfo__Main__body() !dbg !7 {
+entry:
+  %boolean = alloca i1, align 1, !dbg !15
+  store i1 true, i1* %boolean, align 1, !dbg !15
+  call void @llvm.dbg.declare(metadata i1* %boolean, metadata !13, metadata !DIExpression()), !dbg !15
+  br i1 false, label %then0__1, label %continue__1, !dbg !16
+
+then0__1:                                         ; preds = %entry
+  ret i64 1, !dbg !17
+
+continue__1:                                      ; preds = %entry
+  store i1 false, i1* %boolean, align 1, !dbg !18
+  br i1 true, label %then0__2, label %continue__2, !dbg !19
+
+then0__2:                                         ; preds = %continue__1
+  ret i64 0, !dbg !20
+
+continue__2:                                      ; preds = %continue__1
+  ret i64 1, !dbg !21
+}

--- a/src/QsCompiler/Tests.Compiler/TestCases/DebugInfoTests/TestStatementBreakpoints2.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/DebugInfoTests/TestStatementBreakpoints2.ll
@@ -1,0 +1,7 @@
+!15 = !DILocation(line: 5, column: 9, scope: !7)
+!16 = !DILocation(line: 7, column: 9, scope: !7)
+!17 = !DILocation(line: 8, column: 13, scope: !7)
+!18 = !DILocation(line: 11, column: 9, scope: !7)
+!19 = !DILocation(line: 13, column: 9, scope: !7)
+!20 = !DILocation(line: 14, column: 13, scope: !7)
+!21 = !DILocation(line: 17, column: 9, scope: !7)

--- a/src/QsCompiler/Tests.Compiler/TestCases/DebugInfoTests/TestUnsupportedDebugInfoType.qs
+++ b/src/QsCompiler/Tests.Compiler/TestCases/DebugInfoTests/TestUnsupportedDebugInfoType.qs
@@ -1,0 +1,24 @@
+namespace Microsoft.Quantum.Testing.QirDebugInfo {
+
+    @EntryPoint()
+    operation Main() : Unit {
+        // making these mutable so they're not optimized out
+        mutable array = [5, 6, 7];
+        // mutable bigInt = 5L; // bigint doesn't seem to be supported in the version of the libraries we're using
+        mutable func = Add(4, _);
+        mutable op = Subtract(4, _);
+        mutable pauli = PauliX;
+        use qubit = Qubit();
+        mutable range = 1..3;
+        mutable str = "Hello";
+        mutable unitVal = ();
+    }
+
+    function Add(x: Int, y: Int) : Int {
+        return x + y;
+    }
+
+    operation Subtract(x: Int, y: Int) : Int {
+        return y - x;
+    }
+}

--- a/src/QsCompiler/Tests.Compiler/TestCases/DebugInfoTests/TestUnsupportedDebugInfoType1.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/DebugInfoTests/TestUnsupportedDebugInfoType1.ll
@@ -1,0 +1,3 @@
+!17 = !DISubroutineType(types: !18)
+!18 = !{!19, !19}
+!19 = !DIBasicType(name: "This debug type is not yet supported")

--- a/src/QsCompiler/Tests.Compiler/TestCases/DebugInfoTests/TestUnsupportedDebugInfoType2.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/DebugInfoTests/TestUnsupportedDebugInfoType2.ll
@@ -1,0 +1,7 @@
+!21 = !DILocalVariable(name: "array [value display for this type is not currently supported]", scope: !16, file: !5, line: 6, type: !19)
+!22 = !DILocalVariable(name: "func [value display for this type is not currently supported]", scope: !16, file: !5, line: 8, type: !19)
+!23 = !DILocalVariable(name: "op [value display for this type is not currently supported]", scope: !16, file: !5, line: 9, type: !19)
+!24 = !DILocalVariable(name: "pauli [value display for this type is not currently supported]", scope: !16, file: !5, line: 10, type: !19)
+!25 = !DILocalVariable(name: "range [value display for this type is not currently supported]", scope: !16, file: !5, line: 12, type: !19)
+!26 = !DILocalVariable(name: "str [value display for this type is not currently supported]", scope: !16, file: !5, line: 13, type: !19)
+!27 = !DILocalVariable(name: "unitVal [value display for this type is not currently supported]", scope: !16, file: !5, line: 14, type: !19)

--- a/src/QsCompiler/Tests.Compiler/TestCases/DebugInfoTests/TestUnsupportedDebugInfoType3.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/DebugInfoTests/TestUnsupportedDebugInfoType3.ll
@@ -1,0 +1,3 @@
+!8 = !DISubroutineType(types: !9)
+!9 = !{!10, !10, !10}
+!10 = !DIBasicType(name: "Int", size: 64, encoding: DW_ATE_signed)

--- a/src/QsCompiler/Tests.Compiler/TestCases/DebugInfoTests/TestUnsupportedDebugInfoType4.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/DebugInfoTests/TestUnsupportedDebugInfoType4.ll
@@ -1,0 +1,1 @@
+!38 = distinct !DISubprogram(name: "Subtract", linkageName: "Microsoft__Quantum__Testing__QirDebugInfo__Subtract__body", scope: null, file: !5, line: 21, type: !8, scopeLine: 21, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition, unit: !4, retainedNodes: !39)

--- a/src/QsCompiler/Tests.Compiler/Tests.Compiler.fsproj
+++ b/src/QsCompiler/Tests.Compiler/Tests.Compiler.fsproj
@@ -383,6 +383,111 @@
     <Content Include="TestCases\QirTests\TestWhile.qs">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
+    <Content Include="TestCases\DebugInfoTests\TestModuleInfo.qs">
+        <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="TestCases\DebugInfoTests\TestModuleInfo.ll">
+        <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="TestCases\DebugInfoTests\TestStatementBreakpoints.qs">
+        <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="TestCases\DebugInfoTests\TestStatementBreakpoints1.ll">
+        <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="TestCases\DebugInfoTests\TestStatementBreakpoints2.ll">
+        <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="TestCases\DebugInfoTests\TestFunctionReturnsUnit.qs">
+        <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="TestCases\DebugInfoTests\TestFunctionReturnsUnit1.ll">
+        <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="TestCases\DebugInfoTests\TestFunctionReturnsUnit2.ll">
+        <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="TestCases\DebugInfoTests\TestFunctionReturnsUnit3.ll">
+        <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="TestCases\DebugInfoTests\TestFunctionReturnsUnit4.ll">
+        <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="TestCases\DebugInfoTests\TestFunctionReturnsUnit5.ll">
+        <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="TestCases\DebugInfoTests\TestFunctionReturnsUnit6.ll">
+        <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="TestCases\DebugInfoTests\TestFunctionReturnsUnit7.ll">
+        <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="TestCases\DebugInfoTests\TestFunctionReturnsType.qs">
+        <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="TestCases\DebugInfoTests\TestFunctionReturnsType1.ll">
+        <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="TestCases\DebugInfoTests\TestFunctionReturnsType2.ll">
+        <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="TestCases\DebugInfoTests\TestFunctionReturnsType3.ll">
+        <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="TestCases\DebugInfoTests\TestFunctionReturnsType4.ll">
+        <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="TestCases\DebugInfoTests\TestFunctionReturnsType5.ll">
+        <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="TestCases\DebugInfoTests\TestFunctionReturnsType6.ll">
+        <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="TestCases\DebugInfoTests\TestFunctionReturnsType7.ll">
+        <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="TestCases\DebugInfoTests\TestIntVariable.qs">
+        <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="TestCases\DebugInfoTests\TestIntVariable1.ll">
+        <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="TestCases\DebugInfoTests\TestIntVariable2.ll">
+        <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="TestCases\DebugInfoTests\TestDoubleVariable.qs">
+        <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="TestCases\DebugInfoTests\TestDoubleVariable1.ll">
+        <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="TestCases\DebugInfoTests\TestDoubleVariable2.ll">
+        <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="TestCases\DebugInfoTests\TestBooleanVariable.qs">
+        <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="TestCases\DebugInfoTests\TestBooleanVariable1.ll">
+        <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="TestCases\DebugInfoTests\TestBooleanVariable2.ll">
+        <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="TestCases\DebugInfoTests\TestUnsupportedDebugInfoType.qs">
+        <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="TestCases\DebugInfoTests\TestUnsupportedDebugInfoType1.ll">
+        <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="TestCases\DebugInfoTests\TestUnsupportedDebugInfoType2.ll">
+        <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="TestCases\DebugInfoTests\TestUnsupportedDebugInfoType3.ll">
+        <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="TestCases\DebugInfoTests\TestUnsupportedDebugInfoType4.ll">
+        <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
     <None Include="TestCases\CapabilityTests\Verification.qs">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>


### PR DESCRIPTION
There is currently no support implemented for enabling debug symbols via a project property. 
We should add that before merging.