### PR TITLE
Add support for microsoft-qc provider

### DIFF
--- a/src/QsCompiler/CSharpGeneration/Context.fs
+++ b/src/QsCompiler/CSharpGeneration/Context.fs
@@ -168,6 +168,5 @@ type CodegenContext =
             || target = AssemblyConstants.QuantinuumProcessor
             || target = AssemblyConstants.RigettiProcessor
             || target = AssemblyConstants.MicrosoftQuantum
-            || target = AssemblyConstants.MicrosoftSimulator
         else
             true

--- a/src/QsCompiler/CSharpGeneration/Context.fs
+++ b/src/QsCompiler/CSharpGeneration/Context.fs
@@ -167,6 +167,7 @@ type CodegenContext =
             || target = AssemblyConstants.QCIProcessor
             || target = AssemblyConstants.QuantinuumProcessor
             || target = AssemblyConstants.RigettiProcessor
+            || target = AssemblyConstants.MicrosoftQuantum
             || target = AssemblyConstants.MicrosoftSimulator
         else
             true

--- a/src/QsCompiler/DataStructures/ReservedKeywords.fs
+++ b/src/QsCompiler/DataStructures/ReservedKeywords.fs
@@ -267,6 +267,7 @@ module AssemblyConstants =
     let QCIProcessor = "QCIProcessor"
     let QuantinuumProcessor = "QuantinuumProcessor"
     let RigettiProcessor = "RigettiProcessor"
+    let MicrosoftQuantum = "MicrosoftQuantum"
     let MicrosoftSimulator = "MicrosoftSimulator"
     let ExecutionTarget = "ExecutionTarget"
     let TargetCapability = "TargetCapability"

--- a/src/QsCompiler/DataStructures/ReservedKeywords.fs
+++ b/src/QsCompiler/DataStructures/ReservedKeywords.fs
@@ -268,7 +268,6 @@ module AssemblyConstants =
     let QuantinuumProcessor = "QuantinuumProcessor"
     let RigettiProcessor = "RigettiProcessor"
     let MicrosoftQuantum = "MicrosoftQuantum"
-    let MicrosoftSimulator = "MicrosoftSimulator"
     let ExecutionTarget = "ExecutionTarget"
     let TargetCapability = "TargetCapability"
     let DefaultSimulator = "DefaultSimulator"

--- a/src/QsCompiler/TestTargets/Simulation/Target/RewriteStep.cs
+++ b/src/QsCompiler/TestTargets/Simulation/Target/RewriteStep.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Quantum.QsCompiler.Testing.Simulation
             if (!props.TryGetValue(AssemblyConstants.ProcessorArchitecture, out var arch) ||
                 arch?.Trim().ToLower() == "unspecified")
             {
-                props[AssemblyConstants.ProcessorArchitecture] = AssemblyConstants.MicrosoftSimulator;
+                props[AssemblyConstants.ProcessorArchitecture] = AssemblyConstants.MicrosoftQuantum;
             }
 
             return true;

--- a/src/QuantumSdk/DefaultItems/DefaultItems.targets
+++ b/src/QuantumSdk/DefaultItems/DefaultItems.targets
@@ -28,7 +28,7 @@
     <ValidOutputTypes>Possible values are 'Exe', or 'Library'.</ValidOutputTypes>
   </PropertyGroup>
 
-  <!-- Initializing the ResolvedProcessorArchitecture to either IonQProcessor, QCIProcessor, QuantinuumProcessor, RigettiProcessor, MicrosoftSimulator or Unspecified.-->
+  <!-- Initializing the ResolvedProcessorArchitecture to either IonQProcessor, QCIProcessor, QuantinuumProcessor, RigettiProcessor, MicrosoftQuantum, MicrosoftSimulator or Unspecified.-->
   <PropertyGroup>
     <!-- These architectures are in production and available for public use. -->
     <ResolvedProcessorArchitecture Condition="$(ExecutionTarget.ToLowerInvariant().Contains('ionq'))">IonQProcessor</ResolvedProcessorArchitecture>
