### PR TITLE
Fix QIR codegen for repeat loop with array variable

### DIFF
--- a/src/QsCompiler/QirGeneration/Subtransformations/StatementKindTransformation.cs
+++ b/src/QsCompiler/QirGeneration/Subtransformations/StatementKindTransformation.cs
@@ -450,8 +450,10 @@ namespace Microsoft.Quantum.QsCompiler.QIR
                 // We have a do-while pattern here, and the repeat block will be executed one more time than the fixup.
                 // We need to make sure to properly invoke all calls to unreference, release, and remove alias counts
                 // for variables and values in the repeat-block after the statement ends.
+                this.SharedState.StartBranch();
                 this.SharedState.SetCurrentBlock(contBlock);
                 this.SharedState.ScopeMgr.ExitScope();
+                this.SharedState.EndBranch();
                 contBlock = this.SharedState.CurrentBlock;
 
                 this.SharedState.SetCurrentBlock(fixupBlock);

--- a/src/QsCompiler/Tests.Compiler/QirTests.fs
+++ b/src/QsCompiler/Tests.Compiler/QirTests.fs
@@ -158,6 +158,9 @@ let ``QIR repeat loop`` () =
     qirMultiTest true "TestRepeat" [ "TestRepeat1"; "TestRepeat2" ]
 
 [<Fact>]
+let ``QIR repeat loop with array variable`` () = qirTest false "RepeatArray"
+
+[<Fact>]
 let ``QIR integers`` () = qirTest false "TestIntegers"
 
 [<Fact>]

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/RepeatArray.ll
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/RepeatArray.ll
@@ -1,0 +1,149 @@
+
+%Array = type opaque
+%Result = type opaque
+%Qubit = type opaque
+%String = type opaque
+
+define internal i64 @Microsoft__Quantum__Testing__QIR__Main__body() {
+entry:
+  %count = alloca i64, align 8
+  %register = call %Array* @__quantum__rt__qubit_allocate_array(i64 5)
+  call void @__quantum__rt__array_update_alias_count(%Array* %register, i32 1)
+  store i64 0, i64* %count, align 4
+  br label %repeat__1
+
+repeat__1:                                        ; preds = %exit__2, %entry
+  call void @__quantum__rt__array_update_alias_count(%Array* %register, i32 1)
+  %results = call %Array* @__quantum__qis__multim__body(%Array* %register)
+  call void @__quantum__rt__array_update_alias_count(%Array* %register, i32 -1)
+  call void @__quantum__rt__array_update_alias_count(%Array* %results, i32 1)
+  %0 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %results, i64 0)
+  %1 = bitcast i8* %0 to %Result**
+  %2 = load %Result*, %Result** %1, align 8
+  %3 = call %Result* @__quantum__rt__result_get_zero()
+  %4 = call i1 @__quantum__rt__result_equal(%Result* %2, %Result* %3)
+  br i1 %4, label %then0__1, label %continue__1
+
+then0__1:                                         ; preds = %repeat__1
+  %5 = load i64, i64* %count, align 4
+  %6 = add i64 %5, 1
+  store i64 %6, i64* %count, align 4
+  br label %continue__1
+
+continue__1:                                      ; preds = %then0__1, %repeat__1
+  br label %until__1
+
+until__1:                                         ; preds = %continue__1
+  %7 = load i64, i64* %count, align 4
+  %8 = icmp slt i64 %7, 5
+  br i1 %8, label %rend__1, label %fixup__1
+
+fixup__1:                                         ; preds = %until__1
+  call void @__quantum__rt__array_update_alias_count(%Array* %results, i32 -1)
+  %9 = call i64 @__quantum__rt__array_get_size_1d(%Array* %results)
+  %10 = sub i64 %9, 1
+  br label %header__2
+
+rend__1:                                          ; preds = %until__1
+  call void @__quantum__rt__array_update_alias_count(%Array* %results, i32 -1)
+  %11 = call i64 @__quantum__rt__array_get_size_1d(%Array* %results)
+  %12 = sub i64 %11, 1
+  br label %header__1
+
+header__1:                                        ; preds = %exiting__1, %rend__1
+  %13 = phi i64 [ 0, %rend__1 ], [ %18, %exiting__1 ]
+  %14 = icmp sle i64 %13, %12
+  br i1 %14, label %body__1, label %exit__1
+
+body__1:                                          ; preds = %header__1
+  %15 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %results, i64 %13)
+  %16 = bitcast i8* %15 to %Result**
+  %17 = load %Result*, %Result** %16, align 8
+  call void @__quantum__rt__result_update_reference_count(%Result* %17, i32 -1)
+  br label %exiting__1
+
+exiting__1:                                       ; preds = %body__1
+  %18 = add i64 %13, 1
+  br label %header__1
+
+exit__1:                                          ; preds = %header__1
+  call void @__quantum__rt__array_update_reference_count(%Array* %results, i32 -1)
+  %19 = load i64, i64* %count, align 4
+  call void @__quantum__rt__array_update_alias_count(%Array* %register, i32 -1)
+  call void @__quantum__rt__qubit_release_array(%Array* %register)
+  ret i64 %19
+
+header__2:                                        ; preds = %exiting__2, %fixup__1
+  %20 = phi i64 [ 0, %fixup__1 ], [ %25, %exiting__2 ]
+  %21 = icmp sle i64 %20, %10
+  br i1 %21, label %body__2, label %exit__2
+
+body__2:                                          ; preds = %header__2
+  %22 = call i8* @__quantum__rt__array_get_element_ptr_1d(%Array* %results, i64 %20)
+  %23 = bitcast i8* %22 to %Result**
+  %24 = load %Result*, %Result** %23, align 8
+  call void @__quantum__rt__result_update_reference_count(%Result* %24, i32 -1)
+  br label %exiting__2
+
+exiting__2:                                       ; preds = %body__2
+  %25 = add i64 %20, 1
+  br label %header__2
+
+exit__2:                                          ; preds = %header__2
+  call void @__quantum__rt__array_update_reference_count(%Array* %results, i32 -1)
+  br label %repeat__1
+}
+
+declare %Qubit* @__quantum__rt__qubit_allocate()
+
+declare %Array* @__quantum__rt__qubit_allocate_array(i64)
+
+declare void @__quantum__rt__qubit_release_array(%Array*)
+
+declare void @__quantum__rt__array_update_alias_count(%Array*, i32)
+
+declare %Array* @__quantum__qis__multim__body(%Array*)
+
+declare i8* @__quantum__rt__array_get_element_ptr_1d(%Array*, i64)
+
+declare %Result* @__quantum__rt__result_get_zero()
+
+declare i1 @__quantum__rt__result_equal(%Result*, %Result*)
+
+declare i64 @__quantum__rt__array_get_size_1d(%Array*)
+
+declare void @__quantum__rt__result_update_reference_count(%Result*, i32)
+
+declare void @__quantum__rt__array_update_reference_count(%Array*, i32)
+
+define internal %Array* @Microsoft__Quantum__Testing__QIR__MultiM__body(%Array* %targets) {
+entry:
+  call void @__quantum__rt__array_update_alias_count(%Array* %targets, i32 1)
+  %0 = call %Array* @__quantum__qis__multim__body(%Array* %targets)
+  call void @__quantum__rt__array_update_alias_count(%Array* %targets, i32 -1)
+  ret %Array* %0
+}
+
+define i64 @Microsoft__Quantum__Testing__QIR__Main__Interop() #0 {
+entry:
+  %0 = call i64 @Microsoft__Quantum__Testing__QIR__Main__body()
+  ret i64 %0
+}
+
+define void @Microsoft__Quantum__Testing__QIR__Main() #1 {
+entry:
+  %0 = call i64 @Microsoft__Quantum__Testing__QIR__Main__body()
+  %1 = call %String* @__quantum__rt__int_to_string(i64 %0)
+  call void @__quantum__rt__message(%String* %1)
+  call void @__quantum__rt__string_update_reference_count(%String* %1, i32 -1)
+  ret void
+}
+
+declare void @__quantum__rt__message(%String*)
+
+declare %String* @__quantum__rt__int_to_string(i64)
+
+declare void @__quantum__rt__string_update_reference_count(%String*, i32)
+
+attributes #0 = { "InteropFriendly" }
+attributes #1 = { "EntryPoint" }

