### PR TITLE
Update syntax checking to require no namespace{}s in notebooks

### DIFF
--- a/src/QsCompiler/CSharpGeneration/Context.fs
+++ b/src/QsCompiler/CSharpGeneration/Context.fs
@@ -163,6 +163,7 @@ type CodegenContext =
     member internal this.GenerateCodeForSource(source: Source) =
         if source.IsReference then
             let target = this.ProcessorArchitecture
+
             target = AssemblyConstants.IonQProcessor
             || target = AssemblyConstants.QCIProcessor
             || target = AssemblyConstants.QuantinuumProcessor

--- a/src/QsCompiler/CompilationManager/CompilationUnitManager.cs
+++ b/src/QsCompiler/CompilationManager/CompilationUnitManager.cs
@@ -946,18 +946,18 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// Gets whether a file is a notebook cell
         /// </summary>
         /// <returns>
-        /// A boxed bool holding true if it is a notebook cell, else false
+        /// true if this file is a notebook cell, else false
         /// </returns>
         /// <remarks>
         /// Waits for all currently running or queued tasks to finish
         /// before getting the file content by calling <see cref="FlushAndExecute"/>.
         /// </remarks>
-        public object? FileIsNotebookCell(TextDocumentIdentifier textDocument) =>
+        public bool? FileIsNotebookCell(TextDocumentIdentifier textDocument) =>
+            (bool?)this.FlushAndExecute(() =>
 
-            // Boxing needed here because FileQuery() is generic:
-            // https://devblogs.microsoft.com/dotnet/try-out-nullable-reference-types/#the-issue-with-t
-            this.FlushAndExecute(() =>
-                this.FileQuery(textDocument, (file, _) => (object)file.IsNotebook));
+                // Boxing needed here because FileQuery() is generic:
+                // https://devblogs.microsoft.com/dotnet/try-out-nullable-reference-types/#the-issue-with-t
+                this.FileQuery(textDocument, (file, _) => (object)file.IsNotebookCell));
 
         /// <summary>
         /// Gets the current file content (text representation) in memory.

--- a/src/QsCompiler/CompilationManager/ContextBuilder.cs
+++ b/src/QsCompiler/CompilationManager/ContextBuilder.cs
@@ -484,7 +484,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
                 var fragment = tokenIndex.GetFragment();
                 var context = tokenIndex.GetContext();
 
-                var (include, verifications) = Context.VerifySyntaxTokenContext(context, file.BuildConfiguration.IsNotebook);
+                var (include, verifications) = Context.VerifySyntaxTokenContext(context, file.IsNotebook);
                 foreach (var msg in verifications)
                 {
                     messages.Add(Diagnostics.Generate(file.FileName, msg, fragment.Range.Start));
@@ -538,7 +538,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
 
                 // invalid namespace names default to an unknown namespace name, but remain included in the compilation
                 QsCompilerError.Verify(
-                    file.BuildConfiguration.IsNotebook == (ns == null),
+                    file.IsNotebook == (ns == null),
                     "namespace for callable declaration should be null if and only if this is a notebook");
                 return (tuple.Item2.Start, new QsQualifiedName(ns ?? InternalUse.NotebookNamespace, tuple.Item1));
             }).ToList();

--- a/src/QsCompiler/CompilationManager/ContextBuilder.cs
+++ b/src/QsCompiler/CompilationManager/ContextBuilder.cs
@@ -165,7 +165,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
             {
                 return null;
             }
-            else if (file.IsNotebookCell)
+            else if (file.DocumentKind == DocumentKind.NotebookCell)
             {
                 return InternalUse.NotebookNamespace;
             }
@@ -490,7 +490,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
                 var fragment = tokenIndex.GetFragment();
                 var context = tokenIndex.GetContext();
 