@@ -36,10 +36,11 @@
     <ResolvedProcessorArchitecture Condition="$(ExecutionTarget.ToLowerInvariant().Contains('quantinuum'))">QuantinuumProcessor</ResolvedProcessorArchitecture>
     <ResolvedProcessorArchitecture Condition="$(ExecutionTarget.ToLowerInvariant().Contains('honeywell'))">QuantinuumProcessor</ResolvedProcessorArchitecture>
     <ResolvedProcessorArchitecture Condition="$(ExecutionTarget.ToLowerInvariant().Contains('rigetti'))">RigettiProcessor</ResolvedProcessorArchitecture>
+    <ResolvedProcessorArchitecture Condition="$(ExecutionTarget.ToLowerInvariant().Contains('microsoft-qc'))">MicrosoftQuantum</ResolvedProcessorArchitecture>
     <ResolvedProcessorArchitecture Condition="$(ExecutionTarget.ToLowerInvariant().Contains('microsoft.simulator'))">MicrosoftSimulator</ResolvedProcessorArchitecture>
     <ResolvedProcessorArchitecture Condition="$(ExecutionTarget.Equals('Any', StringComparison.InvariantCultureIgnoreCase))">Unspecified</ResolvedProcessorArchitecture>
-    <ResolvedProcessorArchitecture Condition="'$(ResolvedProcessorArchitecture)' != 'IonQProcessor' And '$(ResolvedProcessorArchitecture)' != 'QCIProcessor' And '$(ResolvedProcessorArchitecture)' != 'QuantinuumProcessor' And '$(ResolvedProcessorArchitecture)' != 'RigettiProcessor' And '$(ResolvedProcessorArchitecture)' != 'MicrosoftSimulator' And '$(ResolvedProcessorArchitecture)' != 'Unspecified'"></ResolvedProcessorArchitecture>
-    <ValidExecutionTargets>Possible values must match 'ionq*', 'qci*', 'quantinuum*', 'rigetti*', 'microsoft.simulator*', or 'Any'.</ValidExecutionTargets>
+    <ResolvedProcessorArchitecture Condition="'$(ResolvedProcessorArchitecture)' != 'IonQProcessor' And '$(ResolvedProcessorArchitecture)' != 'QCIProcessor' And '$(ResolvedProcessorArchitecture)' != 'QuantinuumProcessor' And '$(ResolvedProcessorArchitecture)' != 'RigettiProcessor' And '$(ResolvedProcessorArchitecture)' != 'MicrosoftQuantum' And '$(ResolvedProcessorArchitecture)' != 'MicrosoftSimulator' And '$(ResolvedProcessorArchitecture)' != 'Unspecified'"></ResolvedProcessorArchitecture>
+    <ValidExecutionTargets>Possible values must match 'ionq*', 'qci*', 'quantinuum*', 'rigetti*', 'microsoft-qc*', 'microsoft.simulator*', or 'Any'.</ValidExecutionTargets>
   </PropertyGroup>
 
   <!-- Resolving the QuantumInstructionSet to either Type1, Type2, Type3, Type4 or Default.-->
@@ -48,6 +49,7 @@
     <ResolvedQuantumInstructionSet Condition="'$(ResolvedProcessorArchitecture)' == 'IonQProcessor'">Type2</ResolvedQuantumInstructionSet>
     <ResolvedQuantumInstructionSet Condition="'$(ResolvedProcessorArchitecture)' == 'QCIProcessor'">Type3</ResolvedQuantumInstructionSet>
     <ResolvedQuantumInstructionSet Condition="'$(ResolvedProcessorArchitecture)' == 'RigettiProcessor'">Type4</ResolvedQuantumInstructionSet>
+    <ResolvedQuantumInstructionSet Condition="'$(ResolvedProcessorArchitecture)' == 'MicrosoftQuantum'">Default</ResolvedQuantumInstructionSet>
     <ResolvedQuantumInstructionSet Condition="'$(ResolvedProcessorArchitecture)' == 'MicrosoftSimulator'">Default</ResolvedQuantumInstructionSet>
     <ResolvedQuantumInstructionSet Condition="'$(ResolvedProcessorArchitecture)' == 'Unspecified'">Default</ResolvedQuantumInstructionSet>
   </PropertyGroup>
