### PR TITLE
Add more utilties to LlvmBindings

### DIFF
--- a/src/QsCompiler/LlvmBindings/BitcodeModule.cs
+++ b/src/QsCompiler/LlvmBindings/BitcodeModule.cs
@@ -238,6 +238,39 @@ namespace LlvmBindings
 
         public ref LLVMModuleRef ModuleHandle => ref this.moduleHandle;
 
+        /// <summary>Load a bit-code module from a given file.</summary>
+        /// <param name="path">path of the file to load.</param>
+        /// <param name="context">Context to use for creating the module.</param>
+        /// <returns>Loaded <see cref="BitcodeModule"/>.</returns>
+        public static BitcodeModule LoadFrom(string path, Context context)
+        {
+            if (!File.Exists(path))
+            {
+                throw new FileNotFoundException();
+            }
+
+            var buffer = new MemoryBuffer(path);
+            return LoadFrom(buffer, context);
+        }
+
+        /// <summary>Load bit code from a memory buffer.</summary>
+        /// <param name="buffer">Buffer to load from.</param>
+        /// <param name="context">Context to load the module into.</param>
+        /// <returns>Loaded <see cref="BitcodeModule"/>.</returns>
+        /// <remarks>
+        /// This along with <see cref="WriteToBuffer"/> are useful for "cloning"
+        /// a module from one context to another. This allows creation of multiple
+        /// modules on different threads and contexts and later moving them to a
+        /// single context in order to link them into a single final module for
+        /// optimization.
+        /// </remarks>
+        public static BitcodeModule LoadFrom(MemoryBuffer buffer, Context context)
+        {
+            return context.ContextHandle.TryParseBitcode(buffer.BufferHandle, out LLVMModuleRef modRef, out string message)
+                ? context.GetModuleFor(modRef)
+                : throw new InternalCodeGeneratorException(message);
+        }
+
         /// <summary>Disposes the <see cref="BitcodeModule"/>, releasing resources associated with the module in native code.</summary>
         public void Dispose()
         {

--- a/src/QsCompiler/LlvmBindings/Interop/LLVMContextRef.cs
+++ b/src/QsCompiler/LlvmBindings/Interop/LLVMContextRef.cs
@@ -178,5 +178,26 @@ namespace LlvmBindings.Interop
         }
 
         public override string ToString() => $"{nameof(LLVMContextRef)}: {this.Handle:X}";
+
+        public bool TryParseBitcode(LLVMMemoryBufferRef memBuf, out LLVMModuleRef outModule, out string outMessage)
+        {
+            fixed (LLVMModuleRef* pOutModule = &outModule)
+            {
+                sbyte* pMessage = null;
+                var result = LLVM.ParseBitcodeInContext(this, memBuf, (LLVMOpaqueModule**)pOutModule, &pMessage);
+
+                if (pMessage == null)
+                {
+                    outMessage = string.Empty;
+                }
+                else
+                {
+                    var span = new ReadOnlySpan<byte>(pMessage, int.MaxValue);
+                    outMessage = span[..span.IndexOf((byte)'\0')].AsString();
+                }
+
+                return result == 0;
+            }
+        }
     }
 }

--- a/src/QsCompiler/LlvmBindings/Values/IrFunction.cs
+++ b/src/QsCompiler/LlvmBindings/Values/IrFunction.cs
@@ -226,6 +226,9 @@ namespace LlvmBindings.Values
         /// <summary>Gets the basic blocks for the function.</summary>
         public ICollection<BasicBlock> BasicBlocks { get; }
 
+        /// <summary>Gets any blocks that have a return terminator.</summary>
+        public IEnumerable<BasicBlock> ReturnBlocks => this.BasicBlocks.Where(block => block.Terminator?.Opcode == Instructions.OpCode.Return);
+
         /// <summary>Gets the parameters for the function including any method definition specific attributes (i.e. ByVal).</summary>
         public IReadOnlyList<Argument> Parameters => new FunctionParameterList(this);
 


### PR DESCRIPTION
This change adds two utilities to the LlvmBindings for usability. First, it adds back the functionality for parsing `BitcodeModule` objects from a file via a static `LoadFrom` method. Second, it adds a `ReturnBlocks` convenience method to `IrFunction` objects to make it easier for a caller to request any blocks that are terminated by a return.