### PR TITLE
Improve type inference for copy-and-update and named item expressions

### DIFF
--- a/src/QsCompiler/DataStructures/Diagnostics.fs
+++ b/src/QsCompiler/DataStructures/Diagnostics.fs
@@ -155,30 +155,12 @@ type ErrorCode =
     | ControlledAdjointGenArgMismatch = 4114
     | MisplacedDeclarationAttribute = 4115
 
-    // TODO: RELEASE 2021-10: Remove MissingExprInArray.
-    | [<Obsolete "This diagnostic is no longer in use.">] MissingExprInArray = 5001
-    // TODO: RELEASE 2021-10: Remove MultipleTypesInArray.
-    | [<Obsolete "This diagnostic is no longer in use.">] MultipleTypesInArray = 5002
     | InvalidArrayItemIndex = 5003
     | ItemAccessForNonArray = 5004
     | InvalidTypeInArithmeticExpr = 5005
     | InvalidTypeForConcatenation = 5006
     | InvalidTypeInEqualityComparison = 5007
-    // TODO: RELEASE 2021-10: Remove ArgumentMismatchInBinaryOp.
-    | [<Obsolete "This diagnostic is no longer in use.">] ArgumentMismatchInBinaryOp = 5008
-    // TODO: RELEASE 2021-10: Remove TypeMismatchInConditional.
-    | [<Obsolete "This diagnostic is no longer in use.">] TypeMismatchInConditional = 5009
-    // TODO: RELEASE 2021-10: Remove ExpressionOfUnknownType.
-    | [<Obsolete "This diagnostic is no longer in use.">] ExpressionOfUnknownType = 5010
-    // TODO: RELEASE 2021-10: Remove ExpectingUnitExpr.
-    | [<Obsolete "This diagnostic is no longer in use.">] ExpectingUnitExpr = 5011
-    // TODO: RELEASE 2021-10: Remove ExpectingIntExpr.
-    | [<Obsolete "This diagnostic is no longer in use.">] ExpectingIntExpr = 5012
     | ExpectingIntegralExpr = 5013
-    // TODO: RELEASE 2021-10: Remove ExpectingBoolExpr.
-    | [<Obsolete "This diagnostic is no longer in use.">] ExpectingBoolExpr = 5014
-    // TODO: RELEASE 2021-10: Remove ExpectingStringExpr.
-    | [<Obsolete "This diagnostic is no longer in use.">] ExpectingStringExpr = 5015
     | ExpectingUserDefinedType = 5016
     | InvalidAdjointApplication = 5017
     | InvalidControlledApplication = 5018
@@ -190,8 +172,6 @@ type ErrorCode =
     | ReturnInResultConditionedBlock = 5025
     | SetInResultConditionedBlock = 5026
     | UnsupportedCallableCapability = 5027
-    // TODO: RELEASE 2021-07: Remove ErrorCode.UnsupportedCapability.
-    | [<Obsolete "Renamed to UnsupportedCallableCapability.">] UnsupportedCapability = 5027
 
     | CallableRedefinition = 6001
     | CallableOverlapWithTypeConstructor = 6002
@@ -229,40 +209,14 @@ type ErrorCode =
     | InaccessibleTypeInNamespace = 6110
     | InaccessibleCallableInNamespace = 6111
 
-    // TODO: RELEASE 2021-10: Remove ArgumentTupleShapeMismatch.
-    | [<Obsolete "This diagnostic is no longer in use.">] ArgumentTupleShapeMismatch = 6201
-    // TODO: RELEASE 2021-10: Remove ArgumentTupleMismatch.
-    | [<Obsolete "This diagnostic is no longer in use.">] ArgumentTupleMismatch = 6202
     | ArrayBaseTypeMismatch = 6203
-    // TODO: RELEASE 2021-10: Remove UserDefinedTypeMismatch.
-    | [<Obsolete "This diagnostic is no longer in use.">] UserDefinedTypeMismatch = 6204
-    // TODO: RELEASE 2021-10: Remove CallableTypeInputTypeMismatch.
-    | [<Obsolete "This diagnostic is no longer in use.">] CallableTypeInputTypeMismatch = 6205
-    // TODO: RELEASE 2021-10: Remove CallableTypeOutputTypeMismatch.
-    | [<Obsolete "This diagnostic is no longer in use.">] CallableTypeOutputTypeMismatch = 6206
-    // TODO: RELEASE 2021-10: Remove MissingFunctorSupport.
-    | [<Obsolete "This diagnostic is no longer in use.">] MissingFunctorSupport = 6207
-    // TODO: RELEASE 2021-10: Remove ExcessFunctorSupport.
-    | [<Obsolete "This diagnostic is no longer in use.">] ExcessFunctorSupport = 6208
-    // TODO: RELEASE 2021-10: Remove FunctorSupportMismatch.
-    | [<Obsolete "This diagnostic is no longer in use.">] FunctorSupportMismatch = 6209
-    // TODO: RELEASE 2021-10: Remove ArgumentTypeMismatch.
-    | [<Obsolete "This diagnostic is no longer in use.">] ArgumentTypeMismatch = 6210
-    // TODO: RELEASE 2021-10: Remove UnexpectedTupleArgument.
-    | [<Obsolete "This diagnostic is no longer in use.">] UnexpectedTupleArgument = 6211
     | AmbiguousTypeParameterResolution = 6212
-    // TODO: RELEASE 2021-10: Remove ConstrainsTypeParameter.
-    | [<Obsolete "This diagnostic is no longer in use.">] ConstrainsTypeParameter = 6213
     | GlobalTypeAlreadyExists = 6215
     | GlobalCallableAlreadyExists = 6216
     | LocalVariableAlreadyExists = 6217
     | NamedItemAlreadyExists = 6219
     | IdentifierCannotHaveTypeArguments = 6220
     | WrongNumberOfTypeArguments = 6221
-    // TODO: RELEASE 2021-10: Remove InvalidUseOfTypeParameterizedObject.
-    | [<Obsolete "This diagnostic is no longer in use.">] InvalidUseOfTypeParameterizedObject = 6222
-    // TODO: RELEASE 2021-10: Remove PartialApplicationOfTypeParameter.
-    | [<Obsolete "This diagnostic is no longer in use.">] PartialApplicationOfTypeParameter = 6223
     | IndirectlyReferencedExpressionType = 6224
     // TODO: RELEASE 2022-11: Remove TypeMismatchInCopyAndUpdateExpr.
     | [<Obsolete "This diagnostic is no longer in use.">] TypeMismatchInCopyAndUpdateExpr = 6225
@@ -276,28 +230,21 @@ type ErrorCode =
     | UserDefinedTypeInEntryPointSignature = 6233
     | InnerTupleInEntryPointArgument = 6234
     | ArrayOfArrayInEntryPointArgument = 6235