@@ -64,6 +66,7 @@
     <ResolvedTargetCapability Condition="'$(ResolvedProcessorArchitecture)' == 'IonQProcessor'">BasicQuantumFunctionality</ResolvedTargetCapability>
     <ResolvedTargetCapability Condition="'$(ResolvedProcessorArchitecture)' == 'QCIProcessor'">AdaptiveExecution</ResolvedTargetCapability>
     <ResolvedTargetCapability Condition="'$(ResolvedProcessorArchitecture)' == 'RigettiProcessor'">BasicExecution</ResolvedTargetCapability>
+    <ResolvedTargetCapability Condition="'$(ResolvedProcessorArchitecture)' == 'MicrosoftQuantum'">FullComputation</ResolvedTargetCapability>
     <ResolvedTargetCapability Condition="'$(ResolvedProcessorArchitecture)' == 'MicrosoftSimulator'">FullComputation</ResolvedTargetCapability>
     <ResolvedTargetCapability Condition="'$(ResolvedProcessorArchitecture)' == 'Unspecified'">FullComputation</ResolvedTargetCapability>
     <!-- Set the ResolvedTargetCapability to the specified TargetCapability, if that capability is supported by the ResolvedProcessorArchitecture. -->
@@ -71,6 +74,7 @@
     <ResolvedTargetCapability Condition="'$(ResolvedProcessorArchitecture)' == 'IonQProcessor' And $(_EnableBasicQuantumFunctionality)">$(TargetCapability)</ResolvedTargetCapability>
     <ResolvedTargetCapability Condition="'$(ResolvedProcessorArchitecture)' == 'QCIProcessor' And ($(_EnableBasicExecution) Or $(_EnableAdaptiveExecution))">$(TargetCapability)</ResolvedTargetCapability>
     <ResolvedTargetCapability Condition="'$(ResolvedProcessorArchitecture)' == 'RigettiProcessor' And $(_EnableBasicExecution)">$(TargetCapability)</ResolvedTargetCapability>
+    <ResolvedTargetCapability Condition="'$(ResolvedProcessorArchitecture)' == 'MicrosoftQuantum' And $(_EnableFullComputation)">$(TargetCapability)</ResolvedTargetCapability>
     <ResolvedTargetCapability Condition="'$(ResolvedProcessorArchitecture)' == 'MicrosoftSimulator' And $(_EnableFullComputation)">$(TargetCapability)</ResolvedTargetCapability>
     <ResolvedTargetCapability Condition="'$(ResolvedProcessorArchitecture)' == 'Unspecified' And ($(_EnableBasicExecution) Or $(_EnableAdaptiveExecution) Or $(_EnableBasicQuantumFunctionality) Or $(_EnableBasicMeasurementFeedback) Or $(_EnableFullComputation))">$(TargetCapability)</ResolvedTargetCapability>
     <ResolvedTargetCapability Condition="'$(TargetCapability)' != '' And '$(ResolvedTargetCapability)' != '$(TargetCapability)'"></ResolvedTargetCapability>
@@ -80,6 +84,7 @@
     <ValidTargetCapabilities Condition="'$(ResolvedProcessorArchitecture)' == 'IonQProcessor'">$(ValidTargetCapabilities): BasicQuantumFunctionality.</ValidTargetCapabilities>
     <ValidTargetCapabilities Condition="'$(ResolvedProcessorArchitecture)' == 'QCIProcessor'">$(ValidTargetCapabilities): AdaptiveExecution, BasicExecution.</ValidTargetCapabilities>
     <ValidTargetCapabilities Condition="'$(ResolvedProcessorArchitecture)' == 'RigettiProcessor'">$(ValidTargetCapabilities): BasicExecution.</ValidTargetCapabilities>
