### PR TITLE
Skip conditional blocks when condition is known to be false

### DIFF
--- a/src/QsCompiler/QirGeneration/Context.cs
+++ b/src/QsCompiler/QirGeneration/Context.cs
@@ -413,6 +413,9 @@ namespace Microsoft.Quantum.QsCompiler.QIR
             }
         }
 
+        internal void AttachAttributes(QsQualifiedName qualifiedName, QsSpecializationKind specKind, params string[] attributeNames) =>
+            this.CreateBridgeFunction(qualifiedName, specKind, (_, func) => func, attributeNames);
+
         /// <summary>
         /// <inheritdoc cref="Interop.GenerateWrapper(GenerationContext, string, ArgumentTuple, ResolvedType, IrFunction)"/>
         /// <br/>

--- a/src/QsCompiler/QirGeneration/Generator.cs
+++ b/src/QsCompiler/QirGeneration/Generator.cs
@@ -71,10 +71,14 @@ namespace Microsoft.Quantum.QsCompiler.QIR
                 this.Namespaces.OnNamespace(ns);
             }
 
-            foreach (var epName in this.Compilation.EntryPoints)
+            // TODO: get rid of entry point and interop wrappers
+            if (!this.SharedState.TargetQirProfile)
             {
-                this.SharedState.CreateInteropFriendlyWrapper(epName);
-                this.SharedState.CreateEntryPoint(epName);
+                foreach (var epName in this.Compilation.EntryPoints)
+                {
+                    this.SharedState.CreateInteropFriendlyWrapper(epName);
+                    this.SharedState.CreateEntryPoint(epName);
+                }
             }
 
             this.SharedState.GenerateRequiredFunctions();

--- a/src/QsCompiler/QirGeneration/QIR/DataStructures.cs
+++ b/src/QsCompiler/QirGeneration/QIR/DataStructures.cs
@@ -823,6 +823,8 @@ namespace Microsoft.Quantum.QIR.Emission
                         this.QSharpElementType)
                     : throw new InvalidOperationException("invalid pointer access in array");
 
+                // TODO: emit poison value if access is out of bounds
+                // -> requires update to at least llvm 13 across all consumers of this IR (preferably even newer).
                 return element is null
                     ? new PointerValue(this.QSharpElementType, this.LlvmElementType, this.sharedState, Reload, Store)
                     : new PointerValue(element, this.sharedState, Reload, Store);

--- a/src/QsCompiler/QirGeneration/Subtransformations/NamespaceTransformation.cs
+++ b/src/QsCompiler/QirGeneration/Subtransformations/NamespaceTransformation.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Linq;
+using Microsoft.Quantum.QIR;
 using Microsoft.Quantum.QsCompiler.SyntaxTokens;
 using Microsoft.Quantum.QsCompiler.SyntaxTree;
 using Microsoft.Quantum.QsCompiler.Transformations.Core;
@@ -104,6 +105,12 @@ namespace Microsoft.Quantum.QsCompiler.QIR
             this.context.SetCurrentCallable(c);
             c = base.OnCallableDeclaration(c);
             this.context.SetCurrentCallable(null);
+
+            if (this.SharedState.TargetQirProfile && c.Attributes.Any(BuiltIn.MarksEntryPoint))
+            {
+                this.SharedState.AttachAttributes(c.FullName, QsSpecializationKind.QsBody, AttributeNames.EntryPoint);
+            }
+
             return c;
         }
 

--- a/src/QsCompiler/QirGeneration/Subtransformations/StatementKindTransformation.cs
+++ b/src/QsCompiler/QirGeneration/Subtransformations/StatementKindTransformation.cs
@@ -241,7 +241,7 @@ namespace Microsoft.Quantum.QsCompiler.QIR
 
             var clauses = stm.ConditionalBlocks;
             var contBlock = this.SharedState.AddBlockAfterCurrent("continue");
-            var contBlockUsed = false;
+            var (contBlockUsed, skipRest) = (false, false);
 
             // if/then/elif...else
             // The first test goes in the current block. If it succeeds, we go to the "then0" block.
@@ -249,22 +249,8 @@ namespace Microsoft.Quantum.QsCompiler.QIR
             // If the second test succeeds, we go to the "then1" block, otherwise to the "test2" block, etc.
             // If all tests fail, we go to the "else" block if there's a default block, or to the
             // continuation block if not.
-            for (int n = 0; n < clauses.Length; n++)
+            for (int n = 0; n < clauses.Length && !skipRest; n++)
             {
-                // If this is an intermediate clause, then the next block if the test fails
-                // is the next clause's test block.
-                // If this is the last clause, then the next block is the default clause's block
-                // if there is one, or the continue block if not.
-                var conditionalBlock = this.SharedState.CurrentFunction.InsertBasicBlock(
-                            this.SharedState.BlockName($"then{n}"), contBlock);
-                var nextConditional = n < clauses.Length - 1
-                    ? this.SharedState.CurrentFunction.InsertBasicBlock(this.SharedState.BlockName($"test{n + 1}"), contBlock)
-                    : (stm.Default.IsNull
-                        ? contBlock
-                        : this.SharedState.CurrentFunction.InsertBasicBlock(
-                                this.SharedState.BlockName($"else"), contBlock));
-                contBlockUsed = contBlockUsed || nextConditional == contBlock;
-
                 // Evaluate the test, which should be a Boolean at this point, and create the branch.
                 // Note that we need to start the branching and create a scope for the condition
                 // to ensure that anything created as part of the condition is released as part of the condition,
@@ -273,14 +259,33 @@ namespace Microsoft.Quantum.QsCompiler.QIR
                 this.SharedState.ScopeMgr.OpenScope();
                 var testValue = this.SharedState.EvaluateSubexpression(clauses[n].Item1).Value;
                 this.SharedState.ScopeMgr.CloseScope(false);
-                this.SharedState.CurrentBuilder.Branch(testValue, conditionalBlock, nextConditional);
-                contBlockUsed = this.ProcessBlock(conditionalBlock, clauses[n].Item2.Body, contBlock) || contBlockUsed;
+
+                if (!(QirValues.AsConstantInt(testValue) == 0))
+                {
+                    // If this is an intermediate clause, then the next block if the test fails
+                    // is the next clause's test block.
+                    // If this is the last clause, then the next block is the default clause's block
+                    // if there is one, or the continue block if not.
+                    var conditionalBlock = this.SharedState.CurrentFunction.InsertBasicBlock(
+                                this.SharedState.BlockName($"then{n}"), contBlock);
+                    skipRest = (QirValues.AsConstantInt(testValue) & 1) == 1;
+                    var nextConditional = n < clauses.Length - 1 && !skipRest
+                        ? this.SharedState.CurrentFunction.InsertBasicBlock(this.SharedState.BlockName($"test{n + 1}"), contBlock)
+                        : (stm.Default.IsNull || skipRest
+                            ? contBlock
+                            : this.SharedState.CurrentFunction.InsertBasicBlock(this.SharedState.BlockName($"else"), contBlock));
+                    contBlockUsed = contBlockUsed || nextConditional == contBlock;
+
+                    this.SharedState.CurrentBuilder.Branch(testValue, conditionalBlock, nextConditional);
+                    contBlockUsed = this.ProcessBlock(conditionalBlock, clauses[n].Item2.Body, contBlock) || contBlockUsed;
+                    this.SharedState.SetCurrentBlock(nextConditional);
+                }
+
                 this.SharedState.EndBranch();
-                this.SharedState.SetCurrentBlock(nextConditional);
             }
 
             // Deal with the default, if there is any
-            if (stm.Default.IsValue)
+            if (stm.Default.IsValue && !skipRest)
             {
                 this.SharedState.StartBranch();
                 contBlockUsed = this.ProcessBlock(this.SharedState.CurrentBlock, stm.Default.Item.Body, contBlock) || contBlockUsed;

--- a/src/QsCompiler/QirGeneration/Subtransformations/StatementKindTransformation.cs
+++ b/src/QsCompiler/QirGeneration/Subtransformations/StatementKindTransformation.cs
@@ -292,13 +292,9 @@ namespace Microsoft.Quantum.QsCompiler.QIR
                 this.SharedState.EndBranch();
             }
 
-            // Finally, set the continuation block as current and prune it if it is unused.
-            this.SharedState.SetCurrentBlock(contBlock);
-            if (!contBlockUsed)
+            if (contBlockUsed)
             {
-                // This is the savest option to deal with this case from a code rubustness perspective.
-                // The additional code blocks that don't have any predecessors are better trimmed in a separate pass over the generated ir.
-                this.OnFailStatement(SyntaxGenerator.StringLiteral("reached unreachable code...", ImmutableArray<TypedExpression>.Empty));
+                this.SharedState.SetCurrentBlock(contBlock);
             }
 
             return QsStatementKind.EmptyStatement;

