### PR TITLE
Always send telemetry events from Visual Studio and Language Server

### DIFF
--- a/bootstrap.ps1
+++ b/bootstrap.ps1
@@ -49,7 +49,7 @@ if ("$VsCodeVsixVersion".Trim().Length -eq 0) {
 }
 
 
-$Telemetry = "true";
+$Telemetry = "$($Env:ASSEMBLY_CONSTANTS)".Contains("TELEMETRY").ToString().ToLower();
 Write-Host "Enable telemetry: $Telemetry";
 
 Get-ChildItem -Recurse *.v.template `

--- a/bootstrap.ps1
+++ b/bootstrap.ps1
@@ -49,7 +49,7 @@ if ("$VsCodeVsixVersion".Trim().Length -eq 0) {
 }
 
 
-$Telemetry = "$($Env:ASSEMBLY_CONSTANTS)".Contains("TELEMETRY").ToString().ToLower();
+$Telemetry = "true";
 Write-Host "Enable telemetry: $Telemetry";
 
 Get-ChildItem -Recurse *.v.template `

--- a/src/QsCompiler/LanguageServer/LanguageServer.cs
+++ b/src/QsCompiler/LanguageServer/LanguageServer.cs
@@ -177,16 +177,12 @@ namespace Microsoft.Quantum.QsLanguageServer
                 string eventName,
                 Dictionary<string, string?> properties,
                 Dictionary<string, int> measurements) =>
-            #if TELEMETRY
             this.NotifyClientAsync(Methods.TelemetryEventName, new Dictionary<string, object>
             {
                 ["event"] = eventName,
                 ["properties"] = properties,
                 ["measurements"] = measurements,
             });
-            #else
-            Task.CompletedTask;
-            #endif
 
         /// <summary>
         /// to be called when the server encounters an internal error (i.e. a QsCompilerError is raised)

--- a/src/VisualStudioExtension/QSharpVsix/Telemetry.cs
+++ b/src/VisualStudioExtension/QSharpVsix/Telemetry.cs
@@ -46,7 +46,6 @@ namespace Microsoft.Quantum.QsLanguageExtensionVS
         /// Adds the version of the extension assembly as version. 
         public static void SendEvent(string name, IEnumerable<KeyValuePair<string, object>> props = null)
         {
-#if TELEMETRY
             props = props ?? Enumerable.Empty<KeyValuePair<string, object>>();
             var evt = new TelemetryEvent(PrefixEventName(name));
             foreach (var entry in props.Where(p => !string.IsNullOrEmpty(p.Key)))
@@ -58,7 +57,6 @@ namespace Microsoft.Quantum.QsLanguageExtensionVS
             try { TelemetryService.DefaultSession.PostEvent(evt); }
             catch (Exception ex)
             { Debug.Assert(false, $"error sending telemetry: \n{ex}"); }
-#endif
         }
 
         public static void SendEvent(ExtensionEvent id, params (string, object)[] props) =>


### PR DESCRIPTION
The QsCompiler and VisualStudioExtension solutions are being built with the `TELEMETRY` flag undefined. This is preventing telemetry events from being published. The flag should be set as a consequence of Assembly Constants containing `SIGNED:TELEMETRY`, which is set, but in those projects it's not.

For this release, we're directly enabling the telemetry code (on the release branch) while a proper solution is done in 'main' for the next release.