### PR TITLE
Use correct continuation parser in symbolTuple

### DIFF
--- a/src/QsCompiler/Tests.Compiler/SyntaxTests.fs
+++ b/src/QsCompiler/Tests.Compiler/SyntaxTests.fs
@@ -1481,6 +1481,43 @@ let ``Lambda tests`` () =
         |> toExpr,
         []
 
+        "U(7, q => X(q))",
+        true,
+        CallLikeExpression(
+            toIdentifier "U",
+            [
+                toInt 7
+                Lambda.createUnchecked
+                    Operation
+                    (toSymbol "q")
+                    (CallLikeExpression(toIdentifier "X", toTuple [ toIdentifier "q" ]) |> toExpr)
+                |> Lambda
+                |> toExpr
+            ]
+            |> toTuple
+        )
+        |> toExpr,
+        []
+
+        "U(7, i, q => X(q))",
+        true,
+        CallLikeExpression(
+            toIdentifier "U",
+            [
+                toInt 7
+                toIdentifier "i"
+                Lambda.createUnchecked
+                    Operation
+                    (toSymbol "q")
+                    (CallLikeExpression(toIdentifier "X", toTuple [ toIdentifier "q" ]) |> toExpr)
+                |> Lambda
+                |> toExpr
+            ]
+            |> toTuple
+        )
+        |> toExpr,
+        []
+
         "F(_ -> 0, xs)",
         true,
         CallLikeExpression(

--- a/src/QsCompiler/TextProcessor/QsExpressionParsing.fs
+++ b/src/QsCompiler/TextProcessor/QsExpressionParsing.fs
@@ -656,15 +656,15 @@ let internal invalidSymbol = QsSymbol.New(InvalidSymbol, Null)
 let internal buildSymbolTuple (items, range: Range) = QsSymbol.New(SymbolTuple items, range)
 
 let internal symbolTuple continuation =
+    let continuation = continuation >>% () <|> isTupleContinuation
     let empty = unitValue |>> fun unit -> { Symbol = SymbolTuple ImmutableArray.Empty; Range = unit.Range }
-    let continuation' = continuation >>% () <|> isTupleContinuation
-    let symbol = (discardedSymbol <|> localIdentifier) .>>? followedBy continuation'
+    let symbol = (discardedSymbol <|> localIdentifier) .>>? followedBy continuation
 
     // Let's only specifically detect this particular invalid scenario.
     let symbolArray = arrayBrackets (sepBy1 symbol (comma .>>? followedBy symbol) .>> opt comma) |>> snd
 
     let invalid =
-        buildError (symbolArray .>>? followedBy continuation') ErrorCode.InvalidAssignmentToExpression
+        buildError (symbolArray .>>? followedBy continuation) ErrorCode.InvalidAssignmentToExpression
         >>% invalidSymbol
 
     empty


### PR DESCRIPTION
On line 667 of QsExpressionParsing.fs, `continuation` is given to `buildTupleItem` when it should be `continuation'`. I renamed `continuation'` to shadow `continuation` to avoid confusing the two.

Closes #1356.