### PR TITLE
Revert "Using NuGet.ProjectModel from the install path to avoid versi…

### DIFF
--- a/src/QsCompiler/LanguageServer/LanguageServer.csproj
+++ b/src/QsCompiler/LanguageServer/LanguageServer.csproj
@@ -30,7 +30,7 @@
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="16.9.0" ExcludeAssets="runtime" />
     <PackageReference Include="Microsoft.VisualStudio.LanguageServer.Protocol" Version="17.2.8" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="NuGet.ProjectModel" Version="6.2.0" />
+    <PackageReference Include="NuGet.ProjectModel" Version="6.2.1" />
     <PackageReference Include="StreamJsonRpc" Version="2.7.76" />
     <PackageReference Include="System.Reactive" Version="4.4.1" />
   </ItemGroup>

--- a/src/QsCompiler/LanguageServer/Program.cs
+++ b/src/QsCompiler/LanguageServer/Program.cs
@@ -6,7 +6,6 @@ using System.IO;
 using System.IO.Pipes;
 using System.Net.Sockets;
 using System.Reflection;
-using System.Runtime.Loader;
 using CommandLine;
 using CommandLine.Text;
 using Microsoft.Build.Locator;
@@ -117,21 +116,7 @@ namespace Microsoft.Quantum.QsLanguageServer
             // This needs to be done before any MsBuild packages are loaded.
             try
             {
-                VisualStudioInstance vsi = MSBuildLocator.RegisterDefaults();
-
-                // We're using the installed version of the binaries to avoid a dependency between
-                // the .NET Core SDK version and NuGet. This is a workaround due to the issue below:
-                // https://github.com/microsoft/MSBuildLocator/issues/86
-                AssemblyLoadContext.Default.Resolving += (assemblyLoadContext, assemblyName) =>
-                {
-                    string path = Path.Combine(vsi.MSBuildPath, assemblyName.Name + ".dll");
-                    if (File.Exists(path))
-                    {
-                        return assemblyLoadContext.LoadFromAssemblyPath(path);
-                    }
-
-                    return null;
-                };
+                MSBuildLocator.RegisterDefaults();
             }
             catch (Exception ex)
             {

--- a/src/QsCompiler/Tests.LanguageServer/ProjectLoaderTests.cs
+++ b/src/QsCompiler/Tests.LanguageServer/ProjectLoaderTests.cs
@@ -4,8 +4,6 @@
 using System;
 using System.IO;
 using System.Linq;
-using System.Runtime.Loader;
-using Microsoft.Build.Locator;
 using Microsoft.Quantum.QsCompiler.CompilationBuilder;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -15,24 +13,6 @@ namespace Microsoft.Quantum.QsLanguageServer.Testing
     [TestClass]
     public class ProjectLoaderTests
     {
-        [AssemblyInitialize]
-        public static void SetupMSBuildLocator(TestContext testContext)
-        {
-            VisualStudioInstance vsi = MSBuildLocator.RegisterDefaults();
-
-            // This is replicating the approach followed in Microsoft.Quantum.QsLanguageServer.Server.Run()
-            AssemblyLoadContext.Default.Resolving += (assemblyLoadContext, assemblyName) =>
-            {
-                string path = Path.Combine(vsi.MSBuildPath, assemblyName.Name + ".dll");
-                if (File.Exists(path))
-                {
-                    return assemblyLoadContext.LoadFromAssemblyPath(path);
-                }
-
-                return null;
-            };
-        }
-
         private static string ProjectFileName(string project) =>
             Path.Combine("TestProjects", project, $"{project}.csproj");
 
@@ -43,6 +23,12 @@ namespace Microsoft.Quantum.QsLanguageServer.Testing
         {
             var uri = ProjectUri(project);
             return (uri, CompilationContext.Load(uri));
+        }
+
+        [TestInitialize]
+        public void RunMSBuildLocator()
+        {
+            _ = VisualStudioInstanceWrapper.LazyVisualStudioInstance.Value;
         }
 
         [TestMethod]

--- a/src/QsCompiler/Tests.LanguageServer/TestSetup.cs
+++ b/src/QsCompiler/Tests.LanguageServer/TestSetup.cs
@@ -55,6 +55,9 @@ namespace Microsoft.Quantum.QsLanguageServer.Testing
         [TestInitialize]
         public async Task SetupServerConnectionAsync()
         {
+            // Need to run MSBuildLocator for some tests like UpdateProjectFileAsync
+            _ = VisualStudioInstanceWrapper.LazyVisualStudioInstance.Value;
+
             Directory.CreateDirectory(RandomInput.TestInputDirectory);
             var outputDir = new DirectoryInfo(RandomInput.TestInputDirectory);
             foreach (var file in outputDir.GetFiles())

--- a/src/QsCompiler/Tests.LanguageServer/VisualStudioInstanceWrapper.cs
+++ b/src/QsCompiler/Tests.LanguageServer/VisualStudioInstanceWrapper.cs
@@ -1,0 +1,14 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using Microsoft.Build.Locator;
+
+namespace Microsoft.Quantum.QsLanguageServer.Testing
+{
+    internal static class VisualStudioInstanceWrapper
+    {
+        public static Lazy<VisualStudioInstance> LazyVisualStudioInstance { get; }
+            = new Lazy<VisualStudioInstance>(MSBuildLocator.RegisterDefaults);
+    }
+}


### PR DESCRIPTION
…on conflicts (#566)"

 Without this PR, some tests such as the LoadOutdatedQSharpProject test in ProjectLoaderTests were failing as follows:
```
 [Warning]: MSBuild warning in C:\Program Files\dotnet\sdk\6.0.301\Sdks\Microsoft.NET.Sdk\targets\Microsoft.NET.EolTargetFrameworks.targets(28,5): The target framework 'netcoreapp2.0' is out of support and will not receive security updates in the future. Please refer to https://aka.ms/dotnet-core-support for more information about the support policy.
 [Warning]: MSBuild warning in C:\Program Files\dotnet\sdk\6.0.301\Sdks\Microsoft.NET.Sdk\targets\Microsoft.NET.EolTargetFrameworks.targets(28,5): The target framework 'netcoreapp2.0' is out of support and will not receive security updates in the future. Please refer to https://aka.ms/dotnet-core-support for more information about the support policy.
 [Error]: MSBuild error in C:\Program Files\dotnet\sdk\6.0.301\Sdks\Microsoft.NET.Sdk\targets\Microsoft.PackageDependencyResolution.targets(267,5): The "ResolvePackageAssets" task failed unexpectedly.
 System.IO.FileLoadException: Could not load file or assembly 'NuGet.ProjectModel, Version=6.2.1.2, Culture=neutral, PublicKeyToken=31bf3856ad364e35'. Could not find or load a specific file. (0x80131621)
 File name: 'NuGet.ProjectModel, Version=6.2.1.2, Culture=neutral, PublicKeyToken=31bf3856ad364e35'
  ---> System.IO.FileLoadException: Could not load file or assembly 'NuGet.ProjectModel, Version=6.2.1.2, Culture=neutral, PublicKeyToken=31bf3856ad364e35'.
    at System.Runtime.Loader.AssemblyLoadContext.LoadFromPath(IntPtr ptrNativeAssemblyLoadContext, String ilPath, String niPath, ObjectHandleOnStack retAssembly)
    at System.Runtime.Loader.AssemblyLoadContext.LoadFromAssemblyPath(String assemblyPath)
    at Microsoft.Build.Shared.MSBuildLoadContext.Load(AssemblyName assemblyName)
    at System.Runtime.Loader.AssemblyLoadContext.ResolveUsingLoad(AssemblyName assemblyName)
    at System.Runtime.Loader.AssemblyLoadContext.Resolve(IntPtr gchManagedAssemblyLoadContext, AssemblyName assemblyName)
    at Microsoft.NET.Build.Tasks.ResolvePackageAssets.CacheReader.CreateReaderFromMemory(ResolvePackageAssets task, Byte[] settingsHash)
    at Microsoft.NET.Build.Tasks.ResolvePackageAssets.CacheReader..ctor(ResolvePackageAssets task)
    at Microsoft.NET.Build.Tasks.ResolvePackageAssets.ReadItemGroups()
    at Microsoft.NET.Build.Tasks.ResolvePackageAssets.ExecuteCore()
    at Microsoft.NET.Build.Tasks.TaskBase.Execute()
    at Microsoft.Build.BackEnd.TaskExecutionHost.Microsoft.Build.BackEnd.ITaskExecutionHost.Execute()
    at Microsoft.Build.BackEnd.TaskBuilder.ExecuteInstantiatedTask(ITaskExecutionHost taskExecutionHost, TaskLoggingContext taskLoggingContext, TaskHost taskHost, ItemBucket bucket, TaskExecutionMode howToExecuteTask)
 [Error]: Failed to resolve assembly references for project 'C:\Users\t-aadams\Documents\qsharp-compiler\src\QsCompiler\Tests.LanguageServer\bin\Debug\net6.0\TestProjects\test9\test9.csproj'.
```

This reverts commit 5fc3bab3f6f8ac34bdf3f60592bad13855ce3669, aka PR #566, which looks like it was intended to resolve this issue in the past. But from printfs I added, I don't think that additional code was doing anything in this newer version of .NET to locate NuGet assemblies required by msbuild. I don't know why, but this PR will remove that code as it no longer seems necessary to me.

To buy some time for an msbuild god's help, we can upgrade our version of NuGet.ProjectModel. It has already been referenced in the language server project file since 0b3d4b3af7ab40d6eac4118c907e2d98c2de2a71 anyway.

## Testing
* Ran language server locally via VSCode
* Ran all QsCompiler unit tests and they passed.