--- a/src/QsCompiler/Tests.Compiler/TestCases/QirTests/RepeatArray.qs
+++ b/src/QsCompiler/Tests.Compiler/TestCases/QirTests/RepeatArray.qs
@@ -1,0 +1,22 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Microsoft.Quantum.Testing.QIR {
+    @EntryPoint()
+    operation Main() : Int {
+        use register = Qubit[5];
+        mutable count = 0;
+        repeat {
+            let results = MultiM(register);
+            if results[0] == Zero {
+                set count += 1;
+            }
+        }
+        until count < 5;
+        return count;
+    }
+
+    operation MultiM(targets : Qubit[]) : Result[] {
+        body intrinsic;
+    }
+}

--- a/src/QsCompiler/Tests.Compiler/Tests.Compiler.fsproj
+++ b/src/QsCompiler/Tests.Compiler/Tests.Compiler.fsproj
@@ -401,6 +401,12 @@
     <Content Include="TestCases\QirTests\TestWhile.qs">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
+    <Content Include="TestCases\QirTests\RepeatArray.qs">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="TestCases\QirTests\RepeatArray.ll">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
     <None Include="TestCases\LinkingTests\Core.qs">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>


### PR DESCRIPTION
At the end of the repeat scope, codegen loops through the `results` variable to unreference its items. This accesses the length of the array, which is a cached LLVM value. But the value is from a basic block that is not a predecessor of the current block. To make the cache realize that it's invalid, wrap the `contBlock` scope exiting in a codegen "branch."

Closes #1581.