-    | [<Obsolete("This diagnostic is no longer in use. Multiple entry points are now allowed.")>] OtherEntryPointExists = 6236
-    | [<Obsolete("This diagnostic is no longer in use. Multiple entry points are now allowed.")>] MultipleEntryPoints = 6237
     | MissingEntryPoint = 6238
     | InvalidEntryPointSpecialization = 6239
     | DuplicateEntryPointArgumentName = 6240
-    | [<Obsolete("This diagnostic is no longer in use. The warning EntryPointInLibrary is given instead.")>] EntryPointInLibrary = 6241
     | InvalidTestAttributePlacement = 6242
     | InvalidExecutionTargetForTest = 6243
     | ExpectingFullNameAsAttributeArgument = 6244
     | AttributeInvalidOnSpecialization = 6245
     | AttributeInvalidOnCallable = 6246
-    // TODO: RELEASE 2021-10: Remove UnresolvedTypeParameterForRecursiveCall.
-    | [<Obsolete "This diagnostic is no longer in use.">] UnresolvedTypeParameterForRecursiveCall = 6247
-    // TODO: RELEASE 2021-10: Remove TypeParameterResConflictWithTypeArgument.
-    | [<Obsolete "This diagnostic is no longer in use.">] TypeParameterResConflictWithTypeArgument = 6248
     | FullNameConflictsWithNamespace = 6249
     | InvalidCyclicTypeParameterResolution = 6250
     | InvalidCharacterInInterpolatedArgument = 6251
 
-    // TODO: RELEASE 2022-06: Remove TypeMismatchInReturn.
+    // TODO: RELEASE 2022-11: Remove TypeMismatchInReturn.
     | [<Obsolete "This diagnostic is no longer in use.">] TypeMismatchInReturn = 6301
-    // TODO: RELEASE 2022-06: Remove TypeMismatchInValueUpdate.
+    // TODO: RELEASE 2022-11: Remove TypeMismatchInValueUpdate.
     | [<Obsolete "This diagnostic is no longer in use.">] TypeMismatchInValueUpdate = 6302
     | UpdateOfImmutableIdentifier = 6303
     | SymbolTupleShapeMismatch = 6305
@@ -372,7 +319,6 @@ type WarningCode =
     | DeprecatedANDoperator = 3302
     | DeprecatedORoperator = 3303
     | UseOfFutureReservedKeyword = 3304
-    | [<Obsolete("This diagnostic is no longer in use. The error InvalidUseOfUnderscorePattern is given instead.")>] UseOfUnderscorePattern = 3305
     | DeprecatedTupleBrackets = 3306
     | DeprecatedQubitBindingKeyword = 3307
     | DeprecatedNewArray = 3308
@@ -388,10 +334,6 @@ type WarningCode =
     | SetInResultConditionedBlock = 5026
     | UnsupportedCallableCapability = 5027
 
-    // TODO: RELEASE 2021-10: Remove TypeParameterNotResolvedByArgument.
-    | [<Obsolete "This diagnostic is no longer in use.">] TypeParameterNotResolvedByArgument = 6001
-    // TODO: RELEASE 2021-10: Remove ReturnTypeNotResolvedByArgument.
-    | [<Obsolete "This diagnostic is no longer in use.">] ReturnTypeNotResolvedByArgument = 6002
     | NamespaceAleadyOpen = 6003
     | NamespaceAliasIsAlreadyDefined = 6004
     | MissingBodyDeclaration = 6005
@@ -677,8 +619,6 @@ type DiagnosticItem =
             | ErrorCode.MisplacedDeclarationAttribute ->
                 "An attribute must be followed by a callable declaration, a type declaration, or by another attribute."
 
-            | ErrorCode.MissingExprInArray -> "Underscores cannot be used to denote missing array elements."
-            | ErrorCode.MultipleTypesInArray -> "Array items must have a common base type."
             | ErrorCode.InvalidArrayItemIndex ->
                 "Expecting an expression of type Int or Range. Got an expression of type {0}."
             | ErrorCode.ItemAccessForNonArray ->
@@ -687,21 +627,8 @@ type DiagnosticItem =
                 "The type {0} does not support arithmetic operators. Expecting an expression of type Int, BigInt or Double."
             | ErrorCode.InvalidTypeForConcatenation -> "The type {0} does not support the + operator."
             | ErrorCode.InvalidTypeInEqualityComparison -> "The type {0} does not support equality comparison."
-            | ErrorCode.ArgumentMismatchInBinaryOp ->
-                "The given arguments of type {0} and {1} do not have a common base type."
-            | ErrorCode.TypeMismatchInConditional ->
-                "The returned values of type {0} and {1} in the conditional expression do not have a common base type."
-            | ErrorCode.ExpressionOfUnknownType -> "Expression of unknown type."
-            | ErrorCode.ExpectingUnitExpr ->
-                "Expecting expression of type Unit. Only expressions of type Unit can be used as expression statements."
-            | ErrorCode.ExpectingIntExpr ->
-                "Expecting an expression of type Int. Got an expression of type {0} instead."
             | ErrorCode.ExpectingIntegralExpr ->
                 "Expecting an expression of type Int or BigInt. Got an expression of type {0} instead."
-            | ErrorCode.ExpectingBoolExpr ->
-                "Expecting an expression of type Bool. Got an expression of type {0} instead."
-            | ErrorCode.ExpectingStringExpr ->
-                "Expecting an expression of type String. Got an expression of type {0} instead."
             | ErrorCode.ExpectingUserDefinedType ->
                 "The type of the expression needs to be a user defined type. The given expression is of type {0}."
             | ErrorCode.InvalidAdjointApplication -> "No suitable adjoint specialization exists."
@@ -777,25 +704,7 @@ type DiagnosticItem =
             | ErrorCode.InaccessibleCallableInNamespace ->
                 "The callable {0} in namespace {1} is not accessible from here."
 
-            | ErrorCode.ArgumentTupleShapeMismatch ->
-                "The shape of the given tuple does not match the expected type. Got an argument of type {0}, expecting one of type {1} instead."
-            | ErrorCode.ArgumentTupleMismatch ->
-                "The type of the given tuple does not match the expected type. Got an argument of type {0}, expecting one of type {1} instead."
             | ErrorCode.ArrayBaseTypeMismatch -> "The array item type {0} does not match the expected type {1}."
