### PR TITLE
Conditionally treat capability warnings as errors (alternative approach)

### DIFF
--- a/src/ProjectTemplates/Quantum.App1/Quantum.App1.csproj.v.template
+++ b/src/ProjectTemplates/Quantum.App1/Quantum.App1.csproj.v.template
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net6.0</TargetFramework>
+    <WarningsAsErrors>5023 5024 5025 5026 5027 5028</WarningsAsErrors>
   </PropertyGroup>
 
 </Project>

--- a/src/ProjectTemplates/Quantum.App1/Quantum.App1.csproj.v.template
+++ b/src/ProjectTemplates/Quantum.App1/Quantum.App1.csproj.v.template
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net6.0</TargetFramework>
-    <WarningsAsErrors>5023 5024 5025 5026 5027 5028</WarningsAsErrors>
+    <WarningsAsErrors>5023;5024;5025;5026;5027;5028</WarningsAsErrors>
   </PropertyGroup>
 
 </Project>

--- a/src/ProjectTemplates/Quantum.Honeywell.App1/Quantum.Honeywell.App1.csproj.v.template
+++ b/src/ProjectTemplates/Quantum.Honeywell.App1/Quantum.Honeywell.App1.csproj.v.template
@@ -4,6 +4,7 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>net6.0</TargetFramework>
     <ExecutionTarget>quantinuum.qpu.h1</ExecutionTarget>
+    <WarningsAsErrors>5023 5024 5025 5026 5027 5028</WarningsAsErrors>
   </PropertyGroup>
 
 </Project>

--- a/src/ProjectTemplates/Quantum.Honeywell.App1/Quantum.Honeywell.App1.csproj.v.template
+++ b/src/ProjectTemplates/Quantum.Honeywell.App1/Quantum.Honeywell.App1.csproj.v.template
@@ -4,7 +4,7 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>net6.0</TargetFramework>
     <ExecutionTarget>quantinuum.qpu.h1</ExecutionTarget>
-    <WarningsAsErrors>5023 5024 5025 5026 5027 5028</WarningsAsErrors>
+    <WarningsAsErrors>5023;5024;5025;5026;5027;5028</WarningsAsErrors>
   </PropertyGroup>
 
 </Project>

--- a/src/ProjectTemplates/Quantum.IonQ.App1/Quantum.IonQ.App1.csproj.v.template
+++ b/src/ProjectTemplates/Quantum.IonQ.App1/Quantum.IonQ.App1.csproj.v.template
@@ -4,6 +4,7 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>net6.0</TargetFramework>
     <ExecutionTarget>ionq.qpu</ExecutionTarget>
+    <WarningsAsErrors>5023 5024 5025 5026 5027 5028</WarningsAsErrors>
   </PropertyGroup>
 
 </Project>

--- a/src/ProjectTemplates/Quantum.IonQ.App1/Quantum.IonQ.App1.csproj.v.template
+++ b/src/ProjectTemplates/Quantum.IonQ.App1/Quantum.IonQ.App1.csproj.v.template
@@ -4,7 +4,7 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>net6.0</TargetFramework>
     <ExecutionTarget>ionq.qpu</ExecutionTarget>
-    <WarningsAsErrors>5023 5024 5025 5026 5027 5028</WarningsAsErrors>
+    <WarningsAsErrors>5023;5024;5025;5026;5027;5028</WarningsAsErrors>
   </PropertyGroup>
 
 </Project>

--- a/src/ProjectTemplates/Quantum.Library1/Quantum.Library1.csproj.v.template
+++ b/src/ProjectTemplates/Quantum.Library1/Quantum.Library1.csproj.v.template
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
+    <WarningsAsErrors>5023 5024 5025 5026 5027 5028</WarningsAsErrors>
   </PropertyGroup>
 
 </Project>

--- a/src/ProjectTemplates/Quantum.Library1/Quantum.Library1.csproj.v.template
+++ b/src/ProjectTemplates/Quantum.Library1/Quantum.Library1.csproj.v.template
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
-    <WarningsAsErrors>5023 5024 5025 5026 5027 5028</WarningsAsErrors>
+    <WarningsAsErrors>5023;5024;5025;5026;5027;5028</WarningsAsErrors>
   </PropertyGroup>
 
 </Project>

--- a/src/ProjectTemplates/Quantum.Quantinuum.App1/Quantum.Quantinuum.App1.csproj.v.template
+++ b/src/ProjectTemplates/Quantum.Quantinuum.App1/Quantum.Quantinuum.App1.csproj.v.template
@@ -4,6 +4,7 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>net6.0</TargetFramework>
     <ExecutionTarget>quantinuum.qpu.h1</ExecutionTarget>
+    <WarningsAsErrors>5023 5024 5025 5026 5027 5028</WarningsAsErrors>
   </PropertyGroup>
 
 </Project>

--- a/src/ProjectTemplates/Quantum.Quantinuum.App1/Quantum.Quantinuum.App1.csproj.v.template
+++ b/src/ProjectTemplates/Quantum.Quantinuum.App1/Quantum.Quantinuum.App1.csproj.v.template
@@ -4,7 +4,7 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>net6.0</TargetFramework>
     <ExecutionTarget>quantinuum.qpu.h1</ExecutionTarget>
-    <WarningsAsErrors>5023 5024 5025 5026 5027 5028</WarningsAsErrors>
+    <WarningsAsErrors>5023;5024;5025;5026;5027;5028</WarningsAsErrors>
   </PropertyGroup>
 
 </Project>

--- a/src/ProjectTemplates/Quantum.Test1/Quantum.Test1.csproj.v.template
+++ b/src/ProjectTemplates/Quantum.Test1/Quantum.Test1.csproj.v.template
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <IsPackable>false</IsPackable>
-    <WarningsAsErrors>5023 5024 5025 5026 5027 5028</WarningsAsErrors>
+    <WarningsAsErrors>5023;5024;5025;5026;5027;5028</WarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/ProjectTemplates/Quantum.Test1/Quantum.Test1.csproj.v.template
+++ b/src/ProjectTemplates/Quantum.Test1/Quantum.Test1.csproj.v.template
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <IsPackable>false</IsPackable>
+    <WarningsAsErrors>5023 5024 5025 5026 5027 5028</WarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/QsCompiler/CommandLineTool/Commands/Build.cs
+++ b/src/QsCompiler/CommandLineTool/Commands/Build.cs
@@ -227,6 +227,7 @@ namespace Microsoft.Quantum.QsCompiler.CommandLineCompiler
                 ForceRewriteStepExecution = options.ForceRewriteStepExecution,
                 TargetPackageAssemblies = options.TargetSpecificDecompositions ?? Enumerable.Empty<string>(),
                 TargetCapability = options.TargetCapability,
