### PR TITLE
Language Server Notebook Support: Part 1

### DIFF
--- a/build/aznb.ps1
+++ b/build/aznb.ps1
@@ -1,0 +1,33 @@
+# This script is useful for testing integration with Azure Notebooks.
+# It will replace the language server the Azure Notebooks setup script has
+# downloaded and extracted with your local version of the language server.
+
+$ErrorActionPreference = 'Stop'
+
+& "$PSScriptRoot/set-env.ps1"
+
+# Based on your personal setup, you may need to change these two lines
+$DotNetRuntimeID = "win10-x64"
+$TargetDir = Join-Path $PSScriptRoot "../../AzureNotebooks/src/service/aznb/NotebookLanguageServer/dist/qsharp"
+$Project = "../src/QsCompiler/LanguageServer/LanguageServer.csproj"
+
+if (Test-Path -Path $TargetDir) {
+    Remove-Item -Recurse $TargetDir
+}
+
+# These two dotnet commands are taken from the pack-extensions.ps1 script
+
+dotnet build (Join-Path $PSScriptRoot $Project) `
+    -c $Env:BUILD_CONFIGURATION `
+    -v $Env:BUILD_VERBOSITY `
+    /property:Version=$Env:ASSEMBLY_VERSION `
+    /property:InformationalVersion=$Env:SEMVER_VERSION
+
+dotnet publish (Join-Path $PSScriptRoot $Project) `
+    -c $Env:BUILD_CONFIGURATION `
+    -v $Env:BUILD_VERBOSITY `
+    --self-contained `
+    --runtime $DotNetRuntimeID `
+    --output $TargetDir `
+    /property:Version=$Env:ASSEMBLY_VERSION `
+    /property:InformationalVersion=$Env:SEMVER_VERSION

--- a/src/QsCompiler/CompilationManager/FileContentManager.cs
+++ b/src/QsCompiler/CompilationManager/FileContentManager.cs
@@ -473,6 +473,8 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
 
         internal IEnumerable<CodeLine> GetLines() => this.content.Get();
 
+        internal bool AllWhiteSpaceUntil(int index) => index == 0 || this.GetLines(0, index).All(line => line.IsAllWhiteSpace);
+
         /// <summary>
         /// Gets the code line at <paramref name="index"/>.
         /// </summary>
@@ -1018,7 +1020,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
                 // We need to enforce that generated type checking diagnostics are consistent with all other diagnostics.
                 // In particular this means that we cannot have that the type checking runs after the ScopeTracking update completed
                 // but before the other updates (that generate the data structure based on which the type checking is done) are done.
-                QsCompilerError.RaiseOnFailure(() => this.UpdateScopeTacking(change), "error during scope tracking update");
+                QsCompilerError.RaiseOnFailure(() => this.UpdateScopeTracking(change), "error during scope tracking update");
                 QsCompilerError.RaiseOnFailure(() => this.UpdateLanguageProcessing(), "error during language processing update");
                 QsCompilerError.RaiseOnFailure(() => this.UpdateContext(), "error during context update");
             }

--- a/src/QsCompiler/CompilationManager/FileContentManager.cs
+++ b/src/QsCompiler/CompilationManager/FileContentManager.cs
@@ -32,6 +32,8 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
 
         public string FileName { get; }
 
+        public BuildConfiguration BuildConfiguration { get; }
+
         /// <summary>
         /// An arbitrary integer representing the current version number of the file, or null if no version number is available.
         /// The version number may change at any time to any other integer, including a lower number than its current value.
@@ -114,11 +116,12 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
 
         /* constructors, "destructors" & property access: */
 
-        internal FileContentManager(Uri uri, string fileName)
+        internal FileContentManager(Uri uri, string fileName, BuildConfiguration? buildConfiguration = null)
         {
             this.SyncRoot = new ReaderWriterLockSlim(LockRecursionPolicy.SupportsRecursion);
             this.Uri = uri;
             this.FileName = fileName;
+            this.BuildConfiguration = buildConfiguration ?? BuildConfiguration.DefaultConfiguration();
             this.Version = null;
 
             this.content = new ManagedList<CodeLine>(this.SyncRoot);

--- a/src/QsCompiler/CompilationManager/FileContentManager.cs
+++ b/src/QsCompiler/CompilationManager/FileContentManager.cs
@@ -476,6 +476,20 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         internal bool AllWhiteSpaceUntil(int index) => index == 0 || this.GetLines(0, index).All(line => line.IsAllWhiteSpace);
 
         /// <summary>
+        /// Returns true if there is a line within the range [index, this.NrLines()) beginning with
+        /// a % such that all preceding lines in the range are only whitespace. This is useful for
+        /// knowing whether or not to re-compile code when the programmer adds/removes a line before
+        /// a possible magic command that changes whether it is a magic command or not
+        /// </summary>
+        internal bool MagicCandidateExistsStartingAt(int index) =>
+            index < this.NrLines()
+            && (this.GetLines(index, this.NrLines() - index)
+                    .FirstOrDefault(line => !line.IsAllWhiteSpace)?
+                    .Text
+                    .TrimStart()
+                    .StartsWith('%') ?? false);
+
+        /// <summary>
         /// Gets the code line at <paramref name="index"/>.
         /// </summary>
         /// <exception cref="ArgumentOutOfRangeException"><paramref name="index"/> is less than 0.</exception>

--- a/src/QsCompiler/CompilationManager/ProjectManager.cs
+++ b/src/QsCompiler/CompilationManager/ProjectManager.cs
@@ -20,6 +20,31 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
     public delegate void SendTelemetryHandler(string eventName, Dictionary<string, string?> properties, Dictionary<string, int> measures);
 
     /// <summary>
+    /// Holds compilation configuration -- currently, just whether this is a notebook.
+    /// Warning: properties of an instance may change as we get more information from the client.
+    /// </summary>
+    public class BuildConfiguration
+    {
+        /// <summary>
+        /// Indicates whether code is compiled for a notebook (Azure Notebook, Jupyter Notebook, etc.).
+        /// This means inferring an implicit namespace{} block (and banning explicit namespace{}
+        /// blocks), special treatment of use directives, and ignoring magic commands (e.g. %simulate)
+        /// </summary>
+        public bool IsNotebook { get; set; }
+
+        public BuildConfiguration(bool isNotebook)
+        {
+            this.IsNotebook = isNotebook;
+        }
+
+        public static BuildConfiguration DefaultConfiguration()
+        {
+            // By default, assume we are not in a notebook until told otherwise
+            return new BuildConfiguration(isNotebook: false);
+        }
+    }
+
+    /// <summary>
     /// Represents project properties defined in the project file.
     /// </summary>
     public class ProjectProperties
@@ -125,6 +150,8 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
 
         internal ProjectProperties Properties { get; }
 
+        public BuildConfiguration BuildConfiguration { get; }
+
         public ImmutableArray<string> SourceFiles { get; }
 
         public ImmutableArray<string> ProjectReferences { get; }
@@ -145,12 +172,14 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
             IEnumerable<string> sourceFiles,
             IEnumerable<string> projectReferences,
             IEnumerable<string> references,
-            IDictionary<string, string?> buildProperties)
+            IDictionary<string, string?> buildProperties,
+            BuildConfiguration? buildConfiguration = null)
         {
             this.Properties = new ProjectProperties(buildProperties);
             this.SourceFiles = sourceFiles.ToImmutableArray();
             this.ProjectReferences = projectReferences.ToImmutableArray();
             this.References = references.ToImmutableArray();
+            this.BuildConfiguration = buildConfiguration ?? BuildConfiguration.DefaultConfiguration();
         }
     }
 
@@ -163,6 +192,8 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
             public Uri? OutputPath { get; private set; }
 
             public ProjectProperties Properties { get; private set; }
+
+            public BuildConfiguration BuildConfiguration { get; private set; }
 
             private bool isLoaded;
 
@@ -248,6 +279,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
             {
                 this.ProjectFile = projectFile;
                 this.Properties = projectInfo.Properties;
+                this.BuildConfiguration = projectInfo.BuildConfiguration;
                 this.SetProjectInformation(projectInfo);
 
                 var version = projectInfo.Properties.LanguageVersion;
@@ -279,6 +311,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
             private void SetProjectInformation(ProjectInformation projectInfo)
             {
                 this.Properties = projectInfo.Properties;
+                this.BuildConfiguration = projectInfo.BuildConfiguration;
                 this.isLoaded = false;
 
                 var outputPath = projectInfo.Properties.DllOutputPath;
@@ -581,7 +614,8 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
                 var newFilesToAdd = CompilationUnitManager.InitializeFileManagers(
                     addToManager.Except(knownFilesToAdd.Select(m => m.Uri)).ToImmutableDictionary(uri => uri, uri => loaded[uri]),
                     this.Manager.PublishDiagnostics,
-                    this.Manager.LogException);
+                    this.Manager.LogException,
+                    this.BuildConfiguration);
 
                 var removal = this.Manager.TryRemoveSourceFilesAsync(removeFromManager, suppressVerification: true);
                 removeFiles?.Invoke(removeFromManager, removal);
@@ -690,7 +724,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
                     }
                     else
                     {
-                        var file = CompilationUnitManager.InitializeFileManager(sourceFile, content, this.Manager.PublishDiagnostics, this.Manager.LogException);
+                        var file = CompilationUnitManager.InitializeFileManager(sourceFile, content, this.Manager.PublishDiagnostics, this.Manager.LogException, this.BuildConfiguration);
                         this.Manager.AddOrUpdateSourceFileAsync(file);
                     }
                 });
@@ -793,11 +827,12 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
             Action<Exception>? exceptionLogger,
             Action<string, MessageType>? log = null,
             Action<PublishDiagnosticParams>? publishDiagnostics = null,
-            SendTelemetryHandler? sendTelemetry = null)
+            SendTelemetryHandler? sendTelemetry = null,
+            BuildConfiguration? buildConfiguration = null)
         {
             this.load = new ProcessingQueue(exceptionLogger);
             this.projects = new ConcurrentDictionary<Uri, Project>();
-            this.defaultManager = new CompilationUnitManager(ProjectProperties.Empty, exceptionLogger, log, publishDiagnostics, syntaxCheckOnly: true);
+            this.defaultManager = new CompilationUnitManager(ProjectProperties.Empty, exceptionLogger, log, publishDiagnostics, syntaxCheckOnly: true, buildConfiguration);
             this.publishDiagnostics = publishDiagnostics;
             this.logException = exceptionLogger;
             this.log = log;

--- a/src/QsCompiler/CompilationManager/ProjectManager.cs
+++ b/src/QsCompiler/CompilationManager/ProjectManager.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// <summary>
         /// Indicates whether code is compiled for a notebook (Azure Notebook, Jupyter Notebook, etc.).
         /// This means inferring an implicit namespace{} block (and banning explicit namespace{}
-        /// blocks), special treatment of use directives, and ignoring magic commands (e.g. %simulate)
+        /// blocks), special treatment of open directives, and ignoring magic commands (e.g. %simulate)
         /// </summary>
         public bool IsNotebook { get; set; }
 

--- a/src/QsCompiler/CompilationManager/ScopeTracking.cs
+++ b/src/QsCompiler/CompilationManager/ScopeTracking.cs
@@ -98,7 +98,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
             }
 
             var continuation = file.GetLine(continueAt);
-            var updatedContinuation = ComputeCodeLines(new string[] { continuation.Text }, previous).Single();
+            var updatedContinuation = ComputeCodeLines(new string[] { continuation.Text }, previous, file.AllWhiteSpaceUntil(continueAt), file.BuildConfiguration).Single();
             return updatedContinuation.Indentation - continuation.Indentation;
         }
 
@@ -378,6 +378,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
                     prefixDelims,
                     -1, // The comment will have been removed by this point
                     0,
+                    false, // Whether this line is all whitespace is also irrelevant
                     prefixExcessClosings);
             }
 
@@ -506,12 +507,17 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// <remarks>
         /// Specifying <paramref name="previousLine"/> as null indicates that there is no previous line.
         /// </remarks>
-        private static IEnumerable<CodeLine> InitializeCodeLines(IEnumerable<string> texts, CodeLine? previousLine = null)
+        private static IEnumerable<CodeLine> InitializeCodeLines(
+            IEnumerable<string> texts,
+            CodeLine? previousLine,
+            bool allWhiteSpaceUntil,
+            BuildConfiguration buildConfiguration)
         {
             var previousLineStringContext = previousLine?.EndingStringContext ?? CodeLine.StringContext.NoOpenString;
             foreach (string text in texts)
             {
-                var line = new CodeLine(text, previousLineStringContext);
+                var line = new CodeLine(text, previousLineStringContext, allWhiteSpaceUntil, buildConfiguration);
+                allWhiteSpaceUntil &= line.IsAllWhiteSpace;
                 previousLineStringContext = line.EndingStringContext;
                 yield return line;
             }
@@ -556,8 +562,8 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// <remarks>
         /// Specifying <paramref name="previousLine"/> as null indicates that there is no previous line.
         /// </remarks>
-        private static IEnumerable<CodeLine> ComputeCodeLines(IEnumerable<string> texts, CodeLine? previousLine = null) =>
-            SetIndentations(InitializeCodeLines(texts, previousLine), previousLine == null ? 0 : previousLine.FinalIndentation());
+        private static IEnumerable<CodeLine> ComputeCodeLines(IEnumerable<string> texts, CodeLine? previousLine, bool allWhiteSpaceUntil, BuildConfiguration buildConfiguration) =>
+            SetIndentations(InitializeCodeLines(texts, previousLine, allWhiteSpaceUntil, buildConfiguration), previousLine == null ? 0 : previousLine.FinalIndentation());
 
         /// <summary>
         /// Returns an enumerable sequence of new <see cref="CodeLine"/> objects where the initial indentation
@@ -606,7 +612,8 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
             {
                 // we need to recompute everything if the interpretation of what is code and what is a string changes...
                 // since the interpretation of the remaining file changed, we need to update the entire file from start onwards
-                return ComputeCodeLines(remainingLines.Select(line => line.Text), replacements.Last()).ToList();
+                bool allWhiteSpaceUntil = file.AllWhiteSpaceUntil(start) && replacements.All(line => line.IsAllWhiteSpace);
+                return ComputeCodeLines(remainingLines.Select(line => line.Text), replacements.Last(), allWhiteSpaceUntil, file.BuildConfiguration).ToList();
             }
             else if (indentationChange != 0)
             {
@@ -686,7 +693,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         private static void Update(this FileContentManager file, int start, int count, IEnumerable<string> newText)
         {
             CodeLine[] replacements = QsCompilerError.RaiseOnFailure(
-                () => ComputeCodeLines(newText, start > 0 ? file.GetLine(start - 1) : null).ToArray(),
+                () => ComputeCodeLines(newText, start > 0 ? file.GetLine(start - 1) : null, file.AllWhiteSpaceUntil(start), file.BuildConfiguration).ToArray(),
                 "scope tracking update failed during computing the replacements");
 
             IEnumerable<CodeLine>? updateRemaining = QsCompilerError.RaiseOnFailure(
@@ -735,7 +742,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// <para/>
         /// If <paramref name="change"/> is null, then (only) the currently queued unprocessed changes are processed.
         /// </remarks>
-        internal static void UpdateScopeTacking(this FileContentManager file, TextDocumentContentChangeEvent? change)
+        internal static void UpdateScopeTracking(this FileContentManager file, TextDocumentContentChangeEvent? change)
         {
             // Replaces the lines in the range [start, end] with those for the given text.
             void ComputeUpdate(int start, int end, string text)

--- a/src/QsCompiler/DataStructures/ReservedKeywords.fs
+++ b/src/QsCompiler/DataStructures/ReservedKeywords.fs
@@ -198,6 +198,9 @@ module InternalUse =
     /// to be used as name for all namespaces that do not have a valid name
     let UnknownNamespace = "__UnknownNamespaceName__"
 
+    /// the implicit namespace in notebooks
+    let NotebookNamespace = "__NotebookNamespace__"
+
     /// name for the control qubits used for compiler-generated controlled specializations (argument to the controlled functor)
     let ControlQubitsName = "__controlQubits__"
 

--- a/src/QsCompiler/DataStructures/SyntaxTree.fs
+++ b/src/QsCompiler/DataStructures/SyntaxTree.fs
@@ -32,7 +32,7 @@ type QsSpecializationKind =
     | QsAdjoint
     /// indicates the specialization of a declared operation that is executed when the callable is called after applying one or more Controlled functors
     | QsControlled
-    /// indicates the specialization of a declared operation that is executed when the callable is called after applying an odd number of Adjoint functors and one ore more Controlled functors
+    /// indicates the specialization of a declared operation that is executed when the callable is called after applying an odd number of Adjoint functors and one or more Controlled functors
     | QsControlledAdjoint
 
 

--- a/src/QsCompiler/LanguageServer/LanguageServer.cs
+++ b/src/QsCompiler/LanguageServer/LanguageServer.cs
@@ -282,6 +282,12 @@ namespace Microsoft.Quantum.QsLanguageServer
                 {
                     this.clientVersion = null;
                 }
+
+                if (options.TryGetValue("isNotebook", out var isNotebook)
+                        && isNotebook.Type == JTokenType.Boolean)
+                {
+                    this.editorState.IsNotebook = (bool)isNotebook;
+                }
             }
 
             bool supportsCompletion = !this.ClientNameIs("VisualStudio") || this.ClientVersionIsAtLeast(new Version(16, 3));

--- a/src/QsCompiler/LanguageServer/LanguageServer.cs
+++ b/src/QsCompiler/LanguageServer/LanguageServer.cs
@@ -32,6 +32,15 @@ namespace Microsoft.Quantum.QsLanguageServer
 
         internal bool ReadyForExit { get; private set; }
 
+        // Used in unit tests
+        internal bool IsNotebook
+        {
+            get
+            {
+                return this.editorState.IsNotebook;
+            }
+        }
+
         private readonly System.Timers.Timer internalErrorTimer; // used to avoid spamming users with a lot of errors at once
         private bool showInteralErrorMessage = true; // set via timer as needed
 

--- a/src/QsCompiler/LanguageServer/LanguageServer.cs
+++ b/src/QsCompiler/LanguageServer/LanguageServer.cs
@@ -88,7 +88,7 @@ namespace Microsoft.Quantum.QsLanguageServer
                 this.OnDidChangeWatchedFiles(JToken.Parse(JsonConvert.SerializeObject(
                     new DidChangeWatchedFilesParams { Changes = e.ToArray() })));
             this.fileWatcher = new FileWatcher(_ =>
-                this.LogToWindow($"FileSystemWatcher encountered and error", MessageType.Error));
+                this.LogToWindow("FileSystemWatcher encountered an error", MessageType.Error));
             var fileEvents = Observable.FromEvent<FileWatcher.FileEventHandler, FileEvent>(
                     handler => this.fileWatcher.FileEvent += handler,
                     handler => this.fileWatcher.FileEvent -= handler)

--- a/src/QsCompiler/TestProjects/test18/Bell.qs
+++ b/src/QsCompiler/TestProjects/test18/Bell.qs
@@ -1,0 +1,11 @@
+﻿open Microsoft.Quantum.Intrinsic;
+open Microsoft.Quantum.Canon;
+
+@EntryPoint()
+operation Main(): Unit {
+    H(q[0]);
+    CNOT(q[0], q[1]);
+
+    let result = [M(q[0]), M(q[1])];
+    Message($"Results: {result}");
+}

--- a/src/QsCompiler/TestProjects/test18/Magic.qs
+++ b/src/QsCompiler/TestProjects/test18/Magic.qs
@@ -1,0 +1,13 @@
+﻿%azure.target ionq.simulator
+
+namespace Test18 {
+    open Microsoft.Quantum.Intrinsic;
+
+    operation PrintParity(num: Int): Unit {
+        let two = 2;
+        let parity = num
+%two
+        ;
+        Message($"Parity of {num} is {parity}");
+    }
+}

--- a/src/QsCompiler/TestProjects/test18/README.md
+++ b/src/QsCompiler/TestProjects/test18/README.md
@@ -1,0 +1,1 @@
+This is an invalid Q# app for testing parsing differences configured for notebooks.

--- a/src/QsCompiler/TestProjects/test18/test18.csproj
+++ b/src/QsCompiler/TestProjects/test18/test18.csproj
@@ -1,0 +1,9 @@
+﻿<Project Sdk="Microsoft.Quantum.Sdk/0.21.2112180703">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <ExecutionTarget>ionq.qpu</ExecutionTarget>
+  </PropertyGroup>
+
+</Project>

--- a/src/QsCompiler/TestProjects/test18/test18.csproj
+++ b/src/QsCompiler/TestProjects/test18/test18.csproj
@@ -1,8 +1,8 @@
-﻿<Project Sdk="Microsoft.Quantum.Sdk/0.21.2112180703">
+﻿<Project Sdk="Microsoft.Quantum.Sdk/0.25.218240">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <ExecutionTarget>ionq.qpu</ExecutionTarget>
   </PropertyGroup>
 

--- a/src/QsCompiler/Tests.Compiler/LocalVerificationTests.fs
+++ b/src/QsCompiler/Tests.Compiler/LocalVerificationTests.fs
@@ -538,6 +538,8 @@ type LocalVerificationTests() =
         this.Expect "StringParsingTest5" []
         this.Expect "StringParsingTest6" []
         this.Expect "StringParsingTest7" []
+        this.Expect "NotebookStringParsingTest1" [ Error ErrorCode.UnknownCodeFragment ]
+        this.Expect "NotebookStringParsingTest2" [ Error ErrorCode.UnknownCodeFragment ]
 
         this.Expect "MultiLineStringTest1" []
         this.Expect "MultiLineStringTest2" []

--- a/src/QsCompiler/Tests.Compiler/TestCases/StringParsingTests/StringParsing.qs
+++ b/src/QsCompiler/Tests.Compiler/TestCases/StringParsingTests/StringParsing.qs
@@ -32,6 +32,14 @@ namespace Microsoft.Quantum.Testing.LocalVerification {
         let str = "//";
     }
 
+    operation NotebookStringParsingTest1 () : Unit {
+        let str = "hi"; %
+    }
+
+    operation NotebookStringParsingTest2 () : Unit {
+%simulate SampleRandomNumber nQubits=3
+    }
+
     operation MultiLineStringTest1 () : Unit {
         let str = "
         ";

--- a/src/QsCompiler/Tests.LanguageServer/TestSetup.cs
+++ b/src/QsCompiler/Tests.LanguageServer/TestSetup.cs
@@ -32,10 +32,10 @@ namespace Microsoft.Quantum.QsLanguageServer.Testing
                 Methods.WorkspaceExecuteCommand.Name,
                 TestUtils.ServerCommand(CommandIds.FileContentInMemory, TestUtils.GetTextDocumentIdentifier(filename)));
 
-        public Task<Diagnostic[]> GetFileDiagnosticsAsync(string? filename = null) =>
+        public Task<Diagnostic[]> GetFileDiagnosticsAsync(string? filename = null, Uri? uri = null) =>
             this.rpc.InvokeWithParameterObjectAsync<Diagnostic[]>(
                 Methods.WorkspaceExecuteCommand.Name,
-                TestUtils.ServerCommand(CommandIds.FileDiagnostics, filename == null ? new TextDocumentIdentifier { Uri = new Uri("file://unknown") } : TestUtils.GetTextDocumentIdentifier(filename)));
+                TestUtils.ServerCommand(CommandIds.FileDiagnostics, filename == null ? new TextDocumentIdentifier { Uri = uri ?? new Uri("file://unknown") } : TestUtils.GetTextDocumentIdentifier(filename)));
 
         public Task SetupAsync()
         {

--- a/src/QsCompiler/Tests.LanguageServer/TestSetup.cs
+++ b/src/QsCompiler/Tests.LanguageServer/TestSetup.cs
@@ -21,6 +21,7 @@ namespace Microsoft.Quantum.QsLanguageServer.Testing
         /* basic setup */
 
         private Connection? connection;
+        private QsLanguageServer server = null!; // Initialized in SetupServerConnectionAsync
         private JsonRpc rpc = null!; // Initialized in SetupServerConnectionAsync.
         private readonly RandomInput inputGenerator = new RandomInput();
         private readonly Stack<PublishDiagnosticParams> receivedDiagnostics = new Stack<PublishDiagnosticParams>();
@@ -73,7 +74,7 @@ namespace Microsoft.Quantum.QsLanguageServer.Testing
                 var readerPipe = new NamedPipeServerStream(serverWriterPipe, PipeDirection.InOut, 4, PipeTransmissionMode.Message, PipeOptions.Asynchronous, 256, 256);
                 var writerPipe = new NamedPipeServerStream(serverReaderPipe, PipeDirection.InOut, 4, PipeTransmissionMode.Message, PipeOptions.Asynchronous, 256, 256);
 
-                var server = Server.ConnectViaNamedPipe(serverWriterPipe, serverReaderPipe);
+                this.server = Server.ConnectViaNamedPipe(serverWriterPipe, serverReaderPipe);
                 await readerPipe.WaitForConnectionAsync().ConfigureAwait(true);
                 await writerPipe.WaitForConnectionAsync().ConfigureAwait(true);
                 this.connection = new Connection(readerPipe, writerPipe);
@@ -83,7 +84,7 @@ namespace Microsoft.Quantum.QsLanguageServer.Testing
                 var readerPipe = new System.IO.Pipelines.Pipe();
                 var writerPipe = new System.IO.Pipelines.Pipe();
 
-                var server = new QsLanguageServer(sender: writerPipe.Writer.AsStream(), reader: readerPipe.Reader.AsStream());
+                this.server = new QsLanguageServer(sender: writerPipe.Writer.AsStream(), reader: readerPipe.Reader.AsStream());
                 this.connection = new Connection(writerPipe.Reader.AsStream(), readerPipe.Writer.AsStream());
             }
 

--- a/src/QsCompiler/Tests.LanguageServer/TestUtils.cs
+++ b/src/QsCompiler/Tests.LanguageServer/TestUtils.cs
@@ -44,6 +44,9 @@ namespace Microsoft.Quantum.QsLanguageServer.Testing
             return new TextDocumentIdentifier { Uri = GetUri(filename) };
         }
 
+        internal static Uri GenerateNotebookCellUri(Guid notebookGuid) =>
+            new Uri("file:///" + notebookGuid.ToString() + "/" + Guid.NewGuid().ToString() + ".qs");
+
         internal static InitializeParams GetInitializeParams(bool addNotebookConfig = false)
         {
             return new InitializeParams
@@ -60,12 +63,12 @@ namespace Microsoft.Quantum.QsLanguageServer.Testing
             };
         }
 
-        internal static DidOpenTextDocumentParams GetOpenFileParams(string filename)
+        internal static DidOpenTextDocumentParams GetOpenFileParams(string filename, Uri? uri = null)
         {
             var file = Path.GetFullPath(filename);
             var content = File.ReadAllText(file);
             return new DidOpenTextDocumentParams
-            { TextDocument = new TextDocumentItem { Uri = GetUri(filename), Text = content } };
+            { TextDocument = new TextDocumentItem { Uri = uri ?? GetUri(filename), Text = content } };
         }
 
         internal static DidCloseTextDocumentParams GetCloseFileParams(string filename)

--- a/src/QsCompiler/Tests.LanguageServer/TestUtils.cs
+++ b/src/QsCompiler/Tests.LanguageServer/TestUtils.cs
@@ -63,12 +63,17 @@ namespace Microsoft.Quantum.QsLanguageServer.Testing
             };
         }
 
+        internal static DidOpenTextDocumentParams GetOpenParams(Uri uri, string content)
+        {
+            return new DidOpenTextDocumentParams
+            { TextDocument = new TextDocumentItem { Uri = uri, Text = content } };
+        }
+
         internal static DidOpenTextDocumentParams GetOpenFileParams(string filename, Uri? uri = null)
         {
             var file = Path.GetFullPath(filename);
             var content = File.ReadAllText(file);
-            return new DidOpenTextDocumentParams
-            { TextDocument = new TextDocumentItem { Uri = uri ?? GetUri(filename), Text = content } };
+            return TestUtils.GetOpenParams(uri ?? GetUri(filename), content);
         }
 
         internal static DidCloseTextDocumentParams GetCloseFileParams(string filename)
@@ -81,11 +86,16 @@ namespace Microsoft.Quantum.QsLanguageServer.Testing
             return new DidSaveTextDocumentParams { TextDocument = new TextDocumentIdentifier { Uri = GetUri(filename) }, Text = content };
         }
 
-        internal static DidChangeTextDocumentParams GetChangedFileParams(string filename, TextDocumentContentChangeEvent[] changes)
+        internal static DidChangeTextDocumentParams GetChangedParams(Uri uri, TextDocumentContentChangeEvent[] changes)
         {
-            var fileId = new VersionedTextDocumentIdentifier { Uri = GetUri(filename) };
+            var fileId = new VersionedTextDocumentIdentifier { Uri = uri };
             return new DidChangeTextDocumentParams
             { TextDocument = fileId, ContentChanges = changes };
+        }
+
+        internal static DidChangeTextDocumentParams GetChangedFileParams(string filename, TextDocumentContentChangeEvent[] changes)
+        {
+            return GetChangedParams(GetUri(filename), changes);
         }
 
         internal static TextDocumentPositionParams GetTextDocumentPositionParams(string filename, Position pos)

--- a/src/QsCompiler/Tests.LanguageServer/TestUtils.cs
+++ b/src/QsCompiler/Tests.LanguageServer/TestUtils.cs
@@ -10,6 +10,7 @@ using System.Threading.Tasks;
 using Microsoft.Quantum.QsCompiler.CompilationBuilder;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Newtonsoft.Json.Linq;
 using Builder = Microsoft.Quantum.QsCompiler.CompilationBuilder.Utils;
 using Range = Microsoft.VisualStudio.LanguageServer.Protocol.Range;
 
@@ -43,12 +44,13 @@ namespace Microsoft.Quantum.QsLanguageServer.Testing
             return new TextDocumentIdentifier { Uri = GetUri(filename) };
         }
 
-        internal static InitializeParams GetInitializeParams()
+        internal static InitializeParams GetInitializeParams(bool addNotebookConfig = false)
         {
             return new InitializeParams
             {
                 ProcessId = -1,
-                InitializationOptions = null,
+                InitializationOptions = addNotebookConfig ? JObject.FromObject(new { isNotebook = true })
+                                                          : null,
                 Capabilities = new ClientCapabilities
                 {
                     Workspace = new WorkspaceClientCapabilities(),

--- a/src/QsCompiler/Tests.LanguageServer/Tests.cs
+++ b/src/QsCompiler/Tests.LanguageServer/Tests.cs
@@ -66,10 +66,20 @@ namespace Microsoft.Quantum.QsLanguageServer.Testing
             var initParams = TestUtils.GetInitializeParams();
             var initReply = await this.rpc.InvokeWithParameterObjectAsync<InitializeResult>(Methods.Initialize.Name, initParams);
             Assert.IsNotNull(initReply);
+            Assert.IsFalse(this.server.IsNotebook);
 
             var init = await this.rpc.InvokeWithParameterObjectAsync<JToken>(Methods.Initialize.Name, initParams);
             var initializeError = Utils.TryJTokenAs<InitializeError>(init);
             Assert.IsTrue(initializeError != null ? initializeError.Retry : false);
+        }
+
+        [TestMethod]
+        public async Task NotebookInitializationAsync()
+        {
+            var initParams = TestUtils.GetInitializeParams(addNotebookConfig: true);
+            var initReply = await this.rpc.InvokeWithParameterObjectAsync<InitializeResult>(Methods.Initialize.Name, initParams);
+            Assert.IsNotNull(initReply);
+            Assert.IsTrue(this.server.IsNotebook);
         }
 
         [TestMethod]

--- a/src/QsCompiler/Tests.LanguageServer/Tests.cs
+++ b/src/QsCompiler/Tests.LanguageServer/Tests.cs
@@ -551,6 +551,74 @@ namespace Microsoft.Quantum.QsLanguageServer.Testing
             static string PositionToString(Position p) => $"Ln {p.Line}, Col {p.Character}";
         }
 
+        [TestMethod]
+        public async Task NotebookSyntaxRejectedAsync()
+        {
+            var projectFile = ProjectLoaderTests.ProjectUri("test18");
+            var projDir = Path.GetDirectoryName(projectFile.AbsolutePath) ?? "";
+            var programFileWithoutNamespace = Path.Combine(projDir, "Bell.qs");
+            var programFileWithMagic = Path.Combine(projDir, "Magic.qs");
+
+            // initParams.InitializationOptions.isNotebook will be false by default
+            var initParams = TestUtils.GetInitializeParams();
+            initParams.RootUri = new Uri(projDir);
+            await this.rpc.NotifyWithParameterObjectAsync(Methods.Initialize.Name, initParams);
+
+            var openParams1 = TestUtils.GetOpenFileParams(programFileWithoutNamespace);
+            await this.rpc.InvokeWithParameterObjectAsync<Task>(Methods.TextDocumentDidOpen.Name, openParams1);
+            var diagnostics1 = await this.GetFileDiagnosticsAsync(programFileWithoutNamespace);
+
+            var openParams2 = TestUtils.GetOpenFileParams(programFileWithMagic);
+            await this.rpc.InvokeWithParameterObjectAsync<Task>(Methods.TextDocumentDidOpen.Name, openParams2);
+            var diagnostics2 = await this.GetFileDiagnosticsAsync(programFileWithMagic);
+
+            Assert.IsNotNull(diagnostics1);
+            Assert.AreEqual(3, diagnostics1!.Length);
+            for (int i = 0; i < 3; i++)
+            {
+                Assert.AreEqual("QS4002", diagnostics1[i].Code);
+                Assert.AreEqual(DiagnosticSeverity.Error, diagnostics1[i].Severity);
+            }
+
+            Assert.IsNotNull(diagnostics2);
+            Assert.AreEqual(1, diagnostics2!.Length);
+            Assert.AreEqual("QS3001", diagnostics2[0].Code);
+            Assert.AreEqual(DiagnosticSeverity.Error, diagnostics2[0].Severity);
+        }
+
+        [TestMethod]
+        public async Task NotebookSyntaxAcceptedAsync()
+        {
+            var projectFile = ProjectLoaderTests.ProjectUri("test18");
+            var projDir = Path.GetDirectoryName(projectFile.AbsolutePath) ?? "";
+            var programFileWithoutNamespace = Path.Combine(projDir, "Bell.qs");
+            var programFileWithMagic = Path.Combine(projDir, "Magic.qs");
+
+            var notebookGuid = Guid.NewGuid();
+            var uriWithoutNamespace = TestUtils.GenerateNotebookCellUri(notebookGuid);
+            var uriWithMagic = TestUtils.GenerateNotebookCellUri(notebookGuid);
+
+            // Azure Notebooks leaves RootUri=null, so do the same here
+            var initParams = TestUtils.GetInitializeParams(addNotebookConfig: true);
+            await this.rpc.NotifyWithParameterObjectAsync(Methods.Initialize.Name, initParams);
+
+            var openParams1 = TestUtils.GetOpenFileParams(programFileWithoutNamespace, uriWithoutNamespace);
+            await this.rpc.InvokeWithParameterObjectAsync<Task>(Methods.TextDocumentDidOpen.Name, openParams1);
+            var diagnostics1 = await this.GetFileDiagnosticsAsync(uri: uriWithoutNamespace);
+
+            var openParams2 = TestUtils.GetOpenFileParams(programFileWithMagic, uriWithMagic);
+            await this.rpc.InvokeWithParameterObjectAsync<Task>(Methods.TextDocumentDidOpen.Name, openParams2);
+            var diagnostics2 = await this.GetFileDiagnosticsAsync(uri: uriWithMagic);
+
+            Assert.IsNotNull(diagnostics1);
+            Assert.AreEqual(0, diagnostics1!.Length);
+
+            Assert.IsNotNull(diagnostics2);
+            Assert.AreEqual(1, diagnostics2!.Length);
+            Assert.AreEqual("QS3027", diagnostics2[0].Code);
+            Assert.AreEqual(DiagnosticSeverity.Error, diagnostics2[0].Severity);
+        }
+
         private static async Task<ProjectManager> LoadProjectFileAsync(Uri uri)
         {
             var projectManager = new ProjectManager(e => throw e);


### PR DESCRIPTION
Here's my first stab at notebook support in the Q# Language Server. Magic commands still throw diagnostics, and there is no type checking yet, but it can at least catch basic syntax errors in Notebooks.

I don't know the team's style conventions, and I haven't used .NET much, so please bear with me when you see weird things.

## Testing
* StyleCop and Fantomas are happy
* Unit tests passed (`dotnet test QsCompiler.sln`)
* Did end-to-end local test in Azure Notebooks (requires [my branch of AzureNotebooks](https://devdiv.visualstudio.com/OnlineServices/_git/AzureNotebooks?version=GBusers/t-aadams/qsharp-tweaks&_a=history)). Magic commands throw errors as expected, but otherwise it gives useful syntax feedback 