+    <ValidTargetCapabilities Condition="'$(ResolvedProcessorArchitecture)' == 'MicrosoftQuantum'">$(ValidTargetCapabilities): FullComputation.</ValidTargetCapabilities>
     <ValidTargetCapabilities Condition="'$(ResolvedProcessorArchitecture)' == 'MicrosoftSimulator'">$(ValidTargetCapabilities): FullComputation.</ValidTargetCapabilities>
     <ValidTargetCapabilities Condition="'$(ResolvedProcessorArchitecture)' == 'Unspecified'">$(ValidTargetCapabilities): FullComputation, AdaptiveExecution, BasicExecution, BasicMeasurementFeedback, BasicQuantumFunctionality.</ValidTargetCapabilities>
   </PropertyGroup>
@@ -97,7 +102,7 @@
     <QSharpDocsGeneration Condition="'$(QSharpDocsOutputPath)' != '' And '$(QSharpDocsGeneration)' == 'default'">true</QSharpDocsGeneration>
     <QSharpDocsGeneration Condition="'$(QSharpDocsOutputPath)' == '' And '$(QSharpDocsGeneration)' == 'default'">false</QSharpDocsGeneration>
     <CSharpGeneration Condition="$(QirGeneration)">false</CSharpGeneration>
-    <EnableQirSubmission Condition="'$(ResolvedProcessorArchitecture)' == 'MicrosoftSimulator' Or '$(ResolvedTargetCapability)' == 'AdaptiveExecution' Or '$(ResolvedTargetCapability)' == 'BasicExecution'">true</EnableQirSubmission>
+    <EnableQirSubmission Condition="'$(ResolvedProcessorArchitecture)' == 'MicrosoftQuantum' Or '$(ResolvedProcessorArchitecture)' == 'MicrosoftSimulator' Or '$(ResolvedTargetCapability)' == 'AdaptiveExecution' Or '$(ResolvedTargetCapability)' == 'BasicExecution'">true</EnableQirSubmission>
     <!-- path compatible assembly name -->
     <PathCompatibleAssemblyName>$([System.String]::Copy('$(AssemblyName)').Replace(' ',''))</PathCompatibleAssemblyName>
     <!-- output path for files generated during compilation -->

--- a/src/QuantumSdk/DefaultItems/DefaultItems.targets
+++ b/src/QuantumSdk/DefaultItems/DefaultItems.targets
@@ -28,7 +28,7 @@
     <ValidOutputTypes>Possible values are 'Exe', or 'Library'.</ValidOutputTypes>
   </PropertyGroup>
 
-  <!-- Initializing the ResolvedProcessorArchitecture to either IonQProcessor, QCIProcessor, QuantinuumProcessor, RigettiProcessor, MicrosoftQuantum, MicrosoftSimulator or Unspecified.-->
+  <!-- Initializing the ResolvedProcessorArchitecture to either IonQProcessor, QCIProcessor, QuantinuumProcessor, RigettiProcessor, MicrosoftQuantum or Unspecified.-->
   <PropertyGroup>
     <!-- These architectures are in production and available for public use. -->
     <ResolvedProcessorArchitecture Condition="$(ExecutionTarget.ToLowerInvariant().Contains('ionq'))">IonQProcessor</ResolvedProcessorArchitecture>
@@ -36,11 +36,10 @@
     <ResolvedProcessorArchitecture Condition="$(ExecutionTarget.ToLowerInvariant().Contains('quantinuum'))">QuantinuumProcessor</ResolvedProcessorArchitecture>
     <ResolvedProcessorArchitecture Condition="$(ExecutionTarget.ToLowerInvariant().Contains('honeywell'))">QuantinuumProcessor</ResolvedProcessorArchitecture>
     <ResolvedProcessorArchitecture Condition="$(ExecutionTarget.ToLowerInvariant().Contains('rigetti'))">RigettiProcessor</ResolvedProcessorArchitecture>