+                WarningAsError = options.WarningAsError,
                 SkipMonomorphization = options.SkipMonomorphization,
                 LiftLambdaExpressions = true,
                 GenerateFunctorSupport = true,

--- a/src/QsCompiler/CommandLineTool/Commands/Build.cs
+++ b/src/QsCompiler/CommandLineTool/Commands/Build.cs
@@ -227,7 +227,7 @@ namespace Microsoft.Quantum.QsCompiler.CommandLineCompiler
                 ForceRewriteStepExecution = options.ForceRewriteStepExecution,
                 TargetPackageAssemblies = options.TargetSpecificDecompositions ?? Enumerable.Empty<string>(),
                 TargetCapability = options.TargetCapability,
-                WarningAsError = options.WarningAsError,
+                WarningAsErrorNumbers = options.WarningAsErrorNumbers,
                 SkipMonomorphization = options.SkipMonomorphization,
                 LiftLambdaExpressions = true,
                 GenerateFunctorSupport = true,

--- a/src/QsCompiler/CommandLineTool/Commands/Build.cs
+++ b/src/QsCompiler/CommandLineTool/Commands/Build.cs
@@ -227,7 +227,7 @@ namespace Microsoft.Quantum.QsCompiler.CommandLineCompiler
                 ForceRewriteStepExecution = options.ForceRewriteStepExecution,
                 TargetPackageAssemblies = options.TargetSpecificDecompositions ?? Enumerable.Empty<string>(),
                 TargetCapability = options.TargetCapability,
-                WarningAsErrorNumbers = options.WarningAsErrorNumbers,
+                WarningsAsErrors = options.WarningsAsErrors,
                 SkipMonomorphization = options.SkipMonomorphization,
                 LiftLambdaExpressions = true,
                 GenerateFunctorSupport = true,

--- a/src/QsCompiler/CommandLineTool/Options.cs
+++ b/src/QsCompiler/CommandLineTool/Options.cs
@@ -103,7 +103,7 @@ namespace Microsoft.Quantum.QsCompiler.CommandLineCompiler
             "error",
             Required = false,
             Default = null,
-            HelpText = "Comma-separated warning numbers that should be treated as errors.")]
+            HelpText = "Warning numbers that should be treated as errors.")]
         public IEnumerable<int>? WarningsAsErrors { get; set; }
 
         [Option(

--- a/src/QsCompiler/CommandLineTool/Options.cs
+++ b/src/QsCompiler/CommandLineTool/Options.cs
@@ -104,7 +104,7 @@ namespace Microsoft.Quantum.QsCompiler.CommandLineCompiler
             Required = false,
             Default = null,
             HelpText = "Comma-separated warning numbers that should be treated as errors.")]
