### PR TITLE
Treat magic commands as comments in notebooks

### DIFF
--- a/src/QsCompiler/CompilationManager/DataStructures.cs
+++ b/src/QsCompiler/CompilationManager/DataStructures.cs
@@ -49,7 +49,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder.DataStructures
 
         internal string LineEnding { get; } // contains the line break for this line (included in text)
 
-        private static readonly char[] NoOpenStringDelimiters = new[] { '"', '/' };
+        private static readonly char[] NoOpenStringDelimiters = new[] { '"', '/', '%' };
         private static readonly char[] OpenInterpolatedArgumentDelimiters = new[] { '"', '}', '/' };
         private static readonly char[] OpenInterpolatedStringDelimiters = new[] { '"', '{' };
 
@@ -70,6 +70,8 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder.DataStructures
         public string? EndOfLineComment { get; }
 
         internal int Indentation { get; } // Note: This denotes the initial indentation at the beginning of the line
+
+        internal bool IsAllWhiteSpace { get; }
 
         internal ImmutableArray<int> ExcessBracketPositions { get; }
 
@@ -92,6 +94,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder.DataStructures
             string withoutEnding,
             string? endOfLineComment,
             int indentation,
+            bool isAllWhiteSpace,
             IEnumerable<int> excessBracketPositions,
             IEnumerable<int> errorDelimiterPositions,
             IEnumerable<int> stringDelimiters,
@@ -103,6 +106,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder.DataStructures
             this.WithoutEnding = withoutEnding;
             this.EndOfLineComment = endOfLineComment;
             this.Indentation = indentation;
+            this.IsAllWhiteSpace = isAllWhiteSpace;
             this.ExcessBracketPositions = excessBracketPositions.ToImmutableArray();
             this.ErrorDelimiterPositions = errorDelimiterPositions.ToImmutableArray();
             this.StringDelimiters = stringDelimiters.ToImmutableArray();
@@ -123,6 +127,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder.DataStructures
             this.WithoutEnding = string.Empty;
             this.EndOfLineComment = null;
             this.Indentation = 0;
+            this.IsAllWhiteSpace = true;
             this.ExcessBracketPositions = ImmutableArray<int>.Empty;
             this.ErrorDelimiterPositions = ImmutableArray<int>.Empty;
             this.StringDelimiters = ImmutableArray<int>.Empty;
@@ -134,8 +139,8 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder.DataStructures
         /// Constructs a code line from text and optionally a beginning string context.
         /// Other information about the code line is calculated automatically.
         /// </summary>
-        public CodeLine(string text, StringContext beginningStringContext = StringContext.NoOpenString)
-            : this(text, beginningStringContext, 0, new List<int>())
+        public CodeLine(string text, StringContext beginningStringContext = StringContext.NoOpenString, bool allWhiteSpaceUntil = false, DocumentKind? documentKind = null)
+            : this(text, beginningStringContext, 0, new List<int>(), allWhiteSpaceUntil, documentKind)
         {
         }
 
@@ -143,7 +148,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder.DataStructures
         /// Constructs a code line from text. Beginning string context, indentation, and excess brackets are also required.
         /// Other information about the code line is calculated automatically.
         /// </summary>
