### PR TITLE
Removed Null Strings for Open Directive Aliases

### DIFF
--- a/src/QsCompiler/CompilationManager/CompilationUnit.cs
+++ b/src/QsCompiler/CompilationManager/CompilationUnit.cs
@@ -889,7 +889,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// imported within a certain source file for <paramref name="nsName"/>.
         /// </summary>
         /// <exception cref="ArgumentException">No namespace exists with name <paramref name="nsName"/>.</exception>
-        public ILookup<string, (string, string?)> GetOpenDirectives(string nsName)
+        public ILookup<string, (string, string)> GetOpenDirectives(string nsName)
         {
             this.syncRoot.EnterReadLock();
             try

--- a/src/QsCompiler/CompilationManager/CompilationUnitManager.cs
+++ b/src/QsCompiler/CompilationManager/CompilationUnitManager.cs
@@ -1042,7 +1042,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
             /// Contains a dictionary that maps the name of each namespace defined in the compilation to a look-up
             /// containing the names and corresponding short form (if any) of all opened namespaces for that (part of the) namespace in a particular source file.
             /// </summary>
-            private readonly ImmutableDictionary<string, ILookup<string, (string, string?)>> openDirectivesForEachFile;
+            private readonly ImmutableDictionary<string, ILookup<string, (string, string)>> openDirectivesForEachFile;
 
             /// <summary>
             /// Contains a dictionary that given the ID of a file included in the compilation
@@ -1146,10 +1146,10 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
             /// Returns an empty sequence if <paramref name="sourceFile"/> and/or <paramref name="nsName"/>
             /// do not exist in the compilation.
             /// </remarks>
-            public IEnumerable<(string, string?)> OpenDirectives(string sourceFile, string nsName) =>
+            public IEnumerable<(string, string)> OpenDirectives(string sourceFile, string nsName) =>
                 this.openDirectivesForEachFile.TryGetValue(nsName, out var lookUp)
                     ? lookUp[sourceFile]
-                    : Enumerable.Empty<(string, string?)>();
+                    : Enumerable.Empty<(string, string)>();
 
             /// <summary>
             /// Returns all the names of all callable and types defined in namespace <paramref name="nsName"/>.

--- a/src/QsCompiler/CompilationManager/EditorSupport/CodeCompletion.cs
+++ b/src/QsCompiler/CompilationManager/EditorSupport/CodeCompletion.cs
@@ -447,14 +447,13 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
 
             return compilation
                 .GetOpenDirectives(ns)[file.FileName]
-                .SelectNotNull(open => open.Item2?.Apply(alias => (open.Item1, alias)))
-                .Where(open => open.alias.StartsWith(prefix))
-                .GroupBy(open => NextNamespacePart(open.alias, prefix.Length))
+                .Where(open => open.Item2.StartsWith(prefix))
+                .GroupBy(open => NextNamespacePart(open.Item2, prefix.Length))
                 .Select(open => new CompletionItem
                 {
                     Label = open.Key,
                     Kind = CompletionItemKind.Module,
-                    Detail = open.Count() == 1 && prefix + open.Key == open.Single().alias
+                    Detail = open.Count() == 1 && prefix + open.Key == open.Single().Item2
                         ? open.Single().Item1
                         : prefix + open.Key,
                 });
@@ -521,7 +520,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
 
             return compilation
                 .GetOpenDirectives(@namespace)[file.FileName]
-                .Where(open => open.Item2 == null) // Only include open directives without an alias.
+                .Where(open => string.IsNullOrEmpty(open.Item2)) // Only include open directives without an alias.
                 .Select(open => open.Item1)
                 .Concat(new[] { @namespace });
         }

--- a/src/QsCompiler/Transformations/QsharpCodeOutput.cs
+++ b/src/QsCompiler/Transformations/QsharpCodeOutput.cs
@@ -197,7 +197,7 @@ namespace Microsoft.Quantum.QsCompiler.Transformations.QsCodeOutput
         public static bool Apply(
             out List<ImmutableDictionary<string, string>> generatedCode,
             IEnumerable<QsNamespace> namespaces,
-            params (string, ImmutableDictionary<string, ImmutableArray<(string, string?)>>)[] openDirectives)
+            params (string, ImmutableDictionary<string, ImmutableArray<(string, string)>>)[] openDirectives)
         {
             generatedCode = new List<ImmutableDictionary<string, string>>();
             var symbolsInNS = namespaces.ToImmutableDictionary(ns => ns.Name, ns => ns.Elements
@@ -217,16 +217,16 @@ namespace Microsoft.Quantum.QsCompiler.Transformations.QsCodeOutput
                     }
 
                     // determine all symbols that occur in multiple open namespaces
-                    var ambiguousSymbols = symbolsInNS.Where(entry => imports[ns.Name].Contains((entry.Key, null)))
+                    var ambiguousSymbols = symbolsInNS.Where(entry => imports[ns.Name].Contains((entry.Key, string.Empty)))
                         .SelectMany(entry => entry.Value)
                         .GroupBy(name => name)
                         .Where(group => group.Count() > 1)
                         .Select(group => group.Key).ToImmutableHashSet();
 
-                    var openedNS = imports[ns.Name].Where(o => o.Item2 == null).Select(o => o.Item1).ToImmutableHashSet();
+                    var openedNS = imports[ns.Name].Where(o => string.IsNullOrEmpty(o.Item2)).Select(o => o.Item1).ToImmutableHashSet();
                     var nsShortNames = imports[ns.Name]
-                        .SelectNotNull(o => o.Item2?.Apply(item2 => (o.Item1, item2)))
-                        .ToImmutableDictionary(o => o.Item1, o => o.item2);
+                        .Where(o => !string.IsNullOrEmpty(o.Item2))
+                        .ToImmutableDictionary(o => o.Item1, o => o.Item2);
                     var context = new TransformationContext
                     {
                         CurrentNamespace = ns.Name,


### PR DESCRIPTION
Updates several places in code to replace `string?` references to `string` references to reflect the recent changes that make non-aliased open directives use empty strings instead of null. This change fixes a bug in the Q# Print transformation incurred by those changes.