-        public string? WarningAsErrorNumbers { get; set; }
+        public IEnumerable<int>? WarningsAsErrors { get; set; }
 
         [Option(
             "build-exe",

--- a/src/QsCompiler/CommandLineTool/Options.cs
+++ b/src/QsCompiler/CommandLineTool/Options.cs
@@ -100,6 +100,13 @@ namespace Microsoft.Quantum.QsCompiler.CommandLineCompiler
             TargetCapability.TryParse(this.TargetCapabilityName) ?? TargetCapabilityModule.Top;
 
         [Option(
+            "error",
+            Required = false,
+            Default = null,
+            HelpText = "Comma-separated warning numbers that should be treated as errors.")]
+        public string? WarningAsError { get; set; }
+
+        [Option(
             "build-exe",
             Required = false,
             Default = false,

--- a/src/QsCompiler/CommandLineTool/Options.cs
+++ b/src/QsCompiler/CommandLineTool/Options.cs
@@ -104,7 +104,7 @@ namespace Microsoft.Quantum.QsCompiler.CommandLineCompiler
             Required = false,
             Default = null,
             HelpText = "Comma-separated warning numbers that should be treated as errors.")]
-        public string? WarningAsError { get; set; }
+        public string? WarningAsErrorNumbers { get; set; }
 
         [Option(
             "build-exe",

--- a/src/QsCompiler/CompilationManager/Diagnostics.cs
+++ b/src/QsCompiler/CompilationManager/Diagnostics.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
                 _ => throw new ArgumentException("Unrecognized fragment ending."),
             };
 
-        private static DiagnosticSeverity Severity(QsCompilerDiagnostic msg, HashSet<int>? warningAsErrorNumbers)
+        private static DiagnosticSeverity Severity(QsCompilerDiagnostic msg, HashSet<int>? warningsAsErrors)
         {
             if (msg.Diagnostic.IsError)
             {
@@ -35,7 +35,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
             }
             else if (msg.Diagnostic.IsWarning)
             {
-                if (warningAsErrorNumbers != null && warningAsErrorNumbers.Contains(msg.Code))
+                if (warningsAsErrors != null && warningsAsErrors.Contains(msg.Code))
                 {
                     return DiagnosticSeverity.Error;
                 }
@@ -86,10 +86,10 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
             string filename,
             QsCompilerDiagnostic msg,
             Position? positionOffset = null,
-            HashSet<int>? warningAsErrorNumbers = null) =>
+            HashSet<int>? warningsAsErrors = null) =>
             new Diagnostic
             {
-                Severity = Severity(msg, warningAsErrorNumbers),
+                Severity = Severity(msg, warningsAsErrors),
                 Code = Code(msg),
                 Source = filename,
                 Message = msg.Message,

--- a/src/QsCompiler/CompilationManager/Diagnostics.cs
+++ b/src/QsCompiler/CompilationManager/Diagnostics.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
                 _ => throw new ArgumentException("Unrecognized fragment ending."),
             };
 
-        private static DiagnosticSeverity Severity(QsCompilerDiagnostic msg, HashSet<int>? warningAsError)
+        private static DiagnosticSeverity Severity(QsCompilerDiagnostic msg, HashSet<int>? warningAsErrorNumbers)
         {
             if (msg.Diagnostic.IsError)
             {
@@ -35,7 +35,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
             }
             else if (msg.Diagnostic.IsWarning)
             {
-                if (warningAsError != null && warningAsError.Contains(msg.Code))
+                if (warningAsErrorNumbers != null && warningAsErrorNumbers.Contains(msg.Code))
                 {
                     return DiagnosticSeverity.Error;
                 }
@@ -86,10 +86,10 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
             string filename,
             QsCompilerDiagnostic msg,
             Position? positionOffset = null,
-            HashSet<int>? warningAsError = null) =>
+            HashSet<int>? warningAsErrorNumbers = null) =>
             new Diagnostic
             {
-                Severity = Severity(msg, warningAsError),
+                Severity = Severity(msg, warningAsErrorNumbers),
                 Code = Code(msg),
                 Source = filename,
                 Message = msg.Message,

--- a/src/QsCompiler/CompilationManager/Diagnostics.cs
+++ b/src/QsCompiler/CompilationManager/Diagnostics.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
                 _ => throw new ArgumentException("Unrecognized fragment ending."),
             };
 
-        private static DiagnosticSeverity Severity(QsCompilerDiagnostic msg)
+        private static DiagnosticSeverity Severity(QsCompilerDiagnostic msg, HashSet<int>? warningAsError)
         {
             if (msg.Diagnostic.IsError)
             {
@@ -35,7 +35,14 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
             }
             else if (msg.Diagnostic.IsWarning)
             {
-                return DiagnosticSeverity.Warning;
+                if (warningAsError != null && warningAsError.Contains(msg.Code))
+                {
+                    return DiagnosticSeverity.Error;
+                }
+                else
+                {
+                    return DiagnosticSeverity.Warning;
+                }
             }
             else if (msg.Diagnostic.IsInformation)
             {
@@ -75,10 +82,14 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// The message range contained in <paramref name="msg"/> is first converted to a <see cref="Position"/> object,
         /// and then added to <paramref name="positionOffset"/> if the latter is not null.
         /// </remarks>
-        internal static Diagnostic Generate(string filename, QsCompilerDiagnostic msg, Position? positionOffset = null) =>
+        internal static Diagnostic Generate(
+            string filename,
+            QsCompilerDiagnostic msg,
+            Position? positionOffset = null,
+            HashSet<int>? warningAsError = null) =>
             new Diagnostic
             {
-                Severity = Severity(msg),
+                Severity = Severity(msg, warningAsError),
                 Code = Code(msg),
                 Source = filename,
                 Message = msg.Message,

--- a/src/QsCompiler/CompilationManager/ProjectManager.cs
+++ b/src/QsCompiler/CompilationManager/ProjectManager.cs
@@ -121,9 +121,29 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         public static ProjectProperties Empty =>
             new ProjectProperties(ImmutableDictionary<string, string?>.Empty);
 
-        public ProjectProperties(IDictionary<string, string?> buildProperties, IEnumerable<int>? warningsAsErrors = null)
+        private HashSet<int>? ParseWarningsAsErrors()
         {
-            this.WarningsAsErrors = warningsAsErrors != null ? new HashSet<int>(warningsAsErrors) : null;
+            if (!this.BuildProperties.TryGetValue(MSBuildProperties.WarningsAsErrors, out string? list) || list == null)
+            {
+                return null;
+            }
+
+            HashSet<int> result = new HashSet<int>();
+            foreach (string s in list.Split(' ', StringSplitOptions.RemoveEmptyEntries))
+            {
+                if (int.TryParse(s, out int n))
+                {
+                    result.Add(n);
+                }
+            }
+
+            return result;
+        }
+
+        public ProjectProperties(IDictionary<string, string?> buildProperties)
+        {
+
+
             this.BuildProperties = buildProperties.ToImmutableDictionary();
         }
     }

--- a/src/QsCompiler/CompilationManager/ProjectManager.cs
+++ b/src/QsCompiler/CompilationManager/ProjectManager.cs
@@ -76,13 +76,10 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
             ?? TargetCapabilityModule.Top;
 
         /// <summary>
-        /// Returns the hash set constructed from <see cref="MSBuildProperties.WarningAsErrorNumbers"/> value.
-        /// An empty set is returned if no value is specified.
+        /// Returns the hash set of warning numbers that should be treated as errors.
+        /// An empty set means that warnings should remain warnings.
         /// </summary>
-        public HashSet<int>? WarningAsErrorNumbers =>
-            this.BuildProperties.TryGetValue(MSBuildProperties.WarningAsErrorNumbers, out var list)
-                ? this.ParseWarningAsErrorNumbers(list)
-                : null;
+        public HashSet<int>? WarningsAsErrors { get; }
 
         /// <summary>
         /// Returns the value specified by <see cref="MSBuildProperties.ResolvedProcessorArchitecture"/>,
@@ -122,21 +119,19 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         internal ImmutableDictionary<string, string?> BuildProperties { get; }
 
         public static ProjectProperties Empty =>
-            new ProjectProperties(ImmutableDictionary<string, string?>.Empty);
+            new ProjectProperties(ImmutableDictionary<string, string?>.Empty, null);
 
-        private HashSet<int>? ParseWarningAsErrorNumbers(string? list)
+        public ProjectProperties(IDictionary<string, string?> buildProperties, IEnumerable<int>? warningsAsErrors = null)
         {
-            if (list == null)
-            {
-                return null;
-            }
-
-            HashSet<int> result = new HashSet<int>(list.Split(",").Select(s => int.Parse(s)));
-            return result;
-        }
-
-        public ProjectProperties(IDictionary<string, string?> buildProperties) =>
+            this.WarningsAsErrors = warningsAsErrors != null ? new HashSet<int>(warningsAsErrors) : null;
             this.BuildProperties = buildProperties.ToImmutableDictionary();
+
+            if (this.WarningsAsErrors != null) {
+                foreach (int i in this.WarningsAsErrors) {
+                    Console.WriteLine($" *** WaE *** {i}");
+                }
+            }
+        }
     }
 
     public class ProjectInformation

--- a/src/QsCompiler/CompilationManager/ProjectManager.cs
+++ b/src/QsCompiler/CompilationManager/ProjectManager.cs
@@ -79,7 +79,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         /// Returns the hash set of warning numbers that should be treated as errors.
         /// An empty set means that warnings should remain warnings.
         /// </summary>
-        public HashSet<int>? WarningsAsErrors { get; }
+        public HashSet<int>? WarningsAsErrors => this.ParseWarningsAsErrors();
 
         /// <summary>
         /// Returns the value specified by <see cref="MSBuildProperties.ResolvedProcessorArchitecture"/>,
@@ -142,8 +142,6 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
 
         public ProjectProperties(IDictionary<string, string?> buildProperties)
         {
-
-
             this.BuildProperties = buildProperties.ToImmutableDictionary();
         }
     }

--- a/src/QsCompiler/CompilationManager/ProjectManager.cs
+++ b/src/QsCompiler/CompilationManager/ProjectManager.cs
@@ -76,14 +76,13 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
             ?? TargetCapabilityModule.Top;
 
         /// <summary>
-        /// Returns the hash set constructed from <see cref="MSBuildProperties.WarningAsError"/> value.
+        /// Returns the hash set constructed from <see cref="MSBuildProperties.WarningAsErrorNumbers"/> value.
         /// An empty set is returned if no value is specified.
         /// </summary>
-        public HashSet<int> WarningAsError =>
-            // TODO: The result of parsing may need to be cached not to parse every time the property is accessed.
-            this.BuildProperties.TryGetValue(MSBuildProperties.WarningAsError, out var list)
-                ? this.ParseWarningAsErrorList(list)
-                : new HashSet<int>();
+        public HashSet<int>? WarningAsErrorNumbers =>
+            this.BuildProperties.TryGetValue(MSBuildProperties.WarningAsErrorNumbers, out var list)
+                ? this.ParseWarningAsErrorNumbers(list)
+                : null;
 
         /// <summary>
         /// Returns the value specified by <see cref="MSBuildProperties.ResolvedProcessorArchitecture"/>,
@@ -125,16 +124,14 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         public static ProjectProperties Empty =>
             new ProjectProperties(ImmutableDictionary<string, string?>.Empty);
 
-        private HashSet<int> ParseWarningAsErrorList(string? list)
+        private HashSet<int>? ParseWarningAsErrorNumbers(string? list)
         {
             if (list == null)
             {
-                return new HashSet<int>();
+                return null;
             }
 
-            // TODO: Which error should we use when this doesn't parse?
-            HashSet<int> result = new HashSet<int>(
-                list.Split(",").Select(s => int.Parse(s)));
+            HashSet<int> result = new HashSet<int>(list.Split(",").Select(s => int.Parse(s)));
             return result;
         }
 

--- a/src/QsCompiler/CompilationManager/ProjectManager.cs
+++ b/src/QsCompiler/CompilationManager/ProjectManager.cs
@@ -76,6 +76,16 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
             ?? TargetCapabilityModule.Top;
 
         /// <summary>
+        /// Returns the hash set constructed from <see cref="MSBuildProperties.WarningAsError"/> value.
+        /// An empty set is returned if no value is specified.
+        /// </summary>
+        public HashSet<int> WarningAsError =>
+            // TODO: The result of parsing may need to be cached not to parse every time the property is accessed.
+            this.BuildProperties.TryGetValue(MSBuildProperties.WarningAsError, out var list)
+                ? this.ParseWarningAsErrorList(list)
+                : new HashSet<int>();
+
+        /// <summary>
         /// Returns the value specified by <see cref="MSBuildProperties.ResolvedProcessorArchitecture"/>,
         /// or an user friendly string indicating and unspecified processor architecture if no value is specified.
         /// </summary>
@@ -114,6 +124,19 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
 
         public static ProjectProperties Empty =>
             new ProjectProperties(ImmutableDictionary<string, string?>.Empty);
+
+        private HashSet<int> ParseWarningAsErrorList(string? list)
+        {
+            if (list == null)
+            {
+                return new HashSet<int>();
+            }
+
+            // TODO: Which error should we use when this doesn't parse?
+            HashSet<int> result = new HashSet<int>(
+                list.Split(",").Select(s => int.Parse(s)));
+            return result;
+        }
 
         public ProjectProperties(IDictionary<string, string?> buildProperties) =>
             this.BuildProperties = buildProperties.ToImmutableDictionary();

--- a/src/QsCompiler/CompilationManager/ProjectManager.cs
+++ b/src/QsCompiler/CompilationManager/ProjectManager.cs
@@ -119,7 +119,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         internal ImmutableDictionary<string, string?> BuildProperties { get; }
 
         public static ProjectProperties Empty =>
-            new ProjectProperties(ImmutableDictionary<string, string?>.Empty, null);
+            new ProjectProperties(ImmutableDictionary<string, string?>.Empty);
 
         public ProjectProperties(IDictionary<string, string?> buildProperties, IEnumerable<int>? warningsAsErrors = null)
         {

--- a/src/QsCompiler/CompilationManager/ProjectManager.cs
+++ b/src/QsCompiler/CompilationManager/ProjectManager.cs
@@ -125,12 +125,6 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         {
             this.WarningsAsErrors = warningsAsErrors != null ? new HashSet<int>(warningsAsErrors) : null;
             this.BuildProperties = buildProperties.ToImmutableDictionary();
-
-            if (this.WarningsAsErrors != null) {
-                foreach (int i in this.WarningsAsErrors) {
-                    Console.WriteLine($" *** WaE *** {i}");
-                }
-            }
         }
     }
 

--- a/src/QsCompiler/CompilationManager/ProjectManager.cs
+++ b/src/QsCompiler/CompilationManager/ProjectManager.cs
@@ -77,9 +77,21 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
 
         /// <summary>
         /// Returns the hash set of warning numbers that should be treated as errors.
-        /// An empty set means that warnings should remain warnings.
+        /// Null or an empty set means that warnings should remain warnings.
         /// </summary>
-        public HashSet<int>? WarningsAsErrors => this.ParseWarningsAsErrors();
+        public HashSet<int>? WarningsAsErrors
+        {
+            get
+            {
+                if (!this.warningsAsErrorsParsed)
+                {
+                    this.warningsAsErrors = this.ParseWarningsAsErrors();
+                    this.warningsAsErrorsParsed = true;
+                }
+
+                return this.warningsAsErrors;
+            }
+        }
 
         /// <summary>
         /// Returns the value specified by <see cref="MSBuildProperties.ResolvedProcessorArchitecture"/>,
@@ -121,6 +133,9 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
         public static ProjectProperties Empty =>
             new ProjectProperties(ImmutableDictionary<string, string?>.Empty);
 
+        private HashSet<int>? warningsAsErrors = null;
+        private bool warningsAsErrorsParsed = false;
+
         private HashSet<int>? ParseWarningsAsErrors()
         {
             if (!this.BuildProperties.TryGetValue(MSBuildProperties.WarningsAsErrors, out string? list) || list == null)
@@ -129,7 +144,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
             }
 
             HashSet<int> result = new HashSet<int>();
-            foreach (string s in list.Split(' ', StringSplitOptions.RemoveEmptyEntries))
+            foreach (string s in list.Split(';', StringSplitOptions.RemoveEmptyEntries))
             {
                 if (int.TryParse(s, out int n))
                 {

--- a/src/QsCompiler/CompilationManager/TypeChecking.cs
+++ b/src/QsCompiler/CompilationManager/TypeChecking.cs
@@ -1920,7 +1920,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
                 var callable = compilation.GetCallables()[name];
                 foreach (var diagnostic in Capabilities.Diagnose(target, compilation.GlobalSymbols, graph, callable))
                 {
-                    yield return Diagnostics.Generate(callable.Source.AssemblyOrCodeFile, diagnostic, null, properties.WarningAsError);
+                    yield return Diagnostics.Generate(callable.Source.AssemblyOrCodeFile, diagnostic, null, properties.WarningAsErrorNumbers);
                 }
             }
         }

--- a/src/QsCompiler/CompilationManager/TypeChecking.cs
+++ b/src/QsCompiler/CompilationManager/TypeChecking.cs
@@ -1920,7 +1920,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
                 var callable = compilation.GetCallables()[name];
                 foreach (var diagnostic in Capabilities.Diagnose(target, compilation.GlobalSymbols, graph, callable))
                 {
-                    yield return Diagnostics.Generate(callable.Source.AssemblyOrCodeFile, diagnostic, null, properties.WarningAsErrorNumbers);
+                    yield return Diagnostics.Generate(callable.Source.AssemblyOrCodeFile, diagnostic, null, properties.WarningsAsErrors);
                 }
             }
         }