-                var (include, verifications) = Context.VerifySyntaxTokenContext(context, file.IsNotebookCell ? DocumentKind.NotebookCell : DocumentKind.File);
+                var (include, verifications) = Context.VerifySyntaxTokenContext(context, file.DocumentKind);
                 foreach (var msg in verifications)
                 {
                     messages.Add(Diagnostics.Generate(file.FileName, msg, fragment.Range.Start));

--- a/src/QsCompiler/CompilationManager/FileContentManager.cs
+++ b/src/QsCompiler/CompilationManager/FileContentManager.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
 
         public string FileName { get; }
 
-        public BuildConfiguration BuildConfiguration { get; }
+        public bool IsNotebook { get; }
 
         /// <summary>
         /// An arbitrary integer representing the current version number of the file, or null if no version number is available.
@@ -116,12 +116,12 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
 
         /* constructors, "destructors" & property access: */
 
-        internal FileContentManager(Uri uri, string fileName, BuildConfiguration? buildConfiguration = null)
+        internal FileContentManager(Uri uri, string fileName, bool isNotebook = false)
         {
             this.SyncRoot = new ReaderWriterLockSlim(LockRecursionPolicy.SupportsRecursion);
             this.Uri = uri;
             this.FileName = fileName;
-            this.BuildConfiguration = buildConfiguration ?? BuildConfiguration.DefaultConfiguration();
+            this.IsNotebook = isNotebook;
             this.Version = null;
 
             this.content = new ManagedList<CodeLine>(this.SyncRoot);

--- a/src/QsCompiler/CompilationManager/FileContentManager.cs
+++ b/src/QsCompiler/CompilationManager/FileContentManager.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Quantum.QsCompiler.CompilationBuilder.DataStructures;
+using Microsoft.Quantum.QsCompiler.DataTypes;
 using Microsoft.Quantum.QsCompiler.Diagnostics;
 using Microsoft.Quantum.QsCompiler.ReservedKeywords;
 using Microsoft.Quantum.QsCompiler.SyntaxProcessing;
@@ -32,7 +33,10 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
 
         public string FileName { get; }
 
-        public bool IsNotebookCell { get; }
+        /// <summary>
+        /// Represents whether this is a notebook cell or an ordinary .qs file
+        /// </summary>
+        public DocumentKind DocumentKind { get; }
 
         /// <summary>
         /// An arbitrary integer representing the current version number of the file, or null if no version number is available.
@@ -116,12 +120,12 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
 
         /* constructors, "destructors" & property access: */
 
-        internal FileContentManager(Uri uri, string fileName, bool isNotebookCell = false)
+        internal FileContentManager(Uri uri, string fileName, DocumentKind? documentKind = null)
         {
             this.SyncRoot = new ReaderWriterLockSlim(LockRecursionPolicy.SupportsRecursion);
             this.Uri = uri;
             this.FileName = fileName;
-            this.IsNotebookCell = isNotebookCell;
+            this.DocumentKind = documentKind ?? DocumentKind.File;
             this.Version = null;
 
             this.content = new ManagedList<CodeLine>(this.SyncRoot);

--- a/src/QsCompiler/CompilationManager/FileContentManager.cs
+++ b/src/QsCompiler/CompilationManager/FileContentManager.cs
@@ -32,6 +32,8 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
 
         public string FileName { get; }
 
+        public BuildConfiguration BuildConfiguration { get; }
+
         /// <summary>
         /// An arbitrary integer representing the current version number of the file, or null if no version number is available.
         /// The version number may change at any time to any other integer, including a lower number than its current value.
@@ -114,11 +116,12 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
 
         /* constructors, "destructors" & property access: */
 
-        internal FileContentManager(Uri uri, string fileName)
+        internal FileContentManager(Uri uri, string fileName, BuildConfiguration? buildConfiguration = null)
         {
             this.SyncRoot = new ReaderWriterLockSlim(LockRecursionPolicy.SupportsRecursion);
             this.Uri = uri;
             this.FileName = fileName;
+            this.BuildConfiguration = buildConfiguration ?? BuildConfiguration.DefaultConfiguration();
             this.Version = null;
 
             this.content = new ManagedList<CodeLine>(this.SyncRoot);

--- a/src/QsCompiler/CompilationManager/FileContentManager.cs
+++ b/src/QsCompiler/CompilationManager/FileContentManager.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
 
         public string FileName { get; }
 
-        public bool IsNotebook { get; }
+        public bool IsNotebookCell { get; }
 
         /// <summary>
         /// An arbitrary integer representing the current version number of the file, or null if no version number is available.
@@ -116,12 +116,12 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
 
         /* constructors, "destructors" & property access: */
 
-        internal FileContentManager(Uri uri, string fileName, bool isNotebook = false)
+        internal FileContentManager(Uri uri, string fileName, bool isNotebookCell = false)
         {
             this.SyncRoot = new ReaderWriterLockSlim(LockRecursionPolicy.SupportsRecursion);
             this.Uri = uri;
             this.FileName = fileName;
-            this.IsNotebook = isNotebook;
+            this.IsNotebookCell = isNotebookCell;
             this.Version = null;
 
             this.content = new ManagedList<CodeLine>(this.SyncRoot);

--- a/src/QsCompiler/CompilationManager/ProjectManager.cs
+++ b/src/QsCompiler/CompilationManager/ProjectManager.cs
@@ -10,6 +10,7 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
+using Microsoft.Quantum.QsCompiler.DataTypes;
 using Microsoft.Quantum.QsCompiler.Diagnostics;
 using Microsoft.Quantum.QsCompiler.ReservedKeywords;
 using Microsoft.Quantum.QsCompiler.Transformations;
@@ -1436,12 +1437,12 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// is a notebook cell or not.
         /// </summary>
         /// <remarks>
-        /// Returns null if the given file is null.
+        /// Returns null if the given file is null or does not correspond to a known file.
         /// <para/>
         /// This method waits for all currently running or queued tasks to finish
         /// before getting the file content.
         /// </remarks>
-        public bool? FileIsNotebookCell(TextDocumentIdentifier textDocument)
+        public DocumentKind? FileDocumentKind(TextDocumentIdentifier textDocument)
         {
             if (textDocument?.Uri == null)
             {
@@ -1454,10 +1455,10 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
                     // NOTE: the call below prevents any consolidating of the processing queues
                     // of the project manager and the compilation unit manager (dead locks)!
                     var manager = this.Manager(textDocument.Uri);
-                    return manager?.FileIsNotebookCell(textDocument);
+                    return manager?.FileDocumentKind(textDocument);
                 },
                 out var content);
-            return (bool?)content;
+            return content;
         }
 
         /// <summary>

--- a/src/QsCompiler/CompilationManager/ProjectManager.cs
+++ b/src/QsCompiler/CompilationManager/ProjectManager.cs
@@ -1432,7 +1432,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         }
 
         /// <summary>
-        /// Returns a boxed bool (or null) representing if <paramref name="textDocument"/>
+        /// Returns a bool (or null) representing if <paramref name="textDocument"/>
         /// is a notebook cell or not.
         /// </summary>
         /// <remarks>
@@ -1441,7 +1441,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// This method waits for all currently running or queued tasks to finish
         /// before getting the file content.
         /// </remarks>
-        public object? FileIsNotebookCell(TextDocumentIdentifier textDocument)
+        public bool? FileIsNotebookCell(TextDocumentIdentifier textDocument)
         {
             if (textDocument?.Uri == null)
             {
@@ -1457,7 +1457,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
                     return manager?.FileIsNotebookCell(textDocument);
                 },
                 out var content);
-            return content;
+            return (bool?)content;
         }
 
         /// <summary>

--- a/src/QsCompiler/Core/Transformations/SyntaxTreeTransformation.fs
+++ b/src/QsCompiler/Core/Transformations/SyntaxTreeTransformation.fs
@@ -34,6 +34,7 @@ type SyntaxTreeTransformation<'T>(state, options) as this =
 
     /// Invokes the transformation for all namespaces in the given compilation.
     abstract OnCompilation: compilation: QsCompilation -> QsCompilation
+
     default this.OnCompilation compilation =
 
         if options.Rebuild then
@@ -262,6 +263,7 @@ type SyntaxTreeTransformation(options) as this =
 
     /// Invokes the transformation for all namespaces in the given compilation.
     abstract OnCompilation: compilation: QsCompilation -> QsCompilation
+
     default this.OnCompilation compilation =
         if options.Rebuild then
             let namespaces =

--- a/src/QsCompiler/DataStructures/DataTypes.fs
+++ b/src/QsCompiler/DataStructures/DataTypes.fs
@@ -311,6 +311,9 @@ type QsCompilerDiagnostic =
         | Warning code -> DiagnosticItem.Message(code, this.Arguments)
         | Information code -> DiagnosticItem.Message(code, this.Arguments)
 
+type DocumentKind =
+    | File
+    | NotebookCell
 
 /// interface used to pass anything lock-like to the symbol table (could not find an existing one??)
 type IReaderWriterLock =

--- a/src/QsCompiler/DataStructures/ReservedKeywords.fs
+++ b/src/QsCompiler/DataStructures/ReservedKeywords.fs
@@ -248,8 +248,10 @@ module MSBuildProperties =
     let QuantumSdkVersion = "QuantumSdkVersion"
     let TargetPath = "TargetPath"
     let ResolvedProcessorArchitecture = "ResolvedProcessorArchitecture"
+
     [<Obsolete("Replaced by ResolvedTargetCapability for Microsoft.Quantum.Sdk version 0.25 and newer.")>]
     let ResolvedRuntimeCapabilities = "ResolvedRuntimeCapabilities"
+
     let ResolvedTargetCapability = "ResolvedTargetCapability"
     let ResolvedQsharpOutputType = "ResolvedQSharpOutputType"
     let ExposeReferencesViaTestNames = "ExposeReferencesViaTestNames"
@@ -264,8 +266,10 @@ module AssemblyConstants =
     let QsharpExe = "QSharpExe"
     let QsharpLibrary = "QSharpLibrary"
     let ProcessorArchitecture = "ProcessorArchitecture"
+
     [<Obsolete("Replaced by QuantinuumProcessor for Microsoft.Quantum.Sdk version 0.25 and newer.")>]
     let HoneywellProcessor = "HoneywellProcessor"
+
     let IonQProcessor = "IonQProcessor"
     let QCIProcessor = "QCIProcessor"
     let QuantinuumProcessor = "QuantinuumProcessor"

--- a/src/QsCompiler/DataStructures/ReservedKeywords.fs
+++ b/src/QsCompiler/DataStructures/ReservedKeywords.fs
@@ -198,6 +198,9 @@ module InternalUse =
     /// to be used as name for all namespaces that do not have a valid name
     let UnknownNamespace = "__UnknownNamespaceName__"
 
+    /// the implicit namespace in notebooks
+    let NotebookNamespace = "__NotebookNamespace__"
+
     /// name for the control qubits used for compiler-generated controlled specializations (argument to the controlled functor)
     let ControlQubitsName = "__controlQubits__"
 

--- a/src/QsCompiler/DataStructures/SyntaxTree.fs
+++ b/src/QsCompiler/DataStructures/SyntaxTree.fs
@@ -32,7 +32,7 @@ type QsSpecializationKind =
     | QsAdjoint
     /// indicates the specialization of a declared operation that is executed when the callable is called after applying one or more Controlled functors
     | QsControlled
-    /// indicates the specialization of a declared operation that is executed when the callable is called after applying an odd number of Adjoint functors and one ore more Controlled functors
+    /// indicates the specialization of a declared operation that is executed when the callable is called after applying an odd number of Adjoint functors and one or more Controlled functors
     | QsControlledAdjoint
 
 

--- a/src/QsCompiler/LanguageServer/Communication.cs
+++ b/src/QsCompiler/LanguageServer/Communication.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Quantum.QsLanguageServer
         public const string ApplyEdit = "qsLanguageServer/applyEdit";
 
         // commands for diagnostic purposes
-        internal const string FileIsNotebookCell = "qsLanguageServer/fileIsNotebookCell";
+        internal const string FileDocumentKind = "qsLanguageServer/fileDocumentKind";
         internal const string FileContentInMemory = "qsLanguageServer/fileContentInMemory";
         internal const string FileDiagnostics = "qsLanguageServer/fileDiagnostics";
     }

--- a/src/QsCompiler/LanguageServer/Communication.cs
+++ b/src/QsCompiler/LanguageServer/Communication.cs
@@ -11,6 +11,7 @@ namespace Microsoft.Quantum.QsLanguageServer
         public const string ApplyEdit = "qsLanguageServer/applyEdit";
 
         // commands for diagnostic purposes
+        internal const string FileIsNotebookCell = "qsLanguageServer/fileIsNotebookCell";
         internal const string FileContentInMemory = "qsLanguageServer/fileContentInMemory";
         internal const string FileDiagnostics = "qsLanguageServer/fileDiagnostics";
     }

