### PR TITLE
Update .NET SDK check in Language Server to 6.0

### DIFF
--- a/src/QsCompiler/LanguageServer/LanguageServer.cs
+++ b/src/QsCompiler/LanguageServer/LanguageServer.cs
@@ -139,21 +139,21 @@ namespace Microsoft.Quantum.QsLanguageServer
 
         internal async Task CheckDotNetSdkVersionAsync()
         {
-            var isDotNet31Installed = DotNetSdkHelper.IsDotNet31Installed();
-            if (isDotNet31Installed == null)
+            var isDotNet6Installed = DotNetSdkHelper.IsDotNet6Installed();
+            if (isDotNet6Installed == null)
             {
                 this.LogToWindow("Unable to detect .NET SDK versions", MessageType.Error);
             }
             else
             {
-                if (isDotNet31Installed != true)
+                if (isDotNet6Installed != true)
                 {
-                    const string dotnet31Url = "https://dotnet.microsoft.com/download/dotnet-core/3.1";
-                    this.LogToWindow($".NET Core SDK 3.1 not found. Quantum Development Kit Extension requires .NET Core SDK 3.1 to work properly ({dotnet31Url}).", MessageType.Error);
+                    const string dotnet6Url = "https://dotnet.microsoft.com/download/dotnet/6.0";
+                    this.LogToWindow($".NET SDK 6.0 not found. Quantum Development Kit Extension requires .NET SDK 6.0 to work properly ({dotnet6Url}).", MessageType.Error);
                     var downloadAction = new MessageActionItem { Title = "Download" };
                     var cancelAction = new MessageActionItem { Title = "No, thanks" };
                     var selectedAction = await this.ShowDialogInWindowAsync(
-                        "Quantum Development Kit Extension requires .NET Core SDK 3.1 to work properly. Please install .NET Core SDK 3.1 and restart Visual Studio.",
+                        "Quantum Development Kit Extension requires .NET SDK 6.0 to work properly. Please install .NET SDK 6.0 and restart Visual Studio.",
                         MessageType.Error,
                         new[] { downloadAction, cancelAction });
                     if (selectedAction != null
@@ -161,7 +161,7 @@ namespace Microsoft.Quantum.QsLanguageServer
                     {
                         Process.Start(new ProcessStartInfo
                         {
-                            FileName = dotnet31Url,
+                            FileName = dotnet6Url,
                             UseShellExecute = true,
                             CreateNoWindow = true,
                         });

--- a/src/QsCompiler/LanguageServer/Utils.cs
+++ b/src/QsCompiler/LanguageServer/Utils.cs
@@ -224,9 +224,9 @@ namespace Microsoft.Quantum.QsLanguageServer
 
     internal static class DotNetSdkHelper
     {
-        private static readonly Regex DotNet31Regex = new Regex(@"^3\.1\.\d+", RegexOptions.Multiline | RegexOptions.Compiled);
+        private static readonly Regex DotNet31Regex = new Regex(@"^6\.0\.\d+", RegexOptions.Multiline | RegexOptions.Compiled);
 
-        public static bool? IsDotNet31Installed()
+        public static bool? IsDotNet6Installed()
         {
             var process = Process.Start(new ProcessStartInfo
             {

--- a/src/QsCompiler/LanguageServer/Utils.cs
+++ b/src/QsCompiler/LanguageServer/Utils.cs
@@ -224,7 +224,7 @@ namespace Microsoft.Quantum.QsLanguageServer
 
     internal static class DotNetSdkHelper
     {
-        private static readonly Regex DotNet31Regex = new Regex(@"^6\.0\.\d+", RegexOptions.Multiline | RegexOptions.Compiled);
+        private static readonly Regex DotNetVersionRegex = new Regex(@"^6\.0\.\d+", RegexOptions.Multiline | RegexOptions.Compiled);
 
         public static bool? IsDotNet6Installed()
         {
@@ -240,7 +240,7 @@ namespace Microsoft.Quantum.QsLanguageServer
             }
 
             var sdks = process.StandardOutput.ReadToEnd();
-            return DotNet31Regex.IsMatch(sdks);
+            return DotNetVersionRegex.IsMatch(sdks);
         }
     }
 }


### PR DESCRIPTION
As we updated component checks from .NET Core 3.1 to .NET 6.0, this check in the Language Server was missed.