-        private CodeLine(string text, StringContext beginningStringContext, int indentation, IEnumerable<int> excessBrackets)
+        private CodeLine(string text, StringContext beginningStringContext, int indentation, IEnumerable<int> excessBrackets, bool allWhiteSpaceUntil, DocumentKind? documentKind = null)
         {
             this.Text = text;
             this.LineEnding = Utils.EndOfLine.Match(text).Value; // empty string if the matching failed
@@ -152,8 +157,10 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder.DataStructures
             this.EndingStringContext = beginningStringContext;
 
             var endingStringContext = this.EndingStringContext;
-            var delimiters = ComputeStringDelimiters(text, ref endingStringContext, out var commentStart, out var errorDelimiters);
+            documentKind ??= DocumentKind.File;
+            var delimiters = ComputeStringDelimiters(text, allWhiteSpaceUntil, documentKind, ref endingStringContext, out var isAllWhiteSpace, out var commentStart, out var errorDelimiters);
             this.EndingStringContext = endingStringContext;
+            this.IsAllWhiteSpace = isAllWhiteSpace;
             this.ErrorDelimiterPositions = errorDelimiters.ToImmutableArray();
 
             var lineLength = text.Length - this.LineEnding.Length;
@@ -182,7 +189,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder.DataStructures
         /// <summary>
         /// Constructs a code line using provided information. Here, delimiters are provided rather than calculated.
         /// </summary>
-        public CodeLine(string text, StringContext beginningStringContext, IEnumerable<int> delimiters, int commentStart, int indentation, IEnumerable<int> excessBrackets)
+        public CodeLine(string text, StringContext beginningStringContext, IEnumerable<int> delimiters, int commentStart, int indentation, bool isAllWhiteSpace, IEnumerable<int> excessBrackets)
         {
             this.Text = text;
             this.LineEnding = Utils.EndOfLine.Match(text).Value; // empty string if the matching failed
@@ -249,6 +256,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder.DataStructures
             this.StringDelimiters = delimiterBuilder.ToImmutable();
             this.ErrorDelimiterPositions = errorDelimiterBuilder.ToImmutable();
             this.Indentation = indentation;
+            this.IsAllWhiteSpace = isAllWhiteSpace;
             this.ExcessBracketPositions = excessBrackets.ToImmutableArray();
             ScopeTracking.VerifyStringDelimiters(text, this.StringDelimiters);
             ScopeTracking.VerifyExcessBracketPositions(this, excessBrackets);
@@ -260,34 +268,17 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder.DataStructures
         /// </summary>
         private static bool IsInAString(StringContext context) => context >= StringContext.OpenString;
 
-        private static int FindNextDelimOrComment(string text, char[] delimiters, int startIndex)
-        {
-            var delimitersAndComment = delimiters.Append('/').ToArray();
-
-            var index = text.IndexOfAny(delimitersAndComment, startIndex);
-            if (index >= 0 && text[index] == '/')
-            {
-                // Found a comment
-                if (index + 1 < text.Length && text[index + 1] == '/')
-                {
-                    return index;
-                }
-                else
-                {
-                    // Just a lone /, move past it and try again
-                    return FindNextDelimOrComment(text, delimiters, index + 1);
-                }
-            }
-            else
-            {
-                return index;
-            }
-        }
-
         /// <summary>
         /// Computes the location of the string delimiters within a given text.
         /// </summary>
-        private static IEnumerable<int> ComputeStringDelimiters(string text, ref StringContext stringContext, out int commentIndex, out IEnumerable<int> errorDelimiters)
+        private static IEnumerable<int> ComputeStringDelimiters(
+            string text,
+            bool allWhiteSpaceUntil,
+            DocumentKind documentKind,
+            ref StringContext stringContext,
+            out bool isAllWhiteSpace,
+            out int commentIndex,
+            out IEnumerable<int> errorDelimiters)
         {
             var delimiterBuilder = ImmutableArray.CreateBuilder<int>();
             var errorDelimiterBuilder = ImmutableArray.CreateBuilder<int>();
@@ -299,7 +290,12 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder.DataStructures
 
             commentIndex = -1;
 
+            var firstNonWhiteSpaceIndex = text.TakeWhile(char.IsWhiteSpace).Count();
+            isAllWhiteSpace = firstNonWhiteSpaceIndex == text.Length;
+
             bool IsLoneSlash(int index) => index >= 0 && text[index] == '/' && (index + 1 == text.Length || text[index + 1] != '/');
+            bool IsNotMagicCommand(int index) => index >= 0 && text[index] == '%'
+                                                 && (documentKind != DocumentKind.NotebookCell || !allWhiteSpaceUntil || index != firstNonWhiteSpaceIndex);
             bool IsEscaped(int index) => index > 0 && text[index - 1] == '\\';
 
             var pos = 0;
@@ -312,8 +308,8 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder.DataStructures
                         // Find the next " or comment
                         indexOfDelim = text.IndexOfAny(NoOpenStringDelimiters, pos);
 
-                        // Don't stop if index is a lone /
-                        while (IsLoneSlash(indexOfDelim))
+                        // Don't stop if index is a lone /, or if the % is not a magic command
+                        while (IsLoneSlash(indexOfDelim) || IsNotMagicCommand(indexOfDelim))
                         {
                             indexOfDelim = text.IndexOfAny(NoOpenStringDelimiters, indexOfDelim + 1);
                         }
@@ -356,7 +352,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder.DataStructures
                     break;
                 }
 
-                if (text[indexOfDelim] == '/')
+                if (text[indexOfDelim] == '/' || text[indexOfDelim] == '%')
                 {
                     commentIndex = indexOfDelim;
                     break;
@@ -476,6 +472,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder.DataStructures
                 this.WithoutEnding,
                 this.EndOfLineComment,
                 newIndentation,
+                this.IsAllWhiteSpace,
                 this.ExcessBracketPositions,
                 this.ErrorDelimiterPositions,
                 this.StringDelimiters,
@@ -491,6 +488,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder.DataStructures
                 this.WithoutEnding,
                 this.EndOfLineComment,
                 this.Indentation,
+                this.IsAllWhiteSpace,
                 newExcessBrackets,
                 this.ErrorDelimiterPositions,
                 this.StringDelimiters,

--- a/src/QsCompiler/CompilationManager/FileContentManager.cs
+++ b/src/QsCompiler/CompilationManager/FileContentManager.cs
@@ -477,6 +477,8 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
 
         internal IEnumerable<CodeLine> GetLines() => this.content.Get();
 
+        internal bool AllWhiteSpaceUntil(int index) => index == 0 || this.GetLines(0, index).All(line => line.IsAllWhiteSpace);
+
         /// <summary>
         /// Gets the code line at <paramref name="index"/>.
         /// </summary>
@@ -1022,7 +1024,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
                 // We need to enforce that generated type checking diagnostics are consistent with all other diagnostics.
                 // In particular this means that we cannot have that the type checking runs after the ScopeTracking update completed
                 // but before the other updates (that generate the data structure based on which the type checking is done) are done.
-                QsCompilerError.RaiseOnFailure(() => this.UpdateScopeTacking(change), "error during scope tracking update");
+                QsCompilerError.RaiseOnFailure(() => this.UpdateScopeTracking(change), "error during scope tracking update");
                 QsCompilerError.RaiseOnFailure(() => this.UpdateLanguageProcessing(), "error during language processing update");
                 QsCompilerError.RaiseOnFailure(() => this.UpdateContext(), "error during context update");
             }

--- a/src/QsCompiler/CompilationManager/FileContentManager.cs
+++ b/src/QsCompiler/CompilationManager/FileContentManager.cs
@@ -480,6 +480,20 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         internal bool AllWhiteSpaceUntil(int index) => index == 0 || this.GetLines(0, index).All(line => line.IsAllWhiteSpace);
 
         /// <summary>
+        /// Returns true if there is a line within the range [index, this.NrLines()) beginning with
+        /// a % such that all preceding lines in the range are only whitespace. This is useful for
+        /// knowing whether or not to re-compile code when the programmer adds/removes a line before
+        /// a possible magic command that changes whether it is a magic command or not
+        /// </summary>
+        internal bool MagicCandidateExistsStartingAt(int index) =>
+            index < this.NrLines()
+            && (this.GetLines(index, this.NrLines() - index)
+                    .FirstOrDefault(line => !line.IsAllWhiteSpace)?
+                    .Text
+                    .TrimStart()
+                    .StartsWith('%') ?? false);
+
+        /// <summary>
         /// Gets the code line at <paramref name="index"/>.
         /// </summary>
         /// <exception cref="ArgumentOutOfRangeException"><paramref name="index"/> is less than 0.</exception>

--- a/src/QsCompiler/CompilationManager/ScopeTracking.cs
+++ b/src/QsCompiler/CompilationManager/ScopeTracking.cs
@@ -610,7 +610,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
             var indentationChange = GetIndentationChange(file, continueAtInFile, replacements.Last());
             var requiresStringDelimiterUpdate = ContinueString(file.GetLine(continueAtInFile - 1)) ^ ContinueString(replacements.Last());
 
-            // iqsharp accepts magic commands only when they are preceded only by whitespace. If the
+            // iQSharp accepts magic commands only when they are preceded only by whitespace. If the
             // programmer writes some code before a magic command, or removes code before a
             // previously- ineligible magic command, we need to re-parse onward. (Why re-parse?
             // Imagine if some code like `%simulate "` was previously interpreted as a magic
@@ -618,7 +618,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
             // the % is no longer a comment, and that annoying double-quote has changed the
             // StringContext and we need to re-parse everything!) We try to be very picky about when
             // we do this re-parse, since it will be expensive.
-            var requiresMagicUpdate = file.BuildConfiguration.IsNotebook
+            var requiresMagicUpdate = file.DocumentKind == DocumentKind.NotebookCell
                                       && file.AllWhiteSpaceUntil(start)
                                       && file.MagicCandidateExistsStartingAt(continueAtInFile)
                                       && (replacements.All(line => line.IsAllWhiteSpace) ^ file.GetLines(start, count).All(line => line.IsAllWhiteSpace));

--- a/src/QsCompiler/CompilationManager/ScopeTracking.cs
+++ b/src/QsCompiler/CompilationManager/ScopeTracking.cs
@@ -609,7 +609,20 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
             // how much the effective indentation (i.e. absolute indentation plus nr of excess closings up to that point) changed determines how much an what we need to update:
             var indentationChange = GetIndentationChange(file, continueAtInFile, replacements.Last());
             var requiresStringDelimiterUpdate = ContinueString(file.GetLine(continueAtInFile - 1)) ^ ContinueString(replacements.Last());
-            if (requiresStringDelimiterUpdate)
+
+            // iqsharp accepts magic commands only when they are preceded only by whitespace. If the
+            // programmer writes some code before a magic command, or removes code before a
+            // previously- ineligible magic command, we need to re-parse onward. (Why re-parse?
+            // Imagine if some code like `%simulate "` was previously interpreted as a magic
+            // command, but now the programmer added some code before it. Then the text that follows
+            // the % is no longer a comment, and that annoying double-quote has changed the
+            // StringContext and we need to re-parse everything!) We try to be very picky about when
+            // we do this re-parse, since it will be expensive.
+            var requiresMagicUpdate = file.BuildConfiguration.IsNotebook
+                                      && file.AllWhiteSpaceUntil(start)
+                                      && file.MagicCandidateExistsStartingAt(continueAtInFile)
+                                      && (replacements.All(line => line.IsAllWhiteSpace) ^ file.GetLines(start, count).All(line => line.IsAllWhiteSpace));
+            if (requiresStringDelimiterUpdate || requiresMagicUpdate)
             {
                 // we need to recompute everything if the interpretation of what is code and what is a string changes...
                 // since the interpretation of the remaining file changed, we need to update the entire file from start onwards

--- a/src/QsCompiler/CompilationManager/ScopeTracking.cs
+++ b/src/QsCompiler/CompilationManager/ScopeTracking.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using Microsoft.Quantum.QsCompiler.CompilationBuilder.DataStructures;
+using Microsoft.Quantum.QsCompiler.DataTypes;
 using Microsoft.VisualStudio.LanguageServer.Protocol;
 using Position = Microsoft.Quantum.QsCompiler.DataTypes.Position;
 
@@ -98,7 +99,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
             }
 
             var continuation = file.GetLine(continueAt);
-            var updatedContinuation = ComputeCodeLines(new string[] { continuation.Text }, previous).Single();
+            var updatedContinuation = ComputeCodeLines(new string[] { continuation.Text }, previous, file.AllWhiteSpaceUntil(continueAt), file.DocumentKind).Single();
             return updatedContinuation.Indentation - continuation.Indentation;
         }
 
@@ -378,6 +379,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
                     prefixDelims,
                     -1, // The comment will have been removed by this point
                     0,
+                    false, // Whether this line is all whitespace is also irrelevant
                     prefixExcessClosings);
             }
 