-            | ErrorCode.UserDefinedTypeMismatch -> "The type {0} does not match the expected user defined type {1}."
-            | ErrorCode.CallableTypeInputTypeMismatch ->
-                "The argument type {0} of the given callable does not match the expected type {1}."
-            | ErrorCode.CallableTypeOutputTypeMismatch ->
-                "The return type {0} of the given callable does not match the expected type {1}."
-            | ErrorCode.MissingFunctorSupport ->
-                "The given argument does not support the required functor(s). Missing support for the functor(s) {0}."
-            | ErrorCode.ExcessFunctorSupport ->
-                "The given argument is less general than the expected one due to requiring additional support for the functor(s) {0}."
-            | ErrorCode.FunctorSupportMismatch ->
-                "The set of supported functors does not match the expected type. Expecting support for the functor(s) {0}."
-            | ErrorCode.ArgumentTypeMismatch ->
-                "The type of the given argument does not match the expected type. Got an argument of type {0}, expecting one of type {1} instead."
-            | ErrorCode.UnexpectedTupleArgument -> "Unexpected argument tuple. Expecting an argument of type {0}."
             | ErrorCode.AmbiguousTypeParameterResolution ->
                 let note =
                     if Seq.item 1 args |> String.IsNullOrWhiteSpace then
@@ -805,7 +714,6 @@ type DiagnosticItem =
 
                 "The type parameter {0} is ambiguous. More type annotations or usage context may be necessary."
                 + note
-            | ErrorCode.ConstrainsTypeParameter -> "The given expression constrains the type parameter(s) {0}."
             | ErrorCode.GlobalTypeAlreadyExists -> "A type with the name \"{0}\" already exists."
             | ErrorCode.GlobalCallableAlreadyExists -> "A callable with the name \"{0}\" already exists."
             | ErrorCode.LocalVariableAlreadyExists -> "A variable with the name \"{0}\" already exists."
@@ -813,9 +721,6 @@ type DiagnosticItem =
             | ErrorCode.IdentifierCannotHaveTypeArguments -> "The given identifier cannot have type arguments."
             | ErrorCode.WrongNumberOfTypeArguments ->
                 "The number of type arguments does not match the number of type parameters for this identifier. Expecting {0} type argument(s)."
-            | ErrorCode.InvalidUseOfTypeParameterizedObject ->
-                "The type of the given expression cannot be determined. Provide explicit type arguments (\"identifier<commaSeparatedTypeArguments>\")."
-            | ErrorCode.PartialApplicationOfTypeParameter -> "Generic type parameters cannot be partially resolved."
             | ErrorCode.IndirectlyReferencedExpressionType ->
                 "The type {0} of the expression is defined in an assembly that is not referenced."
             | ErrorCode.TypeMismatchInCopyAndUpdateExpr ->
@@ -839,15 +744,12 @@ type DiagnosticItem =
                 "Anonymous tuple items or arrays of tuples are not supported in entry point arguments. All items need to be named."
             | ErrorCode.ArrayOfArrayInEntryPointArgument ->
                 "Multi-dimensional arrays are not supported in entry point arguments."
-            | ErrorCode.OtherEntryPointExists -> "Invalid entry point. An entry point {0} already exists in {1}."
-            | ErrorCode.MultipleEntryPoints -> "The project contains more than one entry point."
             | ErrorCode.MissingEntryPoint ->
                 "Missing entry point. Execution on a quantum processor requires that a Q# entry point is defined using the @EntryPoint() attribute. Any C# driver code should be defined in a separate project."
             | ErrorCode.InvalidEntryPointSpecialization ->
                 "Entry points cannot have any other specializations besides the default body."
             | ErrorCode.DuplicateEntryPointArgumentName ->
                 "Invalid name for entry point argument. A similar argument name is already in use."
-            | ErrorCode.EntryPointInLibrary -> "Invalid entry point. Only executable Q# projects can have entry points."
             | ErrorCode.InvalidTestAttributePlacement ->
                 "Invalid test attribute. Test attributes may only occur on callables that have no arguments and return Unit."
             | ErrorCode.InvalidExecutionTargetForTest ->
@@ -858,10 +760,6 @@ type DiagnosticItem =
                 "Invalid attribute placement. The attribute {0} cannot be attached to a specialization declaration."
             | ErrorCode.AttributeInvalidOnCallable ->
                 "Invalid attribute placement. The attribute {0} cannot be attached to a callable declaration."
-            | ErrorCode.UnresolvedTypeParameterForRecursiveCall ->
-                "The type argument(s) for the recursive call could not be inferred. Please provide explicit type arguments, e.g. Op<Int, Double>(arg)."
-            | ErrorCode.TypeParameterResConflictWithTypeArgument ->
-                "The type of the expression needs to match the defined type argument. Expecting an expression of type {0}."
             | ErrorCode.FullNameConflictsWithNamespace -> "The name {0} conflicts with a namespace name."
             | ErrorCode.InvalidCyclicTypeParameterResolution ->
                 "The call cycle results in an ambiguous or conflicting type parameter resolution."
@@ -977,8 +875,6 @@ type DiagnosticItem =
             | WarningCode.DeprecatedANDoperator -> "Deprecated syntax. Use \"and\" to denote the logical AND operator."
             | WarningCode.DeprecatedORoperator -> "Deprecated syntax. Use \"or\" to denote the logical OR operator."
             | WarningCode.UseOfFutureReservedKeyword -> "The symbol will be reserved for internal use in the future."
-            | WarningCode.UseOfUnderscorePattern ->
-                "Double underscores as well as underscores before a dot or at the end of a namespace name will be reserved for internal use in the future."
             | WarningCode.DeprecatedTupleBrackets ->
                 "Deprecated syntax. Parentheses here are no longer required and will not be supported in the future."
             | WarningCode.DeprecatedQubitBindingKeyword ->
@@ -1016,10 +912,6 @@ type DiagnosticItem =
                 + DiagnosticItem.Message(ErrorCode.UnsupportedCallableCapability, args |> Seq.skip 4)
                 + " [{1}: ln {2}, cn {3}]"
 
-            | WarningCode.TypeParameterNotResolvedByArgument ->
-                "The value of the type parameter is not determined by the argument type. It will always have to be explicitly specified by passing type arguments."
-            | WarningCode.ReturnTypeNotResolvedByArgument ->
-                "The return type is not fully determined by the argument type. It will always have to be explicitly specified by passing type arguments."
             | WarningCode.NamespaceAleadyOpen -> "The namespace is already open."
             | WarningCode.NamespaceAliasIsAlreadyDefined -> "A short name for this namespace is already defined."
             | WarningCode.MissingBodyDeclaration ->

--- a/src/QsCompiler/DataStructures/Diagnostics.fs
+++ b/src/QsCompiler/DataStructures/Diagnostics.fs
@@ -295,8 +295,10 @@ type ErrorCode =
     | InvalidCyclicTypeParameterResolution = 6250
     | InvalidCharacterInInterpolatedArgument = 6251
 
