### PR TITLE
Fix metadata warnings for doc builds

### DIFF
--- a/src/Documentation/DocumentationGenerator/DocumentationWriter.cs
+++ b/src/Documentation/DocumentationGenerator/DocumentationWriter.cs
@@ -148,6 +148,7 @@ namespace Microsoft.Quantum.Documentation
                 ["ms.date"] = DateTime.Today.ToString("MM/dd/yyyy"),
                 ["ms.topic"] = "managed-reference",
                 ["ms.author"] = "quantumdocwriters",
+                ["description"] = docComment.Summary,
 
                 // Q# metadata
                 ["qsharp.kind"] = "namespace",
@@ -195,8 +196,10 @@ namespace Microsoft.Quantum.Documentation
                 ["title"] = title,
 
                 // docs.ms metadata
-                ["ms.date"] = DateTime.Today.ToString(),
+                ["ms.date"] = DateTime.Today.ToString("MM/dd/yyyy"),
                 ["ms.topic"] = "managed-reference",
+                ["ms.author"] = "quantumdocwriters",
+                ["description"] = docComment.Summary,
 
                 // Q# metadata
                 ["qsharp.kind"] = "udt",
@@ -273,8 +276,10 @@ Namespace: [{type.FullName.Namespace}](xref:{type.FullName.Namespace})
                 ["title"] = title,
 
                 // docs.ms metadata
-                ["ms.date"] = DateTime.Today.ToString(),
+                ["ms.date"] = DateTime.Today.ToString("MM/dd/yyyy"),
                 ["ms.topic"] = "managed-reference",
+                ["ms.author"] = "quantumdocwriters",
+                ["description"] = docComment.Summary,
 
                 // Q# metadata
                 ["qsharp.kind"] = kind,

--- a/src/Documentation/DocumentationGenerator/DocumentationWriter.cs
+++ b/src/Documentation/DocumentationGenerator/DocumentationWriter.cs
@@ -145,8 +145,9 @@ namespace Microsoft.Quantum.Documentation
                 ["title"] = title,
 
                 // docs.ms metadata
-                ["ms.date"] = DateTime.Today.ToString(),
+                ["ms.date"] = DateTime.Today.ToString("MM/dd/yyyy"),
                 ["ms.topic"] = "managed-reference",
+                ["ms.author"] = "quantumdocwriters",
 
                 // Q# metadata
                 ["qsharp.kind"] = "namespace",


### PR DESCRIPTION
Add an ms.author value, and format the date correctly. This should fix the thousands of warnings in the API doc builds every month.