### PR TITLE
Fix assembly constants not getting applied at build time

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -370,6 +370,7 @@ src/QsCompiler/QirGeneration/QirGeneration.nuspec
 /examples/QIR/Development/build
 src/Telemetry/Tests/coverage.json
 src/Telemetry/.vscode/settings.json
+build/267DevDivSNKey2048.snk
 
 # MSBuild logs
 MSBuild_Logs/

--- a/build/build.ps1
+++ b/build/build.ps1
@@ -22,14 +22,14 @@ function Build-One {
 
     Write-Host "##[info]Building $project ..."
     if ("" -ne "$Env:ASSEMBLY_CONSTANTS") {
-        $extra_args = @("/property:DefineConstants=$Env:ASSEMBLY_CONSTANTS");
+        $extraArgs = @("/property:DefineConstants=$Env:ASSEMBLY_CONSTANTS");
     }  else {
-        $extra_args = @();
+        $extraArgs = @();
     }
     dotnet build (Join-Path $PSScriptRoot $project) `
         -c $Env:BUILD_CONFIGURATION `
         -v $Env:BUILD_VERBOSITY `
-        @extra_args `
+        @extraArgs `
         /property:Version=$Env:ASSEMBLY_VERSION `
         /property:InformationalVersion=$Env:SEMVER_VERSION `
         /property:TreatWarningsAsErrors=true
@@ -101,16 +101,16 @@ function Build-VS() {
             if (Get-Command msbuild -ErrorAction SilentlyContinue) {
                 Try {
                     if ("" -ne "$Env:ASSEMBLY_CONSTANTS") {
-                        $extra_args = @("/property:DefineConstants=$Env:ASSEMBLY_CONSTANTS");
+                        $extraArgs = @("/property:DefineConstants=$Env:ASSEMBLY_CONSTANTS");
                     } else {
-                        $extra_args = @();
+                        $extraArgs = @();
                     }
 
-                    "##[info]Building with extra_args: $extra_args" | Write-Host
+                    "##[info]Building with extraArgs: $extraArgs" | Write-Host
 
                     msbuild VisualStudioExtension.sln `
                         /property:Configuration=$Env:BUILD_CONFIGURATION `
-                        @extra_args `
+                        @extraArgs `
                         /property:AssemblyVersion=$Env:ASSEMBLY_VERSION `
                         /property:InformationalVersion=$Env:SEMVER_VERSION `
                         /property:TreatWarningsAsErrors=true

--- a/build/build.ps1
+++ b/build/build.ps1
@@ -105,6 +105,9 @@ function Build-VS() {
                     } else {
                         $extra_args = @();
                     }
+
+                    "##[info]Building with extra_args: $extra_args" | Write-Host
+
                     msbuild VisualStudioExtension.sln `
                         /property:Configuration=$Env:BUILD_CONFIGURATION `
                         @extra_args `

--- a/build/build.ps1
+++ b/build/build.ps1
@@ -22,14 +22,14 @@ function Build-One {
 
     Write-Host "##[info]Building $project ..."
     if ("" -ne "$Env:ASSEMBLY_CONSTANTS") {
-        $args = @("/property:DefineConstants=$Env:ASSEMBLY_CONSTANTS");
+        $extra_args = @("/property:DefineConstants=$Env:ASSEMBLY_CONSTANTS");
     }  else {
-        $args = @();
+        $extra_args = @();
     }
     dotnet build (Join-Path $PSScriptRoot $project) `
         -c $Env:BUILD_CONFIGURATION `
         -v $Env:BUILD_VERBOSITY `
-        @args `
+        @extra_args `
         /property:Version=$Env:ASSEMBLY_VERSION `
         /property:InformationalVersion=$Env:SEMVER_VERSION `
         /property:TreatWarningsAsErrors=true
@@ -101,13 +101,13 @@ function Build-VS() {
             if (Get-Command msbuild -ErrorAction SilentlyContinue) {
                 Try {
                     if ("" -ne "$Env:ASSEMBLY_CONSTANTS") {
-                        $args = @("/property:DefineConstants=$Env:ASSEMBLY_CONSTANTS");
+                        $extra_args = @("/property:DefineConstants=$Env:ASSEMBLY_CONSTANTS");
                     } else {
-                        $args = @();
+                        $extra_args = @();
                     }
                     msbuild VisualStudioExtension.sln `
                         /property:Configuration=$Env:BUILD_CONFIGURATION `
-                        @args `
+                        @extra_args `
                         /property:AssemblyVersion=$Env:ASSEMBLY_VERSION `
                         /property:InformationalVersion=$Env:SEMVER_VERSION `
                         /property:TreatWarningsAsErrors=true

--- a/build/build.ps1
+++ b/build/build.ps1
@@ -105,9 +105,6 @@ function Build-VS() {
                     } else {
                         $extraArgs = @();
                     }
-
-                    "##[info]Building with extraArgs: $extraArgs" | Write-Host
-
                     msbuild VisualStudioExtension.sln `
                         /property:Configuration=$Env:BUILD_CONFIGURATION `
                         @extraArgs `

--- a/build/pack-extensions.ps1
+++ b/build/pack-extensions.ps1
@@ -59,16 +59,16 @@ function Pack-SelfContained() {
 
     Write-Host "##[info]Building $project ($action)..."
     if ("" -ne "$Env:ASSEMBLY_CONSTANTS") {
-        $extra_args = @("/property:DefineConstants=$Env:ASSEMBLY_CONSTANTS");
+        $extraArgs = @("/property:DefineConstants=$Env:ASSEMBLY_CONSTANTS");
     }  else {
-        $extra_args = @();
+        $extraArgs = @();
     }
 
     # Make sure the LanguageServer is built on its own:
     dotnet build (Join-Path $PSScriptRoot $project) `
         -c $Env:BUILD_CONFIGURATION `
         -v $Env:BUILD_VERBOSITY `
-        @$extra_args `
+        @extraArgs `
         /property:Version=$Env:ASSEMBLY_VERSION `
         /property:InformationalVersion=$Env:SEMVER_VERSION
 
@@ -83,9 +83,9 @@ function Pack-SelfContained() {
 
         try {
             if ("" -ne "$Env:ASSEMBLY_CONSTANTS") {
-                $extra_args = @("/property:DefineConstants=$Env:ASSEMBLY_CONSTANTS");
+                $extraArgs = @("/property:DefineConstants=$Env:ASSEMBLY_CONSTANTS");
             }  else {
-                $extra_args = @();
+                $extraArgs = @();
             }
             $ArchivePath = Join-Path $ArchiveDir "$BaseName-$DotNetRuntimeID-$Env:SEMVER_VERSION.zip";
             dotnet publish (Join-Path $PSScriptRoot $Project) `
@@ -94,7 +94,7 @@ function Pack-SelfContained() {
                 --self-contained `
                 --runtime $DotNetRuntimeID `
                 --output $TargetDir `
-                @$extra_args `
+                @extraArgs `
                 /property:Version=$Env:ASSEMBLY_VERSION `
                 /property:InformationalVersion=$Env:SEMVER_VERSION
             Write-Host "##[info]Writing self-contained deployment to $ArchivePath..."

--- a/build/pack-extensions.ps1
+++ b/build/pack-extensions.ps1
@@ -59,16 +59,16 @@ function Pack-SelfContained() {
 
     Write-Host "##[info]Building $project ($action)..."
     if ("" -ne "$Env:ASSEMBLY_CONSTANTS") {
-        $args = @("/property:DefineConstants=$Env:ASSEMBLY_CONSTANTS");
+        $extra_args = @("/property:DefineConstants=$Env:ASSEMBLY_CONSTANTS");
     }  else {
-        $args = @();
+        $extra_args = @();
     }
 
     # Make sure the LanguageServer is built on its own:
     dotnet build (Join-Path $PSScriptRoot $project) `
         -c $Env:BUILD_CONFIGURATION `
         -v $Env:BUILD_VERBOSITY `
-        @args `
+        @$extra_args `
         /property:Version=$Env:ASSEMBLY_VERSION `
         /property:InformationalVersion=$Env:SEMVER_VERSION
 
@@ -83,9 +83,9 @@ function Pack-SelfContained() {
 
         try {
             if ("" -ne "$Env:ASSEMBLY_CONSTANTS") {
-                $args = @("/property:DefineConstants=$Env:ASSEMBLY_CONSTANTS");
+                $extra_args = @("/property:DefineConstants=$Env:ASSEMBLY_CONSTANTS");
             }  else {
-                $args = @();
+                $extra_args = @();
             }
             $ArchivePath = Join-Path $ArchiveDir "$BaseName-$DotNetRuntimeID-$Env:SEMVER_VERSION.zip";
             dotnet publish (Join-Path $PSScriptRoot $Project) `
@@ -94,7 +94,7 @@ function Pack-SelfContained() {
                 --self-contained `
                 --runtime $DotNetRuntimeID `
                 --output $TargetDir `
-                @args `
+                @$extra_args `
                 /property:Version=$Env:ASSEMBLY_VERSION `
                 /property:InformationalVersion=$Env:SEMVER_VERSION
             Write-Host "##[info]Writing self-contained deployment to $ArchivePath..."

--- a/build/pack.ps1
+++ b/build/pack.ps1
@@ -17,15 +17,15 @@ function Publish-One {
 
     Write-Host "##[info]Publishing $project ..."
     if ("" -ne "$Env:ASSEMBLY_CONSTANTS") {
-        $args = @("/property:DefineConstants=$Env:ASSEMBLY_CONSTANTS");
+        $extra_args = @("/property:DefineConstants=$Env:ASSEMBLY_CONSTANTS");
     }  else {
-        $args = @();
+        $extra_args = @();
     }
     dotnet publish (Join-Path $PSScriptRoot $project) `
         -c $Env:BUILD_CONFIGURATION `
         -v $Env:BUILD_VERBOSITY `
         --no-build `
-        @args `
+        @$extra_args `
         /property:Version=$Env:ASSEMBLY_VERSION
 
     if  ($LastExitCode -ne 0) {
@@ -57,16 +57,16 @@ function Pack-One() {
 function Pack-Dotnet() {
     Param($project, $option1 = "", $option2 = "", $option3 = "")
     if ("" -ne "$Env:ASSEMBLY_CONSTANTS") {
-        $args = @("/property:DefineConstants=$Env:ASSEMBLY_CONSTANTS");
+        $extra_args = @("/property:DefineConstants=$Env:ASSEMBLY_CONSTANTS");
     }  else {
-        $args = @();
+        $extra_args = @();
     }
     dotnet pack (Join-Path $PSScriptRoot $project) `
         -o $Env:NUGET_OUTDIR `
         -c $Env:BUILD_CONFIGURATION `
         -v detailed `
         --no-build `
-        @args `
+        @$extra_args `
         /property:Version=$Env:ASSEMBLY_VERSION `
         /property:PackageVersion=$Env:NUGET_VERSION `
         $option1 `

--- a/build/pack.ps1
+++ b/build/pack.ps1
@@ -16,16 +16,10 @@ function Publish-One {
     );
 
     Write-Host "##[info]Publishing $project ..."
-    if ("" -ne "$Env:ASSEMBLY_CONSTANTS") {
-        $extra_args = @("/property:DefineConstants=$Env:ASSEMBLY_CONSTANTS");
-    }  else {
-        $extra_args = @();
-    }
     dotnet publish (Join-Path $PSScriptRoot $project) `
         -c $Env:BUILD_CONFIGURATION `
         -v $Env:BUILD_VERBOSITY `
         --no-build `
-        @$extra_args `
         /property:Version=$Env:ASSEMBLY_VERSION
 
     if  ($LastExitCode -ne 0) {
@@ -56,17 +50,11 @@ function Pack-One() {
 
 function Pack-Dotnet() {
     Param($project, $option1 = "", $option2 = "", $option3 = "")
-    if ("" -ne "$Env:ASSEMBLY_CONSTANTS") {
-        $extra_args = @("/property:DefineConstants=$Env:ASSEMBLY_CONSTANTS");
-    }  else {
-        $extra_args = @();
-    }
     dotnet pack (Join-Path $PSScriptRoot $project) `
         -o $Env:NUGET_OUTDIR `
         -c $Env:BUILD_CONFIGURATION `
         -v detailed `
         --no-build `
-        @$extra_args `
         /property:Version=$Env:ASSEMBLY_VERSION `
         /property:PackageVersion=$Env:NUGET_VERSION `
         $option1 `

--- a/build/test.ps1
+++ b/build/test.ps1
@@ -20,15 +20,15 @@ function Test-One {
     Write-Host "##[info]Testing $project..."
 
     if ("" -ne "$Env:ASSEMBLY_CONSTANTS") {
-        $args = @("/property:DefineConstants=$Env:ASSEMBLY_CONSTANTS");
+        $extra_args = @("/property:DefineConstants=$Env:ASSEMBLY_CONSTANTS");
     } else {
-        $args = @();
+        $extra_args = @();
     }
     dotnet test (Join-Path $PSScriptRoot $project) `
         -c $Env:BUILD_CONFIGURATION `
         -v $Env:BUILD_VERBOSITY `
         --logger trx `
-        @args `
+        @$extra_args `
         /property:Version=$Env:ASSEMBLY_VERSION `
         /property:InformationalVersion=$Env:SEMVER_VERSION
 

--- a/build/test.ps1
+++ b/build/test.ps1
@@ -20,15 +20,15 @@ function Test-One {
     Write-Host "##[info]Testing $project..."
 
     if ("" -ne "$Env:ASSEMBLY_CONSTANTS") {
-        $extra_args = @("/property:DefineConstants=$Env:ASSEMBLY_CONSTANTS");
+        $extraArgs = @("/property:DefineConstants=$Env:ASSEMBLY_CONSTANTS");
     } else {
-        $extra_args = @();
+        $extraArgs = @();
     }
     dotnet test (Join-Path $PSScriptRoot $project) `
         -c $Env:BUILD_CONFIGURATION `
         -v $Env:BUILD_VERBOSITY `
         --logger trx `
-        @$extra_args `
+        @extraArgs `
         /property:Version=$Env:ASSEMBLY_VERSION `
         /property:InformationalVersion=$Env:SEMVER_VERSION
 

--- a/src/VisualStudioExtension/QSharpAppTemplate/QSharpAppTemplate.csproj
+++ b/src/VisualStudioExtension/QSharpAppTemplate/QSharpAppTemplate.csproj
@@ -45,9 +45,6 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.VisualStudio.CoreUtility">
-      <Private>False</Private>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Data" />

--- a/src/VisualStudioExtension/QSharpFileTemplate/QSharpFileTemplate.csproj
+++ b/src/VisualStudioExtension/QSharpFileTemplate/QSharpFileTemplate.csproj
@@ -45,9 +45,6 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.VisualStudio.CoreUtility">
-      <Private>False</Private>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Data" />

--- a/src/VisualStudioExtension/QSharpLibTemplate/QSharpLibTemplate.csproj
+++ b/src/VisualStudioExtension/QSharpLibTemplate/QSharpLibTemplate.csproj
@@ -45,9 +45,6 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.VisualStudio.CoreUtility">
-      <Private>False</Private>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Data" />

--- a/src/VisualStudioExtension/QSharpTestTemplate/QSharpTestTemplate.csproj
+++ b/src/VisualStudioExtension/QSharpTestTemplate/QSharpTestTemplate.csproj
@@ -45,9 +45,6 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.VisualStudio.CoreUtility">
-      <Private>False</Private>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Data" />

--- a/src/VisualStudioExtension/QSharpVsix/QSharpVsix.csproj
+++ b/src/VisualStudioExtension/QSharpVsix/QSharpVsix.csproj
@@ -28,6 +28,7 @@
     <StartAction>Program</StartAction>
     <StartProgram Condition="'$(DevEnvDir)' != ''">$(DevEnvDir)devenv.exe</StartProgram>
     <StartArguments>/rootsuffix Exp</StartArguments>
+    <BuildLanguageServer Condition=" '$(BuildLanguageServer)' == '' ">true</BuildLanguageServer>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -176,7 +177,7 @@
       </VSIXSourceItem>
     </ItemGroup>
   </Target>
-  <Target Name="BuildLanguageServer" BeforeTargets="CoreCompile">
+  <Target Name="BuildLanguageServer" BeforeTargets="CoreCompile" Condition="'$(BuildLanguageServer)' == 'true'">
     <ItemGroup>
       <RemoveFiles Include="$(LanguageServerPath)**" />
     </ItemGroup>

--- a/src/VisualStudioExtension/QSharpVsix/QsLanguageClient.cs
+++ b/src/VisualStudioExtension/QSharpVsix/QsLanguageClient.cs
@@ -82,11 +82,20 @@ namespace Microsoft.Quantum.QsLanguageExtensionVS
         /// The server only processes any notifications *after* it has been initialized properly.
         /// Hence we need to wait until after initialization to send all solution events that have already been raised,
         /// and start listening to new ones.
-        public Task OnServerInitializedAsync() =>
-            Task.Run(() => Telemetry.SendEvent(Telemetry.ExtensionEvent.LspReady));
+        public async Task OnServerInitializedAsync()
+        {
+            await PrintMessageAsync("OnServerInitializedAsync\n");
+#if TELEMETRY
+            await PrintMessageAsync("OnServerInitializedAsync: TELEMETRY ON\n");
+#endif
+#if SIGNED
+            await PrintMessageAsync("OnServerInitializedAsync: SIGNED ON\n");
+#endif
+            await Task.Run(() => Telemetry.SendEvent(Telemetry.ExtensionEvent.LspReady));
+        }
 
-        /// We create a new pane to show the encountered exception.
-        public async Task OnServerInitializeFailedAsync(Exception ex)
+        /// Prints a message to VS output window.
+        public async Task PrintMessageAsync(string msg)
         {
             await VisualStudio.Shell.ThreadHelper.JoinableTaskFactory.SwitchToMainThreadAsync();
             var outWindow = GetGlobalService(typeof(SVsOutputWindow)) as IVsOutputWindow;
@@ -95,6 +104,13 @@ namespace Microsoft.Quantum.QsLanguageExtensionVS
             outWindow.CreatePane(ref OutputPaneGuid, windowTitle, 1, 1);
             outWindow.GetPane(ref OutputPaneGuid, out var customPane);
 
+            customPane.OutputStringThreadSafe(msg);
+            customPane.Activate(); // brings the pane into view
+        }
+
+        /// We create a new pane to show the encountered exception.
+        public async Task OnServerInitializeFailedAsync(Exception ex)
+        {
             var messages = new[]
             {
                 $"Server initialization failed.",
@@ -102,8 +118,8 @@ namespace Microsoft.Quantum.QsLanguageExtensionVS
                 $"Path to the log file: \"{this.LogFile}\"",
                 ex.ToString()
             };
-            customPane.OutputStringThreadSafe(String.Join(Environment.NewLine, messages));
-            customPane.Activate(); // brings the pane into view
+
+            await this.PrintMessageAsync(String.Join(Environment.NewLine, messages));
         }
 
         public Task<InitializationFailureContext> OnServerInitializeFailedAsync(ILanguageClientInitializationInfo initializationState)
@@ -125,13 +141,20 @@ namespace Microsoft.Quantum.QsLanguageExtensionVS
         public async Task<Connection> ActivateAsync(CancellationToken token)
         {
             await Task.Yield();
+            await PrintMessageAsync("ActivateAsync\n");
+#if TELEMETRY
+            await PrintMessageAsync("ActivateAsync: TELEMETRY ON\n");
+#endif
+#if SIGNED
+            await PrintMessageAsync("ActivateAsync: SIGNED ON\n");
+#endif
             Telemetry.SendEvent(Telemetry.ExtensionEvent.Activate);
             try
             {
-                #if MANUAL
+#if MANUAL
                 string ServerReaderPipe = $"QsLanguageServerReaderPipe";
                 string ServerWriterPipe = $"QsLanguageServerWriterPipe";
-                #else
+#else
 
                 string ServerReaderPipe = $"QsLanguageServerReaderPipe{this.LaunchTime}";
                 string ServerWriterPipe = $"QsLanguageServerWriterPipe{this.LaunchTime}";
@@ -145,7 +168,7 @@ namespace Microsoft.Quantum.QsLanguageExtensionVS
 
                 Process process = new Process { StartInfo = info };
                 if (!process.Start()) return null;
-                #endif
+#endif
 
                 var bufferSize = 256;
                 var pipeSecurity = new PipeSecurity();
@@ -160,6 +183,8 @@ namespace Microsoft.Quantum.QsLanguageExtensionVS
             }
             catch (Exception e)
             {
+                await PrintMessageAsync($"ActivateAsync Exception: {e.Message}");
+
                 Telemetry.SendEvent(Telemetry.ExtensionEvent.Error, ("id", e.GetType().Name), ("reason", e.Message));
                 throw;
             }
@@ -175,6 +200,7 @@ namespace Microsoft.Quantum.QsLanguageExtensionVS
                 {
                     var name = (string)args["event"];
                     var props = args["properties"]?.ToObject<Dictionary<string, object>>();
+                    //PrintMessageAsync($"OnTelemetry: {name}").Wait();
                     Telemetry.SendEvent(name, props);
                 }
                 catch (Exception ex)

--- a/src/VisualStudioExtension/QsharpHoneywellAppTemplate/QSharpHoneywellAppTemplate.csproj
+++ b/src/VisualStudioExtension/QsharpHoneywellAppTemplate/QSharpHoneywellAppTemplate.csproj
@@ -45,9 +45,6 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.VisualStudio.CoreUtility">
-      <Private>False</Private>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Data" />

--- a/src/VisualStudioExtension/QsharpIonQAppTemplate/QSharpIonQAppTemplate.csproj
+++ b/src/VisualStudioExtension/QsharpIonQAppTemplate/QSharpIonQAppTemplate.csproj
@@ -45,9 +45,6 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.VisualStudio.CoreUtility">
-      <Private>False</Private>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Data" />


### PR DESCRIPTION
As discovered during the July 2022 release, the assembly constant 'SIGNED:TELEMETRY' defined in the QDK build ([here](https://github.com/microsoft/qdk/blob/main/build/qdk.template.yml#L97)) is not propagating as a build time flag 'TELEMETRY' in the [QSharpVsix](https://github.com/microsoft/qsharp-compiler/blob/main/src/VisualStudioExtension/QSharpVsix/Telemetry.cs#L49) and [LanguageServer](https://github.com/microsoft/qsharp-compiler/blob/main/src/QsCompiler/LanguageServer/LanguageServer.cs#L180) projects.

I have find the root cause for this. Powershell now enforces `$args` is read-only. Our script was using this as a variable to provide extra arguments to the build command, but now the value is not longer applied so the flags were not properly set.
Fix simply consists on changing the name of the variable.