--- a/src/QsCompiler/QirGeneration/Subtransformations/StatementKindTransformation.cs
+++ b/src/QsCompiler/QirGeneration/Subtransformations/StatementKindTransformation.cs
@@ -292,9 +292,12 @@ namespace Microsoft.Quantum.QsCompiler.QIR
                 this.SharedState.EndBranch();
             }
 
-            if (contBlockUsed)
+            var currentBlock = this.SharedState.CurrentBlock;
+            this.SharedState.SetCurrentBlock(contBlock);
+            if (!contBlockUsed)
             {
-                this.SharedState.SetCurrentBlock(contBlock);
+                this.SharedState.CurrentBuilder.Unreachable();
+                this.SharedState.SetCurrentBlock(currentBlock);
             }
 
             return QsStatementKind.EmptyStatement;

--- a/src/QsCompiler/Tests.Compiler/ExecutionTests.fs
+++ b/src/QsCompiler/Tests.Compiler/ExecutionTests.fs
@@ -239,7 +239,7 @@ type ExecutionTests(output: ITestOutputHelper) =
     [<Fact>]
     member this.``QIR native llvm type handling``() =
 
-        let functionName = "Microsoft__Quantum__Testing__ExecutionTests__TestNativeTypeHandling"
+        let functionName = "Microsoft__Quantum__Testing__ExecutionTests__TestNativeTypeHandling__body"
         let exitCode, out, err = QirExecutionTest true functionName
         AssertEqual String.Empty err
         Assert.Equal(0, exitCode)
@@ -270,7 +270,6 @@ type ExecutionTests(output: ITestOutputHelper) =
             [[PauliX, PauliZ], [PauliX, PauliX, PauliX], [PauliY], [PauliI]]
             [[], [], [2], [3]]
             [[0, 1], [3, 3, 3], [2], [3]]
