### PR TITLE
Update NuGet Package Dependencies

### DIFF
--- a/src/QsCompiler/LanguageServer/LanguageServer.csproj
+++ b/src/QsCompiler/LanguageServer/LanguageServer.csproj
@@ -30,7 +30,7 @@
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.3.2" ExcludeAssets="runtime" />
     <PackageReference Include="Microsoft.VisualStudio.LanguageServer.Protocol" Version="17.2.8" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="NuGet.ProjectModel" Version="6.2.2" ExcludeAssets="runtime" />
+    <PackageReference Include="NuGet.ProjectModel" Version="6.2.4" ExcludeAssets="runtime" />
     <PackageReference Include="NuGet.Frameworks" Version="6.3.1" ExcludeAssets="runtime" />
     <PackageReference Include="StreamJsonRpc" Version="2.7.76" />
     <PackageReference Include="System.Reactive" Version="4.4.1" />

--- a/src/QsFmt/App/App.fsproj
+++ b/src/QsFmt/App/App.fsproj
@@ -42,7 +42,7 @@
     <PackageReference Include="Microsoft.Build.Framework" Version="17.3.2" ExcludeAssets="runtime" />
     <PackageReference Include="Microsoft.Build.Locator" Version="1.4.1" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.3.2" ExcludeAssets="runtime" />
-    <PackageReference Include="NuGet.ProjectModel" Version="6.2.2" />
+    <PackageReference Include="NuGet.ProjectModel" Version="6.2.4" />
     <PackageReference Include="NuGet.Frameworks" Version="6.3.1" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Updates the NuGet.ProjectModel dependency from 6.2.2 to 6.2.4.

See also: https://github.com/microsoft/iqsharp/pull/805