--- a/src/QsCompiler/LanguageServer/EditorState.cs
+++ b/src/QsCompiler/LanguageServer/EditorState.cs
@@ -11,6 +11,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Build.Execution;
 using Microsoft.Quantum.QsCompiler.CompilationBuilder;
+using Microsoft.Quantum.QsCompiler.DataTypes;
 using Microsoft.Quantum.QsCompiler.ReservedKeywords;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
 
@@ -261,7 +262,7 @@ namespace Microsoft.Quantum.QsLanguageServer
                     return;
                 }
 
-                bool isNotebook = textDocument.LanguageId == "qsharp-notebook";
+                DocumentKind documentKind = textDocument.LanguageId == "qsharp-notebook" ? DocumentKind.NotebookCell : DocumentKind.File;
 
                 var onException = (Exception ex) =>
                 {
@@ -269,7 +270,7 @@ namespace Microsoft.Quantum.QsLanguageServer
                     manager.LogException(ex);
                 };
 
-                var newManager = CompilationUnitManager.InitializeFileManager(textDocument.Uri, textDocument.Text, this.publish, onException, isNotebook);
+                var newManager = CompilationUnitManager.InitializeFileManager(textDocument.Uri, textDocument.Text, this.publish, onException, documentKind);
 
                 // Currently it is not possible to handle both the behavior of VS and VS Code for changes on disk in a manner that will never fail.
                 // To mitigate the impact of failures we choose to just log them as info.