-    | TypeMismatchInReturn = 6301
-    | TypeMismatchInValueUpdate = 6302
+    // TODO: RELEASE 2022-06: Remove TypeMismatchInReturn.
+    | [<Obsolete "This diagnostic is no longer in use.">] TypeMismatchInReturn = 6301
+    // TODO: RELEASE 2022-06: Remove TypeMismatchInValueUpdate.
+    | [<Obsolete "This diagnostic is no longer in use.">] TypeMismatchInValueUpdate = 6302
     | UpdateOfImmutableIdentifier = 6303
     | SymbolTupleShapeMismatch = 6305
     | OperationCallOutsideOfOperation = 6306

--- a/src/QsCompiler/DataStructures/Diagnostics.fs
+++ b/src/QsCompiler/DataStructures/Diagnostics.fs
@@ -621,8 +621,7 @@ type DiagnosticItem =
 
             | ErrorCode.InvalidArrayItemIndex ->
                 "Expecting an expression of type Int or Range. Got an expression of type {0}."
-            | ErrorCode.ItemAccessForNonArray ->
-                "The type {0} does not provide item access. Items can only be accessed for values of array type."
+            | ErrorCode.ItemAccessForNonArray -> "The type {0} is not an array type."
             | ErrorCode.InvalidTypeInArithmeticExpr ->
                 "The type {0} does not support arithmetic operators. Expecting an expression of type Int, BigInt or Double."
             | ErrorCode.InvalidTypeForConcatenation -> "The type {0} does not support the + operator."
@@ -697,7 +696,7 @@ type DiagnosticItem =
             | ErrorCode.UnknownTypeInNamespace -> "No type with the name \"{0}\" exists in the namespace {1}."
             | ErrorCode.TypeParameterRedeclaration -> "A type parameter with the name \"{0}\" already exists."
             | ErrorCode.UnknownTypeParameterName -> "No type parameter with the name \"{0}\" exists."
-            | ErrorCode.UnknownItemName -> "The type {0} does not define an item with name \"{1}\"."
+            | ErrorCode.UnknownItemName -> "The type {0} is not a user-defined type with a field \"{1}\"."
             | ErrorCode.NotMarkedAsAttribute ->
                 "The type {0} is not marked as an attribute. Add \"@Attribute()\" above its declaration to indicate that it may be used as attribute."
             | ErrorCode.InaccessibleTypeInNamespace -> "The type {0} in namespace {1} is not accessible from here."

--- a/src/QsCompiler/DataStructures/Diagnostics.fs
+++ b/src/QsCompiler/DataStructures/Diagnostics.fs
@@ -264,7 +264,8 @@ type ErrorCode =
     // TODO: RELEASE 2021-10: Remove PartialApplicationOfTypeParameter.
     | [<Obsolete "This diagnostic is no longer in use.">] PartialApplicationOfTypeParameter = 6223
     | IndirectlyReferencedExpressionType = 6224
-    | TypeMismatchInCopyAndUpdateExpr = 6225
+    // TODO: RELEASE 2022-11: Remove TypeMismatchInCopyAndUpdateExpr.
+    | [<Obsolete "This diagnostic is no longer in use.">] TypeMismatchInCopyAndUpdateExpr = 6225
     | InterpolatedStringInAttribute = 6226
     | ArgumentOfUserDefinedTypeInAttribute = 6227
     | TypeParameterizedArgumentInAttribute = 6228

