### PR TITLE
Use newer versions of VSSDK build tools

### DIFF
--- a/src/VisualStudioExtension/QSharpVsix/QSharpVsix.csproj
+++ b/src/VisualStudioExtension/QSharpVsix/QSharpVsix.csproj
@@ -129,7 +129,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.VisualStudio.SDK">
-      <Version>17.1.32210.191</Version>
+      <Version>17.2.32505.173</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.CSharp">
       <Version>4.7.0</Version>
@@ -149,7 +149,7 @@
     <PackageReference Include="Microsoft.VisualStudio.Telemetry">
       <Version>16.4.78</Version>
     </PackageReference>
-    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="17.1.4054">
+    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="17.3.2093">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
This updates to newer versions of the VSSDK build tools and VS SDK itself to address build pipeline failures with the latest images.