--- a/src/QsCompiler/CompilationManager/TypeChecking.cs
+++ b/src/QsCompiler/CompilationManager/TypeChecking.cs
@@ -1920,7 +1920,7 @@ namespace Microsoft.Quantum.QsCompiler.CompilationBuilder
                 var callable = compilation.GetCallables()[name];
                 foreach (var diagnostic in Capabilities.Diagnose(target, compilation.GlobalSymbols, graph, callable))
                 {
-                    yield return Diagnostics.Generate(callable.Source.AssemblyOrCodeFile, diagnostic);
+                    yield return Diagnostics.Generate(callable.Source.AssemblyOrCodeFile, diagnostic, null, properties.WarningAsError);
                 }
             }
         }

--- a/src/QsCompiler/Compiler/CompilationLoader.cs
+++ b/src/QsCompiler/Compiler/CompilationLoader.cs
@@ -554,7 +554,7 @@ namespace Microsoft.Quantum.QsCompiler
             buildProperties.Add(MSBuildProperties.ResolvedProcessorArchitecture, processorArchitecture);
             if (this.config.WarningsAsErrors != null)
             {
-                buildProperties.Add(MSBuildProperties.WarningsAsErrors, string.Join(" ", this.config.WarningsAsErrors));
+                buildProperties.Add(MSBuildProperties.WarningsAsErrors, string.Join(";", this.config.WarningsAsErrors));
             }
 
             var compilationManager = new CompilationUnitManager(

--- a/src/QsCompiler/Compiler/CompilationLoader.cs
+++ b/src/QsCompiler/Compiler/CompilationLoader.cs
@@ -99,7 +99,7 @@ namespace Microsoft.Quantum.QsCompiler
             /// Specifies the comma-separated list of warning numbers
             /// that should be treated as errors.
             /// </summary>
-            public string? WarningAsError{ get; set; }
+            public string? WarningAsErrorNumbers{ get; set; }
 
             /// <summary>
             /// Specifies whether the project to build is a Q# command line application.
@@ -553,7 +553,7 @@ namespace Microsoft.Quantum.QsCompiler
             buildProperties.Add(MSBuildProperties.ResolvedTargetCapability, this.config.TargetCapability?.Name);
             buildProperties.Add(MSBuildProperties.ResolvedQsharpOutputType, this.config.IsExecutable ? AssemblyConstants.QsharpExe : AssemblyConstants.QsharpLibrary);
             buildProperties.Add(MSBuildProperties.ResolvedProcessorArchitecture, processorArchitecture);
-            buildProperties.Add(MSBuildProperties.WarningAsError, this.config.WarningAsError);
+            buildProperties.Add(MSBuildProperties.WarningAsErrorNumbers, this.config.WarningAsErrorNumbers);
 
             var compilationManager = new CompilationUnitManager(
                 new ProjectProperties(buildProperties),

--- a/src/QsCompiler/Compiler/CompilationLoader.cs
+++ b/src/QsCompiler/Compiler/CompilationLoader.cs
@@ -99,7 +99,7 @@ namespace Microsoft.Quantum.QsCompiler
             /// Specifies the comma-separated list of warning numbers
             /// that should be treated as errors.
             /// </summary>
-            public string? WarningAsErrorNumbers{ get; set; }
+            public string? WarningAsErrorNumbers { get; set; }
 
             /// <summary>
             /// Specifies whether the project to build is a Q# command line application.

--- a/src/QsCompiler/Compiler/CompilationLoader.cs
+++ b/src/QsCompiler/Compiler/CompilationLoader.cs
@@ -552,9 +552,13 @@ namespace Microsoft.Quantum.QsCompiler
             buildProperties.Add(MSBuildProperties.ResolvedTargetCapability, this.config.TargetCapability?.Name);
             buildProperties.Add(MSBuildProperties.ResolvedQsharpOutputType, this.config.IsExecutable ? AssemblyConstants.QsharpExe : AssemblyConstants.QsharpLibrary);
             buildProperties.Add(MSBuildProperties.ResolvedProcessorArchitecture, processorArchitecture);
+            if (this.config.WarningsAsErrors != null)
+            {
+                buildProperties.Add(MSBuildProperties.WarningsAsErrors, string.Join(" ", this.config.WarningsAsErrors));
+            }
 
             var compilationManager = new CompilationUnitManager(
-                new ProjectProperties(buildProperties, this.config.WarningsAsErrors),
+                new ProjectProperties(buildProperties),
                 this.OnCompilerException);
             compilationManager.UpdateReferencesAsync(references);
             compilationManager.AddOrUpdateSourceFilesAsync(files);

--- a/src/QsCompiler/Compiler/CompilationLoader.cs
+++ b/src/QsCompiler/Compiler/CompilationLoader.cs
@@ -96,10 +96,9 @@ namespace Microsoft.Quantum.QsCompiler
             public TargetCapability? TargetCapability { get; set; }
 
             /// <summary>
-            /// Specifies the comma-separated list of warning numbers
-            /// that should be treated as errors.
+            /// Specifies the list of warning numbers that should be treated as errors.
             /// </summary>
-            public string? WarningAsErrorNumbers { get; set; }
+            public IEnumerable<int>? WarningsAsErrors { get; set; }
 
             /// <summary>
             /// Specifies whether the project to build is a Q# command line application.
@@ -553,10 +552,9 @@ namespace Microsoft.Quantum.QsCompiler
             buildProperties.Add(MSBuildProperties.ResolvedTargetCapability, this.config.TargetCapability?.Name);
             buildProperties.Add(MSBuildProperties.ResolvedQsharpOutputType, this.config.IsExecutable ? AssemblyConstants.QsharpExe : AssemblyConstants.QsharpLibrary);
             buildProperties.Add(MSBuildProperties.ResolvedProcessorArchitecture, processorArchitecture);
-            buildProperties.Add(MSBuildProperties.WarningAsErrorNumbers, this.config.WarningAsErrorNumbers);
 
             var compilationManager = new CompilationUnitManager(
-                new ProjectProperties(buildProperties),
+                new ProjectProperties(buildProperties, this.config.WarningsAsErrors),
                 this.OnCompilerException);
             compilationManager.UpdateReferencesAsync(references);
             compilationManager.AddOrUpdateSourceFilesAsync(files);

--- a/src/QsCompiler/Compiler/CompilationLoader.cs
+++ b/src/QsCompiler/Compiler/CompilationLoader.cs
@@ -96,6 +96,12 @@ namespace Microsoft.Quantum.QsCompiler
             public TargetCapability? TargetCapability { get; set; }
 
             /// <summary>
+            /// Specifies the comma-separated list of warning numbers
+            /// that should be treated as errors.
+            /// </summary>
+            public string? WarningAsError{ get; set; }
+
+            /// <summary>
             /// Specifies whether the project to build is a Q# command line application.
             /// If set to true, a warning will be raised if no entry point is defined.
             /// If set to false, then defined entry points will be ignored and a warning will be raised.
@@ -547,6 +553,7 @@ namespace Microsoft.Quantum.QsCompiler
             buildProperties.Add(MSBuildProperties.ResolvedTargetCapability, this.config.TargetCapability?.Name);
             buildProperties.Add(MSBuildProperties.ResolvedQsharpOutputType, this.config.IsExecutable ? AssemblyConstants.QsharpExe : AssemblyConstants.QsharpLibrary);
             buildProperties.Add(MSBuildProperties.ResolvedProcessorArchitecture, processorArchitecture);
+            buildProperties.Add(MSBuildProperties.WarningAsError, this.config.WarningAsError);
 
             var compilationManager = new CompilationUnitManager(
                 new ProjectProperties(buildProperties),

--- a/src/QsCompiler/DataStructures/ReservedKeywords.fs
+++ b/src/QsCompiler/DataStructures/ReservedKeywords.fs
@@ -248,6 +248,7 @@ module MSBuildProperties =
     [<Obsolete("Replaced by ResolvedTargetCapability for Microsoft.Quantum.Sdk version 0.25 and newer.")>]
     let ResolvedRuntimeCapabilities = "ResolvedRuntimeCapabilities"
     let ResolvedTargetCapability = "ResolvedTargetCapability"
+    let WarningsAsErrors = "WarningsAsErrors"
     let ResolvedQsharpOutputType = "ResolvedQSharpOutputType"
     let ExposeReferencesViaTestNames = "ExposeReferencesViaTestNames"
     let QsFmtExe = "QsFmtExe"

--- a/src/QsCompiler/DataStructures/ReservedKeywords.fs
+++ b/src/QsCompiler/DataStructures/ReservedKeywords.fs
@@ -248,6 +248,7 @@ module MSBuildProperties =
     [<Obsolete("Replaced by ResolvedTargetCapability for Microsoft.Quantum.Sdk version 0.25 and newer.")>]
     let ResolvedRuntimeCapabilities = "ResolvedRuntimeCapabilities"
     let ResolvedTargetCapability = "ResolvedTargetCapability"
+    let WarningAsError = "WarningAsError"
     let ResolvedQsharpOutputType = "ResolvedQSharpOutputType"
     let ExposeReferencesViaTestNames = "ExposeReferencesViaTestNames"
     let QsFmtExe = "QsFmtExe"

--- a/src/QsCompiler/DataStructures/ReservedKeywords.fs
+++ b/src/QsCompiler/DataStructures/ReservedKeywords.fs
@@ -248,7 +248,6 @@ module MSBuildProperties =
     [<Obsolete("Replaced by ResolvedTargetCapability for Microsoft.Quantum.Sdk version 0.25 and newer.")>]
     let ResolvedRuntimeCapabilities = "ResolvedRuntimeCapabilities"
     let ResolvedTargetCapability = "ResolvedTargetCapability"
-    let WarningAsErrorNumbers = "WarningAsErrorNumbers"
     let ResolvedQsharpOutputType = "ResolvedQSharpOutputType"
     let ExposeReferencesViaTestNames = "ExposeReferencesViaTestNames"
     let QsFmtExe = "QsFmtExe"

--- a/src/QsCompiler/DataStructures/ReservedKeywords.fs
+++ b/src/QsCompiler/DataStructures/ReservedKeywords.fs
@@ -248,7 +248,7 @@ module MSBuildProperties =
     [<Obsolete("Replaced by ResolvedTargetCapability for Microsoft.Quantum.Sdk version 0.25 and newer.")>]
     let ResolvedRuntimeCapabilities = "ResolvedRuntimeCapabilities"
     let ResolvedTargetCapability = "ResolvedTargetCapability"
-    let WarningAsError = "WarningAsError"
+    let WarningAsErrorNumbers = "WarningAsErrorNumbers"
     let ResolvedQsharpOutputType = "ResolvedQSharpOutputType"
     let ExposeReferencesViaTestNames = "ExposeReferencesViaTestNames"
     let QsFmtExe = "QsFmtExe"

--- a/src/QsCompiler/LanguageServer/EditorState.cs
+++ b/src/QsCompiler/LanguageServer/EditorState.cs
@@ -151,6 +151,7 @@ namespace Microsoft.Quantum.QsLanguageServer
 #pragma warning disable CS0618 // Type or member is obsolete
             AddProperty(buildProperties, MSBuildProperties.ResolvedTargetCapability, MSBuildProperties.ResolvedRuntimeCapabilities);
 #pragma warning restore CS0618 // Type or member is obsolete
+            AddProperty(buildProperties, MSBuildProperties.WarningsAsErrors);
             AddProperty(buildProperties, MSBuildProperties.ResolvedQsharpOutputType);
             AddProperty(buildProperties, MSBuildProperties.ExposeReferencesViaTestNames);
             AddProperty(buildProperties, MSBuildProperties.QsFmtExe);

--- a/src/QsCompiler/Tests.Compiler/CommandLineTests.fs
+++ b/src/QsCompiler/Tests.Compiler/CommandLineTests.fs
@@ -54,6 +54,16 @@ let ``multiple valid file`` () =
     |]
     |> testInput ReturnCode.Success
 
+[<Fact>]
+let ``warnings-as-errors switch`` () =
+    [|
+        "--input"
+        ("TestCases", "General.qs") |> Path.Combine
+        "--error"
+        "5023"
+        "5024"
+    |]
+    |> testInput ReturnCode.Success
 
 [<Fact>]
 let ``one invalid file`` () =

--- a/src/QsCompiler/Tests.LanguageServer/Tests.cs
+++ b/src/QsCompiler/Tests.LanguageServer/Tests.cs
@@ -340,6 +340,12 @@ namespace Microsoft.Quantum.QsLanguageServer.Testing
             this.projectLoaded.WaitOne();
             var diagnostics3 = await this.GetFileDiagnosticsAsync(programFile);
 
+            this.projectLoaded.Reset();
+            projectFileContent.Root!.Element("PropertyGroup")!.Add(new XElement("WarningsAsErrors", "5023;5024;5025;5026;5027;5028"));
+            File.WriteAllText(projectFile.AbsolutePath, projectFileContent.ToString());
+            this.projectLoaded.WaitOne();
+            var diagnostics4 = await this.GetFileDiagnosticsAsync(programFile);
+
             Assert.IsNotNull(diagnostics1);
             Assert.AreEqual(2, diagnostics1!.Length);
             Assert.AreEqual("QS5023", diagnostics1[0].Code);
@@ -356,6 +362,13 @@ namespace Microsoft.Quantum.QsLanguageServer.Testing
             Assert.AreEqual(DiagnosticSeverity.Warning, diagnostics3[0].Severity);
             Assert.AreEqual("QS5023", diagnostics3[1].Code);
             Assert.AreEqual(DiagnosticSeverity.Warning, diagnostics3[1].Severity);
+
+            Assert.IsNotNull(diagnostics4);
+            Assert.AreEqual(2, diagnostics4!.Length);
+            Assert.AreEqual("QS5023", diagnostics4[0].Code);
+            Assert.AreEqual(DiagnosticSeverity.Error, diagnostics4[0].Severity);
+            Assert.AreEqual("QS5023", diagnostics4[1].Code);
+            Assert.AreEqual(DiagnosticSeverity.Error, diagnostics4[1].Severity);
         }
 
         [TestMethod]

--- a/src/QuantumSdk/Sdk/Sdk.targets
+++ b/src/QuantumSdk/Sdk/Sdk.targets
@@ -97,7 +97,7 @@
       <_QscCommandSkipTargetingFlag Condition="'$(ResolvedQSharpOutputType)' == 'QSharpLibrary' And '$(NoEntryPoint)' != 'true'">$(_NewLine)--skip-targeting</_QscCommandSkipTargetingFlag>
       <_QscCommandSkipMonomorphization Condition="'$(ResolvedTargetCapability)' == 'FullComputation' And $(CSharpGeneration) And !$(EnableQirSubmission)">$(_NewLine)--skip-monomorphization</_QscCommandSkipMonomorphization>
       <_QscCommandPerfDataGenerationFlag Condition="$(PerfDataGeneration)">$(_NewLine)--perf$(_NewLineIndent)$(PerfDataOutputPath)</_QscCommandPerfDataGenerationFlag>
-      <_QscCommandCapabilityWarningsFlag Condition="'$(TreatCapabilityWarningsAsErrors)' == 'true'">$(_NewLine)--error 5023 5024 5025 5026 5027 5028</_QscCommandCapabilityWarningsFlag>
+      <_QscCommandCapabilityWarningsFlag Condition="'$(WarningsAsErrors)' != ''">$(_NewLine)--error $(WarningsAsErrors)</_QscCommandCapabilityWarningsFlag>
       <_QscCommandTargetDecompositionsFlag Condition="@(ResolvedTargetSpecificDecompositions->Count()) &gt; 0">$(_NewLine)--target-specific-decompositions$(_NewLineIndent)"@(ResolvedTargetSpecificDecompositions,'"$(_NewLineIndent)"')"</_QscCommandTargetDecompositionsFlag>
       <_QscPackageLoadFallbackFoldersFlag Condition="@(ResolvedPackageLoadFallbackFolders->Count()) &gt; 0">$(_NewLine)--package-load-fallback-folders$(_NewLineIndent)"@(ResolvedPackageLoadFallbackFolders,'"$(_NewLineIndent)"')"</_QscPackageLoadFallbackFoldersFlag>
       <_QscCommandLlvmLibsPath Condition="'$(LlvmLibsPath)' != ''">$(_NewLine)--llvm-libs$(_NewLineIndent)$(LlvmLibsPath)</_QscCommandLlvmLibsPath>

--- a/src/QuantumSdk/Sdk/Sdk.targets
+++ b/src/QuantumSdk/Sdk/Sdk.targets
@@ -97,6 +97,7 @@
       <_QscCommandSkipTargetingFlag Condition="'$(ResolvedQSharpOutputType)' == 'QSharpLibrary' And '$(NoEntryPoint)' != 'true'">$(_NewLine)--skip-targeting</_QscCommandSkipTargetingFlag>
       <_QscCommandSkipMonomorphization Condition="'$(ResolvedTargetCapability)' == 'FullComputation' And $(CSharpGeneration) And !$(EnableQirSubmission)">$(_NewLine)--skip-monomorphization</_QscCommandSkipMonomorphization>
       <_QscCommandPerfDataGenerationFlag Condition="$(PerfDataGeneration)">$(_NewLine)--perf$(_NewLineIndent)$(PerfDataOutputPath)</_QscCommandPerfDataGenerationFlag>
+      <_QscCommandCapabilityWarningsFlag Condition="'$(TreatCapabilityWarningsAsErrors)' == 'true'">$(_NewLine)--error 5023,5024,5025,5026,5027,5028</_QscCommandCapabilityWarningsFlag>
       <_QscCommandTargetDecompositionsFlag Condition="@(ResolvedTargetSpecificDecompositions->Count()) &gt; 0">$(_NewLine)--target-specific-decompositions$(_NewLineIndent)"@(ResolvedTargetSpecificDecompositions,'"$(_NewLineIndent)"')"</_QscCommandTargetDecompositionsFlag>
       <_QscPackageLoadFallbackFoldersFlag Condition="@(ResolvedPackageLoadFallbackFolders->Count()) &gt; 0">$(_NewLine)--package-load-fallback-folders$(_NewLineIndent)"@(ResolvedPackageLoadFallbackFolders,'"$(_NewLineIndent)"')"</_QscPackageLoadFallbackFoldersFlag>
       <_QscCommandLlvmLibsPath Condition="'$(LlvmLibsPath)' != ''">$(_NewLine)--llvm-libs$(_NewLineIndent)$(LlvmLibsPath)</_QscCommandLlvmLibsPath>

--- a/src/QuantumSdk/Sdk/Sdk.targets
+++ b/src/QuantumSdk/Sdk/Sdk.targets
@@ -97,7 +97,7 @@
       <_QscCommandSkipTargetingFlag Condition="'$(ResolvedQSharpOutputType)' == 'QSharpLibrary' And '$(NoEntryPoint)' != 'true'">$(_NewLine)--skip-targeting</_QscCommandSkipTargetingFlag>
       <_QscCommandSkipMonomorphization Condition="'$(ResolvedTargetCapability)' == 'FullComputation' And $(CSharpGeneration) And !$(EnableQirSubmission)">$(_NewLine)--skip-monomorphization</_QscCommandSkipMonomorphization>
       <_QscCommandPerfDataGenerationFlag Condition="$(PerfDataGeneration)">$(_NewLine)--perf$(_NewLineIndent)$(PerfDataOutputPath)</_QscCommandPerfDataGenerationFlag>
-      <_QscCommandCapabilityWarningsFlag Condition="'$(TreatCapabilityWarningsAsErrors)' == 'true'">$(_NewLine)--error 5023,5024,5025,5026,5027,5028</_QscCommandCapabilityWarningsFlag>
+      <_QscCommandCapabilityWarningsFlag Condition="'$(TreatCapabilityWarningsAsErrors)' == 'true'">$(_NewLine)--error 5023 5024 5025 5026 5027 5028</_QscCommandCapabilityWarningsFlag>
       <_QscCommandTargetDecompositionsFlag Condition="@(ResolvedTargetSpecificDecompositions->Count()) &gt; 0">$(_NewLine)--target-specific-decompositions$(_NewLineIndent)"@(ResolvedTargetSpecificDecompositions,'"$(_NewLineIndent)"')"</_QscCommandTargetDecompositionsFlag>
       <_QscPackageLoadFallbackFoldersFlag Condition="@(ResolvedPackageLoadFallbackFolders->Count()) &gt; 0">$(_NewLine)--package-load-fallback-folders$(_NewLineIndent)"@(ResolvedPackageLoadFallbackFolders,'"$(_NewLineIndent)"')"</_QscPackageLoadFallbackFoldersFlag>
       <_QscCommandLlvmLibsPath Condition="'$(LlvmLibsPath)' != ''">$(_NewLine)--llvm-libs$(_NewLineIndent)$(LlvmLibsPath)</_QscCommandLlvmLibsPath>


### PR DESCRIPTION
Adding optional --error command line argument to treat specified capability errors as warnings. Accepts a list of warning numbers (space separated).

Language server accepts build property WarningsAsErrors - a list of semicolon separated warning numbers.

Diagnostics is generated as Warnings in F# code, but when the corresponding diagnostic in C# is constructed, its severity is controlled by the list of integers passed as the --error option. If the warning number is among the integers passed, it is generated as error.
