### PR TITLE
Add `BigInt` string interpolation test

### DIFF
--- a/src/QsCompiler/TestTargets/Simulation/Example/Example.csproj
+++ b/src/QsCompiler/TestTargets/Simulation/Example/Example.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.Quantum.Sdk/0.27.244707">
+<Project Sdk="Microsoft.Quantum.Sdk/0.27.246390-beta">
   <PropertyGroup>
     <QscVerbosity>Detailed</QscVerbosity>
     <OutputType>Exe</OutputType>
@@ -26,8 +26,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Simulators" Version="0.27.244707" />
-    <PackageReference Include="Microsoft.Quantum.EntryPointDriver" Version="0.27.244707" />
+    <PackageReference Include="Microsoft.Quantum.Simulators" Version="0.27.246390-beta" />
+    <PackageReference Include="Microsoft.Quantum.EntryPointDriver" Version="0.27.246390-beta" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/QsCompiler/TestTargets/Simulation/Target/Simulation.csproj
+++ b/src/QsCompiler/TestTargets/Simulation/Target/Simulation.csproj
@@ -18,7 +18,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Simulators" Version="0.27.244707" ExcludeAssets="compile" GeneratePathProperty="true" />
+    <PackageReference Include="Microsoft.Quantum.Simulators" Version="0.27.246390-beta" ExcludeAssets="compile" GeneratePathProperty="true" />
   </ItemGroup>
 
   <Target Name="PrepareReferenceTests" Condition="'$(DesignTimeBuild)' != 'true' And $([MSBuild]::IsOsPlatform('OSX'))" BeforeTargets="CoreCompile">

--- a/src/QsCompiler/Tests.Compiler/ExecutionTests.fs
+++ b/src/QsCompiler/Tests.Compiler/ExecutionTests.fs
@@ -160,6 +160,7 @@ type ExecutionTests(output: ITestOutputHelper) =
             """
             simple string
             "interpolated string"
+            -9223372036854775808, 9223372036854775807000
             true or false, true, false, true, false
             1, -1, 0
             1.0, 2.0, 100000.0, 0.1, -1.0, 0.0

--- a/src/QsCompiler/Tests.Compiler/TestCases/ExecutionTests/QirTests.qs
+++ b/src/QsCompiler/Tests.Compiler/TestCases/ExecutionTests/QirTests.qs
@@ -1797,8 +1797,7 @@
         
         Message("simple string");
         Message($"{"interpolated string"}");
-        // Todo: bigint is not yet supported in the runtime,
-        // see also https://github.com/microsoft/qsharp-runtime/issues/910
+        Message($"{-9223372036854775808L}, {9223372036854775807000L}");
         Message($"{true} or {false}, {res == Zero ? false | true}, {res == One ? false | true}, {res == One ? true | false}, {res == Zero ? true | false}");
         Message($"{1}, {-1}, {1 - 1}");
         Message($"{1.}, {2.0}, {1e5}, {.1}, {-1.}, {1. - 1.}");

--- a/src/QsCompiler/Tests.Compiler/Tests.Compiler.fsproj
+++ b/src/QsCompiler/Tests.Compiler/Tests.Compiler.fsproj
@@ -609,9 +609,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Simulators" Version="0.27.244707" ExcludeAssets="compile" GeneratePathProperty="true" />
-    <PackageReference Include="Microsoft.Quantum.QSharp.Core" Version="0.27.244707" ExcludeAssets="compile" />
-    <PackageReference Include="Microsoft.Quantum.Type3.Core" Version="0.27.244707" ExcludeAssets="compile" />
+    <PackageReference Include="Microsoft.Quantum.Simulators" Version="0.27.246390-beta" ExcludeAssets="compile" GeneratePathProperty="true" />
+    <PackageReference Include="Microsoft.Quantum.QSharp.Core" Version="0.27.246390-beta" ExcludeAssets="compile" />
+    <PackageReference Include="Microsoft.Quantum.Type3.Core" Version="0.27.246390-beta" ExcludeAssets="compile" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">


### PR DESCRIPTION
This adds a new string interpolation test for `BigInt` which previously had been left as a "todo" comment due to missing runtime support. Now that support is up to date and the runtime pulls the latest qir-stdlib the test case can be added in.

References to the beta package in the test projects can be updated once we have a release of the runtime with the latest fixes.