@@ -506,12 +508,17 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// <remarks>
         /// Specifying <paramref name="previousLine"/> as null indicates that there is no previous line.
         /// </remarks>
-        private static IEnumerable<CodeLine> InitializeCodeLines(IEnumerable<string> texts, CodeLine? previousLine = null)
+        private static IEnumerable<CodeLine> InitializeCodeLines(
+            IEnumerable<string> texts,
+            CodeLine? previousLine,
+            bool allWhiteSpaceUntil,
+            DocumentKind documentKind)
         {
             var previousLineStringContext = previousLine?.EndingStringContext ?? CodeLine.StringContext.NoOpenString;
             foreach (string text in texts)
             {
-                var line = new CodeLine(text, previousLineStringContext);
+                var line = new CodeLine(text, previousLineStringContext, allWhiteSpaceUntil, documentKind);
+                allWhiteSpaceUntil &= line.IsAllWhiteSpace;
                 previousLineStringContext = line.EndingStringContext;
                 yield return line;
             }
@@ -556,8 +563,8 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// <remarks>
         /// Specifying <paramref name="previousLine"/> as null indicates that there is no previous line.
         /// </remarks>
-        private static IEnumerable<CodeLine> ComputeCodeLines(IEnumerable<string> texts, CodeLine? previousLine = null) =>
-            SetIndentations(InitializeCodeLines(texts, previousLine), previousLine == null ? 0 : previousLine.FinalIndentation());
+        private static IEnumerable<CodeLine> ComputeCodeLines(IEnumerable<string> texts, CodeLine? previousLine, bool allWhiteSpaceUntil, DocumentKind documentKind) =>
+            SetIndentations(InitializeCodeLines(texts, previousLine, allWhiteSpaceUntil, documentKind), previousLine == null ? 0 : previousLine.FinalIndentation());
 
         /// <summary>
         /// Returns an enumerable sequence of new <see cref="CodeLine"/> objects where the initial indentation
@@ -606,7 +613,8 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
             {
                 // we need to recompute everything if the interpretation of what is code and what is a string changes...
                 // since the interpretation of the remaining file changed, we need to update the entire file from start onwards
-                return ComputeCodeLines(remainingLines.Select(line => line.Text), replacements.Last()).ToList();
+                bool allWhiteSpaceUntil = file.AllWhiteSpaceUntil(start) && replacements.All(line => line.IsAllWhiteSpace);
+                return ComputeCodeLines(remainingLines.Select(line => line.Text), replacements.Last(), allWhiteSpaceUntil, file.DocumentKind).ToList();
             }
             else if (indentationChange != 0)
             {
@@ -686,7 +694,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         private static void Update(this FileContentManager file, int start, int count, IEnumerable<string> newText)
         {
             CodeLine[] replacements = QsCompilerError.RaiseOnFailure(
-                () => ComputeCodeLines(newText, start > 0 ? file.GetLine(start - 1) : null).ToArray(),
+                () => ComputeCodeLines(newText, start > 0 ? file.GetLine(start - 1) : null, file.AllWhiteSpaceUntil(start), file.DocumentKind).ToArray(),
                 "scope tracking update failed during computing the replacements");
 
             IEnumerable<CodeLine>? updateRemaining = QsCompilerError.RaiseOnFailure(
@@ -735,7 +743,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// <para/>
         /// If <paramref name="change"/> is null, then (only) the currently queued unprocessed changes are processed.
         /// </remarks>
-        internal static void UpdateScopeTacking(this FileContentManager file, TextDocumentContentChangeEvent? change)
+        internal static void UpdateScopeTracking(this FileContentManager file, TextDocumentContentChangeEvent? change)
         {
             // Replaces the lines in the range [start, end] with those for the given text.
             void ComputeUpdate(int start, int end, string text)

--- a/src/QsCompiler/TestProjects/test18/Magic.qs
+++ b/src/QsCompiler/TestProjects/test18/Magic.qs
@@ -1,7 +1,7 @@
 ﻿%azure.target ionq.simulator
 
 namespace Test18 {
-    operation PrintParity(num: Int): Int {
+    operation PrintParity2(num: Int): Int {
         let two = 2;
         let parity = num
 %two

--- a/src/QsCompiler/TestProjects/test18/Magic.qs
+++ b/src/QsCompiler/TestProjects/test18/Magic.qs
@@ -1,0 +1,11 @@
+﻿%azure.target ionq.simulator
+
+namespace Test18 {
+    operation PrintParity(num: Int): Int {
+        let two = 2;
+        let parity = num
+%two
+        ;
+        return parity;
+    }
+}

--- a/src/QsCompiler/TestProjects/test18/Parity.qs
+++ b/src/QsCompiler/TestProjects/test18/Parity.qs
@@ -1,9 +1,10 @@
 ﻿namespace Test18 {
-    operation PrintParity(num: Int): Unit {
+    operation PrintParity(num: Int): Int {
         let two = 2;
         let parity = num
 %two
         ;
+        return parity;
     }
 
     newtype Nested = (Double, (ItemName : Int, String));

--- a/src/QsCompiler/Tests.Compiler/LocalVerificationTests.fs
+++ b/src/QsCompiler/Tests.Compiler/LocalVerificationTests.fs
@@ -542,6 +542,8 @@ type LocalVerificationTests() =
         this.Expect "StringParsingTest5" []
         this.Expect "StringParsingTest6" []
         this.Expect "StringParsingTest7" []
+        this.Expect "NotebookStringParsingTest1" [ Error ErrorCode.UnknownCodeFragment ]
+        this.Expect "NotebookStringParsingTest2" [ Error ErrorCode.UnknownCodeFragment ]
 
         this.Expect "MultiLineStringTest1" []
         this.Expect "MultiLineStringTest2" []

--- a/src/QsCompiler/Tests.Compiler/TestCases/StringParsingTests/StringParsing.qs
+++ b/src/QsCompiler/Tests.Compiler/TestCases/StringParsingTests/StringParsing.qs
@@ -32,6 +32,14 @@ namespace Microsoft.Quantum.Testing.LocalVerification {
         let str = "//";
     }
 
+    operation NotebookStringParsingTest1 () : Unit {
+        let str = "hi"; %
+    }
+
+    operation NotebookStringParsingTest2 () : Unit {
+%simulate SampleRandomNumber nQubits=3
+    }
+
     operation MultiLineStringTest1 () : Unit {
         let str = "
         ";

--- a/src/QsCompiler/Tests.LanguageServer/TestUtils.cs
+++ b/src/QsCompiler/Tests.LanguageServer/TestUtils.cs
@@ -66,6 +66,12 @@ namespace Microsoft.Quantum.QsLanguageServer.Testing
             };
         }
 
+        internal static DidOpenTextDocumentParams GetOpenFileParams(Uri uri, string content, string languageId = "")
+        {
+            return new DidOpenTextDocumentParams
+            { TextDocument = new TextDocumentItem { Uri = uri, LanguageId = languageId, Text = content } };
+        }
+
         internal static DidOpenTextDocumentParams GetOpenFileParams(string filename, Uri? uri = null, string languageId = "")
         {
             var file = Path.GetFullPath(filename);
@@ -84,11 +90,16 @@ namespace Microsoft.Quantum.QsLanguageServer.Testing
             return new DidSaveTextDocumentParams { TextDocument = new TextDocumentIdentifier { Uri = GetUri(filename) }, Text = content };
         }
 
-        internal static DidChangeTextDocumentParams GetChangedFileParams(string filename, TextDocumentContentChangeEvent[] changes)
+        internal static DidChangeTextDocumentParams GetChangedParams(Uri uri, TextDocumentContentChangeEvent[] changes)
         {
-            var fileId = new VersionedTextDocumentIdentifier { Uri = GetUri(filename) };
+            var fileId = new VersionedTextDocumentIdentifier { Uri = uri };
             return new DidChangeTextDocumentParams
             { TextDocument = fileId, ContentChanges = changes };
+        }
+
+        internal static DidChangeTextDocumentParams GetChangedFileParams(string filename, TextDocumentContentChangeEvent[] changes)
+        {
+            return GetChangedParams(GetUri(filename), changes);
         }
 
         internal static TextDocumentPositionParams GetTextDocumentPositionParams(string filename, Position pos)

--- a/src/QsCompiler/Tests.LanguageServer/Tests.cs
+++ b/src/QsCompiler/Tests.LanguageServer/Tests.cs
@@ -569,8 +569,8 @@ namespace Microsoft.Quantum.QsLanguageServer.Testing
 
             var openParams3 = TestUtils.GetOpenFileParams(programFileWithMagic);
             await this.rpc.InvokeWithParameterObjectAsync<Task>(Methods.TextDocumentDidOpen.Name, openParams3);
-            Assert.AreEqual(DocumentKind.File, await this.GetFileDocumentKindAsync(programFileWithNamespace));
-            var diagnostics3 = await this.GetFileDiagnosticsAsync(programFileWithNamespace);
+            Assert.AreEqual(DocumentKind.File, await this.GetFileDocumentKindAsync(programFileWithMagic));
+            var diagnostics3 = await this.GetFileDiagnosticsAsync(programFileWithMagic);
 
             Assert.IsNotNull(diagnostics1);
             Assert.AreEqual(3, diagnostics1!.Length);
@@ -619,7 +619,7 @@ namespace Microsoft.Quantum.QsLanguageServer.Testing
             Assert.AreEqual(DocumentKind.NotebookCell, await this.GetFileDocumentKindAsync(uri: uriWithNamespace));
             var diagnostics2 = await this.GetFileDiagnosticsAsync(uri: uriWithNamespace);
 
-            var openParams3 = TestUtils.GetOpenFileParams(programFileWithMagic, uriWithMagic);
+            var openParams3 = TestUtils.GetOpenFileParams(programFileWithMagic, uriWithMagic, languageId);
             await this.rpc.InvokeWithParameterObjectAsync<Task>(Methods.TextDocumentDidOpen.Name, openParams3);
             Assert.AreEqual(DocumentKind.NotebookCell, await this.GetFileDocumentKindAsync(uri: uriWithMagic));
             var diagnostics3 = await this.GetFileDiagnosticsAsync(uri: uriWithMagic);
@@ -634,7 +634,6 @@ namespace Microsoft.Quantum.QsLanguageServer.Testing
         }
 
         [TestMethod]
-<<<<<<< HEAD
         public async Task NotebookTypeCheckingAsync()
         {
             var projectFile = ProjectLoaderTests.ProjectUri("test18");
@@ -754,7 +753,7 @@ namespace Microsoft.Quantum.QsLanguageServer.Testing
 
             // Same value sent by Azure Notebooks
             var languageId = "qsharp-notebook";
-            var openParams = TestUtils.GetOpenParams(cellUri, content: "", languageId);
+            var openParams = TestUtils.GetOpenFileParams(cellUri, content: "", languageId);
             await this.rpc.InvokeWithParameterObjectAsync<Task>(Methods.TextDocumentDidOpen.Name, openParams);
             Assert.AreEqual(DocumentKind.NotebookCell, await this.GetFileDocumentKindAsync(uri: cellUri));
 


### PR DESCRIPTION
This is a rebase of the magic command code from #1457 against the most recent `feature/langserver-notebooks` branch. It treats magic commands as comments _if_ they are the first non-whitespace character in the cell. That requires some state tracking which isn't too beautiful

This may or may not be a good idea to merge, but I'm posting this for discussion/for reference at least

## Testing
* Ran unit tests for all of `Compiler.sln` and also the language server tests (both of which include new tests)
* Did manual test locally with Azure Notebooks