### PR TITLE
Testing removal of the old (c#-based) resource estimator

### DIFF
--- a/src/QsCompiler/CSharpGeneration/EntryPoint.fs
+++ b/src/QsCompiler/CSharpGeneration/EntryPoint.fs
@@ -397,7 +397,6 @@ let private driverSettings context =
         namedArg "quantumSimulatorName" <| literal AssemblyConstants.QuantumSimulator
         namedArg "sparseSimulatorName" <| literal AssemblyConstants.SparseSimulator
         namedArg "toffoliSimulatorName" <| literal AssemblyConstants.ToffoliSimulator
-        namedArg "resourcesEstimatorName" <| literal AssemblyConstants.ResourcesEstimator
         namedArg "defaultSimulatorName" <| literal defaultSimulator
         namedArg "defaultExecutionTarget" <| defaultExecutionTarget
         namedArg "targetCapability" <| targetCapability

--- a/src/QsCompiler/DataStructures/Diagnostics.fs
+++ b/src/QsCompiler/DataStructures/Diagnostics.fs
@@ -736,7 +736,7 @@ type DiagnosticItem =
             | ErrorCode.InvalidTestAttributePlacement ->
                 "Invalid test attribute. Test attributes may only occur on callables that have no arguments and return Unit."
             | ErrorCode.InvalidExecutionTargetForTest ->
-                "Invalid execution target. Currently, valid execution targets for tests are the QuantumSimulator, the SparseSimulator, the ToffoliSimulator, or the ResourcesEstimator."
+                "Invalid execution target. Currently, valid execution targets for tests are the QuantumSimulator, the SparseSimulator, or the ToffoliSimulator."
             | ErrorCode.ExpectingFullNameAsAttributeArgument ->
                 "Invalid attribute argument. Expecting a fully qualified name as argument to the {0} attribute."
             | ErrorCode.AttributeInvalidOnSpecialization ->

--- a/src/QsCompiler/DataStructures/ReservedKeywords.fs
+++ b/src/QsCompiler/DataStructures/ReservedKeywords.fs
@@ -273,7 +273,6 @@ module AssemblyConstants =
     let QuantumSimulator = "QuantumSimulator"
     let SparseSimulator = "SparseSimulator"
     let ToffoliSimulator = "ToffoliSimulator"
-    let ResourcesEstimator = "ResourcesEstimator"
     let ExposeReferencesViaTestNames = "ExposeReferencesViaTestNames"
     let QirOutputPath = "QirOutputPath"
     let PerfDataOutputPath = "PerfDataOutputPath"
@@ -293,7 +292,6 @@ module CommandLineArguments =
             AssemblyConstants.QuantumSimulator
             AssemblyConstants.SparseSimulator
             AssemblyConstants.ToffoliSimulator
-            AssemblyConstants.ResourcesEstimator
         ]
         |> ImmutableHashSet.CreateRange
 

--- a/src/QsCompiler/Tests.CSharpGeneration/Circuits/UnitTests.qs
+++ b/src/QsCompiler/Tests.CSharpGeneration/Circuits/UnitTests.qs
@@ -26,7 +26,6 @@ namespace Microsoft.Quantum.Tests.UnitTests {
     operation UnitTest2() : Unit {
 	}
 
-    @Test("ResourcesEstimator")
     @Test("SparseSimulator")
     operation UnitTest3 () : Unit {
     }

--- a/src/QsCompiler/Tests.Compiler/TestCases/LocalVerification.qs
+++ b/src/QsCompiler/Tests.Compiler/TestCases/LocalVerification.qs
@@ -1350,7 +1350,7 @@ namespace Microsoft.Quantum.Testing.LocalVerification {
     @Test("QuantumSimulator")
     function ValidTestAttribute1 () : Unit {}
 
-    @Test("ResourcesEstimator")
+    @Test("SparseSimulator")
     function ValidTestAttribute2 () : Unit {}
 
     @Test("ToffoliSimulator")
@@ -1359,7 +1359,7 @@ namespace Microsoft.Quantum.Testing.LocalVerification {
     @Test("QuantumSimulator")
     operation ValidTestAttribute4 () : Unit {}
 
-    @Test("ResourcesEstimator")
+    @Test("SparseSimulator")
     operation ValidTestAttribute5 () : Unit {}
 
     @Test("ToffoliSimulator")
@@ -1369,7 +1369,7 @@ namespace Microsoft.Quantum.Testing.LocalVerification {
     operation ValidTestAttribute7 () : Unit
     is Adj + Ctl{}
 
-    @Test("ResourcesEstimator")
+    @Test("SparseSimulator")
     operation ValidTestAttribute8 () : Unit
     is Adj {}
 
@@ -1380,7 +1380,6 @@ namespace Microsoft.Quantum.Testing.LocalVerification {
     @Test("QuantumSimulator")
     function ValidTestAttribute10 () : ((Unit)) {}
 
-    @Test("ResourcesEstimator")
     function ValidTestAttribute11 (arg : Unit) : Unit { }
 
     @Test("ToffoliSimulator")
@@ -1388,13 +1387,11 @@ namespace Microsoft.Quantum.Testing.LocalVerification {
 
     @Test("QuantumSimulator")
     @Test("ToffoliSimulator")
-    @Test("ResourcesEstimator")
     @Test("SparseSimulator")
     function ValidTestAttribute13 () : Unit { }
 
     @Test("QuantumSimulator")
     @Test("ToffoliSimulator")
-    @Test("ResourcesEstimator")
     @Test("SparseSimulator")
     operation ValidTestAttribute14 () : Unit { }
 
@@ -1443,17 +1440,17 @@ namespace Microsoft.Quantum.Testing.LocalVerification {
     }
 
     operation InvalidTestAttribute3 () : Unit {
-        @Test("ResourcesEstimator")
+        @Test("QuantumSimulator")
         body (...) {}
     }
 
     operation InvalidTestAttribute4 () : Unit {
         body (...) { }
-        @Test("ResourcesEstimator")
+        @Test("SparseSimulator")
         adjoint (...) { }
     }
 
-    @Test("ResourcesEstimator")
+    @Test("ToffoliSimulator")
     function InvalidTestAttribute5<'T> () : Unit { }
 
     @Test("QuantumSimulator")
@@ -1472,7 +1469,7 @@ namespace Microsoft.Quantum.Testing.LocalVerification {
     @Test("QuantumSimulator")
     function InvalidTestAttribute9 (a : Unit, b : Unit) : Unit { }
 
-    @Test("ResourcesEstimator")
+    @Test("ToffoliSimulator")
     operation InvalidTestAttribute10 (a : Bool) : Unit { }
 
     @Test("SparseSimulator")


### PR DESCRIPTION
DO NOT MERGE!
This is a test of the upcoming removal of the old (c#-based) resource estimator.
The deprecation and removal will be announced and is expected to happen later this year.