### PR TITLE
Remove WarninsAsErrors from project templates - attempt 2

### DIFF
--- a/src/ProjectTemplates/Quantum.App1/Quantum.App1.csproj.v.template
+++ b/src/ProjectTemplates/Quantum.App1/Quantum.App1.csproj.v.template
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net6.0</TargetFramework>
-    <WarningsAsErrors>5023;5024;5025;5026;5027;5028</WarningsAsErrors>
   </PropertyGroup>
 
 </Project>

--- a/src/ProjectTemplates/Quantum.Honeywell.App1/Quantum.Honeywell.App1.csproj.v.template
+++ b/src/ProjectTemplates/Quantum.Honeywell.App1/Quantum.Honeywell.App1.csproj.v.template
@@ -4,7 +4,6 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>net6.0</TargetFramework>
     <ExecutionTarget>quantinuum.qpu.h1</ExecutionTarget>
-    <WarningsAsErrors>5023;5024;5025;5026;5027;5028</WarningsAsErrors>
   </PropertyGroup>
 
 </Project>

--- a/src/ProjectTemplates/Quantum.IonQ.App1/Quantum.IonQ.App1.csproj.v.template
+++ b/src/ProjectTemplates/Quantum.IonQ.App1/Quantum.IonQ.App1.csproj.v.template
@@ -4,7 +4,6 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>net6.0</TargetFramework>
     <ExecutionTarget>ionq.qpu</ExecutionTarget>
-    <WarningsAsErrors>5023;5024;5025;5026;5027;5028</WarningsAsErrors>
   </PropertyGroup>
 
 </Project>

--- a/src/ProjectTemplates/Quantum.Library1/Quantum.Library1.csproj.v.template
+++ b/src/ProjectTemplates/Quantum.Library1/Quantum.Library1.csproj.v.template
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
-    <WarningsAsErrors>5023;5024;5025;5026;5027;5028</WarningsAsErrors>
   </PropertyGroup>
 
 </Project>

--- a/src/ProjectTemplates/Quantum.Quantinuum.App1/Quantum.Quantinuum.App1.csproj.v.template
+++ b/src/ProjectTemplates/Quantum.Quantinuum.App1/Quantum.Quantinuum.App1.csproj.v.template
@@ -4,7 +4,6 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>net6.0</TargetFramework>
     <ExecutionTarget>quantinuum.qpu.h1</ExecutionTarget>
-    <WarningsAsErrors>5023;5024;5025;5026;5027;5028</WarningsAsErrors>
   </PropertyGroup>
 
 </Project>

--- a/src/ProjectTemplates/Quantum.Test1/Quantum.Test1.csproj.v.template
+++ b/src/ProjectTemplates/Quantum.Test1/Quantum.Test1.csproj.v.template
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <IsPackable>false</IsPackable>
-    <WarningsAsErrors>5023;5024;5025;5026;5027;5028</WarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Remove WarninsAsErrors from project templates.
Clean version of the change.