-    <ResolvedProcessorArchitecture Condition="$(ExecutionTarget.ToLowerInvariant().Contains('microsoft')) And !$(ExecutionTarget.ToLowerInvariant().Contains('microsoft.simulator'))">MicrosoftQuantum</ResolvedProcessorArchitecture>
-    <ResolvedProcessorArchitecture Condition="$(ExecutionTarget.ToLowerInvariant().Contains('microsoft.simulator'))">MicrosoftSimulator</ResolvedProcessorArchitecture>
+    <ResolvedProcessorArchitecture Condition="$(ExecutionTarget.ToLowerInvariant().Contains('microsoft'))">MicrosoftQuantum</ResolvedProcessorArchitecture>
     <ResolvedProcessorArchitecture Condition="$(ExecutionTarget.Equals('Any', StringComparison.InvariantCultureIgnoreCase))">Unspecified</ResolvedProcessorArchitecture>
-    <ResolvedProcessorArchitecture Condition="'$(ResolvedProcessorArchitecture)' != 'IonQProcessor' And '$(ResolvedProcessorArchitecture)' != 'QCIProcessor' And '$(ResolvedProcessorArchitecture)' != 'QuantinuumProcessor' And '$(ResolvedProcessorArchitecture)' != 'RigettiProcessor' And '$(ResolvedProcessorArchitecture)' != 'MicrosoftQuantum' And '$(ResolvedProcessorArchitecture)' != 'MicrosoftSimulator' And '$(ResolvedProcessorArchitecture)' != 'Unspecified'"></ResolvedProcessorArchitecture>
-    <ValidExecutionTargets>Possible values must match 'ionq*', 'qci*', 'quantinuum*', 'rigetti*', 'microsoft-qc*', 'microsoft.simulator*', or 'Any'.</ValidExecutionTargets>
+    <ResolvedProcessorArchitecture Condition="'$(ResolvedProcessorArchitecture)' != 'IonQProcessor' And '$(ResolvedProcessorArchitecture)' != 'QCIProcessor' And '$(ResolvedProcessorArchitecture)' != 'QuantinuumProcessor' And '$(ResolvedProcessorArchitecture)' != 'RigettiProcessor' And '$(ResolvedProcessorArchitecture)' != 'MicrosoftQuantum' And '$(ResolvedProcessorArchitecture)' != 'Unspecified'"></ResolvedProcessorArchitecture>
+    <ValidExecutionTargets>Possible values must match 'ionq*', 'qci*', 'quantinuum*', 'rigetti*', 'microsoft*', or 'Any'.</ValidExecutionTargets>
   </PropertyGroup>
 
   <!-- Resolving the QuantumInstructionSet to either Type1, Type2, Type3, Type4 or Default.-->
@@ -50,7 +49,6 @@
     <ResolvedQuantumInstructionSet Condition="'$(ResolvedProcessorArchitecture)' == 'QCIProcessor'">Type3</ResolvedQuantumInstructionSet>
     <ResolvedQuantumInstructionSet Condition="'$(ResolvedProcessorArchitecture)' == 'RigettiProcessor'">Type4</ResolvedQuantumInstructionSet>
     <ResolvedQuantumInstructionSet Condition="'$(ResolvedProcessorArchitecture)' == 'MicrosoftQuantum'">Default</ResolvedQuantumInstructionSet>
-    <ResolvedQuantumInstructionSet Condition="'$(ResolvedProcessorArchitecture)' == 'MicrosoftSimulator'">Default</ResolvedQuantumInstructionSet>
     <ResolvedQuantumInstructionSet Condition="'$(ResolvedProcessorArchitecture)' == 'Unspecified'">Default</ResolvedQuantumInstructionSet>
   </PropertyGroup>
 
@@ -67,7 +65,6 @@
     <ResolvedTargetCapability Condition="'$(ResolvedProcessorArchitecture)' == 'QCIProcessor'">AdaptiveExecution</ResolvedTargetCapability>
     <ResolvedTargetCapability Condition="'$(ResolvedProcessorArchitecture)' == 'RigettiProcessor'">BasicExecution</ResolvedTargetCapability>
     <ResolvedTargetCapability Condition="'$(ResolvedProcessorArchitecture)' == 'MicrosoftQuantum'">FullComputation</ResolvedTargetCapability>