@@ -543,11 +544,13 @@ namespace Microsoft.Quantum.QsLanguageServer
             this.projects.FileContentInMemory(textDocument);
 
         /// <summary>
-        /// Waits for all currently running or queued tasks to finish before returning if this file is a cell in a notebook
+        /// Waits for all currently running or queued tasks to finish before returning the
+        /// DocumentKind of this file, which represents whether is a cell in a notebook or an
+        /// ordinary .qs file. Returns null for unknown files.
         /// -> Method to be used for testing/diagnostic purposes only!
         /// </summary>
-        internal object? FileIsNotebookCell(TextDocumentIdentifier textDocument) =>
-            this.projects.FileIsNotebookCell(textDocument);
+        internal DocumentKind? FileDocumentKind(TextDocumentIdentifier textDocument) =>
+            this.projects.FileDocumentKind(textDocument);
 
         /// <summary>
         /// Waits for all currently running or queued tasks to finish before getting the diagnostics for the given file.

--- a/src/QsCompiler/LanguageServer/EditorState.cs
+++ b/src/QsCompiler/LanguageServer/EditorState.cs
@@ -261,7 +261,7 @@ namespace Microsoft.Quantum.QsLanguageServer
                     return;
                 }
 
-                bool isNotebook = textDocument.LanguageId.Contains("notebook");
+                bool isNotebook = textDocument.LanguageId == "qsharp-notebook";
 
                 var onException = (Exception ex) =>
                 {

--- a/src/QsCompiler/LanguageServer/LanguageServer.cs
+++ b/src/QsCompiler/LanguageServer/LanguageServer.cs
@@ -764,7 +764,7 @@ namespace Microsoft.Quantum.QsLanguageServer
                 return
                     param.Command == CommandIds.ApplyEdit ? CastAndExecute<ApplyWorkspaceEditParams>(edit =>
                         this.rpc.InvokeWithParameterObjectAsync<ApplyWorkspaceEditResponse>(Methods.WorkspaceApplyEditName, edit)) :
-                    param.Command == CommandIds.FileIsNotebookCell ? CastAndExecute<TextDocumentIdentifier>(this.editorState.FileIsNotebookCell) :
+                    param.Command == CommandIds.FileDocumentKind ? CastAndExecute<TextDocumentIdentifier>(this.editorState.FileDocumentKind) :
                     param.Command == CommandIds.FileContentInMemory ? CastAndExecute<TextDocumentIdentifier>(this.editorState.FileContentInMemory) :
                     param.Command == CommandIds.FileDiagnostics ? CastAndExecute<TextDocumentIdentifier>(this.editorState.FileDiagnostics) :
                     null;

--- a/src/QsCompiler/SyntaxProcessor/ContextVerification.fs
+++ b/src/QsCompiler/SyntaxProcessor/ContextVerification.fs
@@ -10,7 +10,6 @@ open Microsoft.Quantum.QsCompiler.Diagnostics
 open Microsoft.Quantum.QsCompiler.SyntaxProcessing.VerificationTools
 open Microsoft.Quantum.QsCompiler.SyntaxTokens
 
-
 type SyntaxTokenContext =
     {
         Range: Range
@@ -25,21 +24,24 @@ let private ApplyOrDefaultTo fallback nullable apply =
     | Null -> fallback
     | Value v -> apply v
 
-
 /// Verifies that the number of parents in the given context is 0.
 /// Returns an array with suitable diagnostics.
-let private verifyNamespace (context: SyntaxTokenContext) (isNotebook: bool) =
-    if isNotebook then false, [| (ErrorCode.InvalidNamespaceDeclaration |> Error, context.Range) |]
-    elif context.Parents.Length = 0 then true, [||]
-    else false, [| (ErrorCode.NotWithinGlobalScope |> Error, context.Range) |]
+let private verifyNamespace (context: SyntaxTokenContext) (documentKind: DocumentKind) =
+    match documentKind with
+    | NotebookCell -> false, [| (ErrorCode.InvalidNamespaceDeclaration |> Error, context.Range) |]
+    | File ->
+        if context.Parents.Length = 0 then
+            true, [||]
+        else
+            false, [| (ErrorCode.NotWithinGlobalScope |> Error, context.Range) |]
 
 /// Verifies that the direct parent in the given context is a namespace declaration.
 /// Indicates that the fragment is to be excluded from compilation if the direct parent is not a namespace declaration.
 /// Returns an array with suitable diagnostics.
-let private verifyDeclaration (context: SyntaxTokenContext) (isNotebook: bool) =
-    if isNotebook then
-        true, [||]
-    else
+let private verifyDeclaration (context: SyntaxTokenContext) (documentKind: DocumentKind) =
+    match documentKind with
+    | NotebookCell -> true, [||]
+    | File ->
         let errMsg = false, [| (ErrorCode.NotWithinNamespace |> Error, context.Range) |]
 
         let isNamespace =
@@ -57,22 +59,22 @@ let private verifyDeclaration (context: SyntaxTokenContext) (isNotebook: bool) =
 /// or the preceding fragment is another open directive.
 /// Verifies that the direct parent is a namespace declaration.
 /// Returns an array with suitable diagnostics.
-let private verifyOpenDirective (context: SyntaxTokenContext) (isNotebook: bool) =
+let private verifyOpenDirective (context: SyntaxTokenContext) (documentKind: DocumentKind) =
     match context.Previous with
     | Value (OpenDirective _)
-    | Null -> verifyDeclaration context isNotebook
+    | Null -> verifyDeclaration context documentKind
     | Value InvalidFragment -> false, [||]
     | _ -> false, [| (ErrorCode.MisplacedOpenDirective |> Error, context.Range) |] // open directives may only occur at the beginning of a namespace
 
 /// Verifies that the next fragment is either another attribute or a function, operation, or type declaration.
 /// Verifies that the direct parent is a namespace declaration.
 /// Returns an array with suitable diagnostics.
-let private verifyDeclarationAttribute (context: SyntaxTokenContext) (isNotebook: bool) =
+let private verifyDeclarationAttribute (context: SyntaxTokenContext) (documentKind: DocumentKind) =
     match context.Next with
     | Value (FunctionDeclaration _)
     | Value (OperationDeclaration _)
     | Value (TypeDefinition _)
-    | Value (DeclarationAttribute _) -> verifyDeclaration context isNotebook
+    | Value (DeclarationAttribute _) -> verifyDeclaration context documentKind
     | Value InvalidFragment -> false, [||]
     | _ -> false, [| (ErrorCode.MisplacedDeclarationAttribute |> Error, context.Range) |]
 
@@ -258,8 +260,7 @@ let private followedByApply context =
     | Value InvalidFragment -> false, [||]
     | _ -> false, [| (ErrorCode.MissingContinuationApply |> Error, context.Range) |]
 
-
-type ContextVerification = delegate of SyntaxTokenContext * bool -> (bool * QsCompilerDiagnostic [])
+type ContextVerification = delegate of SyntaxTokenContext * DocumentKind -> (bool * QsCompilerDiagnostic [])
 
 /// Verifies that Self is valid within the given context -
 /// i.e. that it is indeed preceded and followed by suitable fragments (if required), and that it has suitable parents.
@@ -267,7 +268,7 @@ type ContextVerification = delegate of SyntaxTokenContext * bool -> (bool * QsCo
 /// In particular, specialization declarations with invalid generators are *not* marked as to be excluded.
 /// Marked as excluded, on the other hand, are invalid or empty fragments.
 let VerifySyntaxTokenContext =
-    new ContextVerification(fun context isNotebook ->
+    new ContextVerification(fun context documentKind ->
         match context.Self with
         | Null -> false, [||]
         | Value kind ->
@@ -293,12 +294,12 @@ let VerifySyntaxTokenContext =
             | AdjointDeclaration _ -> verifySpecialization context
             | ControlledDeclaration _ -> verifySpecialization context
             | ControlledAdjointDeclaration _ -> verifySpecialization context
-            | OperationDeclaration _ -> verifyDeclaration context isNotebook
-            | FunctionDeclaration _ -> verifyDeclaration context isNotebook
-            | TypeDefinition _ -> verifyDeclaration context isNotebook
-            | OpenDirective _ -> verifyOpenDirective context isNotebook
-            | DeclarationAttribute _ -> verifyDeclarationAttribute context isNotebook
-            | NamespaceDeclaration _ -> verifyNamespace context isNotebook
+            | OperationDeclaration _ -> verifyDeclaration context documentKind
+            | FunctionDeclaration _ -> verifyDeclaration context documentKind
+            | TypeDefinition _ -> verifyDeclaration context documentKind
+            | OpenDirective _ -> verifyOpenDirective context documentKind
+            | DeclarationAttribute _ -> verifyDeclarationAttribute context documentKind
+            | NamespaceDeclaration _ -> verifyNamespace context documentKind
             | InvalidFragment _ -> false, [||]
         |> fun (kind, tuple) -> kind, tuple |> Array.map (fun (x, y) -> QsCompilerDiagnostic.New (x, []) y))
 

--- a/src/QsCompiler/TestProjects/test18/Bell.qs
+++ b/src/QsCompiler/TestProjects/test18/Bell.qs
@@ -1,0 +1,11 @@
+﻿open Microsoft.Quantum.Intrinsic;
+open Microsoft.Quantum.Canon;
+
+@EntryPoint()
+operation Main(): Unit {
+    H(q[0]);
+    CNOT(q[0], q[1]);
+
+    let result = [M(q[0]), M(q[1])];
+    Message($"Results: {result}");
+}

--- a/src/QsCompiler/TestProjects/test18/Parity.qs
+++ b/src/QsCompiler/TestProjects/test18/Parity.qs
@@ -1,0 +1,11 @@
+﻿namespace Test18 {
+    open Microsoft.Quantum.Intrinsic;
+
+    operation PrintParity(num: Int): Unit {
+        let two = 2;
+        let parity = num
+%two
+        ;
+        Message($"Parity of {num} is {parity}");
+    }
+}

--- a/src/QsCompiler/TestProjects/test18/README.md
+++ b/src/QsCompiler/TestProjects/test18/README.md
@@ -1,0 +1,1 @@
+This is an invalid Q# app for testing parsing differences configured for notebooks.

--- a/src/QsCompiler/TestProjects/test18/test18.csproj
+++ b/src/QsCompiler/TestProjects/test18/test18.csproj
@@ -1,0 +1,9 @@
+﻿<Project Sdk="Microsoft.Quantum.Sdk/0.25.218240">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net6.0</TargetFramework>
+    <ExecutionTarget>ionq.qpu</ExecutionTarget>
+  </PropertyGroup>
+
+</Project>

--- a/src/QsCompiler/Tests.Compiler/LocalVerificationTests.fs
+++ b/src/QsCompiler/Tests.Compiler/LocalVerificationTests.fs
@@ -542,6 +542,8 @@ type LocalVerificationTests() =
         this.Expect "StringParsingTest5" []
         this.Expect "StringParsingTest6" []
         this.Expect "StringParsingTest7" []
+        this.Expect "NotebookStringParsingTest1" [ Error ErrorCode.UnknownCodeFragment ]
+        this.Expect "NotebookStringParsingTest2" [ Error ErrorCode.UnknownCodeFragment ]
 
         this.Expect "MultiLineStringTest1" []
         this.Expect "MultiLineStringTest2" []

--- a/src/QsCompiler/Tests.Compiler/LocalVerificationTests.fs
+++ b/src/QsCompiler/Tests.Compiler/LocalVerificationTests.fs
@@ -542,8 +542,6 @@ type LocalVerificationTests() =
         this.Expect "StringParsingTest5" []
         this.Expect "StringParsingTest6" []
         this.Expect "StringParsingTest7" []
-        this.Expect "NotebookStringParsingTest1" [ Error ErrorCode.UnknownCodeFragment ]
-        this.Expect "NotebookStringParsingTest2" [ Error ErrorCode.UnknownCodeFragment ]
 
         this.Expect "MultiLineStringTest1" []
         this.Expect "MultiLineStringTest2" []

--- a/src/QsCompiler/Tests.Compiler/TestCases/StringParsingTests/StringParsing.qs
+++ b/src/QsCompiler/Tests.Compiler/TestCases/StringParsingTests/StringParsing.qs
@@ -32,6 +32,14 @@ namespace Microsoft.Quantum.Testing.LocalVerification {
         let str = "//";
     }
 
+    operation NotebookStringParsingTest1 () : Unit {
+        let str = "hi"; %
+    }
+
+    operation NotebookStringParsingTest2 () : Unit {
+%simulate SampleRandomNumber nQubits=3
+    }
+
     operation MultiLineStringTest1 () : Unit {
         let str = "
         ";

--- a/src/QsCompiler/Tests.Compiler/TestCases/StringParsingTests/StringParsing.qs
+++ b/src/QsCompiler/Tests.Compiler/TestCases/StringParsingTests/StringParsing.qs
@@ -32,14 +32,6 @@ namespace Microsoft.Quantum.Testing.LocalVerification {
         let str = "//";
     }
 
-    operation NotebookStringParsingTest1 () : Unit {
-        let str = "hi"; %
-    }
-
-    operation NotebookStringParsingTest2 () : Unit {
-%simulate SampleRandomNumber nQubits=3
-    }
-
     operation MultiLineStringTest1 () : Unit {
         let str = "
         ";

--- a/src/QsCompiler/Tests.LanguageServer/TestSetup.cs
+++ b/src/QsCompiler/Tests.LanguageServer/TestSetup.cs
@@ -8,6 +8,7 @@ using System.IO.Pipes;
 using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Quantum.QsCompiler.DataTypes;
 using Microsoft.VisualStudio.LanguageServer.Client;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -26,10 +27,10 @@ namespace Microsoft.Quantum.QsLanguageServer.Testing
         private readonly Stack<PublishDiagnosticParams> receivedDiagnostics = new Stack<PublishDiagnosticParams>();
         private readonly ManualResetEvent projectLoaded = new ManualResetEvent(false);
 
-        public Task<bool> GetFileIsNotebookCellAsync(string? filename = null, Uri? uri = null) =>
-            this.rpc.InvokeWithParameterObjectAsync<bool>(
+        public Task<DocumentKind> GetFileDocumentKindAsync(string? filename = null, Uri? uri = null) =>
+            this.rpc.InvokeWithParameterObjectAsync<DocumentKind>(
                 Methods.WorkspaceExecuteCommand.Name,
-                TestUtils.ServerCommand(CommandIds.FileIsNotebookCell, filename == null ? new TextDocumentIdentifier { Uri = uri ?? new Uri("file://unknown") } : TestUtils.GetTextDocumentIdentifier(filename)));
+                TestUtils.ServerCommand(CommandIds.FileDocumentKind, filename == null ? new TextDocumentIdentifier { Uri = uri ?? new Uri("file://unknown") } : TestUtils.GetTextDocumentIdentifier(filename)));
 
         public Task<string[]> GetFileContentInMemoryAsync(string filename) =>
             this.rpc.InvokeWithParameterObjectAsync<string[]>(

--- a/src/QsCompiler/Tests.LanguageServer/TestUtils.cs
+++ b/src/QsCompiler/Tests.LanguageServer/TestUtils.cs
@@ -10,6 +10,7 @@ using System.Threading.Tasks;
 using Microsoft.Quantum.QsCompiler.CompilationBuilder;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Newtonsoft.Json.Linq;
 using Builder = Microsoft.Quantum.QsCompiler.CompilationBuilder.Utils;
 using Range = Microsoft.VisualStudio.LanguageServer.Protocol.Range;
 
@@ -43,12 +44,16 @@ namespace Microsoft.Quantum.QsLanguageServer.Testing
             return new TextDocumentIdentifier { Uri = GetUri(filename) };
         }
 
-        internal static InitializeParams GetInitializeParams()
+        internal static Uri GenerateNotebookCellUri(Guid notebookGuid) =>
+            new Uri("file:///" + notebookGuid.ToString() + "/" + Guid.NewGuid().ToString() + ".qs");
+
+        internal static InitializeParams GetInitializeParams(bool addNotebookConfig = false)
         {
             return new InitializeParams
             {
                 ProcessId = -1,
-                InitializationOptions = null,
+                InitializationOptions = addNotebookConfig ? JObject.FromObject(new { isNotebook = true })
+                                                          : null,
                 Capabilities = new ClientCapabilities
                 {
                     Workspace = new WorkspaceClientCapabilities(),
@@ -58,12 +63,12 @@ namespace Microsoft.Quantum.QsLanguageServer.Testing
             };
         }
 
-        internal static DidOpenTextDocumentParams GetOpenFileParams(string filename)
+        internal static DidOpenTextDocumentParams GetOpenFileParams(string filename, Uri? uri = null)
         {
             var file = Path.GetFullPath(filename);
             var content = File.ReadAllText(file);
             return new DidOpenTextDocumentParams
-            { TextDocument = new TextDocumentItem { Uri = GetUri(filename), Text = content } };
+            { TextDocument = new TextDocumentItem { Uri = uri ?? GetUri(filename), Text = content } };
         }
 
         internal static DidCloseTextDocumentParams GetCloseFileParams(string filename)

--- a/src/QsCompiler/Tests.LanguageServer/TestUtils.cs
+++ b/src/QsCompiler/Tests.LanguageServer/TestUtils.cs
@@ -10,7 +10,6 @@ using System.Threading.Tasks;
 using Microsoft.Quantum.QsCompiler.CompilationBuilder;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Newtonsoft.Json.Linq;
 using Builder = Microsoft.Quantum.QsCompiler.CompilationBuilder.Utils;
 using Range = Microsoft.VisualStudio.LanguageServer.Protocol.Range;
 
@@ -47,13 +46,12 @@ namespace Microsoft.Quantum.QsLanguageServer.Testing
         internal static Uri GenerateNotebookCellUri(Guid notebookGuid) =>
             new Uri("file:///" + notebookGuid.ToString() + "/" + Guid.NewGuid().ToString() + ".qs");
 
-        internal static InitializeParams GetInitializeParams(bool addNotebookConfig = false)
+        internal static InitializeParams GetInitializeParams()
         {
             return new InitializeParams
             {
                 ProcessId = -1,
-                InitializationOptions = addNotebookConfig ? JObject.FromObject(new { isNotebook = true })
-                                                          : null,
+                InitializationOptions = null,
                 Capabilities = new ClientCapabilities
                 {
                     Workspace = new WorkspaceClientCapabilities(),
@@ -63,12 +61,12 @@ namespace Microsoft.Quantum.QsLanguageServer.Testing
             };
         }
 
-        internal static DidOpenTextDocumentParams GetOpenFileParams(string filename, Uri? uri = null)
+        internal static DidOpenTextDocumentParams GetOpenFileParams(string filename, Uri? uri = null, string languageId = "")
         {
             var file = Path.GetFullPath(filename);
             var content = File.ReadAllText(file);
             return new DidOpenTextDocumentParams
-            { TextDocument = new TextDocumentItem { Uri = uri ?? GetUri(filename), Text = content } };
+            { TextDocument = new TextDocumentItem { Uri = uri ?? GetUri(filename), LanguageId = languageId, Text = content } };
         }
 
         internal static DidCloseTextDocumentParams GetCloseFileParams(string filename)

--- a/src/QsCompiler/Tests.LanguageServer/Tests.cs
+++ b/src/QsCompiler/Tests.LanguageServer/Tests.cs
@@ -9,10 +9,12 @@ using System.Linq;
 using System.Threading.Tasks;
 using System.Xml.Linq;
 using Microsoft.Quantum.QsCompiler.CompilationBuilder;
+using Microsoft.Quantum.QsCompiler.DataTypes;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Newtonsoft.Json.Linq;
 using Builder = Microsoft.Quantum.QsCompiler.CompilationBuilder.Utils;
+using Position = Microsoft.VisualStudio.LanguageServer.Protocol.Position;
 using Range = Microsoft.VisualStudio.LanguageServer.Protocol.Range;
 
 namespace Microsoft.Quantum.QsLanguageServer.Testing
@@ -556,13 +558,13 @@ namespace Microsoft.Quantum.QsLanguageServer.Testing
             // By default, LanguageId will not contain "notebook"
             var openParams1 = TestUtils.GetOpenFileParams(programFileWithoutNamespace);
             await this.rpc.InvokeWithParameterObjectAsync<Task>(Methods.TextDocumentDidOpen.Name, openParams1);
-            Assert.IsFalse(await this.GetFileIsNotebookCellAsync(programFileWithoutNamespace));
+            Assert.AreEqual(DocumentKind.File, await this.GetFileDocumentKindAsync(programFileWithoutNamespace));
             var diagnostics1 = await this.GetFileDiagnosticsAsync(programFileWithoutNamespace);
 
             // By default, LanguageId will not contain "notebook"
             var openParams2 = TestUtils.GetOpenFileParams(programFileWithNamespace);
             await this.rpc.InvokeWithParameterObjectAsync<Task>(Methods.TextDocumentDidOpen.Name, openParams2);
-            Assert.IsFalse(await this.GetFileIsNotebookCellAsync(programFileWithNamespace));
+            Assert.AreEqual(DocumentKind.File, await this.GetFileDocumentKindAsync(programFileWithNamespace));
             var diagnostics2 = await this.GetFileDiagnosticsAsync(programFileWithNamespace);
 
             Assert.IsNotNull(diagnostics1);
@@ -598,12 +600,12 @@ namespace Microsoft.Quantum.QsLanguageServer.Testing
 
             var openParams1 = TestUtils.GetOpenFileParams(programFileWithoutNamespace, uriWithoutNamespace, languageId);
             await this.rpc.InvokeWithParameterObjectAsync<Task>(Methods.TextDocumentDidOpen.Name, openParams1);
-            Assert.IsTrue(await this.GetFileIsNotebookCellAsync(uri: uriWithoutNamespace));
+            Assert.AreEqual(DocumentKind.NotebookCell, await this.GetFileDocumentKindAsync(uri: uriWithoutNamespace));
             var diagnostics1 = await this.GetFileDiagnosticsAsync(uri: uriWithoutNamespace);
 
             var openParams2 = TestUtils.GetOpenFileParams(programFileWithNamespace, uriWithNamespace, languageId);
             await this.rpc.InvokeWithParameterObjectAsync<Task>(Methods.TextDocumentDidOpen.Name, openParams2);
-            Assert.IsTrue(await this.GetFileIsNotebookCellAsync(uri: uriWithNamespace));
+            Assert.AreEqual(DocumentKind.NotebookCell, await this.GetFileDocumentKindAsync(uri: uriWithNamespace));
             var diagnostics2 = await this.GetFileDiagnosticsAsync(uri: uriWithNamespace);
 
             Assert.IsNotNull(diagnostics1);


### PR DESCRIPTION
This is a smaller PR for syntax checking (no semantic checking) for `namespace{}` blocks in notebooks, because #1457 was getting out of control.

Magic commands are broken in this code, but that is out of scope for this PR. The goal here is to get this code for syntax checking for `namespace{}` blocks (which hasn't changed too much in several weeks) reviewed and merged into the feature branch.

## Testing
* Ran unit tests, which includes some tests I added for both the compiler and the language server
* Did manual test locally with Azure Notebooks (with [this notebook](https://github.com/microsoft/Quantum/blob/feature/samples-gallery/samples/azure-quantum/parallel-qrng/ParallelQrng.ipynb)). As expected, the language server returns angry diagnostics for magic commands, but other syntax errors are caught