--- a/src/QsCompiler/SyntaxProcessor/ExpressionVerification.fs
+++ b/src/QsCompiler/SyntaxProcessor/ExpressionVerification.fs
@@ -291,23 +291,6 @@ let private verifyIdentifier (inference: InferenceContext) (symbols: SymbolTrack
 
         TypedExpression.New(identifier, resolutions, resId.Type, exInfo, symbol.Range), Seq.toList diagnostics
 
-/// Verifies that an expression of the given rhsType, used within the given parent (i.e. specialization declaration),
-/// can be used when an expression of expectedType is expected by callaing TypeMatchArgument.
-/// Generates an error with the given error code mismatchErr for the given range if this is not the case.
-/// Verifies that any internal type parameters are "matched" only with themselves (or with an invalid type),
-/// and generates a ConstrainsTypeParameter error if this is not the case.
-/// If the given rhsEx is Some value, verifies whether it contains an identifier referring to the parent
-/// that is not part of a call-like expression but does not specify all needed type arguments.
-/// Calls the given function addError on all generated errors.
-/// IMPORTANT: ignores any external type parameter occuring in expectedType without raising an error!
-let internal verifyAssignment (inference: InferenceContext) expectedType mismatchErr rhs =
-    [
-        if inference.Constrain(expectedType .> rhs.ResolvedType) |> List.isEmpty |> not then
-            QsCompilerDiagnostic.Error
-                (mismatchErr, [ inference.Resolve rhs.ResolvedType |> showType; showType expectedType ])
-                (rangeOrDefault rhs)
-    ]
-
 /// Given a Q# symbol, as well as the resolved type of the right hand side that is assigned to it,
 /// shape matches the symbol tuple with the type to determine whether the assignment is valid, and
 /// calls the given function tryBuildDeclaration on each symbol item and its matched type.

--- a/src/QsCompiler/SyntaxProcessor/ExpressionVerification.fs
+++ b/src/QsCompiler/SyntaxProcessor/ExpressionVerification.fs
@@ -466,13 +466,13 @@ type QsExpression with
             | RangeLiteral (lhs, end_) ->
                 match lhs.Expression with
                 | RangeLiteral (start, step) ->
-                    // cases arr[...step..ex], arr[ex..step...], arr[ex1..step..ex2], and arr[...ex...]
+                    // Cases: xs[...step..end], xs[start..step...], xs[start..step..end], xs[...step...].
                     resolveSlicingRange start (Some step) end_
                 | _ ->
-                    // case arr[...ex], arr[ex...] and arr[ex1..ex2]
+                    // Cases: xs[...end], xs[start...], xs[start..end], xs[...].
                     resolveSlicingRange lhs None end_
             | _ ->
-                // case arr[ex]
+                // Case: xs[i].
                 resolve context index
 
         /// Resolves and verifies the interpolated expressions, and returns the StringLiteral as typed expression.

--- a/src/QsCompiler/SyntaxProcessor/ExpressionVerification.fs
+++ b/src/QsCompiler/SyntaxProcessor/ExpressionVerification.fs
@@ -634,10 +634,11 @@ type QsExpression with
                 | _ ->
                     resolveSlicing container accessor |> Option.map arrayUpdate |> Option.defaultWith trivialArrayUpdate
 
+            inference.Constrain(Class cls) |> List.iter diagnose
+
             verifyAssignment inference itemType ErrorCode.TypeMismatchInCopyAndUpdateExpr value
             |> List.iter diagnose
 
-            inference.Constrain(Class cls) |> List.iter diagnose
             expr
 
         /// Resolves and verifies the given left hand side and right hand side of a range operator,

--- a/src/QsCompiler/SyntaxProcessor/ExpressionVerification.fs
+++ b/src/QsCompiler/SyntaxProcessor/ExpressionVerification.fs
@@ -582,9 +582,9 @@ type QsExpression with
 
         /// Resolves and verifies the given left hand side, access expression, and right hand side of a copy-and-update expression,
         /// and returns the corresponding copy-and-update expression as typed expression.
-        let buildCopyAndUpdate (container, accessor: QsExpression, value) =
+        let buildCopyAndUpdate (container, accessor: QsExpression, item) =
             let container = resolve context container
-            let value = resolve context value
+            let item = resolve context item
             let itemType = inference.Fresh this.RangeOrDefault
 
             let unqualifiedSymbol, isRecordUpdate =
@@ -608,12 +608,10 @@ type QsExpression with
                 | _ -> resolveSlicing container accessor |> arrayUpdate
 
             inference.Constrain(Class cls) |> List.iter diagnose
+            inference.Constrain(itemType .> item.ResolvedType) |> List.iter diagnose
 
-            verifyAssignment inference itemType ErrorCode.TypeMismatchInCopyAndUpdateExpr value
-            |> List.iter diagnose
-
-            (CopyAndUpdate(container, accessor, value), container.ResolvedType)
-            |> exprWithoutTypeArgs this.Range (inferred false ([ container; accessor; value ] |> anyQuantumDep))
+            (CopyAndUpdate(container, accessor, item), container.ResolvedType)
+            |> exprWithoutTypeArgs this.Range (inferred false ([ container; accessor; item ] |> anyQuantumDep))
 
         /// Resolves and verifies the given left hand side and right hand side of a range operator,
         /// and returns the corresponding RANGE expression as typed expression.

--- a/src/QsCompiler/SyntaxProcessor/StatementVerification.fs
+++ b/src/QsCompiler/SyntaxProcessor/StatementVerification.fs
@@ -83,9 +83,7 @@ let NewFailStatement comments location context expr =
 /// (specified by the given SymbolTracker) are also included in the returned diagnostics.
 let NewReturnStatement comments (location: QsLocation) context expr =
     let expr, diagnostics = resolveExpr context expr
-
-    verifyAssignment context.Inference context.ReturnType ErrorCode.TypeMismatchInReturn expr
-    |> diagnostics.AddRange
+    context.Inference.Constrain(context.ReturnType .> expr.ResolvedType) |> diagnostics.AddRange
 
     onAutoInvertGenerateError ((ErrorCode.ReturnStatementWithinAutoInversion, []), location.Range) context.Symbols
     |> diagnostics.AddRange
@@ -104,9 +102,7 @@ let NewValueUpdate comments (location: QsLocation) context (lhs, rhs) =
     let rhs, rhsDiagnostics = resolveExpr context rhs
     let localQdep = rhs.InferredInformation.HasLocalQuantumDependency
     diagnostics.AddRange rhsDiagnostics
-
-    verifyAssignment context.Inference lhs.ResolvedType ErrorCode.TypeMismatchInValueUpdate rhs
-    |> diagnostics.AddRange
+    context.Inference.Constrain(lhs.ResolvedType .> rhs.ResolvedType) |> diagnostics.AddRange
 
     let rec verifyMutability: TypedExpression -> _ =
         function

--- a/src/QsCompiler/SyntaxProcessor/TypeInference/Constraint.fsi
+++ b/src/QsCompiler/SyntaxProcessor/TypeInference/Constraint.fsi
@@ -20,16 +20,18 @@ type internal ClassConstraint =
     /// A type that supports equality.
     | Eq of ResolvedType
 
+    | HasField of record: ResolvedType * field: Identifier * item: ResolvedType
+
     /// If the callable is an operation, then it supports all functors in the set. Types other than operations are
     /// automatically members of this class.
     | HasFunctorsIfOperation of callable: ResolvedType * functors: QsFunctor Set
 
+    /// A container type that can be indexed, yielding the item type.
+    | HasIndex of container: ResolvedType * index: ResolvedType * item: ResolvedType
+
     /// A callable that can be partially applied, yielding a new callable that has the same output type and the missing
     /// parameters as its input type.
     | HasPartialApplication of callable: ResolvedType * missing: ResolvedType * callable': ResolvedType
-
-    /// A container type that can be indexed, yielding the item type.
-    | Index of container: ResolvedType * index: ResolvedType * item: ResolvedType
 
     /// A type that represents an integer.
     | Integral of ResolvedType

--- a/src/QsCompiler/SyntaxProcessor/TypeInference/Constraint.fsi
+++ b/src/QsCompiler/SyntaxProcessor/TypeInference/Constraint.fsi
@@ -20,6 +20,7 @@ type internal ClassConstraint =
     /// A type that supports equality.
     | Eq of ResolvedType
 
+    /// A record that has a field with the given name and type.
     | HasField of record: ResolvedType * field: Identifier * item: ResolvedType
 
     /// If the callable is an operation, then it supports all functors in the set. Types other than operations are

--- a/src/QsCompiler/SyntaxProcessor/TypeInference/InferenceContext.fs
+++ b/src/QsCompiler/SyntaxProcessor/TypeInference/InferenceContext.fs
@@ -169,9 +169,10 @@ module Inference =
         | Callable (callable, _, _) -> [ callable ]
         | ClassConstraint.Controllable (operation, _) -> [ operation ]
         | Eq ty -> [ ty ]
+        | HasField (record, _, _) -> [ record ]
         | HasFunctorsIfOperation (callable, _) -> [ callable ]
+        | HasIndex (container, index, _) -> [ container; index ]
         | HasPartialApplication (callable, _, _) -> [ callable ]
-        | Index (container, index, _) -> [ container; index ]
         | Integral ty -> [ ty ]
         | Iterable (container, _) -> [ container ]
         | Num ty -> [ ty ]
@@ -412,6 +413,22 @@ type InferenceContext(symbolTracker: SymbolTracker) =
                 if Option.isNone ty.supportsEqualityComparison then
                     error ErrorCode.InvalidTypeInEqualityComparison [ SyntaxTreeToQsharp.Default.ToCode ty ] ty.Range
             ]
+        | HasField (record, field, item) ->
+            let record = context.Resolve record
+
+            match record.Resolution with
+            | QsTypeKind.UserDefinedType udt ->
+                let diagnostics = ResizeArray()
+
+                let diagnose (code, args) =
+                    error code args record.Range |> diagnostics.Add
+
+                let actualItem = symbolTracker.GetItemType field diagnose udt
+                Seq.toList diagnostics @ context.ConstrainImpl(item .> actualItem)
+            | _ ->
+                [
+                    error ErrorCode.ExpectingUserDefinedType [ SyntaxTreeToQsharp.Default.ToCode record ] record.Range
+                ]
         | HasFunctorsIfOperation (callable, functors) ->
             let callable = context.Resolve callable
 
