### PR TITLE
Cleanup after removal of the resources estimator

### DIFF
--- a/src/QsCompiler/CSharpGeneration/EntryPoint.fs
+++ b/src/QsCompiler/CSharpGeneration/EntryPoint.fs
@@ -401,7 +401,6 @@ let private driverSettings context =
         namedArg "defaultExecutionTarget" <| defaultExecutionTarget
         namedArg "targetCapability" <| targetCapability
         namedArg "createDefaultCustomSimulator" <| customSimulatorFactory defaultSimulator
-        namedArg "resourcesEstimatorName" <| literal ""
     ]
     |> SyntaxFactory.SeparatedList
     |> SyntaxFactory.ArgumentList

--- a/src/QsCompiler/TestTargets/Simulation/Example/Example.csproj
+++ b/src/QsCompiler/TestTargets/Simulation/Example/Example.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.Quantum.Sdk/0.27.246390-beta">
+<Project Sdk="Microsoft.Quantum.Sdk/0.27.260812-beta">
   <PropertyGroup>
     <QscVerbosity>Detailed</QscVerbosity>
     <OutputType>Exe</OutputType>
@@ -26,8 +26,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Quantum.Simulators" Version="0.27.246390-beta" />
-    <PackageReference Include="Microsoft.Quantum.EntryPointDriver" Version="0.27.246390-beta" />
+    <PackageReference Include="Microsoft.Quantum.Simulators" Version="0.27.260812-beta" />
+    <PackageReference Include="Microsoft.Quantum.EntryPointDriver" Version="0.27.260812-beta" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/QsCompiler/Tests.Compiler/LocalVerificationTests.fs
+++ b/src/QsCompiler/Tests.Compiler/LocalVerificationTests.fs
@@ -436,7 +436,6 @@ type LocalVerificationTests() =
         this.Expect "ValidTestAttribute8" []
         this.Expect "ValidTestAttribute9" []
         this.Expect "ValidTestAttribute10" []
-        this.Expect "ValidTestAttribute11" []
         this.Expect "ValidTestAttribute12" []
         this.Expect "ValidTestAttribute13" []
         this.Expect "ValidTestAttribute14" []

--- a/src/QsCompiler/Tests.Compiler/TestCases/LocalVerification.qs
+++ b/src/QsCompiler/Tests.Compiler/TestCases/LocalVerification.qs
@@ -1380,8 +1380,6 @@ namespace Microsoft.Quantum.Testing.LocalVerification {
     @Test("QuantumSimulator")
     function ValidTestAttribute10 () : ((Unit)) {}
 
-    function ValidTestAttribute11 (arg : Unit) : Unit { }
-
     @Test("ToffoliSimulator")
     operation ValidTestAttribute12 (arg : (Unit)) : Unit { }
 


### PR DESCRIPTION
1. Removed parameter that is no longer used (and switched to a beta package to do that)
2. Removed test that is no longer tests anything.