### PR TITLE
Auto-open Canon and Intrinsic in notebooks

### DIFF
--- a/src/QsCompiler/CompilationManager/CompilationUnitManager.cs
+++ b/src/QsCompiler/CompilationManager/CompilationUnitManager.cs
@@ -605,7 +605,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
             {
                 this.compilationUnit.GlobalSymbols.Clear();
                 compilation.GlobalSymbols.CopyTo(this.compilationUnit.GlobalSymbols);
-                this.compilationUnit.GlobalSymbols.ResolveAll(BuiltIn.NamespacesToAutoOpen);
+                this.compilationUnit.GlobalSymbols.ResolveAll();
             }
             finally
             {

--- a/src/QsCompiler/CompilationManager/TypeChecking.cs
+++ b/src/QsCompiler/CompilationManager/TypeChecking.cs
@@ -458,7 +458,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// </remarks>
         internal static void ResolveGlobalSymbols(NamespaceManager symbols, List<Diagnostic> diagnostics, string? fileName = null)
         {
-            var declDiagnostics = symbols.ResolveAll(BuiltIn.NamespacesToAutoOpen);
+            var declDiagnostics = symbols.ResolveAll();
             var cycleDiagnostics = SyntaxProcessing.SyntaxTree.CheckDefinedTypesForCycles(symbols.DefinedTypes());
 
             void AddDiagnostics(string source, IEnumerable<QsCompilerDiagnostic> msgs) =>

--- a/src/QsCompiler/Core/Dependencies.fs
+++ b/src/QsCompiler/Core/Dependencies.fs
@@ -36,7 +36,11 @@ type BuiltIn =
     static member internal MathNamespace = "Microsoft.Quantum.Math"
 
     /// Returns the set of namespaces that is automatically opened for each compilation.
-    static member NamespacesToAutoOpen = ImmutableHashSet.Create(BuiltIn.CoreNamespace)
+    static member NamespacesToAutoOpen documentKind =
+        match documentKind with
+        | File -> [ BuiltIn.CoreNamespace ]
+        // To match iQSharp behavior
+        | NotebookCell -> [ BuiltIn.CoreNamespace; BuiltIn.IntrinsicNamespace; BuiltIn.CanonNamespace ]
 
     /// Returns the set of callables that rewrite steps take dependencies on.
     /// These should be non-Generic callables only.

--- a/src/QsCompiler/Core/SymbolTable/Namespace.fs
+++ b/src/QsCompiler/Core/SymbolTable/Namespace.fs
@@ -13,6 +13,7 @@ open System.Linq
 open Microsoft.Quantum.QsCompiler
 open Microsoft.Quantum.QsCompiler.DataTypes
 open Microsoft.Quantum.QsCompiler.Diagnostics
+open Microsoft.Quantum.QsCompiler.ReservedKeywords
 open Microsoft.Quantum.QsCompiler.SyntaxTokens
 open Microsoft.Quantum.QsCompiler.SyntaxTree
 open Microsoft.Quantum.QsCompiler.Utils
@@ -58,6 +59,9 @@ type Namespace
 
     /// name of the namespace
     member this.Name = name
+
+    /// The type of "file" where this namespace is defined: notebook cells or ordinary files?
+    member this.DocumentKind = if this.Name = InternalUse.NotebookNamespace then NotebookCell else File
 
     /// Immutable array with the names of all source files that contain (a part of) the namespace.
     /// Note that files contained in referenced assemblies that implement part of the namespace

--- a/src/QsCompiler/TestProjects/test21/NotebookCell.qs
+++ b/src/QsCompiler/TestProjects/test21/NotebookCell.qs
@@ -1,0 +1,6 @@
+operation Bell(): (Result, Result) {
+    use (q1, q2) = (Qubit(), Qubit());
+    H(q1);
+    CX(q1, q2);
+    return (M(q1), M(q2));
+}

--- a/src/QsCompiler/TestProjects/test21/fakeStandardLibrary/Canon.qs
+++ b/src/QsCompiler/TestProjects/test21/fakeStandardLibrary/Canon.qs
@@ -1,0 +1,5 @@
+namespace Microsoft.Quantum.Canon {
+    operation CX (control : Qubit, target : Qubit) : Unit is Adj + Ctl {
+        body intrinsic;
+    }
+}

--- a/src/QsCompiler/TestProjects/test21/fakeStandardLibrary/Intrinsic.qs
+++ b/src/QsCompiler/TestProjects/test21/fakeStandardLibrary/Intrinsic.qs
@@ -1,0 +1,9 @@
+namespace Microsoft.Quantum.Intrinsic {
+    operation H (qubit : Qubit) : Unit is Adj + Ctl {
+        body intrinsic;
+    }
+
+    operation M (qubit : Qubit) : Result {
+        body intrinsic;
+    }
+}

--- a/src/QsCompiler/TestProjects/test21/ordinaryProject/OrdinaryFile.qs
+++ b/src/QsCompiler/TestProjects/test21/ordinaryProject/OrdinaryFile.qs
@@ -1,0 +1,8 @@
+namespace Test21 {
+    operation Bell(): (Result, Result) {
+        use (q1, q2) = (Qubit(), Qubit());
+        H(q1);
+        CX(q1, q2);
+        return (M(q1), M(q2));
+    }
+}

--- a/src/QsCompiler/TestProjects/test21/ordinaryProject/ordinaryProject.csproj
+++ b/src/QsCompiler/TestProjects/test21/ordinaryProject/ordinaryProject.csproj
@@ -1,0 +1,9 @@
+﻿<Project Sdk="Microsoft.Quantum.Sdk/0.25.218240">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net6.0</TargetFramework>
+    <ExecutionTarget>ionq.qpu</ExecutionTarget>
+  </PropertyGroup>
+
+</Project>

--- a/src/QsCompiler/Transformations/QsharpCodeOutput.cs
+++ b/src/QsCompiler/Transformations/QsharpCodeOutput.cs
@@ -1726,7 +1726,7 @@ namespace Microsoft.Quantum.QsCompiler.Transformations.QsCodeOutput
                 this.AddBlock(() =>
                 {
                     var context = this.SharedState.Context;
-                    var explicitImports = context.OpenedNamespaces.Where(opened => !BuiltIn.NamespacesToAutoOpen.Contains(opened));
+                    var explicitImports = context.OpenedNamespaces.Where(opened => !BuiltIn.NamespacesToAutoOpen(DocumentKind.File).Contains(opened));
                     if (explicitImports.Any() || context.NamespaceShortNames.Any())
                     {
                         this.AddToOutput("");


### PR DESCRIPTION
Pretty simple change to match IQ# behavior of auto-opening Canon and Intrinsic until we implement preludes. I think this has been rejected but posting it anyway

## Testing
* Ran unit tests locally for compiler and language server
* Tested locally with Azure Notebooks