@@ -428,19 +445,7 @@ type InferenceContext(symbolTracker: SymbolTracker) =
                             callable.Range
                 ]
             | _ -> []
-        | HasPartialApplication (callable, missing, callable') ->
-            let callable = context.Resolve callable
-
-            match callable.Resolution with
-            | QsTypeKind.Function (_, output) ->
-                context.ConstrainImpl(ResolvedType.New(QsTypeKind.Function(missing, output)) <. callable')
-            | QsTypeKind.Operation ((_, output), info) ->
-                context.ConstrainImpl(ResolvedType.New(QsTypeKind.Operation((missing, output), info)) <. callable')
-            | _ ->
-                [
-                    error ErrorCode.ExpectingCallableExpr [ SyntaxTreeToQsharp.Default.ToCode callable ] callable.Range
-                ]
-        | Index (container, index, item) ->
+        | HasIndex (container, index, item) ->
             let container = context.Resolve container
             let index = context.Resolve index
 
@@ -458,6 +463,18 @@ type InferenceContext(symbolTracker: SymbolTracker) =
                         ErrorCode.ItemAccessForNonArray
                         [ SyntaxTreeToQsharp.Default.ToCode container ]
                         container.Range
+                ]
+        | HasPartialApplication (callable, missing, callable') ->
+            let callable = context.Resolve callable
+
+            match callable.Resolution with
+            | QsTypeKind.Function (_, output) ->
+                context.ConstrainImpl(ResolvedType.New(QsTypeKind.Function(missing, output)) <. callable')
+            | QsTypeKind.Operation ((_, output), info) ->
+                context.ConstrainImpl(ResolvedType.New(QsTypeKind.Operation((missing, output), info)) <. callable')
+            | _ ->
+                [
+                    error ErrorCode.ExpectingCallableExpr [ SyntaxTreeToQsharp.Default.ToCode callable ] callable.Range
                 ]
         | Integral ty ->
             let ty = context.Resolve ty

--- a/src/QsCompiler/SyntaxProcessor/TypeInference/InferenceContext.fs
+++ b/src/QsCompiler/SyntaxProcessor/TypeInference/InferenceContext.fs
@@ -427,8 +427,10 @@ type InferenceContext(symbolTracker: SymbolTracker) =
                 let actualItem = symbolTracker.GetItemType field diagnose udt
                 Seq.toList diagnostics @ context.ConstrainImpl(item .> actualItem)
             | _ ->
+                let fieldName = Identifier(field, Null) |> SyntaxTreeToQsharp.Default.ToCode
+
                 [
-                    error ErrorCode.ExpectingUserDefinedType [ SyntaxTreeToQsharp.Default.ToCode record ] record.Range
+                    error ErrorCode.UnknownItemName [ SyntaxTreeToQsharp.Default.ToCode record; fieldName ] record.Range
                 ]
         | HasFunctorsIfOperation (callable, functors) ->
             let callable = context.Resolve callable

--- a/src/QsCompiler/SyntaxProcessor/TypeInference/InferenceContext.fs
+++ b/src/QsCompiler/SyntaxProcessor/TypeInference/InferenceContext.fs
@@ -326,7 +326,8 @@ type InferenceContext(symbolTracker: SymbolTracker) =
         match expected.Resolution, actual.Resolution with
         | _ when expected = actual -> []
         | TypeParameter param, _ when variables.ContainsKey param -> tryBind param actual
-        | _, TypeParameter param when variables.ContainsKey param -> tryBind param expected
+        | _, TypeParameter param when variables.ContainsKey param ->
+            ResolvedType.withAllRanges actual.Range expected |> tryBind param
         | ArrayType item1, ArrayType item2 -> context.ConstrainImpl(item1 .= item2)
         | TupleType items1, TupleType items2 ->
             [

--- a/src/QsCompiler/Tests.Compiler/LocalVerificationTests.fs
+++ b/src/QsCompiler/Tests.Compiler/LocalVerificationTests.fs
@@ -159,18 +159,18 @@ type LocalVerificationTests() =
         this.Expect "CopyAndUpdateArray2" []
         this.Expect "CopyAndUpdateArray3" []
         this.Expect "CopyAndUpdateArray4" [ Warning WarningCode.DeprecatedNewArray ]
-        this.Expect "CopyAndUpdateArray5" [ Error ErrorCode.TypeMismatchInCopyAndUpdateExpr ]
-        this.Expect "CopyAndUpdateArray6" [ Error ErrorCode.TypeMismatchInCopyAndUpdateExpr ]
-        this.Expect "CopyAndUpdateArray7" [ Error ErrorCode.TypeMismatchInCopyAndUpdateExpr ]
-        this.Expect "CopyAndUpdateArray8" [ Error ErrorCode.TypeMismatchInCopyAndUpdateExpr ]
+        this.Expect "CopyAndUpdateArray5" [ Error ErrorCode.TypeMismatch ]
+        this.Expect "CopyAndUpdateArray6" [ Error ErrorCode.TypeMismatch ]
+        this.Expect "CopyAndUpdateArray7" [ Error ErrorCode.TypeMismatch ]
+        this.Expect "CopyAndUpdateArray8" [ Error ErrorCode.TypeMismatch ]
         this.Expect "CopyAndUpdateArray9" []
         this.Expect "CopyAndUpdateArray10" []
         this.Expect "CopyAndUpdateArray11" []
         this.Expect "CopyAndUpdateArray12" []
         this.Expect "CopyAndUpdateArray13" []
         this.Expect "CopyAndUpdateArray14" []
-        this.Expect "CopyAndUpdateArray15" [ Error ErrorCode.TypeMismatchInCopyAndUpdateExpr ]
-        this.Expect "CopyAndUpdateArray16" [ Error ErrorCode.TypeMismatchInCopyAndUpdateExpr ]
+        this.Expect "CopyAndUpdateArray15" [ Error ErrorCode.TypeMismatch ]
+        this.Expect "CopyAndUpdateArray16" [ Error ErrorCode.TypeMismatch ]
 
 
     [<Fact>]
@@ -178,25 +178,13 @@ type LocalVerificationTests() =
         this.Expect "UpdateAndReassign1" []
         this.Expect "UpdateAndReassign2" []
         this.Expect "UpdateAndReassign3" []
-        this.Expect "UpdateAndReassign4" [ Error ErrorCode.TypeMismatchInCopyAndUpdateExpr ]
-        this.Expect "UpdateAndReassign5" [ Error ErrorCode.TypeMismatchInCopyAndUpdateExpr ]
+        this.Expect "UpdateAndReassign4" [ Error ErrorCode.TypeMismatch ]
+        this.Expect "UpdateAndReassign5" [ Error ErrorCode.TypeMismatch ]
         this.Expect "UpdateAndReassign6" [ Warning WarningCode.DeprecatedNewArray ]
         this.Expect "UpdateAndReassign7" [ Warning WarningCode.DeprecatedNewArray ]
         this.Expect "UpdateAndReassign8" [ Warning WarningCode.DeprecatedNewArray ]
-
-        this.Expect
-            "UpdateAndReassign9"
-            [
-                Error ErrorCode.TypeMismatchInCopyAndUpdateExpr
-                Warning WarningCode.DeprecatedNewArray
-            ]
-
-        this.Expect
-            "UpdateAndReassign10"
-            [
-                Error ErrorCode.TypeMismatchInCopyAndUpdateExpr
-                Warning WarningCode.DeprecatedNewArray
-            ]
+        this.Expect "UpdateAndReassign9" [ Error ErrorCode.TypeMismatch; Warning WarningCode.DeprecatedNewArray ]
+        this.Expect "UpdateAndReassign10" [ Error ErrorCode.TypeMismatch; Warning WarningCode.DeprecatedNewArray ]
 
 
     [<Fact>]
@@ -254,20 +242,13 @@ type LocalVerificationTests() =
     [<Fact>]
     member this.``Named type item update``() =
         this.Expect "ItemUpdate1" []
-        this.Expect "ItemUpdate2" [ Error ErrorCode.TypeMismatchInCopyAndUpdateExpr ]
-        this.Expect "ItemUpdate3" [ Error ErrorCode.TypeMismatchInCopyAndUpdateExpr ]
+        this.Expect "ItemUpdate2" [ Error ErrorCode.TypeMismatch ]
+        this.Expect "ItemUpdate3" [ Error ErrorCode.TypeMismatch ]
         this.Expect "ItemUpdate4" []
         this.Expect "ItemUpdate5" [ Error ErrorCode.UpdateOfImmutableIdentifier ]
-        this.Expect "ItemUpdate6" [ Error ErrorCode.TypeMismatchInCopyAndUpdateExpr ]
-        this.Expect "ItemUpdate7" [ Error ErrorCode.TypeMismatchInCopyAndUpdateExpr ]
-
-        this.Expect
-            "ItemUpdate8"
-            [
-                Error ErrorCode.TypeMismatchInCopyAndUpdateExpr
-                Error ErrorCode.TypeMismatchInCopyAndUpdateExpr
-            ]
-
+        this.Expect "ItemUpdate6" [ Error ErrorCode.TypeMismatch ]
+        this.Expect "ItemUpdate7" [ Error ErrorCode.TypeMismatch ]
+        this.Expect "ItemUpdate8" [ Error ErrorCode.TypeMismatch; Error ErrorCode.TypeMismatch ]
         this.Expect "ItemUpdate9" [ Warning WarningCode.DeprecatedNewArray ]
 
         this.Expect
@@ -288,14 +269,14 @@ type LocalVerificationTests() =
         this.Expect
             "ItemUpdate12"
             [
-                Error ErrorCode.TypeMismatchInCopyAndUpdateExpr
-                Error ErrorCode.TypeMismatchInCopyAndUpdateExpr
+                Error ErrorCode.TypeMismatch
+                Error ErrorCode.TypeMismatch
                 Warning WarningCode.DeprecatedNewArray
             ]
 
         this.Expect "ItemUpdate13" []
-        this.Expect "ItemUpdate14" [ Error ErrorCode.TypeMismatchInCopyAndUpdateExpr ]
-        this.Expect "ItemUpdate15" [ Error ErrorCode.TypeMismatchInCopyAndUpdateExpr ]
+        this.Expect "ItemUpdate14" [ Error ErrorCode.TypeMismatch ]
+        this.Expect "ItemUpdate15" [ Error ErrorCode.TypeMismatch ]
 
         this.Expect
             "ItemUpdate16"

--- a/src/QsCompiler/Tests.Compiler/LocalVerificationTests.fs
+++ b/src/QsCompiler/Tests.Compiler/LocalVerificationTests.fs
@@ -204,7 +204,7 @@ type LocalVerificationTests() =
 
     [<Fact>]
     member this.``Named type item access``() =
-        this.Expect "ItemAccess1" [ Error ErrorCode.ExpectingUserDefinedType ]
+        this.Expect "ItemAccess1" [ Error ErrorCode.UnknownItemName ]
         this.Expect "ItemAccess2" [ Error ErrorCode.UnknownItemName ]
         this.Expect "ItemAccess3" []
         this.Expect "ItemAccess4" []

--- a/src/QsCompiler/Tests.Compiler/TestCases/TypeChecking.qs
+++ b/src/QsCompiler/Tests.Compiler/TestCases/TypeChecking.qs
@@ -935,9 +935,9 @@ namespace Microsoft.Quantum.Testing.TypeChecking {
         let op = q => GenericFunction(Adjointable(q), Controllable(q));
     }
 
-    function Lambda23() : Unit {
+    function Lambda23() : Int {
         let numbers = [14, 15, 3, -4, 18];
-        let _ = Fold((x, y) -> x + y, 0, numbers);
+        return Fold((x, y) -> x + y, 0, numbers);
     }
 
     function Lambda24(xs : Int[]) : Int[] {
@@ -958,20 +958,24 @@ namespace Microsoft.Quantum.Testing.TypeChecking {
         return f(1);
     }
 
-    function Lambda28() : Unit {
+    function Lambda28() : Int[] {
         let f = (n, i) -> [0, size = n] w/ i <- 1;
-        let _ = f(2, 0);
+        return f(2, 0);
     }
 
-    function Lambda29() : Unit {
+    function Lambda29() : NamedItems1 {
         let f = x -> x w/ Im <- 1;
-        let _ = f(NamedItems1(1, 0));
+        return f(NamedItems1(1, 0));
     }
 
-    function Lambda30() : Unit {
+    function Lambda30() : Int[] {
         let i = 0;
         let f = xs -> xs w/ i <- 1;
-        let _ = f([1, 0]);
+        return f([1, 0]);
+    }
+
+    function Lambda31(xs : NamedItems1[]) : Int[] {
+        return Mapped(x -> x::Re, xs);
     }
 
     function LambdaInvalid1() : Qubit => Unit is Adj {
@@ -1005,5 +1009,14 @@ namespace Microsoft.Quantum.Testing.TypeChecking {
     function LambdaInvalid7() : Int -> Int {
         mutable x = 0;
         return x -> x;
+    }
+
+    function LambdaInvalid8() : Unit {
+        let f = x -> x w/ Invalid <- 1;
+        let _ = f(NamedItems1(1, 0));
+    }
+
+    function LambdaInvalid9(xs : NamedItems1[]) : Int[] {
+        return Mapped(x -> x::Invalid, xs);
     }
 }

--- a/src/QsCompiler/Tests.Compiler/TestCases/TypeChecking.qs
+++ b/src/QsCompiler/Tests.Compiler/TestCases/TypeChecking.qs
@@ -963,6 +963,17 @@ namespace Microsoft.Quantum.Testing.TypeChecking {
         let _ = f(2, 0);
     }
 
+    function Lambda29() : Unit {
+        let f = x -> x w/ Im <- 1;
+        let _ = f(NamedItems1(1, 0));
+    }
+
+    function Lambda30() : Unit {
+        let i = 0;
+        let f = xs -> xs w/ i <- 1;
+        let _ = f([1, 0]);
+    }
+
     function LambdaInvalid1() : Qubit => Unit is Adj {
         return q => Operation(q);
     }

--- a/src/QsCompiler/Tests.Compiler/TypeCheckingTests.fs
+++ b/src/QsCompiler/Tests.Compiler/TypeCheckingTests.fs
@@ -119,7 +119,7 @@ module TypeCheckingTests =
 
     [<Fact>]
     let ``Supports lambda expressions`` () =
-        allValid "Lambda" 30
+        allValid "Lambda" 31
         expect "LambdaInvalid1" [ Error ErrorCode.TypeMismatchInReturn ]
         expect "LambdaInvalid2" [ Error ErrorCode.TypeMismatchInReturn ]
         expect "LambdaInvalid3" (Error ErrorCode.InfiniteType |> List.replicate 2)
@@ -127,6 +127,8 @@ module TypeCheckingTests =
         expect "LambdaInvalid5" [ Error ErrorCode.MutableClosure; Error ErrorCode.MutableClosure ]
         expect "LambdaInvalid6" [ Error ErrorCode.LocalVariableAlreadyExists ]
         expect "LambdaInvalid7" [ Error ErrorCode.LocalVariableAlreadyExists ]
+        expect "LambdaInvalid8" [ Error ErrorCode.UnknownItemName ]
+        expect "LambdaInvalid9" [ Error ErrorCode.UnknownItemName ]
 
     [<Fact>]
     let ``Operation lambda with non-unit return (1)`` () =

--- a/src/QsCompiler/Tests.Compiler/TypeCheckingTests.fs
+++ b/src/QsCompiler/Tests.Compiler/TypeCheckingTests.fs
@@ -119,7 +119,7 @@ module TypeCheckingTests =
 
     [<Fact>]
     let ``Supports lambda expressions`` () =
-        allValid "Lambda" 28
+        allValid "Lambda" 30
         expect "LambdaInvalid1" [ Error ErrorCode.TypeMismatchInReturn ]
         expect "LambdaInvalid2" [ Error ErrorCode.TypeMismatchInReturn ]
         expect "LambdaInvalid3" (Error ErrorCode.InfiniteType |> List.replicate 2)

--- a/src/QsCompiler/Tests.Compiler/TypeCheckingTests.fs
+++ b/src/QsCompiler/Tests.Compiler/TypeCheckingTests.fs
@@ -120,8 +120,8 @@ module TypeCheckingTests =
     [<Fact>]
     let ``Supports lambda expressions`` () =
         allValid "Lambda" 31
-        expect "LambdaInvalid1" [ Error ErrorCode.TypeMismatchInReturn ]
-        expect "LambdaInvalid2" [ Error ErrorCode.TypeMismatchInReturn ]
+        expect "LambdaInvalid1" [ Error ErrorCode.TypeMismatch ]
+        expect "LambdaInvalid2" [ Error ErrorCode.TypeMismatch ]
         expect "LambdaInvalid3" (Error ErrorCode.InfiniteType |> List.replicate 2)
         expect "LambdaInvalid4" [ Error ErrorCode.MutableClosure ]
         expect "LambdaInvalid5" [ Error ErrorCode.MutableClosure; Error ErrorCode.MutableClosure ]
@@ -257,7 +257,7 @@ type TypeCheckingTests() =
         this.Expect
             "CommonBaseType4"
             [
-                Error ErrorCode.TypeMismatchInReturn
+                Error ErrorCode.TypeMismatch
                 Warning WarningCode.DeprecatedNewArray
                 Warning WarningCode.DeprecatedNewArray
             ]
@@ -265,14 +265,14 @@ type TypeCheckingTests() =
         this.Expect "CommonBaseType5" []
         this.Expect "CommonBaseType6" []
         this.Expect "CommonBaseType7" []
-        this.Expect "CommonBaseType8" [ Error ErrorCode.TypeMismatchInReturn ]
+        this.Expect "CommonBaseType8" [ Error ErrorCode.TypeMismatch ]
         this.Expect "CommonBaseType9" []
         this.Expect "CommonBaseType10" []
-        this.Expect "CommonBaseType11" [ Error ErrorCode.TypeMismatchInReturn ]
+        this.Expect "CommonBaseType11" [ Error ErrorCode.TypeMismatch ]
         this.Expect "CommonBaseType12" [ Error ErrorCode.TypeIntersectionMismatch ]
         this.Expect "CommonBaseType13" []
         this.Expect "CommonBaseType14" []
-        this.Expect "CommonBaseType15" [ Error ErrorCode.TypeMismatchInReturn ]
+        this.Expect "CommonBaseType15" [ Error ErrorCode.TypeMismatch ]
         this.Expect "CommonBaseType16" [ Error ErrorCode.TypeIntersectionMismatch ]
         this.Expect "CommonBaseType17" []
         this.Expect "CommonBaseType18" []
@@ -370,7 +370,7 @@ type TypeCheckingTests() =
         this.Expect "MatchArgument7" []
         this.Expect "MatchArgument8" []
         this.Expect "MatchArgument9" [ Error ErrorCode.TypeMismatch ]
-        this.Expect "MatchArgument10" [ Error ErrorCode.TypeMismatch; Error ErrorCode.TypeMismatchInReturn ]
+        this.Expect "MatchArgument10" (Error ErrorCode.TypeMismatch |> List.replicate 2)
         this.Expect "MatchArgument11" []
         this.Expect "MatchArgument12" []
         this.Expect "MatchArgument13" []
@@ -450,7 +450,7 @@ type TypeCheckingTests() =
                 Error ErrorCode.TypeMismatch
             ]
 
-        this.Expect "PartialApplication28" [ Error ErrorCode.TypeMismatchInReturn ]
+        this.Expect "PartialApplication28" [ Error ErrorCode.TypeMismatch ]
         this.Expect "PartialApplication29" []
         this.Expect "PartialApplication30" []
 


### PR DESCRIPTION
- Decides whether a copy-and-update expression is a record update or an array update based on the names of local variables, not the type of the container operand.
- Adds the `HasField` class constraint to support record copy-and-update and field access expressions on undetermined types (e.g. in lambdas).
- Clean up related diagnostics and remove all other obsolete diagnostics.

Closes #1365 and closes #1380.