-    <ResolvedTargetCapability Condition="'$(ResolvedProcessorArchitecture)' == 'MicrosoftSimulator'">FullComputation</ResolvedTargetCapability>
     <ResolvedTargetCapability Condition="'$(ResolvedProcessorArchitecture)' == 'Unspecified'">FullComputation</ResolvedTargetCapability>
     <!-- Set the ResolvedTargetCapability to the specified TargetCapability, if that capability is supported by the ResolvedProcessorArchitecture. -->
     <ResolvedTargetCapability Condition="'$(ResolvedProcessorArchitecture)' == 'QuantinuumProcessor' And ($(_EnableBasicExecution) Or $(_EnableAdaptiveExecution) Or $(_EnableBasicQuantumFunctionality) Or $(_EnableBasicMeasurementFeedback))">$(TargetCapability)</ResolvedTargetCapability>
@@ -75,7 +72,6 @@
     <ResolvedTargetCapability Condition="'$(ResolvedProcessorArchitecture)' == 'QCIProcessor' And ($(_EnableBasicExecution) Or $(_EnableAdaptiveExecution))">$(TargetCapability)</ResolvedTargetCapability>
     <ResolvedTargetCapability Condition="'$(ResolvedProcessorArchitecture)' == 'RigettiProcessor' And $(_EnableBasicExecution)">$(TargetCapability)</ResolvedTargetCapability>
     <ResolvedTargetCapability Condition="'$(ResolvedProcessorArchitecture)' == 'MicrosoftQuantum' And $(_EnableFullComputation)">$(TargetCapability)</ResolvedTargetCapability>
-    <ResolvedTargetCapability Condition="'$(ResolvedProcessorArchitecture)' == 'MicrosoftSimulator' And $(_EnableFullComputation)">$(TargetCapability)</ResolvedTargetCapability>
     <ResolvedTargetCapability Condition="'$(ResolvedProcessorArchitecture)' == 'Unspecified' And ($(_EnableBasicExecution) Or $(_EnableAdaptiveExecution) Or $(_EnableBasicQuantumFunctionality) Or $(_EnableBasicMeasurementFeedback) Or $(_EnableFullComputation))">$(TargetCapability)</ResolvedTargetCapability>
     <ResolvedTargetCapability Condition="'$(TargetCapability)' != '' And '$(ResolvedTargetCapability)' != '$(TargetCapability)'"></ResolvedTargetCapability>
     <!-- Define a suitable error message for failing the build when the TargetCapability is not compatible with the ExecutionTarget. -->
@@ -85,7 +81,6 @@
     <ValidTargetCapabilities Condition="'$(ResolvedProcessorArchitecture)' == 'QCIProcessor'">$(ValidTargetCapabilities): AdaptiveExecution, BasicExecution.</ValidTargetCapabilities>
     <ValidTargetCapabilities Condition="'$(ResolvedProcessorArchitecture)' == 'RigettiProcessor'">$(ValidTargetCapabilities): BasicExecution.</ValidTargetCapabilities>
     <ValidTargetCapabilities Condition="'$(ResolvedProcessorArchitecture)' == 'MicrosoftQuantum'">$(ValidTargetCapabilities): FullComputation.</ValidTargetCapabilities>
-    <ValidTargetCapabilities Condition="'$(ResolvedProcessorArchitecture)' == 'MicrosoftSimulator'">$(ValidTargetCapabilities): FullComputation.</ValidTargetCapabilities>
     <ValidTargetCapabilities Condition="'$(ResolvedProcessorArchitecture)' == 'Unspecified'">$(ValidTargetCapabilities): FullComputation, AdaptiveExecution, BasicExecution, BasicMeasurementFeedback, BasicQuantumFunctionality.</ValidTargetCapabilities>
   </PropertyGroup>
 