-            Zero
             """
 
         AssertEqual expected out

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestBools.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestBools.ll
@@ -14,7 +14,5 @@ else__1:                                          ; preds = %entry
   ret i1 %e
 
 continue__1:                                      ; No predecessors!
-  %1 = call %String* @__quantum__rt__string_create(i8* getelementptr inbounds ([28 x i8], [28 x i8]* @0, i32 0, i32 0))
-  call void @__quantum__rt__fail(%String* %1)
   unreachable
 }

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestConditional1.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestConditional1.ll
@@ -22,9 +22,5 @@ else__1:                                          ; preds = %entry
   ret i64 0
 
 continue__1:                                      ; No predecessors!
-  %4 = call %String* @__quantum__rt__string_create(i8* getelementptr inbounds ([28 x i8], [28 x i8]* @4, i32 0, i32 0))
-  call void @__quantum__rt__array_update_alias_count(%Array* %arg__1, i32 -1)
-  call void @__quantum__rt__tuple_update_alias_count(%Tuple* %1, i32 -1)
-  call void @__quantum__rt__fail(%String* %4)
   unreachable
 }

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestConditional3.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestConditional3.ll
@@ -12,8 +12,6 @@ else__2:                                          ; preds = %then0__1
   ret i64 2
 
 continue__2:                                      ; No predecessors!
-  %0 = call %String* @__quantum__rt__string_create(i8* getelementptr inbounds ([28 x i8], [28 x i8]* @4, i32 0, i32 0))
-  call void @__quantum__rt__fail(%String* %0)
   unreachable
 
 else__1:                                          ; preds = %entry
@@ -26,12 +24,8 @@ else__3:                                          ; preds = %else__1
   ret i64 4
 
 continue__3:                                      ; No predecessors!
-  %1 = call %String* @__quantum__rt__string_create(i8* getelementptr inbounds ([28 x i8], [28 x i8]* @4, i32 0, i32 0))
-  call void @__quantum__rt__fail(%String* %1)
   unreachable
 
 continue__1:                                      ; No predecessors!
-  %2 = call %String* @__quantum__rt__string_create(i8* getelementptr inbounds ([28 x i8], [28 x i8]* @4, i32 0, i32 0))
-  call void @__quantum__rt__fail(%String* %2)
   unreachable
 }

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestConditional4.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestConditional4.ll
@@ -1,7 +1,7 @@
 define internal i64 @Microsoft__Quantum__Testing__QIR__TestConditions__body(%String* %input, %Array* %arr) {
 entry:
   call void @__quantum__rt__array_update_alias_count(%Array* %arr, i32 1)
-  %0 = call %String* @__quantum__rt__string_create(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @5, i32 0, i32 0))
+  %0 = call %String* @__quantum__rt__string_create(i8* getelementptr inbounds ([5 x i8], [5 x i8]* @4, i32 0, i32 0))
   %1 = call i1 @__quantum__rt__string_equal(%String* %input, %String* %0)
   call void @__quantum__rt__string_update_reference_count(%String* %0, i32 -1)
   br i1 %1, label %then0__1, label %test1__1
@@ -10,7 +10,7 @@ then0__1:                                         ; preds = %entry
   br label %continue__1
 
 test1__1:                                         ; preds = %entry
-  %2 = call %String* @__quantum__rt__string_create(i8* getelementptr inbounds ([6 x i8], [6 x i8]* @6, i32 0, i32 0))
+  %2 = call %String* @__quantum__rt__string_create(i8* getelementptr inbounds ([6 x i8], [6 x i8]* @5, i32 0, i32 0))
   %3 = call i1 @__quantum__rt__string_equal(%String* %input, %String* %2)
   call void @__quantum__rt__string_update_reference_count(%String* %2, i32 -1)
   br i1 %3, label %then1__1, label %test2__1

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestReferenceCounts2.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestReferenceCounts2.ll
@@ -49,20 +49,5 @@ else__1:                                          ; preds = %entry
   ret { %String*, %Array* }* %s
 
 continue__1:                                      ; No predecessors!
-  %14 = call %String* @__quantum__rt__string_create(i8* getelementptr inbounds ([28 x i8], [28 x i8]* @1, i32 0, i32 0))
-  %15 = getelementptr inbounds { %String*, %Array* }, { %String*, %Array* }* %s, i32 0, i32 0
-  %16 = load %String*, %String** %15, align 8
-  call void @__quantum__rt__array_update_alias_count(%Array* %5, i32 -1)
-  call void @__quantum__rt__tuple_update_alias_count(%Tuple* %6, i32 -1)
-  call void @__quantum__rt__array_update_alias_count(%Array* %9, i32 -1)
-  call void @__quantum__rt__tuple_update_alias_count(%Tuple* %7, i32 -1)
-  call void @__quantum__rt__string_update_reference_count(%String* %0, i32 -1)
-  call void @__quantum__rt__array_update_reference_count(%Array* %1, i32 -1)
-  call void @__quantum__rt__string_update_reference_count(%String* %16, i32 -1)
-  call void @__quantum__rt__array_update_reference_count(%Array* %5, i32 -1)
-  call void @__quantum__rt__tuple_update_reference_count(%Tuple* %6, i32 -1)
-  call void @__quantum__rt__array_update_reference_count(%Array* %9, i32 -1)
-  call void @__quantum__rt__tuple_update_reference_count(%Tuple* %7, i32 -1)
-  call void @__quantum__rt__fail(%String* %14)
   unreachable
 }

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestTargetingProfile.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestTargetingProfile.ll
@@ -83,6 +83,7 @@ entry:
   store i64 1, i64* %37, align 4
   %38 = bitcast i64* %37 to i8*
   call void @__quantum__qis__dumpmachine__body(i8* %38)
+  call void @__quantum__qis__logpauli__body(i2 -2)
   %39 = alloca i64, align 8
   store i64 2, i64* %39, align 4
   %40 = bitcast i64* %39 to i8*
@@ -103,6 +104,7 @@ entry:
   store { [4 x { [2 x i64], i64 }], i64 } { [4 x { [2 x i64], i64 }] [{ [2 x i64], i64 } { [2 x i64] [i64 2, i64 1], i64 2 }, { [2 x i64], i64 } zeroinitializer, { [2 x i64], i64 } { [2 x i64] [i64 3, i64 0], i64 1 }, { [2 x i64], i64 } { [2 x i64] zeroinitializer, i64 1 }], i64 4 }, { [4 x { [2 x i64], i64 }], i64 }* %47, align 4
   %48 = bitcast { [4 x { [2 x i64], i64 }], i64 }* %47 to i8*
   call void @__quantum__qis__dumpmachine__body(i8* %48)
+  call void @__quantum__qis__logpauli__body(i2 0)
   %49 = alloca { [4 x { [2 x i64], i64 }], i64 }, align 8
   store { [4 x { [2 x i64], i64 }], i64 } { [4 x { [2 x i64], i64 }] [{ [2 x i64], i64 } zeroinitializer, { [2 x i64], i64 } zeroinitializer, { [2 x i64], i64 } { [2 x i64] [i64 3, i64 0], i64 1 }, { [2 x i64], i64 } { [2 x i64] zeroinitializer, i64 1 }], i64 4 }, { [4 x { [2 x i64], i64 }], i64 }* %49, align 4
   %50 = bitcast { [4 x { [2 x i64], i64 }], i64 }* %49 to i8*
@@ -111,161 +113,253 @@ entry:
   store { [4 x { [3 x i64], i64 }], i64 } { [4 x { [3 x i64], i64 }] [{ [3 x i64], i64 } { [3 x i64] [i64 2, i64 1, i64 0], i64 2 }, { [3 x i64], i64 } { [3 x i64] [i64 1, i64 2, i64 3], i64 3 }, { [3 x i64], i64 } { [3 x i64] [i64 3, i64 0, i64 0], i64 1 }, { [3 x i64], i64 } { [3 x i64] zeroinitializer, i64 1 }], i64 4 }, { [4 x { [3 x i64], i64 }], i64 }* %51, align 4
   %52 = bitcast { [4 x { [3 x i64], i64 }], i64 }* %51 to i8*
   call void @__quantum__qis__dumpmachine__body(i8* %52)
-  %53 = call %Qubit* @__quantum__rt__qubit_allocate()
-  %54 = call %Qubit* @__quantum__rt__qubit_allocate()
-  %55 = insertvalue [2 x %Qubit*] zeroinitializer, %Qubit* %53, 0
-  %56 = insertvalue { [2 x %Qubit*], i64 } zeroinitializer, [2 x %Qubit*] %55, 0
-  %57 = insertvalue { [2 x %Qubit*], i64 } %56, i64 2, 1
-  %58 = extractvalue { [2 x %Qubit*], i64 } %57, 0
-  %59 = extractvalue { [2 x %Qubit*], i64 } %57, 1
-  %60 = insertvalue [2 x %Qubit*] %58, %Qubit* %54, 1
-  %61 = insertvalue { [2 x %Qubit*], i64 } zeroinitializer, [2 x %Qubit*] %60, 0
-  %qs1 = insertvalue { [2 x %Qubit*], i64 } %61, i64 2, 1
-  %62 = call %Qubit* @__quantum__rt__qubit_allocate()
-  %63 = insertvalue [1 x %Qubit*] zeroinitializer, %Qubit* %62, 0
-  %64 = insertvalue { [1 x %Qubit*], i64 } zeroinitializer, [1 x %Qubit*] %63, 0
-  %qs2 = insertvalue { [1 x %Qubit*], i64 } %64, i64 1, 1
+  %53 = alloca { [3 x { [2 x i2], i64 }], i64 }, align 8
+  store { [3 x { [2 x i2], i64 }], i64 } { [3 x { [2 x i2], i64 }] [{ [2 x i2], i64 } zeroinitializer, { [2 x i2], i64 } { [2 x i2] [i2 -1, i2 0], i64 1 }, { [2 x i2], i64 } { [2 x i2] zeroinitializer, i64 1 }], i64 3 }, { [3 x { [2 x i2], i64 }], i64 }* %53, align 4
+  %54 = bitcast { [3 x { [2 x i2], i64 }], i64 }* %53 to i8*
+  call void @__quantum__qis__dumpmachine__body(i8* %54)
+  %55 = alloca { [3 x { [3 x i2], i64 }], i64 }, align 8
+  store { [3 x { [3 x i2], i64 }], i64 } { [3 x { [3 x i2], i64 }] [{ [3 x i2], i64 } { [3 x i2] [i2 1, i2 -2, i2 0], i64 2 }, { [3 x i2], i64 } { [3 x i2] [i2 1, i2 1, i2 1], i64 3 }, { [3 x i2], i64 } { [3 x i2] zeroinitializer, i64 1 }], i64 3 }, { [3 x { [3 x i2], i64 }], i64 }* %55, align 4
+  %56 = bitcast { [3 x { [3 x i2], i64 }], i64 }* %55 to i8*
+  call void @__quantum__qis__dumpmachine__body(i8* %56)
+  %57 = call %Qubit* @__quantum__rt__qubit_allocate()
+  %58 = call %Qubit* @__quantum__rt__qubit_allocate()
+  %59 = insertvalue [2 x %Qubit*] zeroinitializer, %Qubit* %57, 0
+  %60 = insertvalue { [2 x %Qubit*], i64 } zeroinitializer, [2 x %Qubit*] %59, 0
+  %61 = insertvalue { [2 x %Qubit*], i64 } %60, i64 2, 1
+  %62 = extractvalue { [2 x %Qubit*], i64 } %61, 0
+  %63 = extractvalue { [2 x %Qubit*], i64 } %61, 1
+  %64 = insertvalue [2 x %Qubit*] %62, %Qubit* %58, 1
+  %65 = insertvalue { [2 x %Qubit*], i64 } zeroinitializer, [2 x %Qubit*] %64, 0
+  %qs1 = insertvalue { [2 x %Qubit*], i64 } %65, i64 2, 1
+  %66 = call %Qubit* @__quantum__rt__qubit_allocate()
+  %67 = insertvalue [1 x %Qubit*] zeroinitializer, %Qubit* %66, 0
+  %68 = insertvalue { [1 x %Qubit*], i64 } zeroinitializer, [1 x %Qubit*] %67, 0
+  %qs2 = insertvalue { [1 x %Qubit*], i64 } %68, i64 1, 1
   %q = call %Qubit* @__quantum__rt__qubit_allocate()
-  %65 = insertvalue [1 x %Qubit*] zeroinitializer, %Qubit* %q, 0
-  %66 = insertvalue { [1 x %Qubit*], i64 } zeroinitializer, [1 x %Qubit*] %65, 0
-  %67 = insertvalue { [1 x %Qubit*], i64 } %66, i64 1, 1
-  %68 = extractvalue { [2 x %Qubit*], i64 } %qs1, 0
-  %69 = extractvalue { [2 x %Qubit*], i64 } %qs1, 1
-  %70 = extractvalue { [1 x %Qubit*], i64 } %qs2, 0
-  %71 = extractvalue { [1 x %Qubit*], i64 } %qs2, 1
-  %72 = extractvalue { [1 x %Qubit*], i64 } %67, 0
-  %73 = extractvalue { [1 x %Qubit*], i64 } %67, 1
-  %74 = insertvalue [2 x %Qubit*] zeroinitializer, %Qubit* %53, 0
-  %75 = insertvalue { [2 x %Qubit*], i64 } zeroinitializer, [2 x %Qubit*] %74, 0
-  %76 = insertvalue { [2 x %Qubit*], i64 } %75, i64 2, 1
-  %77 = extractvalue { [2 x %Qubit*], i64 } %76, 0
-  %78 = extractvalue { [2 x %Qubit*], i64 } %76, 1
-  %79 = insertvalue [2 x %Qubit*] %77, %Qubit* %54, 1
-  %80 = insertvalue { [2 x %Qubit*], i64 } zeroinitializer, [2 x %Qubit*] %79, 0
-  %81 = insertvalue { [2 x %Qubit*], i64 } %80, i64 2, 1
-  %82 = insertvalue [2 x %Qubit*] zeroinitializer, %Qubit* %62, 0
-  %83 = insertvalue { [2 x %Qubit*], i64 } zeroinitializer, [2 x %Qubit*] %82, 0
-  %84 = insertvalue { [2 x %Qubit*], i64 } %83, i64 1, 1
-  %85 = insertvalue [2 x %Qubit*] zeroinitializer, %Qubit* %q, 0
-  %86 = insertvalue { [2 x %Qubit*], i64 } zeroinitializer, [2 x %Qubit*] %85, 0
-  %87 = insertvalue { [2 x %Qubit*], i64 } %86, i64 1, 1
-  %88 = insertvalue [4 x { [2 x %Qubit*], i64 }] zeroinitializer, { [2 x %Qubit*], i64 } %81, 0
-  %89 = insertvalue { [4 x { [2 x %Qubit*], i64 }], i64 } zeroinitializer, [4 x { [2 x %Qubit*], i64 }] %88, 0
-  %90 = insertvalue { [4 x { [2 x %Qubit*], i64 }], i64 } %89, i64 4, 1
-  %91 = extractvalue { [4 x { [2 x %Qubit*], i64 }], i64 } %90, 0
-  %92 = extractvalue { [4 x { [2 x %Qubit*], i64 }], i64 } %90, 1
-  %93 = insertvalue [4 x { [2 x %Qubit*], i64 }] %91, { [2 x %Qubit*], i64 } zeroinitializer, 1
-  %94 = insertvalue { [4 x { [2 x %Qubit*], i64 }], i64 } zeroinitializer, [4 x { [2 x %Qubit*], i64 }] %93, 0
-  %95 = insertvalue { [4 x { [2 x %Qubit*], i64 }], i64 } %94, i64 4, 1
-  %96 = extractvalue { [4 x { [2 x %Qubit*], i64 }], i64 } %95, 0
-  %97 = extractvalue { [4 x { [2 x %Qubit*], i64 }], i64 } %95, 1
-  %98 = insertvalue [4 x { [2 x %Qubit*], i64 }] %96, { [2 x %Qubit*], i64 } %84, 2
-  %99 = insertvalue { [4 x { [2 x %Qubit*], i64 }], i64 } zeroinitializer, [4 x { [2 x %Qubit*], i64 }] %98, 0
-  %100 = insertvalue { [4 x { [2 x %Qubit*], i64 }], i64 } %99, i64 4, 1
-  %101 = extractvalue { [4 x { [2 x %Qubit*], i64 }], i64 } %100, 0
-  %102 = extractvalue { [4 x { [2 x %Qubit*], i64 }], i64 } %100, 1
-  %103 = insertvalue [4 x { [2 x %Qubit*], i64 }] %101, { [2 x %Qubit*], i64 } %87, 3
-  %104 = insertvalue { [4 x { [2 x %Qubit*], i64 }], i64 } zeroinitializer, [4 x { [2 x %Qubit*], i64 }] %103, 0
-  %qubitArrArr = insertvalue { [4 x { [2 x %Qubit*], i64 }], i64 } %104, i64 4, 1
-  %105 = extractvalue { [4 x { [2 x %Qubit*], i64 }], i64 } %qubitArrArr, 0
-  %106 = extractvalue { [4 x { [2 x %Qubit*], i64 }], i64 } %qubitArrArr, 1
-  %107 = extractvalue { [2 x %Qubit*], i64 } %81, 0
-  %108 = extractvalue { [2 x %Qubit*], i64 } %81, 1
-  %109 = extractvalue { [2 x %Qubit*], i64 } %84, 0
-  %110 = extractvalue { [2 x %Qubit*], i64 } %84, 1
-  %111 = extractvalue { [2 x %Qubit*], i64 } %87, 0
-  %112 = extractvalue { [2 x %Qubit*], i64 } %87, 1
-  %113 = insertvalue [2 x %Qubit*] zeroinitializer, %Qubit* %53, 0
-  %114 = insertvalue { [2 x %Qubit*], i64 } zeroinitializer, [2 x %Qubit*] %113, 0
-  %115 = insertvalue { [2 x %Qubit*], i64 } %114, i64 2, 1
-  %116 = extractvalue { [2 x %Qubit*], i64 } %115, 0
-  %117 = extractvalue { [2 x %Qubit*], i64 } %115, 1
-  %118 = insertvalue [2 x %Qubit*] %116, %Qubit* %54, 1
-  %119 = insertvalue { [2 x %Qubit*], i64 } zeroinitializer, [2 x %Qubit*] %118, 0
-  %120 = insertvalue { [2 x %Qubit*], i64 } %119, i64 2, 1
-  %121 = insertvalue [2 x %Qubit*] zeroinitializer, %Qubit* %62, 0
-  %122 = insertvalue { [2 x %Qubit*], i64 } zeroinitializer, [2 x %Qubit*] %121, 0
-  %123 = insertvalue { [2 x %Qubit*], i64 } %122, i64 1, 1
-  %124 = insertvalue [2 x %Qubit*] zeroinitializer, %Qubit* %q, 0
-  %125 = insertvalue { [2 x %Qubit*], i64 } zeroinitializer, [2 x %Qubit*] %124, 0
-  %126 = insertvalue { [2 x %Qubit*], i64 } %125, i64 1, 1
-  %127 = insertvalue [4 x { [2 x %Qubit*], i64 }] zeroinitializer, { [2 x %Qubit*], i64 } %120, 0
-  %128 = insertvalue [4 x { [2 x %Qubit*], i64 }] %127, { [2 x %Qubit*], i64 } zeroinitializer, 1
-  %129 = insertvalue [4 x { [2 x %Qubit*], i64 }] %128, { [2 x %Qubit*], i64 } %123, 2
-  %130 = insertvalue [4 x { [2 x %Qubit*], i64 }] %129, { [2 x %Qubit*], i64 } %126, 3
-  %131 = insertvalue [4 x { [2 x %Qubit*], i64 }] %130, { [2 x %Qubit*], i64 } zeroinitializer, 0
-  %132 = insertvalue { [4 x { [2 x %Qubit*], i64 }], i64 } zeroinitializer, [4 x { [2 x %Qubit*], i64 }] %131, 0
-  %133 = insertvalue { [4 x { [2 x %Qubit*], i64 }], i64 } %132, i64 4, 1
-  %134 = alloca { [4 x { [2 x %Qubit*], i64 }], i64 }, align 8
-  store { [4 x { [2 x %Qubit*], i64 }], i64 } %133, { [4 x { [2 x %Qubit*], i64 }], i64 }* %134, align 8
-  %135 = bitcast { [4 x { [2 x %Qubit*], i64 }], i64 }* %134 to i8*
-  call void @__quantum__qis__dumpmachine__body(i8* %135)
-  %136 = insertvalue [3 x %Qubit*] zeroinitializer, %Qubit* %q, 0
-  %137 = insertvalue { [3 x %Qubit*], i64 } zeroinitializer, [3 x %Qubit*] %136, 0
-  %138 = insertvalue { [3 x %Qubit*], i64 } %137, i64 3, 1
-  %139 = extractvalue { [3 x %Qubit*], i64 } %138, 0
-  %140 = extractvalue { [3 x %Qubit*], i64 } %138, 1
-  %141 = insertvalue [3 x %Qubit*] %139, %Qubit* %q, 1
-  %142 = insertvalue { [3 x %Qubit*], i64 } zeroinitializer, [3 x %Qubit*] %141, 0
-  %143 = insertvalue { [3 x %Qubit*], i64 } %142, i64 3, 1
-  %144 = extractvalue { [3 x %Qubit*], i64 } %143, 0
-  %145 = extractvalue { [3 x %Qubit*], i64 } %143, 1
-  %146 = insertvalue [3 x %Qubit*] %144, %Qubit* %q, 2
-  %147 = insertvalue { [3 x %Qubit*], i64 } zeroinitializer, [3 x %Qubit*] %146, 0
-  %148 = insertvalue { [3 x %Qubit*], i64 } %147, i64 3, 1
-  %149 = extractvalue { [4 x { [2 x %Qubit*], i64 }], i64 } %qubitArrArr, 0
-  %150 = extractvalue { [4 x { [2 x %Qubit*], i64 }], i64 } %qubitArrArr, 1
-  %151 = extractvalue { [3 x %Qubit*], i64 } %148, 0
-  %152 = extractvalue { [3 x %Qubit*], i64 } %148, 1
-  %153 = extractvalue { [2 x %Qubit*], i64 } %81, 0
-  %154 = extractvalue { [2 x %Qubit*], i64 } %81, 1
-  %155 = extractvalue { [2 x %Qubit*], i64 } %84, 0
-  %156 = extractvalue { [2 x %Qubit*], i64 } %84, 1
-  %157 = extractvalue { [2 x %Qubit*], i64 } %87, 0
-  %158 = extractvalue { [2 x %Qubit*], i64 } %87, 1
-  %159 = insertvalue [3 x %Qubit*] zeroinitializer, %Qubit* %q, 0
-  %160 = insertvalue { [3 x %Qubit*], i64 } zeroinitializer, [3 x %Qubit*] %159, 0
-  %161 = insertvalue { [3 x %Qubit*], i64 } %160, i64 3, 1
-  %162 = extractvalue { [3 x %Qubit*], i64 } %161, 0
-  %163 = extractvalue { [3 x %Qubit*], i64 } %161, 1
-  %164 = insertvalue [3 x %Qubit*] %162, %Qubit* %q, 1
-  %165 = insertvalue { [3 x %Qubit*], i64 } zeroinitializer, [3 x %Qubit*] %164, 0
-  %166 = insertvalue { [3 x %Qubit*], i64 } %165, i64 3, 1
-  %167 = extractvalue { [3 x %Qubit*], i64 } %166, 0
-  %168 = extractvalue { [3 x %Qubit*], i64 } %166, 1
-  %169 = insertvalue [3 x %Qubit*] %167, %Qubit* %q, 2
-  %170 = insertvalue { [3 x %Qubit*], i64 } zeroinitializer, [3 x %Qubit*] %169, 0
-  %171 = insertvalue { [3 x %Qubit*], i64 } %170, i64 3, 1
-  %172 = insertvalue [3 x %Qubit*] zeroinitializer, %Qubit* %53, 0
-  %173 = insertvalue { [3 x %Qubit*], i64 } zeroinitializer, [3 x %Qubit*] %172, 0
-  %174 = insertvalue { [3 x %Qubit*], i64 } %173, i64 2, 1
-  %175 = extractvalue { [3 x %Qubit*], i64 } %174, 0
-  %176 = extractvalue { [3 x %Qubit*], i64 } %174, 1
-  %177 = insertvalue [3 x %Qubit*] %175, %Qubit* %54, 1
-  %178 = insertvalue { [3 x %Qubit*], i64 } zeroinitializer, [3 x %Qubit*] %177, 0
-  %179 = insertvalue { [3 x %Qubit*], i64 } %178, i64 2, 1
-  %180 = insertvalue [3 x %Qubit*] zeroinitializer, %Qubit* %62, 0
-  %181 = insertvalue { [3 x %Qubit*], i64 } zeroinitializer, [3 x %Qubit*] %180, 0
-  %182 = insertvalue { [3 x %Qubit*], i64 } %181, i64 1, 1
-  %183 = insertvalue [3 x %Qubit*] zeroinitializer, %Qubit* %q, 0
-  %184 = insertvalue { [3 x %Qubit*], i64 } zeroinitializer, [3 x %Qubit*] %183, 0
-  %185 = insertvalue { [3 x %Qubit*], i64 } %184, i64 1, 1
-  %186 = insertvalue [4 x { [3 x %Qubit*], i64 }] zeroinitializer, { [3 x %Qubit*], i64 } %179, 0
-  %187 = insertvalue [4 x { [3 x %Qubit*], i64 }] %186, { [3 x %Qubit*], i64 } zeroinitializer, 1
-  %188 = insertvalue [4 x { [3 x %Qubit*], i64 }] %187, { [3 x %Qubit*], i64 } %182, 2
-  %189 = insertvalue [4 x { [3 x %Qubit*], i64 }] %188, { [3 x %Qubit*], i64 } %185, 3
-  %190 = insertvalue [4 x { [3 x %Qubit*], i64 }] %189, { [3 x %Qubit*], i64 } %171, 1
-  %191 = insertvalue { [4 x { [3 x %Qubit*], i64 }], i64 } zeroinitializer, [4 x { [3 x %Qubit*], i64 }] %190, 0
-  %192 = insertvalue { [4 x { [3 x %Qubit*], i64 }], i64 } %191, i64 4, 1
-  %193 = alloca { [4 x { [3 x %Qubit*], i64 }], i64 }, align 8
-  store { [4 x { [3 x %Qubit*], i64 }], i64 } %192, { [4 x { [3 x %Qubit*], i64 }], i64 }* %193, align 8
-  %194 = bitcast { [4 x { [3 x %Qubit*], i64 }], i64 }* %193 to i8*
-  call void @__quantum__qis__dumpmachine__body(i8* %194)
+  %69 = insertvalue [1 x %Qubit*] zeroinitializer, %Qubit* %q, 0
+  %70 = insertvalue { [1 x %Qubit*], i64 } zeroinitializer, [1 x %Qubit*] %69, 0
+  %71 = insertvalue { [1 x %Qubit*], i64 } %70, i64 1, 1
+  %72 = extractvalue { [2 x %Qubit*], i64 } %qs1, 0
+  %73 = extractvalue { [2 x %Qubit*], i64 } %qs1, 1
+  %74 = extractvalue { [1 x %Qubit*], i64 } %qs2, 0
+  %75 = extractvalue { [1 x %Qubit*], i64 } %qs2, 1
+  %76 = extractvalue { [1 x %Qubit*], i64 } %71, 0
+  %77 = extractvalue { [1 x %Qubit*], i64 } %71, 1
+  %78 = insertvalue [2 x %Qubit*] zeroinitializer, %Qubit* %57, 0
+  %79 = insertvalue { [2 x %Qubit*], i64 } zeroinitializer, [2 x %Qubit*] %78, 0
+  %80 = insertvalue { [2 x %Qubit*], i64 } %79, i64 2, 1
+  %81 = extractvalue { [2 x %Qubit*], i64 } %80, 0
+  %82 = extractvalue { [2 x %Qubit*], i64 } %80, 1
+  %83 = insertvalue [2 x %Qubit*] %81, %Qubit* %58, 1
+  %84 = insertvalue { [2 x %Qubit*], i64 } zeroinitializer, [2 x %Qubit*] %83, 0
+  %85 = insertvalue { [2 x %Qubit*], i64 } %84, i64 2, 1
+  %86 = insertvalue [2 x %Qubit*] zeroinitializer, %Qubit* %66, 0
+  %87 = insertvalue { [2 x %Qubit*], i64 } zeroinitializer, [2 x %Qubit*] %86, 0
+  %88 = insertvalue { [2 x %Qubit*], i64 } %87, i64 1, 1
+  %89 = insertvalue [2 x %Qubit*] zeroinitializer, %Qubit* %q, 0
+  %90 = insertvalue { [2 x %Qubit*], i64 } zeroinitializer, [2 x %Qubit*] %89, 0
+  %91 = insertvalue { [2 x %Qubit*], i64 } %90, i64 1, 1
+  %92 = insertvalue [4 x { [2 x %Qubit*], i64 }] zeroinitializer, { [2 x %Qubit*], i64 } %85, 0
+  %93 = insertvalue { [4 x { [2 x %Qubit*], i64 }], i64 } zeroinitializer, [4 x { [2 x %Qubit*], i64 }] %92, 0
+  %94 = insertvalue { [4 x { [2 x %Qubit*], i64 }], i64 } %93, i64 4, 1
+  %95 = extractvalue { [4 x { [2 x %Qubit*], i64 }], i64 } %94, 0
+  %96 = extractvalue { [4 x { [2 x %Qubit*], i64 }], i64 } %94, 1
+  %97 = insertvalue [4 x { [2 x %Qubit*], i64 }] %95, { [2 x %Qubit*], i64 } zeroinitializer, 1
+  %98 = insertvalue { [4 x { [2 x %Qubit*], i64 }], i64 } zeroinitializer, [4 x { [2 x %Qubit*], i64 }] %97, 0
+  %99 = insertvalue { [4 x { [2 x %Qubit*], i64 }], i64 } %98, i64 4, 1
+  %100 = extractvalue { [4 x { [2 x %Qubit*], i64 }], i64 } %99, 0
+  %101 = extractvalue { [4 x { [2 x %Qubit*], i64 }], i64 } %99, 1
+  %102 = insertvalue [4 x { [2 x %Qubit*], i64 }] %100, { [2 x %Qubit*], i64 } %88, 2
+  %103 = insertvalue { [4 x { [2 x %Qubit*], i64 }], i64 } zeroinitializer, [4 x { [2 x %Qubit*], i64 }] %102, 0
+  %104 = insertvalue { [4 x { [2 x %Qubit*], i64 }], i64 } %103, i64 4, 1
+  %105 = extractvalue { [4 x { [2 x %Qubit*], i64 }], i64 } %104, 0
+  %106 = extractvalue { [4 x { [2 x %Qubit*], i64 }], i64 } %104, 1
+  %107 = insertvalue [4 x { [2 x %Qubit*], i64 }] %105, { [2 x %Qubit*], i64 } %91, 3
+  %108 = insertvalue { [4 x { [2 x %Qubit*], i64 }], i64 } zeroinitializer, [4 x { [2 x %Qubit*], i64 }] %107, 0
+  %qubitArrArr = insertvalue { [4 x { [2 x %Qubit*], i64 }], i64 } %108, i64 4, 1
+  %109 = extractvalue { [4 x { [2 x %Qubit*], i64 }], i64 } %qubitArrArr, 0
+  %110 = extractvalue { [4 x { [2 x %Qubit*], i64 }], i64 } %qubitArrArr, 1
+  %111 = extractvalue { [2 x %Qubit*], i64 } %85, 0
+  %112 = extractvalue { [2 x %Qubit*], i64 } %85, 1
+  %113 = extractvalue { [2 x %Qubit*], i64 } %88, 0
+  %114 = extractvalue { [2 x %Qubit*], i64 } %88, 1
+  %115 = extractvalue { [2 x %Qubit*], i64 } %91, 0
+  %116 = extractvalue { [2 x %Qubit*], i64 } %91, 1
+  %117 = insertvalue [2 x %Qubit*] zeroinitializer, %Qubit* %57, 0
+  %118 = insertvalue { [2 x %Qubit*], i64 } zeroinitializer, [2 x %Qubit*] %117, 0
+  %119 = insertvalue { [2 x %Qubit*], i64 } %118, i64 2, 1
+  %120 = extractvalue { [2 x %Qubit*], i64 } %119, 0
+  %121 = extractvalue { [2 x %Qubit*], i64 } %119, 1
+  %122 = insertvalue [2 x %Qubit*] %120, %Qubit* %58, 1
+  %123 = insertvalue { [2 x %Qubit*], i64 } zeroinitializer, [2 x %Qubit*] %122, 0
+  %124 = insertvalue { [2 x %Qubit*], i64 } %123, i64 2, 1
+  %125 = insertvalue [2 x %Qubit*] zeroinitializer, %Qubit* %66, 0
+  %126 = insertvalue { [2 x %Qubit*], i64 } zeroinitializer, [2 x %Qubit*] %125, 0
+  %127 = insertvalue { [2 x %Qubit*], i64 } %126, i64 1, 1
+  %128 = insertvalue [2 x %Qubit*] zeroinitializer, %Qubit* %q, 0
+  %129 = insertvalue { [2 x %Qubit*], i64 } zeroinitializer, [2 x %Qubit*] %128, 0
+  %130 = insertvalue { [2 x %Qubit*], i64 } %129, i64 1, 1
+  %131 = insertvalue [4 x { [2 x %Qubit*], i64 }] zeroinitializer, { [2 x %Qubit*], i64 } %124, 0
+  %132 = insertvalue [4 x { [2 x %Qubit*], i64 }] %131, { [2 x %Qubit*], i64 } zeroinitializer, 1
+  %133 = insertvalue [4 x { [2 x %Qubit*], i64 }] %132, { [2 x %Qubit*], i64 } %127, 2
+  %134 = insertvalue [4 x { [2 x %Qubit*], i64 }] %133, { [2 x %Qubit*], i64 } %130, 3
+  %135 = insertvalue [4 x { [2 x %Qubit*], i64 }] %134, { [2 x %Qubit*], i64 } zeroinitializer, 0
+  %136 = insertvalue { [4 x { [2 x %Qubit*], i64 }], i64 } zeroinitializer, [4 x { [2 x %Qubit*], i64 }] %135, 0
+  %137 = insertvalue { [4 x { [2 x %Qubit*], i64 }], i64 } %136, i64 4, 1
+  %138 = alloca { [4 x { [2 x %Qubit*], i64 }], i64 }, align 8
+  store { [4 x { [2 x %Qubit*], i64 }], i64 } %137, { [4 x { [2 x %Qubit*], i64 }], i64 }* %138, align 8
+  %139 = bitcast { [4 x { [2 x %Qubit*], i64 }], i64 }* %138 to i8*
+  call void @__quantum__qis__dumpmachine__body(i8* %139)
+  %140 = insertvalue [3 x %Qubit*] zeroinitializer, %Qubit* %q, 0
+  %141 = insertvalue { [3 x %Qubit*], i64 } zeroinitializer, [3 x %Qubit*] %140, 0
+  %142 = insertvalue { [3 x %Qubit*], i64 } %141, i64 3, 1
+  %143 = extractvalue { [3 x %Qubit*], i64 } %142, 0
+  %144 = extractvalue { [3 x %Qubit*], i64 } %142, 1
+  %145 = insertvalue [3 x %Qubit*] %143, %Qubit* %q, 1
+  %146 = insertvalue { [3 x %Qubit*], i64 } zeroinitializer, [3 x %Qubit*] %145, 0
+  %147 = insertvalue { [3 x %Qubit*], i64 } %146, i64 3, 1
+  %148 = extractvalue { [3 x %Qubit*], i64 } %147, 0
+  %149 = extractvalue { [3 x %Qubit*], i64 } %147, 1
+  %150 = insertvalue [3 x %Qubit*] %148, %Qubit* %q, 2
+  %151 = insertvalue { [3 x %Qubit*], i64 } zeroinitializer, [3 x %Qubit*] %150, 0
+  %152 = insertvalue { [3 x %Qubit*], i64 } %151, i64 3, 1
+  %153 = extractvalue { [4 x { [2 x %Qubit*], i64 }], i64 } %qubitArrArr, 0
+  %154 = extractvalue { [4 x { [2 x %Qubit*], i64 }], i64 } %qubitArrArr, 1
+  %155 = extractvalue { [3 x %Qubit*], i64 } %152, 0
+  %156 = extractvalue { [3 x %Qubit*], i64 } %152, 1
+  %157 = extractvalue { [2 x %Qubit*], i64 } %85, 0
+  %158 = extractvalue { [2 x %Qubit*], i64 } %85, 1
+  %159 = extractvalue { [2 x %Qubit*], i64 } %88, 0
+  %160 = extractvalue { [2 x %Qubit*], i64 } %88, 1
+  %161 = extractvalue { [2 x %Qubit*], i64 } %91, 0
+  %162 = extractvalue { [2 x %Qubit*], i64 } %91, 1
+  %163 = insertvalue [3 x %Qubit*] zeroinitializer, %Qubit* %q, 0
+  %164 = insertvalue { [3 x %Qubit*], i64 } zeroinitializer, [3 x %Qubit*] %163, 0
+  %165 = insertvalue { [3 x %Qubit*], i64 } %164, i64 3, 1
+  %166 = extractvalue { [3 x %Qubit*], i64 } %165, 0
+  %167 = extractvalue { [3 x %Qubit*], i64 } %165, 1
+  %168 = insertvalue [3 x %Qubit*] %166, %Qubit* %q, 1
+  %169 = insertvalue { [3 x %Qubit*], i64 } zeroinitializer, [3 x %Qubit*] %168, 0
+  %170 = insertvalue { [3 x %Qubit*], i64 } %169, i64 3, 1
+  %171 = extractvalue { [3 x %Qubit*], i64 } %170, 0
+  %172 = extractvalue { [3 x %Qubit*], i64 } %170, 1
+  %173 = insertvalue [3 x %Qubit*] %171, %Qubit* %q, 2
+  %174 = insertvalue { [3 x %Qubit*], i64 } zeroinitializer, [3 x %Qubit*] %173, 0
+  %175 = insertvalue { [3 x %Qubit*], i64 } %174, i64 3, 1
+  %176 = insertvalue [3 x %Qubit*] zeroinitializer, %Qubit* %57, 0
+  %177 = insertvalue { [3 x %Qubit*], i64 } zeroinitializer, [3 x %Qubit*] %176, 0
+  %178 = insertvalue { [3 x %Qubit*], i64 } %177, i64 2, 1
+  %179 = extractvalue { [3 x %Qubit*], i64 } %178, 0
+  %180 = extractvalue { [3 x %Qubit*], i64 } %178, 1
+  %181 = insertvalue [3 x %Qubit*] %179, %Qubit* %58, 1
+  %182 = insertvalue { [3 x %Qubit*], i64 } zeroinitializer, [3 x %Qubit*] %181, 0
+  %183 = insertvalue { [3 x %Qubit*], i64 } %182, i64 2, 1
+  %184 = insertvalue [3 x %Qubit*] zeroinitializer, %Qubit* %66, 0
+  %185 = insertvalue { [3 x %Qubit*], i64 } zeroinitializer, [3 x %Qubit*] %184, 0
+  %186 = insertvalue { [3 x %Qubit*], i64 } %185, i64 1, 1
+  %187 = insertvalue [3 x %Qubit*] zeroinitializer, %Qubit* %q, 0
+  %188 = insertvalue { [3 x %Qubit*], i64 } zeroinitializer, [3 x %Qubit*] %187, 0
+  %189 = insertvalue { [3 x %Qubit*], i64 } %188, i64 1, 1
+  %190 = insertvalue [4 x { [3 x %Qubit*], i64 }] zeroinitializer, { [3 x %Qubit*], i64 } %183, 0
+  %191 = insertvalue [4 x { [3 x %Qubit*], i64 }] %190, { [3 x %Qubit*], i64 } zeroinitializer, 1
+  %192 = insertvalue [4 x { [3 x %Qubit*], i64 }] %191, { [3 x %Qubit*], i64 } %186, 2
+  %193 = insertvalue [4 x { [3 x %Qubit*], i64 }] %192, { [3 x %Qubit*], i64 } %189, 3
+  %194 = insertvalue [4 x { [3 x %Qubit*], i64 }] %193, { [3 x %Qubit*], i64 } %175, 1
+  %195 = insertvalue { [4 x { [3 x %Qubit*], i64 }], i64 } zeroinitializer, [4 x { [3 x %Qubit*], i64 }] %194, 0
+  %196 = insertvalue { [4 x { [3 x %Qubit*], i64 }], i64 } %195, i64 4, 1
+  %197 = alloca { [4 x { [3 x %Qubit*], i64 }], i64 }, align 8
+  store { [4 x { [3 x %Qubit*], i64 }], i64 } %196, { [4 x { [3 x %Qubit*], i64 }], i64 }* %197, align 8
+  %198 = bitcast { [4 x { [3 x %Qubit*], i64 }], i64 }* %197 to i8*
+  call void @__quantum__qis__dumpmachine__body(i8* %198)
+  %199 = call %Result* @__quantum__rt__result_get_zero()
+  %200 = call i1 @__quantum__rt__result_equal(%Result* %m1, %Result* %199)
+  br i1 %200, label %then1__1, label %test2__1
+
+then1__1:                                         ; preds = %entry
+  %q__1 = call %Qubit* @__quantum__rt__qubit_allocate()
+  %201 = call %Result* @__quantum__qis__m__body(%Qubit* %q__1)
+  %202 = insertvalue { i64, %Result* } { i64 2, %Result* null }, %Result* %201, 1
+  %203 = alloca { i64, %Result* }, align 8
+  store { i64, %Result* } %202, { i64, %Result* }* %203, align 8
+  %204 = bitcast { i64, %Result* }* %203 to i8*
+  call void @__quantum__qis__dumpmachine__body(i8* %204)
+  call void @__quantum__rt__qubit_release(%Qubit* %q__1)
+  br label %continue__1
+
+test2__1:                                         ; preds = %entry
+  %q__2 = call %Qubit* @__quantum__rt__qubit_allocate()
+  %205 = call %Result* @__quantum__qis__m__body(%Qubit* %q__2)
+  %206 = insertvalue { i64, %Result* } { i64 4, %Result* null }, %Result* %205, 1
+  %207 = alloca { i64, %Result* }, align 8
+  store { i64, %Result* } %206, { i64, %Result* }* %207, align 8
+  %208 = bitcast { i64, %Result* }* %207 to i8*
+  call void @__quantum__qis__dumpmachine__body(i8* %208)
+  call void @__quantum__rt__qubit_release(%Qubit* %q__2)
+  br label %continue__1
+
+continue__1:                                      ; preds = %test2__1, %then1__1
+  br i1 true, label %then1__2, label %continue__2
+
+then1__2:                                         ; preds = %continue__1
+  %q__3 = call %Qubit* @__quantum__rt__qubit_allocate()
+  %209 = call %Result* @__quantum__qis__m__body(%Qubit* %q__3)
+  %210 = insertvalue { i64, %Result* } { i64 6, %Result* null }, %Result* %209, 1
+  %211 = alloca { i64, %Result* }, align 8
+  store { i64, %Result* } %210, { i64, %Result* }* %211, align 8
+  %212 = bitcast { i64, %Result* }* %211 to i8*
+  call void @__quantum__qis__dumpmachine__body(i8* %212)
+  call void @__quantum__rt__qubit_release(%Qubit* %q__3)
+  br label %continue__2
+
+continue__2:                                      ; preds = %then1__2, %continue__1
+  %q2 = call %Qubit* @__quantum__rt__qubit_allocate()
+  br i1 true, label %then0__1, label %continue__3
+
+then0__1:                                         ; preds = %continue__2
+  %q__4 = call %Qubit* @__quantum__rt__qubit_allocate()
+  %213 = call %Result* @__quantum__qis__m__body(%Qubit* %q__4)
+  %214 = insertvalue { i64, %Result* } { i64 9, %Result* null }, %Result* %213, 1
+  %215 = alloca { i64, %Result* }, align 8
+  store { i64, %Result* } %214, { i64, %Result* }* %215, align 8
+  %216 = bitcast { i64, %Result* }* %215 to i8*
+  call void @__quantum__qis__dumpmachine__body(i8* %216)
+  call void @__quantum__rt__qubit_release(%Qubit* %q__4)
+  br label %continue__3
+
+continue__3:                                      ; preds = %then0__1, %continue__2
+  call void @__quantum__rt__qubit_release(%Qubit* %q2)
+  %217 = call %Result* @__quantum__rt__result_get_zero()
+  %218 = call i1 @__quantum__rt__result_equal(%Result* %m2, %Result* %217)
+  br i1 %218, label %then0__2, label %else__1
+
+then0__2:                                         ; preds = %continue__3
+  %q__5 = call %Qubit* @__quantum__rt__qubit_allocate()
+  %219 = call %Result* @__quantum__qis__m__body(%Qubit* %q__5)
+  %220 = insertvalue { i64, %Result* } { i64 12, %Result* null }, %Result* %219, 1
+  %221 = alloca { i64, %Result* }, align 8
+  store { i64, %Result* } %220, { i64, %Result* }* %221, align 8
+  %222 = bitcast { i64, %Result* }* %221 to i8*
+  call void @__quantum__qis__dumpmachine__body(i8* %222)
+  call void @__quantum__rt__qubit_release(%Qubit* %q__5)
+  br label %continue__4
+
+else__1:                                          ; preds = %continue__3
+  %q__6 = call %Qubit* @__quantum__rt__qubit_allocate()
+  %223 = call %Result* @__quantum__qis__m__body(%Qubit* %q__6)
+  %224 = insertvalue { i64, %Result* } { i64 13, %Result* null }, %Result* %223, 1
+  %225 = alloca { i64, %Result* }, align 8
+  store { i64, %Result* } %224, { i64, %Result* }* %225, align 8
+  %226 = bitcast { i64, %Result* }* %225 to i8*
+  call void @__quantum__qis__dumpmachine__body(i8* %226)
+  call void @__quantum__rt__qubit_release(%Qubit* %q__6)
+  br label %continue__4
+
+continue__4:                                      ; preds = %else__1, %then0__2
   call void @__quantum__rt__result_update_reference_count(%Result* %m1, i32 -1)
   call void @__quantum__rt__result_update_reference_count(%Result* %m2, i32 -1)
-  call void @__quantum__rt__qubit_release(%Qubit* %53)
-  call void @__quantum__rt__qubit_release(%Qubit* %54)
-  call void @__quantum__rt__qubit_release(%Qubit* %62)
+  call void @__quantum__rt__qubit_release(%Qubit* %57)
+  call void @__quantum__rt__qubit_release(%Qubit* %58)
+  call void @__quantum__rt__qubit_release(%Qubit* %66)
   call void @__quantum__rt__qubit_release(%Qubit* %q)
   call void @__quantum__rt__qubit_release(%Qubit* %qubit)
   call void @__quantum__rt__qubit_release(%Qubit* %target)

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestTargetingProfile.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestTargetingProfile.ll
@@ -1,4 +1,4 @@
-define internal i64 @Microsoft__Quantum__Testing__QIR__TestProfileTargeting__body() {
+define internal i64 @Microsoft__Quantum__Testing__QIR__TestProfileTargeting__body() #0 {
 entry:
   %0 = alloca { [3 x i64], i64 }, align 8
   store { [3 x i64], i64 } { [3 x i64] [i64 1, i64 2, i64 3], i64 3 }, { [3 x i64], i64 }* %0, align 4

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestTargetingProfile.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestTargetingProfile.ll
@@ -355,6 +355,47 @@ else__1:                                          ; preds = %continue__3
   br label %continue__4
 
 continue__4:                                      ; preds = %else__1, %then0__2
+  %rand = alloca i64, align 8
+  store i64 0, i64* %rand, align 4
+  store i64 0, i64* %rand, align 4
+  %227 = insertvalue [1 x %Qubit*] zeroinitializer, %Qubit* %qubit, 0
+  %228 = insertvalue { [1 x %Qubit*], i64 } zeroinitializer, [1 x %Qubit*] %227, 0
+  %qubits = insertvalue { [1 x %Qubit*], i64 } %228, i64 1, 1
+  %229 = call %Result* @__quantum__rt__result_get_one()
+  call void @__quantum__rt__result_update_reference_count(%Result* %229, i32 1)
+  %230 = call %Result* @__quantum__rt__result_get_one()
+  %231 = call i1 @__quantum__rt__result_equal(%Result* %229, %Result* %230)
+  call void @__quantum__rt__result_update_reference_count(%Result* %229, i32 -1)
+  br i1 %231, label %then0__3, label %continue__5
+
+continue__6:                                      ; No predecessors!
+
+then0__3:                                         ; preds = %continue__4
+  store i64 1, i64* %rand, align 4
+  br label %continue__5
+
+continue__5:                                      ; preds = %then0__3, %continue__4
+  %232 = load i64, i64* %rand, align 4
+  %233 = shl i64 %232, 1
+  store i64 %233, i64* %rand, align 4
+  %234 = insertvalue [1 x %Qubit*] zeroinitializer, %Qubit* %target, 0
+  %235 = insertvalue { [1 x %Qubit*], i64 } zeroinitializer, [1 x %Qubit*] %234, 0
+  %qubits__1 = insertvalue { [1 x %Qubit*], i64 } %235, i64 1, 1
+  %236 = call %Result* @__quantum__rt__result_get_one()
+  call void @__quantum__rt__result_update_reference_count(%Result* %236, i32 1)
+  %237 = call %Result* @__quantum__rt__result_get_one()
+  %238 = call i1 @__quantum__rt__result_equal(%Result* %236, %Result* %237)
+  call void @__quantum__rt__result_update_reference_count(%Result* %236, i32 -1)
+  br i1 %238, label %then0__4, label %continue__7
+
+continue__8:                                      ; No predecessors!
+
+then0__4:                                         ; preds = %continue__5
+  %239 = add i64 %233, 1
+  store i64 %239, i64* %rand, align 4
+  br label %continue__7
+
+continue__7:                                      ; preds = %then0__4, %continue__5
   call void @__quantum__rt__result_update_reference_count(%Result* %m1, i32 -1)
   call void @__quantum__rt__result_update_reference_count(%Result* %m2, i32 -1)
   call void @__quantum__rt__qubit_release(%Qubit* %57)

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestTargetingProfile.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestTargetingProfile.ll
@@ -369,6 +369,7 @@ continue__4:                                      ; preds = %else__1, %then0__2
   br i1 %231, label %then0__3, label %continue__5
 
 continue__6:                                      ; No predecessors!
+  unreachable
 
 then0__3:                                         ; preds = %continue__4
   store i64 1, i64* %rand, align 4
@@ -389,6 +390,7 @@ continue__5:                                      ; preds = %then0__3, %continue
   br i1 %238, label %then0__4, label %continue__7
 
 continue__8:                                      ; No predecessors!
+  unreachable
 
 then0__4:                                         ; preds = %continue__5
   %239 = add i64 %233, 1

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestTargetingProfile.qs
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestTargetingProfile.qs
@@ -80,8 +80,12 @@ namespace Microsoft.Quantum.Testing.QIR {
         let (m1, m2) = (M(qs[0]), M(qs[1]));
         
         let tupleArr = [(2, 0.), (1, 1.), (3, 2.)];
-        let (pauli, _) = tupleArr[1];
-        DumpMachine(pauli);
+        let (intValue, _) = tupleArr[1];
+        DumpMachine(intValue);
+
+        let tupleArr2 = [(PauliX, 0), (PauliZ, 1), (PauliY, 2)];
+        let (pauli, _) = tupleArr2[1];
+        LogPauli(pauli);
         
         let arrTuple = ([1,2], true);
         let (vals, _) = arrTuple;
@@ -93,28 +97,110 @@ namespace Microsoft.Quantum.Testing.QIR {
         DumpMachine(pauliY);
         DumpMachine((arrArr[1], arrArr[3]));
         DumpMachine(arrArr);
+
+        let arrArr2 = [[PauliX, PauliZ], [PauliY], [PauliI]];
+        let pauliI = arrArr2[2][0];
+        LogPauli(pauliI);
         
         let updatedArrArr1 = arrArr w/ 0 <- [];
         let updatedArrArr2 = arrArr w/ 1 <- [1,2,3];
+        let updatedArrArr3 = arrArr2 w/ 0 <- [];
+        let updatedArrArr4 = arrArr2 w/ 1 <- [PauliX, PauliX, PauliX];
         DumpMachine(updatedArrArr1);
         DumpMachine(updatedArrArr2);
+        DumpMachine(updatedArrArr3);
+        DumpMachine(updatedArrArr4);
 
         use (qs1, qs2, q) = (Qubit[2], Qubit[1], Qubit());
         let qubitArrArr = [qs1, [], qs2, [q]];
         DumpMachine(qubitArrArr w/ 0 <- []);
         DumpMachine(qubitArrArr w/ 1 <- [q, q, q]);
 
-        //let tupleArr = [(PauliX, 0), (PauliZ, 1), (PauliY, 2)];
-        //let (pauli, _) = tupleArr[1];
-        //LogPauli(pauli);
-
-        //let arrArr = [[PauliX, PauliZ], [PauliY], [PauliI]];
-        //let pauliI = arrArr[2][0];
-        //LogPauli(pauliI);
-
-
+        TestIfClauses1(m1);
+        TestIfClauses2();
+        TestIfClauses3();
+        TestIfClauses4(m2);
 
         return sum; // m1 == m2 ? sum | 0; // TODO: check branching
+    }
+
+
+    operation TestIfClauses1(m : Result) : Unit {
+
+        if (false) {
+            use q = Qubit();
+            DumpMachine((1, M(q)));
+        }
+        elif (m == Zero) {
+            use q = Qubit();
+            DumpMachine((2, M(q)));
+        }
+        elif (false) {
+            use q = Qubit();
+            DumpMachine((3, M(q)));
+        }
+        else {
+            use q = Qubit();
+            DumpMachine((4, M(q)));
+        }
+    }
+
+    operation TestIfClauses2() : Unit {
+
+        if (false)
+        {
+            use q = Qubit();
+            DumpMachine((5, M(q)));
+        }
+        elif (true)
+        {
+            use q = Qubit();
+            DumpMachine((6, M(q)));
+        }
+        elif (true)
+        {
+            use q = Qubit();
+            DumpMachine((7, M(q)));
+        }
+        else
+        {
+            use q = Qubit();
+            DumpMachine((8, M(q)));
+        }
+    }
+
+    operation TestIfClauses3() : Unit {
+
+        use q2 = Qubit();
+        if (true)
+        {
+            use q = Qubit();
+            DumpMachine((9, M(q)));
+        }
+        elif (M(q2) == Zero)
+        {
+            use q = Qubit();
+            DumpMachine((10, M(q)));
+        }
+        else
+        {
+            use q = Qubit();
+            DumpMachine((11, M(q)));
+        }
+    }
+
+    operation TestIfClauses4(m : Result) : Unit {
+
+        if (m == Zero)
+        {
+            use q = Qubit();
+            DumpMachine((12, M(q)));
+        }
+        else
+        {
+            use q = Qubit();
+            DumpMachine((13, M(q)));
+        }
     }
 }
 

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestTargetingProfile.qs
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/TestTargetingProfile.qs
@@ -34,6 +34,13 @@ namespace Microsoft.Quantum.Testing.QIR {
         body intrinsic;
     }
 
+    operation CheckLength (bases : Pauli[], qubits : Qubit[]) : Result {
+        if Length(bases) != Length(qubits) {
+            DumpMachine(bases);
+        }
+        return One;
+    }
+
     @EntryPoint()
     operation TestProfileTargeting() : Int {
         let arr1 = [1,2,3];
@@ -121,7 +128,17 @@ namespace Microsoft.Quantum.Testing.QIR {
         TestIfClauses3();
         TestIfClauses4(m2);
 
-        return sum; // m1 == m2 ? sum | 0; // TODO: check branching
+        mutable rand = 0;
+        for item in qs {
+            set rand <<<= 1;
+            if CheckLength([PauliX], [item]) == One {
+                set rand += 1;
+            }
+        }
+
+        //mutable foo = m1 == m2 ? sum | 0; // TODO: check branching
+
+        return sum; //(sum, rand); TODO: requires output transformation
     }
 
 


### PR DESCRIPTION
... and don't generate interop and entry point wrappers when targeting a qir profile.