### PR TITLE
Migration of Language Server protocol and client to version 17.2

### DIFF
--- a/src/QsCompiler/CompilationManager/CompilationManager.csproj
+++ b/src/QsCompiler/CompilationManager/CompilationManager.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.VisualStudio.LanguageServer.Protocol" Version="17.1.8" />
+    <PackageReference Include="Microsoft.VisualStudio.LanguageServer.Protocol" Version="17.2.8" />
     <PackageReference Include="Newtonsoft.Json.Bson" Version="1.0.2" />
   </ItemGroup>
 

--- a/src/QsCompiler/LanguageServer/LanguageServer.csproj
+++ b/src/QsCompiler/LanguageServer/LanguageServer.csproj
@@ -28,7 +28,7 @@
     <PackageReference Include="Microsoft.Build.Framework" Version="16.9.0" ExcludeAssets="runtime" />
     <PackageReference Include="Microsoft.Build.Locator" Version="1.4.1" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="16.9.0" ExcludeAssets="runtime" />
-    <PackageReference Include="Microsoft.VisualStudio.LanguageServer.Protocol" Version="17.1.8" />
+    <PackageReference Include="Microsoft.VisualStudio.LanguageServer.Protocol" Version="17.2.2105" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="NuGet.ProjectModel" Version="6.2.0" />
     <PackageReference Include="StreamJsonRpc" Version="2.7.76" />

--- a/src/QsCompiler/LanguageServer/LanguageServer.csproj
+++ b/src/QsCompiler/LanguageServer/LanguageServer.csproj
@@ -28,7 +28,7 @@
     <PackageReference Include="Microsoft.Build.Framework" Version="16.9.0" ExcludeAssets="runtime" />
     <PackageReference Include="Microsoft.Build.Locator" Version="1.4.1" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="16.9.0" ExcludeAssets="runtime" />
-    <PackageReference Include="Microsoft.VisualStudio.LanguageServer.Protocol" Version="17.2.2105" />
+    <PackageReference Include="Microsoft.VisualStudio.LanguageServer.Protocol" Version="17.2.8" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="NuGet.ProjectModel" Version="6.2.0" />
     <PackageReference Include="StreamJsonRpc" Version="2.7.76" />

--- a/src/QsCompiler/Tests.LanguageServer/Tests.LanguageServer.csproj
+++ b/src/QsCompiler/Tests.LanguageServer/Tests.LanguageServer.csproj
@@ -15,7 +15,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
-    <PackageReference Include="Microsoft.VisualStudio.LanguageServer.Client" Version="17.1.68" />
+    <PackageReference Include="Microsoft.VisualStudio.LanguageServer.Client" Version="17.2.2105" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.0.0" />
     <PackageReference Include="MSTest.TestFramework" Version="2.0.0" />
     <PackageReference Include="System.IO.Pipelines" Version="6.0.1" />


### PR DESCRIPTION
With this change we are updating the Language Server and its tests to the most recently published version of the LSP protocol. 