@@ -102,7 +97,7 @@
     <QSharpDocsGeneration Condition="'$(QSharpDocsOutputPath)' != '' And '$(QSharpDocsGeneration)' == 'default'">true</QSharpDocsGeneration>
     <QSharpDocsGeneration Condition="'$(QSharpDocsOutputPath)' == '' And '$(QSharpDocsGeneration)' == 'default'">false</QSharpDocsGeneration>
     <CSharpGeneration Condition="$(QirGeneration)">false</CSharpGeneration>
-    <EnableQirSubmission Condition="'$(ResolvedProcessorArchitecture)' == 'MicrosoftQuantum' Or '$(ResolvedProcessorArchitecture)' == 'MicrosoftSimulator' Or '$(ResolvedTargetCapability)' == 'AdaptiveExecution' Or '$(ResolvedTargetCapability)' == 'BasicExecution'">true</EnableQirSubmission>
+    <EnableQirSubmission Condition="'$(ResolvedProcessorArchitecture)' == 'MicrosoftQuantum' Or '$(ResolvedTargetCapability)' == 'AdaptiveExecution' Or '$(ResolvedTargetCapability)' == 'BasicExecution'">true</EnableQirSubmission>
     <!-- path compatible assembly name -->
     <PathCompatibleAssemblyName>$([System.String]::Copy('$(AssemblyName)').Replace(' ',''))</PathCompatibleAssemblyName>
     <!-- output path for files generated during compilation -->

--- a/src/QuantumSdk/DefaultItems/DefaultItems.targets
+++ b/src/QuantumSdk/DefaultItems/DefaultItems.targets
@@ -36,7 +36,7 @@
     <ResolvedProcessorArchitecture Condition="$(ExecutionTarget.ToLowerInvariant().Contains('quantinuum'))">QuantinuumProcessor</ResolvedProcessorArchitecture>
     <ResolvedProcessorArchitecture Condition="$(ExecutionTarget.ToLowerInvariant().Contains('honeywell'))">QuantinuumProcessor</ResolvedProcessorArchitecture>
     <ResolvedProcessorArchitecture Condition="$(ExecutionTarget.ToLowerInvariant().Contains('rigetti'))">RigettiProcessor</ResolvedProcessorArchitecture>
-    <ResolvedProcessorArchitecture Condition="$(ExecutionTarget.ToLowerInvariant().Contains('microsoft-qc'))">MicrosoftQuantum</ResolvedProcessorArchitecture>
+    <ResolvedProcessorArchitecture Condition="$(ExecutionTarget.ToLowerInvariant().Contains('microsoft')) And !$(ExecutionTarget.ToLowerInvariant().Contains('microsoft.simulator'))">MicrosoftQuantum</ResolvedProcessorArchitecture>
     <ResolvedProcessorArchitecture Condition="$(ExecutionTarget.ToLowerInvariant().Contains('microsoft.simulator'))">MicrosoftSimulator</ResolvedProcessorArchitecture>
     <ResolvedProcessorArchitecture Condition="$(ExecutionTarget.Equals('Any', StringComparison.InvariantCultureIgnoreCase))">Unspecified</ResolvedProcessorArchitecture>
     <ResolvedProcessorArchitecture Condition="'$(ResolvedProcessorArchitecture)' != 'IonQProcessor' And '$(ResolvedProcessorArchitecture)' != 'QCIProcessor' And '$(ResolvedProcessorArchitecture)' != 'QuantinuumProcessor' And '$(ResolvedProcessorArchitecture)' != 'RigettiProcessor' And '$(ResolvedProcessorArchitecture)' != 'MicrosoftQuantum' And '$(ResolvedProcessorArchitecture)' != 'MicrosoftSimulator' And '$(ResolvedProcessorArchitecture)' != 'Unspecified'"></ResolvedProcessorArchitecture>


### PR DESCRIPTION
Add support for new microsoft-qc provider.

This new provider, called Microsoft Quantum Computing will contain all future targets for Microsoft's first party quantum offerings. With targets such as:

- microsoft.estimator
- microsoft.sim.*
- microsoft.qpu.*

For now, maintain support for older provider called Microsoft.Simulator (soon to be deprecated) and older targets such as:

- microsoft.simulator.*